### PR TITLE
Some small improvements to the initial dev setup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,5 @@
         "php" : ">=5.4",
         "squizlabs/php_codesniffer" : "^2.6.0 || ^3.1.0",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.3 || ^0.4.1 || ^0.5.0"
-    },
-    "require-dev" : {
-        "roave/security-advisories" : "dev-master"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require" : {
         "php" : ">=5.4",
         "squizlabs/php_codesniffer" : "^2.6.0 || ^3.1.0",
-        "dealerdirect/phpcodesniffer-composer-installer" : "^0.5"
+        "dealerdirect/phpcodesniffer-composer-installer" : "^0.3 || ^0.4.1 || ^0.5.0"
     },
     "require-dev" : {
         "roave/security-advisories" : "dev-master"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^2.6.0 || ^3.0.2",
+        "squizlabs/php_codesniffer" : "^2.6.0 || ^3.1.0",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.5"
     },
     "require-dev" : {


### PR DESCRIPTION
### Composer: set minimum PHPCS 3.x version to `^3.1.0`

When `installed_paths` is set via a custom, the PHPCS native autoloader cannot find non-sniff files provided by an external standard, including the PHPCSUtils files.

As PHPCS 3.0.2 is rarely used anymore anyway, let's just not support it.

Ref: squizlabs/PHP_CodeSniffer#1591

### Composer: make the version requirement for the Composer PHPCS plugin more flexible

... to prevent conflicts with projects, be it external standards or end-user projects, which require the plugin themselves as well.

Note: Composer treat minors before `1.0.0` as majors, so each supported minor needs to be explicitly allowed.

Note: Version `0.4.0` is excluded from being installed due to a [bug](Dealerdirect/phpcodesniffer-composer-installer#33) which made it far less usable.

Ref: https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases

### Composer: remove the security-advisories `dev` dependency

... as it would block unit testing this repo on old PHPCS versions.

