### PR TITLE
Add the base rulesets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore
+/phpcs.xml.dist export-ignore
 
 #
 # Auto detect text files and perform LF normalization

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vendor/
-composer.lock
+/composer.lock
+/.phpcs.xml
+/phpcs.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: php
 
 ## Cache composer and apt downloads.
 cache:
+  apt: true
   directories:
     # Cache directory for older Composer versions.
     - $HOME/.composer/cache/files
@@ -14,13 +15,36 @@ php:
   - 5.4
   - 7.3
 
+# Define the stages used.
+stages:
+  - name: sniff
+  - name: test
+
 jobs:
   fast_finish: true
+  include:
+    #### SNIFF STAGE ####
+    - stage: sniff
+      php: 7.3
+      addons:
+        apt:
+          packages:
+            - libxml2-utils
+      script:
+        # Validate the xml files.
+        # @link http://xmlsoft.org/xmllint.html
+        - xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./PHPCSUtils/ruleset.xml
+        - xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./PHPCS23Utils/ruleset.xml
 
+        # Check the code-style consistency of the xml files.
+        - diff -B ./PHPCSUtils/ruleset.xml <(xmllint --format "./PHPCSUtils/ruleset.xml")
+        - diff -B ./PHPCS23Utils/ruleset.xml <(xmllint --format "./PHPCS23Utils/ruleset.xml")
 
 before_install:
   # Speed up build time by disabling Xdebug when its not needed.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+
+  - export XMLLINT_INDENT="    "
 
   # --prefer-dist will allow for optimal use of the travis caching ability.
   - composer install --prefer-dist --no-suggest

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ cache:
 php:
   - 5.4
   - 7.3
+  - "nightly"
 
 # Define the stages used.
 stages:
@@ -40,6 +41,11 @@ jobs:
         - diff -B ./PHPCSUtils/ruleset.xml <(xmllint --format "./PHPCSUtils/ruleset.xml")
         - diff -B ./PHPCS23Utils/ruleset.xml <(xmllint --format "./PHPCS23Utils/ruleset.xml")
 
+  allow_failures:
+    # Allow failures for unstable builds.
+    - php: "nightly"
+
+
 before_install:
   # Speed up build time by disabling Xdebug when its not needed.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
@@ -51,6 +57,9 @@ before_install:
 
 
 script:
+  # Lint PHP files against parse errors.
+  - composer lint
+
   # Validate the composer.json file on low/high PHP versions.
   # @link https://getcomposer.org/doc/03-cli.md#validate
   - composer validate --no-check-all --strict

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,13 @@ jobs:
           packages:
             - libxml2-utils
       script:
+        # Validate the composer.json file.
+        # @link https://getcomposer.org/doc/03-cli.md#validate
+        - composer validate --no-check-all --strict
+
+        # Check the code style of the code base.
+        - composer travis-checkcs
+
         # Validate the xml files.
         # @link http://xmlsoft.org/xmllint.html
         - xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./PHPCSUtils/ruleset.xml
@@ -53,13 +60,10 @@ before_install:
   - export XMLLINT_INDENT="    "
 
   # --prefer-dist will allow for optimal use of the travis caching ability.
+  # The Composer PHPCS plugin takes care of setting the installed_paths for PHPCS.
   - composer install --prefer-dist --no-suggest
 
 
 script:
   # Lint PHP files against parse errors.
   - composer lint
-
-  # Validate the composer.json file on low/high PHP versions.
-  # @link https://getcomposer.org/doc/03-cli.md#validate
-  - composer validate --no-check-all --strict

--- a/PHPCS23Utils/Sniffs/Load/LoadUtilsSniff.php
+++ b/PHPCS23Utils/Sniffs/Load/LoadUtilsSniff.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCS23Utils\Sniffs\Load;
+
+/*
+ * Here be magic.
+ *
+ * This include allows for the Utility functions to work PHPCS cross-version.
+ */
+require_once \dirname(\dirname(\dirname(__DIR__))) . '/phpcsutils-autoload.php';
+
+/**
+ * Dummy Sniff.
+ *
+ * This sniff doesn't do anything. It's just here to trigger the above include.
+ *
+ * @since 1.0.0
+ */
+class LoadUtilsSniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [];
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process($phpcsFile, $stackPtr)
+    {
+    }
+}

--- a/PHPCS23Utils/ruleset.xml
+++ b/PHPCS23Utils/ruleset.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCS23Utils" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+    <description>Standard which makes the PHPCSUtils utility methods for external PHPCS standards available in PHPCS 2.x.</description>
+</ruleset>

--- a/PHPCSUtils/ruleset.xml
+++ b/PHPCSUtils/ruleset.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCSUtils" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+    <description>Utility methods for external PHPCS standards.</description>
+</ruleset>

--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,8 @@
         "php" : ">=5.4",
         "squizlabs/php_codesniffer" : "^2.6.0 || ^3.1.0",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.3 || ^0.4.1 || ^0.5.0"
+    },
+    "autoload": {
+        "classmap": ["PHPCSUtils/"]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,34 @@
         "jakub-onderka/php-parallel-lint": "^1.0",
         "jakub-onderka/php-console-highlighter": "^0.4"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "classmap": ["PHPCSUtils/"]
     },
     "scripts" : {
         "lint": [
             "@php ./vendor/jakub-onderka/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+        ],
+        "install-devtools": [
+            "composer require --dev phpcsstandards/phpcsdevtools:\"^1.0 || dev-develop\" --no-suggest"
+        ],
+        "remove-devtools": [
+            "composer remove --dev phpcsstandards/phpcsdevtools"
+        ],
+        "checkcs": [
+            "@install-devtools",
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
+            "@remove-devtools"
+        ],
+        "fixcs": [
+            "@install-devtools",
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf",
+            "@remove-devtools"
+        ],
+        "travis-checkcs": [
+            "@install-devtools",
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,16 @@
         "squizlabs/php_codesniffer" : "^2.6.0 || ^3.1.0",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.3 || ^0.4.1 || ^0.5.0"
     },
+    "require-dev" : {
+        "jakub-onderka/php-parallel-lint": "^1.0",
+        "jakub-onderka/php-console-highlighter": "^0.4"
+    },
     "autoload": {
         "classmap": ["PHPCSUtils/"]
+    },
+    "scripts" : {
+        "lint": [
+            "@php ./vendor/jakub-onderka/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+        ]
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Coding Standard for PHPCSUtils" xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+    <description>Check the code of the PHPCSUtils standard.</description>
+
+    <!--
+    #############################################################################
+    COMMAND LINE ARGUMENTS
+    https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+    #############################################################################
+    -->
+
+    <file>.</file>
+
+    <!-- Exclude Composer vendor directory. -->
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+
+    <!-- Only check PHP files. -->
+    <arg name="extensions" value="php"/>
+
+    <!-- Show progress, show the error codes for each message (source). -->
+    <arg value="ps"/>
+
+    <!-- Strip the filepaths down to the relevant bit. -->
+    <arg name="basepath" value="./"/>
+
+    <!-- Check up to 8 files simultaneously. -->
+    <arg name="parallel" value="8"/>
+
+    <!--
+    #############################################################################
+    USE THE PHPCSDev RULESET
+    #############################################################################
+    -->
+
+    <rule ref="PHPCSDev">
+        <!-- Allow for the file docblock on the line directly following the PHP open tag.
+             As the sniff in PHPCS does not use modular error codes (yet - see PR #2729),
+             the complete error code needs to be disabled, not just the bit involving
+             the file docblocks.
+        -->
+        <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock"/>
+    </rule>
+
+    <!-- Set minimum PHP version supported to PHP 5.4. -->
+    <config name="testVersion" value="5.4-"/>
+
+    <!-- Enforce short arrays. -->
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+
+
+    <!--
+    #############################################################################
+    SELECTIVE EXCLUSIONS
+    Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
+    #############################################################################
+    -->
+
+    <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
+        <exclude-pattern>/phpcsutils-autoload\.php$</exclude-pattern>
+        <exclude-pattern>/PHPCS23Utils/Sniffs/Load/LoadUtilsSniff\.php$</exclude-pattern>
+    </rule>
+
+</ruleset>

--- a/phpcsutils-autoload.php
+++ b/phpcsutils-autoload.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * Autoloader for the PHPCSUtils files.
+ *
+ * - If an external standard only supports PHPCS >= 3.1.0 and uses the PHPCS
+ *   native unit test framework, this file does not need to be included.
+ *
+ * - If an external standard uses its own unit test setup, this file should
+ *   be included from the unit test bootstrap file.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ *
+ * @since 1.0.0
+ */
+
+if (defined('PHPCSUTILS_AUTOLOAD') === false) {
+    /*
+     * Register an autoloader.
+     *
+     * External PHPCS standards which have their own unit test suite
+     * should include this file in their test runner bootstrap.
+     */
+    spl_autoload_register(function ($class) {
+        // Only try & load our own classes.
+        if (stripos($class, 'PHPCSUtils') !== 0) {
+            return;
+        }
+
+        $file = realpath(__DIR__) . DIRECTORY_SEPARATOR . strtr($class, '\\', DIRECTORY_SEPARATOR) . '.php';
+
+        if (file_exists($file)) {
+            include_once $file;
+        }
+    });
+
+    define('PHPCSUTILS_AUTOLOAD', true);
+}

--- a/phpcsutils-autoload.php
+++ b/phpcsutils-autoload.php
@@ -3,9 +3,16 @@
  * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
  *
  * Autoloader for the PHPCSUtils files.
+ * Also provides PHPCS cross-version class aliases.
  *
  * - If an external standard only supports PHPCS >= 3.1.0 and uses the PHPCS
  *   native unit test framework, this file does not need to be included.
+ *
+ * - When PHPCS 2.x support is desired, include the "PHPCS23Utils" standard
+ *   in the ruleset of the external standard and this file will be included
+ *   automatically.
+ *   Including this file will allow PHPCSUtils to work in both PHPCS 2.x
+ *   as well as PHPCS 3.x.
  *
  * - If an external standard uses its own unit test setup, this file should
  *   be included from the unit test bootstrap file.
@@ -39,4 +46,50 @@ if (defined('PHPCSUTILS_AUTOLOAD') === false) {
     });
 
     define('PHPCSUTILS_AUTOLOAD', true);
+}
+
+if (defined('PHPCSUTILS_PHPCS_ALIASES_SET') === false) {
+    /*
+     * Alias a number of PHPCS 2.x classes to their PHPCS 3.x equivalents.
+     *
+     * {@internal The PHPCS file have been reorganized in PHPCS 3.x, quite
+     * a few "old" classes have been split and spread out over several "new"
+     * classes. In other words, this will only work for a limited number
+     * of classes.}}
+     *
+     * {@internal The `class_exists` wrappers are needed to play nice with other
+     * external PHPCS standards creating cross-version compatibility in a
+     * similar manner.}}
+     */
+    if (interface_exists('\PHP_CodeSniffer_Sniff') === true
+        && interface_exists('\PHP_CodeSniffer\Sniffs\Sniff') === false
+    ) {
+        class_alias('\PHP_CodeSniffer_Sniff', '\PHP_CodeSniffer\Sniffs\Sniff');
+    }
+
+    if (class_exists('\PHP_CodeSniffer_File') === true
+        && class_exists('\PHP_CodeSniffer\Files\File') === false
+    ) {
+        class_alias('\PHP_CodeSniffer_File', '\PHP_CodeSniffer\Files\File');
+    }
+
+    if (class_exists('\PHP_CodeSniffer_Tokens') === true
+        && class_exists('\PHP_CodeSniffer\Util\Tokens') === false
+    ) {
+        class_alias('\PHP_CodeSniffer_Tokens', '\PHP_CodeSniffer\Util\Tokens');
+    }
+
+    if (class_exists('\PHP_CodeSniffer_Exception') === true
+        && class_exists('\PHP_CodeSniffer\Exceptions\RuntimeException') === false
+    ) {
+        class_alias('\PHP_CodeSniffer_Exception', '\PHP_CodeSniffer\Exceptions\RuntimeException');
+    }
+
+    if (class_exists('\PHP_CodeSniffer_Exception') === true
+        && class_exists('\PHP_CodeSniffer\Exceptions\TokenizerException') === false
+    ) {
+        class_alias('\PHP_CodeSniffer_Exception', '\PHP_CodeSniffer\Exceptions\TokenizerException');
+    }
+
+    define('PHPCSUTILS_PHPCS_ALIASES_SET', true);
 }


### PR DESCRIPTION
This PR adds the base rulesets for PHPCSUtils.

It also puts QA in place to:
- Validate the ruleset XML files and verify code style compliance for them.
- Lint PHP files, as the first PHP files are now being introduced into the repo.
- Check the code style of the PHP code.


## Commit details:

### PHPCSUtils: add the ruleset file

This will allow PHPCS to recognize PHPCSUtils as if it were an external PHPCS standard and handle the autoloading of all PHPCSUtils files automatically when using PHPCS 3+.

External standards using PHPCSUtils **_don't_** even need to add `<rule ref="PHPCSUtils"/>` to their own ruleset.
All that is needed is for the PHPCSUtils standard to be in the PHPCS `installed_paths` which - for Composer based installs - will automatically be taken care of by the DealerDirect Composer PHPCS plugin which is a `require`d dependency for this package.

### PHPCSUtils: add an (optional) autoloader

... for external standards which have their own test suite.

In PHPCS > 3.0.2+, when using the PHPCS native test suite, the files from PHPCSUtils will automatically load correctly.

However, when using a custom test suite, this will generally not be the case.
Requiring the `phpcsutils-autoload.php` file in the test runner bootstrap file will fix this.

Alternatively, if only Composer-based installs are supported, loading the `vendor/autoload.php` file generated by Composer should also fix this.

Notes:
* The file is named `phpcsutils-autoload.php` instead of `autoload.php` to prevent potential confusion with other autoload files.
    Also see: squizlabs/PHP_CodeSniffer#2751
* The autoloader definition is wrapped within a constant check to prevent conflicts/the autoloader from being registered multiple times, when several external PHPCS standards each use PHPCSUtils.

### PHPCS23Utils: add support for PHPCS 2.x

This commit is two-fold:

1. It enhances the `phpcsutils-autoload.php` file to contain class aliases to translate the relevant PHPCS 3.x class names to PHPCS 2.x class names which, in effect, allows for the PHPCSUtils utilities to be used in both PHPCS 2.x as well as PHPCS 3.x.

2. It adds a `PHPCS23Utils` ruleset with one `PHPCS23Utils.Load.LoadUtils` sniff.
The only thing this standard does is trigger the PHPCSUtils autoload file in PHPCS 2.x.

This standard will not include any utilities or real sniffs. It is just in place to enable support for PHPCS 2.x in an as-simple-as-possible manner.

### :wrench: QA: lint the ruleset XML files

### :wrench: QA: lint PHP files in this repo

### :wrench: QA: add code style check for the code in this repo

This:
* Adds a custom PHPCS ruleset which uses the `PHPCSDev` ruleset to check the code style of code in this repo, with a few, very select, exclusions.
* Adds convenience scripts to the `composer.json` file to check the code of the repo.
* And allows for individual developers to overload the `phpcs.xml.dist` file by ignoring the typical overload files.

**Important notes**:
1. The `compose require` is done directly in the Composer script rather than in the `require-dev` section as the PHPCS requirements for the `PHPCSDevTools` package can conflict with the PHPCS requirements of this package.

The CS check for this package should always be run on a recent PHPCS version to get the benefit of new sniffs, while the Utils themselves are - and should be - compatible with a wider range of PHPCS versions.

2. Using the above "trick" runs into issues when trying to remove the package on Travis due to some phantom _uncommitted changes in the `vendor/phpcstandards/phpcsdevtools` directory_. So, a separate script is used for Travis which doesn't `composer remove` of `PHPCSDevTools`.

3. For the time being - until v 1.0.0 has been tagged for the `PHPCSDevTools` package -, the `require` will use the `dev-develop` branch of `PHPCSDevTools`.

Also, the `composer validate` check doesn't need to be run on every build. Running it on just one build is sufficient, so moving it to the `sniff` stage.

