### PR TITLE
New BackCompat\Helper class (includes unit test setup)

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,3 @@
+coverage_clover: build/logs/clover.xml
+json_path: build/logs/coveralls-upload.json
+service_name: travis-ci

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 # https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production
 # https://blog.madewithlove.be/post/gitattributes/
 #
+/.coveralls.yml export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,8 @@
 /.gitignore export-ignore
 /.travis.yml export-ignore
 /phpcs.xml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/Tests/ export-ignore
 
 #
 # Auto detect text files and perform LF normalization

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build/
 vendor/
 /composer.lock
 /.phpcs.xml

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ vendor/
 /composer.lock
 /.phpcs.xml
 /phpcs.xml
+/phpunit.xml
+/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,29 @@ cache:
 
 php:
   - 5.4
-  - 7.3
-  - "nightly"
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+
+env:
+  - PHPCS_VERSION="dev-master" LINT=1
+  - PHPCS_VERSION="3.1.0"
+  - PHPCS_VERSION="2.9.2"
+  - PHPCS_VERSION="2.6.0"
 
 # Define the stages used.
+# For non-PRs, only the sniff and quicktest stages are run.
+# For pull requests and merges, the full script is run (skipping quicktest).
+# Note: for pull requests, "develop" is the base branch name.
+# See: https://docs.travis-ci.com/user/conditions-v1
 stages:
   - name: sniff
+  - name: quicktest
+    if: type = push AND branch NOT IN (master, develop)
   - name: test
+    if: branch IN (master, develop)
 
 jobs:
   fast_finish: true
@@ -27,10 +43,12 @@ jobs:
     #### SNIFF STAGE ####
     - stage: sniff
       php: 7.3
+      env: PHPCS_VERSION="dev-master"
       addons:
         apt:
           packages:
             - libxml2-utils
+      install: skip
       script:
         # Validate the composer.json file.
         # @link https://getcomposer.org/doc/03-cli.md#validate
@@ -48,6 +66,48 @@ jobs:
         - diff -B ./PHPCSUtils/ruleset.xml <(xmllint --format "./PHPCSUtils/ruleset.xml")
         - diff -B ./PHPCS23Utils/ruleset.xml <(xmllint --format "./PHPCS23Utils/ruleset.xml")
 
+    #### QUICK TEST STAGE ####
+    # This is a much quicker test which only runs the unit tests and linting against the low/high
+    # supported PHP/PHPCS combinations.
+    - stage: quicktest
+      php: 7.4
+      env: PHPCS_VERSION="dev-master" LINT=1
+    - stage: quicktest
+      php: 7.3
+      # PHPCS is only compatible with PHP 7.3 as of version 3.3.1/2.9.2.
+      env: PHPCS_VERSION="2.9.2"
+
+    - stage: quicktest
+      php: 5.4
+      env: PHPCS_VERSION="dev-master" LINT=1
+    - stage: quicktest
+      php: 5.4
+      env: PHPCS_VERSION="2.6.0"
+
+    #### TEST STAGE ####
+    # Additional builds to prevent issues with PHPCS versions incompatible with certain PHP versions.
+    - stage: test
+      php: 7.3
+      env: PHPCS_VERSION="dev-master" LINT=1
+    # PHPCS is only compatible with PHP 7.3 as of version 3.3.1/2.9.2.
+    - php: 7.3
+      env: PHPCS_VERSION="3.3.1"
+    - php: 7.3
+      env: PHPCS_VERSION="2.9.2"
+
+    - php: 7.4
+      env: PHPCS_VERSION="dev-master" LINT=1
+    # PHPCS is only compatible with PHP 7.4 as of version 3.5.0.
+    - php: 7.4
+      env: PHPCS_VERSION="3.5.0"
+
+    # One extra build to verify issues around PHPCS annotations when they weren't fully accounted for yet.
+    - php: 7.2
+      env: PHPCS_VERSION="3.2.0"
+
+    - php: "nightly"
+      env: PHPCS_VERSION="n/a" LINT=1
+
   allow_failures:
     # Allow failures for unstable builds.
     - php: "nightly"
@@ -57,7 +117,33 @@ before_install:
   # Speed up build time by disabling Xdebug when its not needed.
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
 
+  # On stable PHPCS versions, allow for PHP deprecation notices.
+  # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
+  - |
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" != "Sniff" && $PHPCS_VERSION != "dev-master" && "$PHPCS_VERSION" != "n/a" ]]; then
+      echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    fi
+
   - export XMLLINT_INDENT="    "
+
+
+install:
+  # Set up test environment using Composer.
+  - |
+    if [[ $PHPCS_VERSION != "n/a" ]]; then
+      composer require --no-update --no-scripts squizlabs/php_codesniffer:${PHPCS_VERSION}
+    fi
+  - |
+    if [[ $PHPCS_VERSION == "n/a" ]]; then
+      # Don't install PHPUnit when it's not needed.
+      composer remove --dev phpunit/phpunit --no-update --no-scripts
+    elif [[ "$PHPCS_VERSION" < "3.1.0" ]]; then
+      # PHPCS < 3.1.0 is not compatible with PHPUnit 6.x.
+      composer require --dev phpunit/phpunit:"^4.0||^5.0" --no-update --no-scripts
+    elif [[ "$PHPCS_VERSION" < "3.2.3" ]]; then
+      # PHPCS < 3.2.3 is not compatible with PHPUnit 7.x.
+      composer require --dev phpunit/phpunit:"^4.0||^5.0||^6.0" --no-update --no-scripts
+    fi
 
   # --prefer-dist will allow for optimal use of the travis caching ability.
   # The Composer PHPCS plugin takes care of setting the installed_paths for PHPCS.
@@ -66,4 +152,7 @@ before_install:
 
 script:
   # Lint PHP files against parse errors.
-  - composer lint
+  - if [[ "$LINT" == "1" ]]; then composer lint; fi
+
+  # Run the unit tests.
+  - if [[ $PHPCS_VERSION != "n/a" ]]; then composer test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ cache:
     - $HOME/.cache/composer/files
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
@@ -35,6 +34,8 @@ stages:
   - name: quicktest
     if: type = push AND branch NOT IN (master, develop)
   - name: test
+    if: branch IN (master, develop)
+  - name: coverage
     if: branch IN (master, develop)
 
 jobs:
@@ -69,6 +70,8 @@ jobs:
     #### QUICK TEST STAGE ####
     # This is a much quicker test which only runs the unit tests and linting against the low/high
     # supported PHP/PHPCS combinations.
+    # These are basically the same builds as in the Coverage stage, but then without doing
+    # the code-coverage.
     - stage: quicktest
       php: 7.4
       env: PHPCS_VERSION="dev-master" LINT=1
@@ -89,14 +92,15 @@ jobs:
     - stage: test
       php: 7.3
       env: PHPCS_VERSION="dev-master" LINT=1
-    # PHPCS is only compatible with PHP 7.3 as of version 3.3.1/2.9.2.
     - php: 7.3
+      # PHPCS is only compatible with PHP 7.3 as of version 3.3.1/2.9.2.
       env: PHPCS_VERSION="3.3.1"
-    - php: 7.3
+
+    - php: 5.4
+      env: PHPCS_VERSION="3.1.0"
+    - php: 5.4
       env: PHPCS_VERSION="2.9.2"
 
-    - php: 7.4
-      env: PHPCS_VERSION="dev-master" LINT=1
     # PHPCS is only compatible with PHP 7.4 as of version 3.5.0.
     - php: 7.4
       env: PHPCS_VERSION="3.5.0"
@@ -108,6 +112,23 @@ jobs:
     - php: "nightly"
       env: PHPCS_VERSION="n/a" LINT=1
 
+    #### CODE COVERAGE STAGE ####
+    # N.B.: Coverage is only checked on the lowest and highest stable PHP versions for all PHPCS versions.
+    # These builds are left out off the "test" stage so as not to duplicate test runs.
+    # The script used is the default script below, the same as for the `test` stage.
+    - stage: coverage
+      php: 7.4
+      env: PHPCS_VERSION="dev-master" LINT=1 COVERALLS_VERSION="^2.0"
+    - php: 7.3
+      # PHPCS is only compatible with PHP 7.3 as of version 3.3.1/2.9.2.
+      env: PHPCS_VERSION="2.9.2" COVERALLS_VERSION="^2.0"
+
+    - php: 5.4
+      env: PHPCS_VERSION="dev-master" LINT=1 COVERALLS_VERSION="^1.0"
+    - php: 5.4
+      env: PHPCS_VERSION="2.6.0" COVERALLS_VERSION="^1.0"
+
+
   allow_failures:
     # Allow failures for unstable builds.
     - php: "nightly"
@@ -115,7 +136,10 @@ jobs:
 
 before_install:
   # Speed up build time by disabling Xdebug when its not needed.
-  - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+  - |
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" != "Coverage" ]]; then
+      phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+    fi
 
   # On stable PHPCS versions, allow for PHP deprecation notices.
   # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
@@ -134,6 +158,10 @@ install:
       composer require --no-update --no-scripts squizlabs/php_codesniffer:${PHPCS_VERSION}
     fi
   - |
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Coverage" ]]; then
+      composer require --dev --no-update --no-suggest --no-scripts php-coveralls/php-coveralls:${COVERALLS_VERSION}
+    fi
+  - |
     if [[ $PHPCS_VERSION == "n/a" ]]; then
       # Don't install PHPUnit when it's not needed.
       composer remove --dev phpunit/phpunit --no-update --no-scripts
@@ -150,9 +178,29 @@ install:
   - composer install --prefer-dist --no-suggest
 
 
+before_script:
+  - if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Coverage" ]]; then mkdir -p build/logs; fi
+  - phpenv rehash
+
+
 script:
   # Lint PHP files against parse errors.
   - if [[ "$LINT" == "1" ]]; then composer lint; fi
 
   # Run the unit tests.
-  - if [[ $PHPCS_VERSION != "n/a" ]]; then composer test; fi
+  - |
+    if [[ $PHPCS_VERSION != "n/a" && "$TRAVIS_BUILD_STAGE_NAME" != "Coverage" ]]; then
+      composer test
+    elif [[ $PHPCS_VERSION != "n/a" && "$TRAVIS_BUILD_STAGE_NAME" == "Coverage" ]]; then
+      composer coverage
+    fi
+
+after_success:
+  - |
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Coverage" && $COVERALLS_VERSION == "^1.0" ]]; then
+      php vendor/bin/coveralls -v -x build/logs/clover.xml
+    fi
+  - |
+    if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Coverage" && $COVERALLS_VERSION == "^2.0" ]]; then
+      php vendor/bin/php-coveralls -v -x build/logs/clover.xml
+    fi

--- a/PHPCSUtils/BackCompat/Helper.php
+++ b/PHPCSUtils/BackCompat/Helper.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\BackCompat;
+
+/**
+ * Utility methods to retrieve (configuration) information from PHP_CodeSniffer.
+ *
+ * PHP_CodeSniffer cross-version compatibility helper for PHPCS 2.x vs PHPCS 3.x.
+ *
+ * A number of PHPCS classes were split up into several classes in PHPCS 3.x
+ * Those classes cannot be aliased as they don't represent the same object.
+ * This class provides helper methods for functions which were contained in
+ * one of these classes and which are commonly used by external standards.
+ *
+ * @since 1.0.0 The initial methods in this class have been ported over from
+ *              the external PHPCompatibility & WPCS standards.
+ */
+class Helper
+{
+
+    /**
+     * Get the PHP_CodeSniffer version number.
+     *
+     * @since 1.0.0
+     *
+     * @return string
+     */
+    public static function getVersion()
+    {
+        if (\defined('\PHP_CodeSniffer\Config::VERSION') === false) {
+            // PHPCS 2.x.
+            return \PHP_CodeSniffer::VERSION;
+        }
+
+        // PHPCS 3.x.
+        return \PHP_CodeSniffer\Config::VERSION;
+    }
+
+    /**
+     * Pass config data to PHP_CodeSniffer.
+     *
+     * @since 1.0.0
+     *
+     * @param string      $key   The name of the config value.
+     * @param string|null $value The value to set. If null, the config entry
+     *                           is deleted, reverting it to the default value.
+     * @param bool        $temp  Set this config data temporarily for this script run.
+     *                           This will not write the config data to the config file.
+     *
+     * @return bool Whether the setting of the data was successfull.
+     */
+    public static function setConfigData($key, $value, $temp = false)
+    {
+        if (\method_exists('\PHP_CodeSniffer\Config', 'setConfigData') === false) {
+            // PHPCS 2.x.
+            return \PHP_CodeSniffer::setConfigData($key, $value, $temp);
+        }
+
+        // PHPCS 3.x.
+        return \PHP_CodeSniffer\Config::setConfigData($key, $value, $temp);
+    }
+
+    /**
+     * Get the value of a single PHP_CodeSniffer config key.
+     *
+     * @since 1.0.0
+     *
+     * @param string $key The name of the config value.
+     *
+     * @return string|null
+     */
+    public static function getConfigData($key)
+    {
+        if (\method_exists('\PHP_CodeSniffer\Config', 'getConfigData') === false) {
+            // PHPCS 2.x.
+            return \PHP_CodeSniffer::getConfigData($key);
+        }
+
+        // PHPCS 3.x.
+        return \PHP_CodeSniffer\Config::getConfigData($key);
+    }
+}

--- a/Tests/BackCompat/Helper/ConfigDataTest.php
+++ b/Tests/BackCompat/Helper/ConfigDataTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\Helper;
+
+use PHPCSUtils\BackCompat\Helper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\BackCompat\Helper::setConfigData
+ * @covers \PHPCSUtils\BackCompat\Helper::getConfigData
+ *
+ * @group helper
+ *
+ * @since 1.0.0
+ */
+class ConfigDataTest extends TestCase
+{
+
+    /**
+     * Test the getConfigData() and setConfigData() method.
+     *
+     * @return void
+     */
+    public function testConfigData()
+    {
+        $original = Helper::getConfigData('arbitrary_name');
+        $expected = 'expected';
+
+        $return = Helper::setConfigData('arbitrary_name', $expected, true);
+        $this->assertTrue($return);
+
+        $result = Helper::getConfigData('arbitrary_name');
+        $this->assertSame($expected, $result);
+
+        // Reset the value after the test.
+        $return = Helper::setConfigData('arbitrary_name', $original, true);
+    }
+}

--- a/Tests/BackCompat/Helper/GetVersionTest.php
+++ b/Tests/BackCompat/Helper/GetVersionTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\Helper;
+
+use PHPCSUtils\BackCompat\Helper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\BackCompat\Helper::getVersion
+ *
+ * @group helper
+ *
+ * @since 1.0.0
+ */
+class GetVersionTest extends TestCase
+{
+
+    /**
+     * Version number of the last PHPCS release.
+     *
+     * {@internal This should be updated regularly, but shouldn't cause issues if it isn't.}
+     *
+     * @var string
+     */
+    const DEVMASTER = '3.5.3';
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testGetVersion()
+    {
+        $expected = \getenv('PHPCS_VERSION');
+        if ($expected === false) {
+            $this->markTestSkipped('The test for the Helper::getVersion() method will only run'
+                . ' if the PHPCS_VERSION environment variable is set, such as during a Travis CI build'
+                . ' or when this variable has been set in the PHPUnit configuration file.');
+
+            return;
+        }
+
+        $result = Helper::getVersion();
+
+        if ($expected === 'dev-master') {
+            $this->assertTrue(\version_compare(self::DEVMASTER, $result, '<='));
+        } else {
+            $this->assertSame($expected, $result);
+        }
+    }
+}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * Bootstrap file for the unit tests.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ *
+ * @since 1.0
+ */
+
+namespace PHPCSUtils\Tests;
+
+if (\defined('PHP_CODESNIFFER_IN_TESTS') === false) {
+    \define('PHP_CODESNIFFER_IN_TESTS', true);
+}
+
+// The below two defines are needed for PHPCS 3.x.
+if (\defined('PHP_CODESNIFFER_CBF') === false) {
+    \define('PHP_CODESNIFFER_CBF', false);
+}
+
+if (\defined('PHP_CODESNIFFER_VERBOSITY') === false) {
+    \define('PHP_CODESNIFFER_VERBOSITY', 0);
+}
+
+// Get the PHPCS dir from an environment variable.
+$phpcsDir = \getenv('PHPCS_DIR');
+
+// This may be a Composer install.
+if ($phpcsDir === false && \is_dir(\dirname(__DIR__) . '/vendor/squizlabs/php_codesniffer')) {
+    $vendorDir = \dirname(__DIR__) . '/vendor';
+    $phpcsDir  = $vendorDir . '/squizlabs/php_codesniffer';
+} elseif ($phpcsDir !== false) {
+    $phpcsDir = \realpath($phpcsDir);
+}
+
+// Try and load the PHPCS autoloader.
+if ($phpcsDir !== false && \file_exists($phpcsDir . '/autoload.php')) {
+    // PHPCS 3.x.
+    require_once $phpcsDir . '/autoload.php';
+
+    // Pre-load the token back-fills to prevent undefined constant notices.
+    require_once $phpcsDir . '/src/Util/Tokens.php';
+} elseif ($phpcsDir !== false && \file_exists($phpcsDir . '/CodeSniffer.php')) {
+    // PHPCS 2.x.
+    require_once $phpcsDir . '/CodeSniffer.php';
+
+    // Pre-load the token back-fills to prevent undefined constant notices.
+    require_once $phpcsDir . '/CodeSniffer/Tokens.php';
+} else {
+// @todo: change URL!!!!
+    echo 'Uh oh... can\'t find PHPCS.
+
+If you use Composer, please run `composer install`.
+Otherwise, make sure you set a `PHPCS_DIR` environment variable in your phpunit.xml file
+pointing to the PHPCS directory.
+';
+    die(1);
+}
+
+// Load the composer autoload if available.
+if (isset($vendorDir) && \file_exists($vendorDir . '/autoload.php')) {
+    require_once $vendorDir . '/autoload.php';
+} else {
+    /*
+     * Autoloader specifically for the test files.
+     * Fixes issues with PHPUnit not being able to find test classes being extended when running
+     * in a non-Composer context.
+     */
+    \spl_autoload_register(function ($class) {
+        // Only try & load our own classes.
+        if (\stripos($class, 'PHPCSUtils\Tests\\') !== 0) {
+            return;
+        }
+
+        // Strip namespace prefix 'PHPCSUtils\Tests\'.
+        $class = \substr($class, 17);
+        $file  = \realpath(__DIR__) . \DIRECTORY_SEPARATOR . \strtr($class, '\\', \DIRECTORY_SEPARATOR) . '.php';
+        if (\file_exists($file)) {
+            include_once $file;
+        }
+    });
+}
+
+/*
+ * Alias the PHPCS 2.x classes to their PHPCS 3.x equivalent if necessary.
+ *
+ * Also alias the non-namespaced PHPUnit 4.x/5.x test case class to the
+ * namespaced PHPUnit 6+ version.
+ */
+require_once \dirname(__DIR__) . '/phpcsutils-autoload.php';
+
+unset($phpcsDir, $vendorDir);

--- a/composer.json
+++ b/composer.json
@@ -26,22 +26,28 @@
     },
     "require-dev" : {
         "jakub-onderka/php-parallel-lint": "^1.0",
-        "jakub-onderka/php-console-highlighter": "^0.4"
+        "jakub-onderka/php-console-highlighter": "^0.4",
+        "phpunit/phpunit" : "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {
         "classmap": ["PHPCSUtils/"]
     },
+    "autoload-dev" : {
+        "psr-4": {
+            "PHPCSUtils\\Tests\\": "Tests/"
+        }
+    },
     "scripts" : {
         "lint": [
             "@php ./vendor/jakub-onderka/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
         ],
         "install-devtools": [
-            "composer require --dev phpcsstandards/phpcsdevtools:\"^1.0 || dev-develop\" --no-suggest"
+            "composer require phpcsstandards/phpcsdevtools:\"^1.0 || dev-develop\" --no-suggest --update-no-dev"
         ],
         "remove-devtools": [
-            "composer remove --dev phpcsstandards/phpcsdevtools"
+            "composer remove phpcsstandards/phpcsdevtools --update-no-dev"
         ],
         "checkcs": [
             "@install-devtools",
@@ -56,6 +62,9 @@
         "travis-checkcs": [
             "@install-devtools",
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+        ],
+        "test": [
+            "@php ./vendor/phpunit/phpunit/phpunit"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,13 @@
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
         ],
         "test": [
+            "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
+        ],
+        "coverage": [
             "@php ./vendor/phpunit/phpunit/phpunit"
+        ],
+        "coverage-local": [
+            "@php ./vendor/phpunit/phpunit/phpunit --coverage-html ./build/coverage-html"
         ]
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -58,6 +58,12 @@
     <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
         <exclude-pattern>/phpcsutils-autoload\.php$</exclude-pattern>
         <exclude-pattern>/PHPCS23Utils/Sniffs/Load/LoadUtilsSniff\.php$</exclude-pattern>
+        <exclude-pattern>/Tests/bootstrap\.php$</exclude-pattern>
+    </rule>
+
+    <!-- Double arrow alignment gets very fiddly with multi-line test data provider arrays. -->
+    <rule ref="Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned">
+        <exclude-pattern>/Tests/*Test\.php$</exclude-pattern>
     </rule>
 
 </ruleset>

--- a/phpcsutils-autoload.php
+++ b/phpcsutils-autoload.php
@@ -93,3 +93,24 @@ if (defined('PHPCSUTILS_PHPCS_ALIASES_SET') === false) {
 
     define('PHPCSUTILS_PHPCS_ALIASES_SET', true);
 }
+
+if (defined('PHPCSUTILS_PHPUNIT_ALIASES_SET') === false) {
+    /*
+     * Alias the PHPUnit 4/5 TestCase class to its PHPUnit 6+ name.
+     *
+     * This allows the both the PHPCSUtils native unit tests as well as the
+     * `UtilityMethodTestCase` class to work cross-version with PHPUnit
+     * below 6.x and above.
+     *
+     * {@internal The `class_exists` wrappers are needed to play nice with
+     * PHPUnit bootstrap files of external standards which may be creating
+     * cross-version compatibility in a similar manner.}}
+     */
+    if (class_exists('PHPUnit_Framework_TestCase') === true
+        && class_exists('PHPUnit\Framework\TestCase') === false
+    ) {
+        class_alias('PHPUnit_Framework_TestCase', 'PHPUnit\Framework\TestCase');
+    }
+
+    define('PHPCSUTILS_PHPUNIT_ALIASES_SET', true);
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
+    backupGlobals="true"
+    bootstrap="./Tests/bootstrap.php"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    colors="true"
+    forceCoversAnnotation="true">
+
+    <testsuites>
+        <testsuite name="PHPCSUtils">
+            <directory suffix="Test.php">./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,4 +14,15 @@
         </testsuite>
     </testsuites>
 
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
+            <!-- Not recording coverage for PHPCS23Utils as there is nothing directly testable. -->
+            <directory suffix=".php">./PHPCSUtils/</directory>
+        </whitelist>
+    </filter>
+
+    <logging>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
+
 </phpunit>


### PR DESCRIPTION
## New BackCompat\Helper class

Add a `PHPCSUtils\BackCompat\Helper` class for external standards which provides a number of utility functions to help with cross-version compatibility between PHPCS 2.x and PHPCS 3.x.

Initial methods:
* `getVersion()` - get the version number of PHP_CodeSniffer.
* `setConfigData()` - set PHPCS config data.
* `getConfigData()` - get PHPCS config data.

Includes minimal unit tests.

_The initial methods in this class were originally written by me for the external PHPCompatibility & WPCS standards._

-----

As this feature introduces the first unit tests to the repo, the two additional commits sort out the unit test set up and the code coverage monitoring.

----

### QA: enable unit testing for the code in this repo

This:
* Adds a PHPUnit `phpunit.xml.dist` configuration file.
* Adds a `Tests/bootstrap.php` file to load the necessary prerequisites for the unit testing.
* Adds a class alias to the `phpcsutils-autoload.php` file aliasing the PHPUnit 6+ `TestCase` class to it's PHPUnit 4/5 equivalent for PHPUnit cross-version compatibility.
* Adds convenience script to the `composer.json` file to run the unit tests for the repo.
* Adds the necessary changes to the Travis script to test against the relevant PHP / PHPCS combinations.
    Includes moving the build against `nightly` to the `test` stage to allow it to lint files. The `PHPCS_VERSION` has been set to `n/a` to skip unit testing (for now).
* And allows for individual developers to overload the `phpunit.xml.dist` file by ignoring the typical overload files.

Other tweaks included:
* Moving the `composer install` to the Travis `install` step and skipping that step for the `sniff` stage as we don't need a full composer install for that stage.
    To that end, adjust the `install/remove-devtools` scrips to install as `no-dev`.

Note: the `stage: quicktest` shouldn't need to be repeated for each build in the stage, however, there appears to be a bug on `travis-ci.com` which causes the matrix to not expand correctly.

### QA: enable code coverage recording & checking

Enable Coveralls for code coverage checking.

Includes:
* Convenience script for code coverage checking, including generating the HTML output for local runs.
* Adjusting the existing Composer `test` script to run without generating coverage data.
* Adding a separate `coverage` stage to the Travis script and adjusting the script to handle this in an as optimal way as possible.

