### PR TITLE
New BackCompat\BCTokens class

### DIFF
--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -1,0 +1,355 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\BackCompat;
+
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Token arrays related utility methods.
+ *
+ * PHPCS provides a number of static token arrays in the {@see \PHP_CodeSniffer\Util\Tokens}
+ * class.
+ * Some of these token arrays will not be available in older PHPCS versions.
+ * Some will not contain the same set of tokens across PHPCS versions.
+ *
+ * This class is a compatibility layer to allow for retrieving these token arrays
+ * with a consistent token content across PHPCS versions.
+ * The one caveat is that the token constants do need to be available.
+ *
+ * Recommended usage:
+ * Only use the methods in this class when needed. I.e. when your sniff unit tests indicate
+ * a PHPCS cross-version compatibility issue related to inconsistent token arrays.
+ *
+ * All PHPCS token arrays are supported, though only a limited number of them are different
+ * across PHPCS versions.
+ *
+ * The names of the PHPCS native token arrays translate one-on-one to the methods in this class:
+ * `PHP_CodeSniffer\Util\Tokens::$emptyTokens` => `PHPCSUtils\BackCompat\BCTokens::emptyTokens()`
+ * `PHP_CodeSniffer\Util\Tokens::$operators`   => `PHPCSUtils\BackCompat\BCTokens::operators()`
+ * ... etc
+ *
+ * The order of the tokens in the arrays may differ between the PHPCS native token arrays and
+ * the token arrays returned by this class.
+ *
+ * @since 1.0.0
+ */
+class BCTokens
+{
+
+    /**
+     * Token types that are comments containing PHPCS instructions.
+     *
+     * @since 1.0.0
+     *
+     * @var string[]
+     */
+    protected static $phpcsCommentTokensTypes = [
+        'T_PHPCS_ENABLE',
+        'T_PHPCS_DISABLE',
+        'T_PHPCS_SET',
+        'T_PHPCS_IGNORE',
+        'T_PHPCS_IGNORE_FILE',
+    ];
+
+    /**
+     * Tokens that open class and object scopes.
+     *
+     * @since 1.0.0
+     *
+     * @var array <int|string> => <int|string>
+     */
+    protected static $ooScopeTokens = [
+        \T_CLASS      => \T_CLASS,
+        \T_ANON_CLASS => \T_ANON_CLASS,
+        \T_INTERFACE  => \T_INTERFACE,
+        \T_TRAIT      => \T_TRAIT,
+    ];
+
+    /**
+     * Tokens that represent text strings.
+     *
+     * @since 1.0.0
+     *
+     * @var array <int|string> => <int|string>
+     */
+    protected static $textStringTokens = [
+        \T_CONSTANT_ENCAPSED_STRING => \T_CONSTANT_ENCAPSED_STRING,
+        \T_DOUBLE_QUOTED_STRING     => \T_DOUBLE_QUOTED_STRING,
+        \T_INLINE_HTML              => \T_INLINE_HTML,
+        \T_HEREDOC                  => \T_HEREDOC,
+        \T_NOWDOC                   => \T_NOWDOC,
+    ];
+
+    /**
+     * Handle calls to (undeclared) methods for token arrays which haven't received any
+     * changes since PHPCS 2.6.0.
+     *
+     * @since 1.0.0
+     *
+     * @param string $name The name of the method which has been called.
+     * @param array  $args Any arguments passed to the method.
+     *                     Unused as none of the methods take arguments.
+     *
+     * @return array <int|string> => <int|string> Token array
+     */
+    public static function __callStatic($name, $args)
+    {
+        if (isset(Tokens::${$name})) {
+            return Tokens::${$name};
+        }
+
+        // Default to an empty array.
+        return [];
+    }
+
+    /**
+     * Retrieve the PHPCS assignment tokens array in a cross-version compatible manner.
+     *
+     * Changelog for the PHPCS native array:
+     * - Introduced in PHPCS 0.0.5.
+     * - PHPCS 2.9.0: The PHP 7.4 `T_COALESCE_EQUAL` token was added to the array.
+     *                The `T_COALESCE_EQUAL` token was introduced in PHPCS 2.8.1.
+     * - PHPCS 3.2.0: The JS `T_ZSR_EQUAL` token was added to the array.
+     *                The `T_ZSR_EQUAL` token was introduced in PHPCS 2.8.0.
+     *
+     * @see \PHP_CodeSniffer\Util\Tokens::$assignmentTokens Original array.
+     *
+     * @since 1.0.0
+     *
+     * @return array <int|string> => <int|string> Token array.
+     */
+    public static function assignmentTokens()
+    {
+        $tokens = Tokens::$assignmentTokens;
+
+        /*
+         * The `T_COALESCE_EQUAL` token may be available pre-PHPCS 2.8.1 depending on
+         * the PHP version used to run PHPCS.
+         */
+        if (\defined('T_COALESCE_EQUAL')) {
+            $tokens[\T_COALESCE_EQUAL] = \T_COALESCE_EQUAL;
+        }
+
+        if (\defined('T_ZSR_EQUAL')) {
+            $tokens[\T_ZSR_EQUAL] = \T_ZSR_EQUAL;
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * Retrieve the PHPCS comparison tokens array in a cross-version compatible manner.
+     *
+     * Changelog for the PHPCS native array:
+     * - Introduced in PHPCS 0.5.0.
+     * - PHPCS 2.9.0: The PHP 7.0 `T_COALESCE` token was added to the array.
+     *                The `T_COALESCE` token was introduced in PHPCS 2.6.1.
+     * - PHPCS 2.9.0: The PHP 7.0 `T_SPACESHIP` token was added to the array.
+     *                The `T_SPACESHIP` token was introduced in PHPCS 2.5.1.
+     *
+     * @see \PHP_CodeSniffer\Util\Tokens::$comparisonTokens Original array.
+     *
+     * @since 1.0.0
+     *
+     * @return array <int|string> => <int|string> Token array.
+     */
+    public static function comparisonTokens()
+    {
+        $tokens = Tokens::$comparisonTokens + [\T_SPACESHIP => \T_SPACESHIP];
+
+        if (\defined('T_COALESCE')) {
+            $tokens[\T_COALESCE] = \T_COALESCE;
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * Retrieve the PHPCS arithmetic tokens array in a cross-version compatible manner.
+     *
+     * Changelog for the PHPCS native array:
+     * - Introduced in PHPCS 0.5.0.
+     * - PHPCS 2.9.0: The PHP 5.6 `T_POW` token was added to the array.
+     *                The `T_POW` token was introduced in PHPCS 2.4.0.
+     *
+     * @see \PHP_CodeSniffer\Util\Tokens::$arithmeticTokens Original array.
+     *
+     * @since 1.0.0
+     *
+     * @return array <int|string> => <int|string> Token array or an empty array for PHPCS versions in
+     *                         which the PHPCS native comment tokens did not exist yet.
+     */
+    public static function arithmeticTokens()
+    {
+        return Tokens::$arithmeticTokens + [ \T_POW => \T_POW ];
+    }
+
+    /**
+     * Retrieve the PHPCS operator tokens array in a cross-version compatible manner.
+     *
+     * Changelog for the PHPCS native array:
+     * - Introduced in PHPCS 0.0.5.
+     * - PHPCS 2.6.1: The PHP 7.0 `T_COALESCE` token was backfilled and added to the array.
+     * - PHPCS 2.8.1: The PHP 7.4 `T_COALESCE_EQUAL` token was backfilled and (incorrectly)
+     *                added to the array.
+     * - PHPCS 2.9.0: The `T_COALESCE_EQUAL` token was removed from the array.
+     *
+     * @see \PHP_CodeSniffer\Util\Tokens::$operators Original array.
+     *
+     * @since 1.0.0
+     *
+     * @return array <int|string> => <int|string> Token array.
+     */
+    public static function operators()
+    {
+        $tokens = Tokens::$operators;
+
+        /*
+         * The `T_COALESCE` token may be available pre-PHPCS 2.6.1 depending on the PHP version
+         * used to run PHPCS.
+         */
+        if (\defined('T_COALESCE')) {
+            $tokens[\T_COALESCE] = \T_COALESCE;
+        }
+
+        if (\defined('T_COALESCE_EQUAL')) {
+            unset($tokens[\T_COALESCE_EQUAL]);
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * Retrieve the PHPCS parenthesis openers tokens array in a cross-version compatible manner.
+     *
+     * Changelog for the PHPCS native array:
+     * - Introduced in PHPCS 0.0.5.
+     * - PHPCS 3.5.0: `T_LIST` and `T_ANON_CLASS` added to the array.
+     *
+     * Note: While `T_LIST` and `T_ANON_CLASS` will be included in the return value for this
+     * method, the associated parentheses will not have the `'parenthesis_owner'` index set
+     * until PHPCS 3.5.0.
+     *
+     * @see \PHP_CodeSniffer\Util\Tokens::$parenthesisOpeners Original array.
+     *
+     * @since 1.0.0
+     *
+     * @return array <int|string> => <int|string> Token array.
+     */
+    public static function parenthesisOpeners()
+    {
+        $tokens                = Tokens::$parenthesisOpeners;
+        $tokens[\T_LIST]       = \T_LIST;
+        $tokens[\T_ANON_CLASS] = \T_ANON_CLASS;
+
+        return $tokens;
+    }
+
+    /**
+     * Retrieve the PHPCS comment tokens array in a cross-version compatible manner.
+     *
+     * Changelog for the PHPCS native array:
+     * - Introduced in PHPCS 3.2.3.
+     *
+     * @see \PHP_CodeSniffer\Util\Tokens::$phpcsCommentTokens Original array.
+     *
+     * @since 1.0.0
+     *
+     * @return array <string> => <string> Token array or an empty array for PHPCS
+     *                                    versions in which the PHPCS native annotation
+     *                                    tokens did not exist yet.
+     */
+    public static function phpcsCommentTokens()
+    {
+        static $tokenArray = [];
+
+        if (isset(Tokens::$phpcsCommentTokens)) {
+            return Tokens::$phpcsCommentTokens;
+        }
+
+        if (\defined('T_PHPCS_IGNORE')) {
+            // PHPCS 3.2.0 - 3.2.2.
+            if (empty($tokenArray)) {
+                foreach (self::$phpcsCommentTokensTypes as $type) {
+                    $tokenArray[\constant($type)] = \constant($type);
+                }
+            }
+
+            return $tokenArray;
+        }
+
+        return [];
+    }
+
+    /**
+     * Retrieve the PHPCS text string tokens array in a cross-version compatible manner.
+     *
+     * Changelog for the PHPCS native array:
+     * - Introduced in PHPCS 2.9.0.
+     *
+     * @see \PHP_CodeSniffer\Util\Tokens::$textStringTokens Original array.
+     *
+     * @since 1.0.0
+     *
+     * @return array <int|string> => <int|string> Token array.
+     */
+    public static function textStringTokens()
+    {
+        if (isset(Tokens::$textStringTokens)) {
+            return Tokens::$textStringTokens;
+        }
+
+        return self::$textStringTokens;
+    }
+
+    /**
+     * Retrieve the PHPCS function name tokens array in a cross-version compatible manner.
+     *
+     * Changelog for the PHPCS native array:
+     * - Introduced in PHPCS 2.3.3.
+     * - PHPCS 3.1.0: `T_SELF` and `T_STATIC` added to the array.
+     *
+     * @see \PHP_CodeSniffer\Util\Tokens::$functionNameTokens Original array.
+     *
+     * @since 1.0.0
+     *
+     * @return array <int|string> => <int|string> Token array.
+     */
+    public static function functionNameTokens()
+    {
+        $tokens            = Tokens::$functionNameTokens;
+        $tokens[\T_SELF]   = \T_SELF;
+        $tokens[\T_STATIC] = \T_STATIC;
+
+        return $tokens;
+    }
+
+    /**
+     * Retrieve the OO scope tokens array in a cross-version compatible manner.
+     *
+     * Changelog for the PHPCS native array:
+     * - Introduced in PHPCS 3.1.0.
+     *
+     * @see \PHP_CodeSniffer\Util\Tokens::$ooScopeTokens Original array.
+     *
+     * @since 1.0.0
+     *
+     * @return array <int|string> => <int|string> Token array.
+     */
+    public static function ooScopeTokens()
+    {
+        if (isset(Tokens::$ooScopeTokens)) {
+            return Tokens::$ooScopeTokens;
+        }
+
+        return self::$ooScopeTokens;
+    }
+}

--- a/Tests/BackCompat/BCTokens/ArithmeticTokensTest.php
+++ b/Tests/BackCompat/BCTokens/ArithmeticTokensTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCTokens;
+
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCTokens::arithmeticTokens
+ *
+ * @group tokens
+ *
+ * @since 1.0.0
+ */
+class ArithmeticTokensTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testArithmeticTokens()
+    {
+        $expected = [
+            \T_PLUS     => \T_PLUS,
+            \T_MINUS    => \T_MINUS,
+            \T_MULTIPLY => \T_MULTIPLY,
+            \T_DIVIDE   => \T_DIVIDE,
+            \T_MODULUS  => \T_MODULUS,
+            \T_POW      => \T_POW,
+        ];
+
+        $this->assertSame($expected, BCTokens::arithmeticTokens());
+    }
+}

--- a/Tests/BackCompat/BCTokens/AssignmentTokensTest.php
+++ b/Tests/BackCompat/BCTokens/AssignmentTokensTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCTokens;
+
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\BackCompat\Helper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCTokens::assignmentTokens
+ *
+ * @group tokens
+ *
+ * @since 1.0.0
+ */
+class AssignmentTokensTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testAssignmentTokens()
+    {
+        $version  = Helper::getVersion();
+        $expected = [
+            \T_EQUAL        => \T_EQUAL,
+            \T_AND_EQUAL    => \T_AND_EQUAL,
+            \T_OR_EQUAL     => \T_OR_EQUAL,
+            \T_CONCAT_EQUAL => \T_CONCAT_EQUAL,
+            \T_DIV_EQUAL    => \T_DIV_EQUAL,
+            \T_MINUS_EQUAL  => \T_MINUS_EQUAL,
+            \T_POW_EQUAL    => \T_POW_EQUAL,
+            \T_MOD_EQUAL    => \T_MOD_EQUAL,
+            \T_MUL_EQUAL    => \T_MUL_EQUAL,
+            \T_PLUS_EQUAL   => \T_PLUS_EQUAL,
+            \T_XOR_EQUAL    => \T_XOR_EQUAL,
+            \T_DOUBLE_ARROW => \T_DOUBLE_ARROW,
+            \T_SL_EQUAL     => \T_SL_EQUAL,
+            \T_SR_EQUAL     => \T_SR_EQUAL,
+        ];
+
+        if (\version_compare($version, '2.8.1', '>=') === true
+            || \version_compare(\PHP_VERSION_ID, '70399', '>=') === true
+        ) {
+            $expected[\T_COALESCE_EQUAL] = \T_COALESCE_EQUAL;
+        }
+
+        if (\version_compare($version, '2.8.0', '>=') === true) {
+            $expected[\T_ZSR_EQUAL] = \T_ZSR_EQUAL;
+        }
+
+        $this->assertSame($expected, BCTokens::assignmentTokens());
+    }
+}

--- a/Tests/BackCompat/BCTokens/ComparisonTokensTest.php
+++ b/Tests/BackCompat/BCTokens/ComparisonTokensTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCTokens;
+
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\BackCompat\Helper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCTokens::comparisonTokens
+ *
+ * @group tokens
+ *
+ * @since 1.0.0
+ */
+class ComparisonTokensTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testComparisonTokens()
+    {
+        $version  = Helper::getVersion();
+        $expected = [
+            \T_IS_EQUAL            => \T_IS_EQUAL,
+            \T_IS_IDENTICAL        => \T_IS_IDENTICAL,
+            \T_IS_NOT_EQUAL        => \T_IS_NOT_EQUAL,
+            \T_IS_NOT_IDENTICAL    => \T_IS_NOT_IDENTICAL,
+            \T_LESS_THAN           => \T_LESS_THAN,
+            \T_GREATER_THAN        => \T_GREATER_THAN,
+            \T_IS_SMALLER_OR_EQUAL => \T_IS_SMALLER_OR_EQUAL,
+            \T_IS_GREATER_OR_EQUAL => \T_IS_GREATER_OR_EQUAL,
+            \T_SPACESHIP           => \T_SPACESHIP,
+        ];
+
+        if (\version_compare($version, '2.6.1', '>=') === true
+            || \version_compare(\PHP_VERSION_ID, '60999', '>=') === true
+        ) {
+            $expected[\T_COALESCE] = \T_COALESCE;
+        }
+
+        $this->assertSame($expected, BCTokens::comparisonTokens());
+    }
+}

--- a/Tests/BackCompat/BCTokens/EmptyTokensTest.php
+++ b/Tests/BackCompat/BCTokens/EmptyTokensTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCTokens;
+
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\BackCompat\Helper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @group tokens
+ *
+ * @since 1.0.0
+ */
+class EmptyTokensTest extends TestCase
+{
+
+    /**
+     * Tokens that are comments.
+     *
+     * @var array <int|string> => <int|string>
+     */
+    protected $commentTokens = [
+        \T_COMMENT                => \T_COMMENT,
+        \T_DOC_COMMENT            => \T_DOC_COMMENT,
+        \T_DOC_COMMENT_STAR       => \T_DOC_COMMENT_STAR,
+        \T_DOC_COMMENT_WHITESPACE => \T_DOC_COMMENT_WHITESPACE,
+        \T_DOC_COMMENT_TAG        => \T_DOC_COMMENT_TAG,
+        \T_DOC_COMMENT_OPEN_TAG   => \T_DOC_COMMENT_OPEN_TAG,
+        \T_DOC_COMMENT_CLOSE_TAG  => \T_DOC_COMMENT_CLOSE_TAG,
+        \T_DOC_COMMENT_STRING     => \T_DOC_COMMENT_STRING,
+    ];
+
+    /**
+     * Token types that are comments containing PHPCS instructions.
+     *
+     * @var array <string> => <string>
+     */
+    protected $phpcsCommentTokens = [
+        'PHPCS_T_PHPCS_ENABLE'      => 'PHPCS_T_PHPCS_ENABLE',
+        'PHPCS_T_PHPCS_DISABLE'     => 'PHPCS_T_PHPCS_DISABLE',
+        'PHPCS_T_PHPCS_SET'         => 'PHPCS_T_PHPCS_SET',
+        'PHPCS_T_PHPCS_IGNORE'      => 'PHPCS_T_PHPCS_IGNORE',
+        'PHPCS_T_PHPCS_IGNORE_FILE' => 'PHPCS_T_PHPCS_IGNORE_FILE',
+    ];
+
+    /**
+     * Test the Tokens::emptyTokens() method.
+     *
+     * @covers \PHPCSUtils\BackCompat\BCTokens::__callStatic
+     *
+     * @return void
+     */
+    public function testEmptyTokens()
+    {
+        $version  = Helper::getVersion();
+        $expected = [\T_WHITESPACE => \T_WHITESPACE] + $this->commentTokens;
+
+        if (\version_compare($version, '3.2.0', '>=') === true) {
+            $expected += $this->phpcsCommentTokens;
+        }
+
+        $this->assertSame($expected, BCTokens::emptyTokens());
+    }
+
+    /**
+     * Test the Tokens::commentTokens() method.
+     *
+     * @covers \PHPCSUtils\BackCompat\BCTokens::__callStatic
+     *
+     * @return void
+     */
+    public function testCommentTokens()
+    {
+        $version  = Helper::getVersion();
+        $expected = $this->commentTokens;
+
+        if (\version_compare($version, '3.2.0', '>=') === true) {
+            $expected += $this->phpcsCommentTokens;
+        }
+
+        $this->assertSame($expected, BCTokens::commentTokens());
+    }
+
+    /**
+     * Test the Tokens::phpcsCommentTokens() method.
+     *
+     * @covers \PHPCSUtils\BackCompat\BCTokens::phpcsCommentTokens
+     *
+     * @return void
+     */
+    public function testPhpcsCommentTokens()
+    {
+        $version  = Helper::getVersion();
+        $expected = [];
+
+        if (\version_compare($version, '3.2.0', '>=') === true) {
+            $expected = $this->phpcsCommentTokens;
+        }
+
+        $this->assertSame($expected, BCTokens::phpcsCommentTokens());
+    }
+}

--- a/Tests/BackCompat/BCTokens/FunctionNameTokensTest.php
+++ b/Tests/BackCompat/BCTokens/FunctionNameTokensTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCTokens;
+
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCTokens::functionNameTokens
+ *
+ * @group tokens
+ *
+ * @since 1.0.0
+ */
+class FunctionNameTokensTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testFunctionNameTokens()
+    {
+        $expected = [
+            \T_STRING       => \T_STRING,
+            \T_EVAL         => \T_EVAL,
+            \T_EXIT         => \T_EXIT,
+            \T_INCLUDE      => \T_INCLUDE,
+            \T_INCLUDE_ONCE => \T_INCLUDE_ONCE,
+            \T_REQUIRE      => \T_REQUIRE,
+            \T_REQUIRE_ONCE => \T_REQUIRE_ONCE,
+            \T_ISSET        => \T_ISSET,
+            \T_UNSET        => \T_UNSET,
+            \T_EMPTY        => \T_EMPTY,
+            \T_SELF         => \T_SELF,
+            \T_STATIC       => \T_STATIC,
+        ];
+
+        $this->assertSame($expected, BCTokens::functionNameTokens());
+    }
+}

--- a/Tests/BackCompat/BCTokens/OoScopeTokensTest.php
+++ b/Tests/BackCompat/BCTokens/OoScopeTokensTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCTokens;
+
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCTokens::ooScopeTokens
+ *
+ * @group tokens
+ *
+ * @since 1.0.0
+ */
+class OoScopeTokensTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testOoScopeTokens()
+    {
+        $expected = [
+            \T_CLASS      => \T_CLASS,
+            \T_ANON_CLASS => \T_ANON_CLASS,
+            \T_INTERFACE  => \T_INTERFACE,
+            \T_TRAIT      => \T_TRAIT,
+        ];
+
+        $this->assertSame($expected, BCTokens::ooScopeTokens());
+    }
+}

--- a/Tests/BackCompat/BCTokens/OperatorsTest.php
+++ b/Tests/BackCompat/BCTokens/OperatorsTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCTokens;
+
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\BackCompat\Helper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCTokens::operators
+ *
+ * @group tokens
+ *
+ * @since 1.0.0
+ */
+class OperatorsTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testOperators()
+    {
+        $version  = Helper::getVersion();
+        $expected = [
+            \T_MINUS       => \T_MINUS,
+            \T_PLUS        => \T_PLUS,
+            \T_MULTIPLY    => \T_MULTIPLY,
+            \T_DIVIDE      => \T_DIVIDE,
+            \T_MODULUS     => \T_MODULUS,
+            \T_POW         => \T_POW,
+            \T_SPACESHIP   => \T_SPACESHIP,
+            \T_BITWISE_AND => \T_BITWISE_AND,
+            \T_BITWISE_OR  => \T_BITWISE_OR,
+            \T_BITWISE_XOR => \T_BITWISE_XOR,
+            \T_SL          => \T_SL,
+            \T_SR          => \T_SR,
+        ];
+
+        if (\version_compare($version, '2.6.1', '>=') === true
+            || \version_compare(\PHP_VERSION_ID, '60999', '>=') === true
+        ) {
+            $expected[\T_COALESCE] = \T_COALESCE;
+        }
+
+        \asort($expected);
+
+        $result = BCTokens::operators();
+        \asort($result);
+
+        $this->assertSame($expected, $result);
+    }
+}

--- a/Tests/BackCompat/BCTokens/ParenthesisOpenersTest.php
+++ b/Tests/BackCompat/BCTokens/ParenthesisOpenersTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCTokens;
+
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCTokens::parenthesisOpeners
+ *
+ * @group tokens
+ *
+ * @since 1.0.0
+ */
+class ParenthesisOpenersTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testParenthesisOpeners()
+    {
+        $expected = [
+            \T_ARRAY      => \T_ARRAY,
+            \T_LIST       => \T_LIST,
+            \T_FUNCTION   => \T_FUNCTION,
+            \T_CLOSURE    => \T_CLOSURE,
+            \T_ANON_CLASS => \T_ANON_CLASS,
+            \T_WHILE      => \T_WHILE,
+            \T_FOR        => \T_FOR,
+            \T_FOREACH    => \T_FOREACH,
+            \T_SWITCH     => \T_SWITCH,
+            \T_IF         => \T_IF,
+            \T_ELSEIF     => \T_ELSEIF,
+            \T_CATCH      => \T_CATCH,
+            \T_DECLARE    => \T_DECLARE,
+        ];
+
+        \asort($expected);
+
+        $result = BCTokens::parenthesisOpeners();
+        \asort($result);
+
+        $this->assertSame($expected, $result);
+    }
+}

--- a/Tests/BackCompat/BCTokens/TextStringTokensTest.php
+++ b/Tests/BackCompat/BCTokens/TextStringTokensTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCTokens;
+
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCTokens::textStringTokens
+ *
+ * @group tokens
+ *
+ * @since 1.0.0
+ */
+class TextStringTokensTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testTextStringTokens()
+    {
+        $expected = [
+            \T_CONSTANT_ENCAPSED_STRING => \T_CONSTANT_ENCAPSED_STRING,
+            \T_DOUBLE_QUOTED_STRING     => \T_DOUBLE_QUOTED_STRING,
+            \T_INLINE_HTML              => \T_INLINE_HTML,
+            \T_HEREDOC                  => \T_HEREDOC,
+            \T_NOWDOC                   => \T_NOWDOC,
+        ];
+
+        $this->assertSame($expected, BCTokens::textStringTokens());
+    }
+}

--- a/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
+++ b/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCTokens;
+
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCTokens::__callStatic
+ *
+ * @group tokens
+ *
+ * @since 1.0.0
+ */
+class UnchangedTokenArraysTest extends TestCase
+{
+
+    /**
+     * Tokens that represent equality comparisons.
+     *
+     * @var array <int|string> => <int|string>
+     */
+    protected $equalityTokens = [
+        \T_IS_EQUAL            => \T_IS_EQUAL,
+        \T_IS_NOT_EQUAL        => \T_IS_NOT_EQUAL,
+        \T_IS_IDENTICAL        => \T_IS_IDENTICAL,
+        \T_IS_NOT_IDENTICAL    => \T_IS_NOT_IDENTICAL,
+        \T_IS_SMALLER_OR_EQUAL => \T_IS_SMALLER_OR_EQUAL,
+        \T_IS_GREATER_OR_EQUAL => \T_IS_GREATER_OR_EQUAL,
+    ];
+
+    /**
+     * Tokens that perform boolean operations.
+     *
+     * @var array <int|string> => <int|string>
+     */
+    protected $booleanOperators = [
+        \T_BOOLEAN_AND => \T_BOOLEAN_AND,
+        \T_BOOLEAN_OR  => \T_BOOLEAN_OR,
+        \T_LOGICAL_AND => \T_LOGICAL_AND,
+        \T_LOGICAL_OR  => \T_LOGICAL_OR,
+        \T_LOGICAL_XOR => \T_LOGICAL_XOR,
+    ];
+
+    /**
+     * Tokens that represent casting.
+     *
+     * @var array <int|string> => <int|string>
+     */
+    protected $castTokens = [
+        \T_INT_CAST    => \T_INT_CAST,
+        \T_STRING_CAST => \T_STRING_CAST,
+        \T_DOUBLE_CAST => \T_DOUBLE_CAST,
+        \T_ARRAY_CAST  => \T_ARRAY_CAST,
+        \T_BOOL_CAST   => \T_BOOL_CAST,
+        \T_OBJECT_CAST => \T_OBJECT_CAST,
+        \T_UNSET_CAST  => \T_UNSET_CAST,
+        \T_BINARY_CAST => \T_BINARY_CAST,
+    ];
+
+    /**
+     * Tokens that are allowed to open scopes.
+     *
+     * @var array <int|string> => <int|string>
+     */
+    protected $scopeOpeners = [
+        \T_CLASS      => \T_CLASS,
+        \T_ANON_CLASS => \T_ANON_CLASS,
+        \T_INTERFACE  => \T_INTERFACE,
+        \T_TRAIT      => \T_TRAIT,
+        \T_NAMESPACE  => \T_NAMESPACE,
+        \T_FUNCTION   => \T_FUNCTION,
+        \T_CLOSURE    => \T_CLOSURE,
+        \T_IF         => \T_IF,
+        \T_SWITCH     => \T_SWITCH,
+        \T_CASE       => \T_CASE,
+        \T_DECLARE    => \T_DECLARE,
+        \T_DEFAULT    => \T_DEFAULT,
+        \T_WHILE      => \T_WHILE,
+        \T_ELSE       => \T_ELSE,
+        \T_ELSEIF     => \T_ELSEIF,
+        \T_FOR        => \T_FOR,
+        \T_FOREACH    => \T_FOREACH,
+        \T_DO         => \T_DO,
+        \T_TRY        => \T_TRY,
+        \T_CATCH      => \T_CATCH,
+        \T_FINALLY    => \T_FINALLY,
+        \T_PROPERTY   => \T_PROPERTY,
+        \T_OBJECT     => \T_OBJECT,
+        \T_USE        => \T_USE,
+    ];
+
+    /**
+     * Tokens that represent scope modifiers.
+     *
+     * @var array <int|string> => <int|string>
+     */
+    protected $scopeModifiers = [
+        \T_PRIVATE   => \T_PRIVATE,
+        \T_PUBLIC    => \T_PUBLIC,
+        \T_PROTECTED => \T_PROTECTED,
+    ];
+
+    /**
+     * Tokens that can prefix a method name
+     *
+     * @var array <int|string> => <int|string>
+     */
+    protected $methodPrefixes = [
+        \T_PRIVATE   => \T_PRIVATE,
+        \T_PUBLIC    => \T_PUBLIC,
+        \T_PROTECTED => \T_PROTECTED,
+        \T_ABSTRACT  => \T_ABSTRACT,
+        \T_STATIC    => \T_STATIC,
+        \T_FINAL     => \T_FINAL,
+    ];
+
+    /**
+     * Tokens that open code blocks.
+     *
+     * @var array <int|string> => <int|string>
+     */
+    protected $blockOpeners = [
+        \T_OPEN_CURLY_BRACKET  => \T_OPEN_CURLY_BRACKET,
+        \T_OPEN_SQUARE_BRACKET => \T_OPEN_SQUARE_BRACKET,
+        \T_OPEN_PARENTHESIS    => \T_OPEN_PARENTHESIS,
+        \T_OBJECT              => \T_OBJECT,
+    ];
+
+    /**
+     * Tokens that represent strings.
+     *
+     * @var array <int|string> => <int|string>
+     */
+    protected $stringTokens = [
+        \T_CONSTANT_ENCAPSED_STRING => \T_CONSTANT_ENCAPSED_STRING,
+        \T_DOUBLE_QUOTED_STRING     => \T_DOUBLE_QUOTED_STRING,
+    ];
+
+    /**
+     * Tokens that represent brackets and parenthesis.
+     *
+     * @var array <int|string> => <int|string>
+     */
+    protected $bracketTokens = [
+        \T_OPEN_CURLY_BRACKET   => \T_OPEN_CURLY_BRACKET,
+        \T_CLOSE_CURLY_BRACKET  => \T_CLOSE_CURLY_BRACKET,
+        \T_OPEN_SQUARE_BRACKET  => \T_OPEN_SQUARE_BRACKET,
+        \T_CLOSE_SQUARE_BRACKET => \T_CLOSE_SQUARE_BRACKET,
+        \T_OPEN_PARENTHESIS     => \T_OPEN_PARENTHESIS,
+        \T_CLOSE_PARENTHESIS    => \T_CLOSE_PARENTHESIS,
+    ];
+
+    /**
+     * Tokens that include files.
+     *
+     * @var array <int|string> => <int|string>
+     */
+    protected $includeTokens = [
+        \T_REQUIRE_ONCE => \T_REQUIRE_ONCE,
+        \T_REQUIRE      => \T_REQUIRE,
+        \T_INCLUDE_ONCE => \T_INCLUDE_ONCE,
+        \T_INCLUDE      => \T_INCLUDE,
+    ];
+
+    /**
+     * Tokens that make up a heredoc string.
+     *
+     * @var array <int|string> => <int|string>
+     */
+    protected $heredocTokens = [
+        \T_START_HEREDOC => \T_START_HEREDOC,
+        \T_END_HEREDOC   => \T_END_HEREDOC,
+        \T_HEREDOC       => \T_HEREDOC,
+        \T_START_NOWDOC  => \T_START_NOWDOC,
+        \T_END_NOWDOC    => \T_END_NOWDOC,
+        \T_NOWDOC        => \T_NOWDOC,
+    ];
+
+    /**
+     * Test the method.
+     *
+     * @dataProvider dataUnchangedTokenArrays
+     *
+     * @param string $name     The token array name.
+     * @param array  $expected The token array content.
+     *
+     * @return void
+     */
+    public function testUnchangedTokenArrays($name, $expected)
+    {
+        $this->assertSame($expected, BCTokens::$name());
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testUnchangedTokenArrays() For the array format.
+     *
+     * @return array
+     */
+    public function dataUnchangedTokenArrays()
+    {
+        $phpunitProp = [
+            'backupGlobals'                   => true,
+            'backupGlobalsBlacklist'          => true,
+            'backupStaticAttributes'          => true,
+            'backupStaticAttributesBlacklist' => true,
+            'runTestInSeparateProcess'        => true,
+            'preserveGlobalState'             => true,
+        ];
+
+        $data        = [];
+        $tokenArrays = \get_object_vars($this);
+        foreach ($tokenArrays as $name => $expected) {
+            if (isset($phpunitProp[$name])) {
+                continue;
+            }
+
+            $data[$name] = [$name, $expected];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Test calling a token property method for a token array which doesn't exist.
+     *
+     * @return void
+     */
+    public function testUndeclaredTokenArray()
+    {
+        $this->assertSame([], BCTokens::notATokenArray());
+    }
+}


### PR DESCRIPTION
PHPCS provides a number of static token arrays in the `PHP_CodeSniffer\Util\Tokens` class.
Some of these token arrays will not be available in older PHPCS versions.
Some will not contain the same set of tokens across PHPCS versions.

The `PHPCSUtils\BackCompat\BCTokens` class is a compatibility layer to allow for retrieving these token arrays with a consistent token content across PHPCS versions.
The one caveat is that the token constants do need to be available.

The class is named `BCTokens` instead of `Tokens` on purpose to more easily allow sniffs to use both the PHPCS native Tokens class as well as this class without always having to alias one of the two.

Recommended usage:
Only use the methods in this class when needed. I.e. when your sniff unit tests indicate a PHPCS cross-version compatibility issue related to inconsistent token arrays.

All PHPCS token arrays are supported, though only a limited number of them are different across PHPCS versions.

The names of the PHPCS native token arrays translate one-on-one to the methods in this class:
- `PHP_CodeSniffer\Util\Tokens::$emptyTokens` => `PHPCSUtils\BackCompat\BCTokens::emptyTokens()`
- `PHP_CodeSniffer\Util\Tokens::$operators`     => `PHPCSUtils\BackCompat\BCTokens::operators()`
    ... etc

The order of the tokens in the arrays may differ between the PHPCS native token arrays and the token arrays returned by this class.

Also note: While `T_LIST` and `T_ANON_CLASS` will be included in the return value for the `parenthesisOpeners()` method, the associated parentheses will not have the `'parenthesis_owner'` index set until PHPCS 3.5.0.

Methods:
* `assignmentTokens()`
* `comparisonTokens()`
* `arithmeticTokens()`
* `operators()`
* `parenthesisOpeners()`
* `phpcsCommentTokens()`
* `textStringTokens()`
* `functionNameTokens()`
* `ooScopeTokens()`
* `__callStatic()` - to retrieve the other token arrays which haven't had any relevant changes between PHPCS 2.6.0 and current.

Includes unit tests for all token arrays.
The unit tests contain a hard-coded copy of the PHPCS native token arrays as they are now.
This means that they will also serve as an early warning system for future changes to these arrays in PHPCS itself.