### PR TITLE
New BackCompat\BCFile class - import of utilities from phpcs itself

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -54,6 +54,20 @@ class BCFile
     /**
      * Returns the declaration names for classes, interfaces, traits, and functions.
      *
+     * PHPCS cross-version compatible version of the File::getDeclarationName() method.
+     *
+     * Changelog for the PHPCS native function:
+     * - Introduced in PHPCS 0.0.5.
+     * - PHPCS 2.8.0: Returns null when passed an anonymous class. Previously, the method
+     *                would throw a "token not of an accepted type" exception.
+     * - PHPCS 2.9.0: Returns null when passed a PHP closure. Previously, the method
+     *                would throw a "token not of an accepted type" exception.
+     * - PHPCS 3.0.0: Added support for ES6 class/method syntax.
+     * - PHPCS 3.0.0: The Exception thrown changed from a `PHP_CodeSniffer_Exception` to
+     *                `\PHP_CodeSniffer\Exceptions\RuntimeException`.
+     *
+     * @see \PHP_CodeSniffer\Files\File::getDeclarationName() Original source.
+     *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1409,14 +1409,13 @@ class BCFile
     /**
      * Returns the names of the interfaces that the specified class implements.
      *
-     * Returns FALSE on error or if there are no implemented interface names.
-     *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The stack position of the class.
      *
-     * @return array|false
+     * @return array|false Array with names of the implemented interfaces or FALSE on
+     *                     error or if there are no implemented interface names.
      */
     public static function findImplementedInterfaceNames(File $phpcsFile, $stackPtr)
     {

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -764,6 +764,7 @@ class BCFile
                 T_SELF         => T_SELF,
                 T_PARENT       => T_PARENT,
                 T_NS_SEPARATOR => T_NS_SEPARATOR,
+                T_ARRAY_HINT   => T_ARRAY_HINT, // Array property type declarations in PHPCS < 3.3.0.
             ];
 
             for ($i; $i < $stackPtr; $i++) {
@@ -772,7 +773,10 @@ class BCFile
                     break;
                 }
 
-                if ($tokens[$i]['code'] === T_NULLABLE) {
+                if ($tokens[$i]['type'] === 'T_NULLABLE'
+                    // Handle nullable property types in PHPCS < 3.5.0.
+                    || $tokens[$i]['code'] === T_INLINE_THEN
+                ) {
                     $nullableType = true;
                 }
 

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1082,6 +1082,14 @@ class BCFile
     /**
      * Returns the position of the first non-whitespace token in a statement.
      *
+     * PHPCS cross-version compatible version of the File::findStartOfStatement() method.
+     *
+     * Changelog for the PHPCS native function:
+     * - Introduced in PHPCS 2.1.0.
+     * - PHPCS 2.6.2: New optional `$ignore` parameter to selectively ignore stop points.
+     *
+     * @see \PHP_CodeSniffer\Files\File::findStartOfStatement() Original source.
+     *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1034,7 +1034,7 @@ class BCFile
      *
      * @return string The token contents.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position does not exist.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified start position does not exist.
      */
     public static function getTokensAsString(File $phpcsFile, $start, $length, $origContent = false)
     {

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -883,15 +883,13 @@ class BCFile
     /**
      * Determine if the passed token is a reference operator.
      *
-     * Returns true if the specified token position represents a reference.
-     * Returns false if the token represents a bitwise operator.
-     *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the T_BITWISE_AND token.
      *
-     * @return boolean
+     * @return bool TRUE if the specified token position represents a reference.
+     *              FALSE if the token represents a bitwise operator.
      */
     public static function isReference(File $phpcsFile, $stackPtr)
     {

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -614,7 +614,7 @@ class BCFile
      *    'scope'           => string,  // Public, private, or protected.
      *    'scope_specified' => boolean, // TRUE if the scope was explicitly specified.
      *    'is_static'       => boolean, // TRUE if the static keyword was found.
-     *    'type'            => string,  // The type of the var (empty if no type specifed).
+     *    'type'            => string,  // The type of the var (empty if no type specified).
      *    'type_token'      => integer, // The stack pointer to the start of the type
      *                                  // or FALSE if there is no type.
      *    'type_end_token'  => integer, // The stack pointer to the end of the type

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -268,22 +268,23 @@ class BCFile
                 }
             }
 
-            switch ($tokens[$i]['code']) {
-                case T_BITWISE_AND:
+            // Changed from checking 'code' to 'type' to allow for T_NULLABLE not existing in PHPCS < 2.8.0.
+            switch ($tokens[$i]['type']) {
+                case 'T_BITWISE_AND':
                     if ($defaultStart === null) {
                         $passByReference = true;
                         $referenceToken  = $i;
                     }
                     break;
-                case T_VARIABLE:
+                case 'T_VARIABLE':
                     $currVar = $i;
                     break;
-                case T_ELLIPSIS:
+                case 'T_ELLIPSIS':
                     $variableLength = true;
                     $variadicToken  = $i;
                     break;
-                case T_ARRAY_HINT: // PHPCS < 3.3.0.
-                case T_CALLABLE:
+                case 'T_ARRAY_HINT': // PHPCS < 3.3.0.
+                case 'T_CALLABLE':
                     if ($typeHintToken === false) {
                         $typeHintToken = $i;
                     }
@@ -291,9 +292,9 @@ class BCFile
                     $typeHint        .= $tokens[$i]['content'];
                     $typeHintEndToken = $i;
                     break;
-                case T_SELF:
-                case T_PARENT:
-                case T_STATIC:
+                case 'T_SELF':
+                case 'T_PARENT':
+                case 'T_STATIC':
                     // Self and parent are valid, static invalid, but was probably intended as type hint.
                     if (isset($defaultStart) === false) {
                         if ($typeHintToken === false) {
@@ -304,7 +305,7 @@ class BCFile
                         $typeHintEndToken = $i;
                     }
                     break;
-                case T_STRING:
+                case 'T_STRING':
                     // This is a string, so it may be a type hint, but it could
                     // also be a constant used as a default value.
                     $prevComma = false;
@@ -338,7 +339,7 @@ class BCFile
                         $typeHintEndToken = $i;
                     }
                     break;
-                case T_NS_SEPARATOR:
+                case 'T_NS_SEPARATOR':
                     // Part of a type hint or default value.
                     if ($defaultStart === null) {
                         if ($typeHintToken === false) {
@@ -349,15 +350,16 @@ class BCFile
                         $typeHintEndToken = $i;
                     }
                     break;
-                case T_NULLABLE:
+                case 'T_NULLABLE':
+                case 'T_INLINE_THEN': // PHPCS < 2.8.0.
                     if ($defaultStart === null) {
                         $nullableType     = true;
                         $typeHint        .= $tokens[$i]['content'];
                         $typeHintEndToken = $i;
                     }
                     break;
-                case T_CLOSE_PARENTHESIS:
-                case T_COMMA:
+                case 'T_CLOSE_PARENTHESIS':
+                case 'T_COMMA':
                     // If it's null, then there must be no parameters for this
                     // method.
                     if ($currVar === null) {
@@ -406,7 +408,7 @@ class BCFile
 
                     $paramCount++;
                     break;
-                case T_EQUAL:
+                case 'T_EQUAL':
                     $defaultStart = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
                     $equalToken   = $i;
                     break;

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -446,7 +446,7 @@ class BCFile
      * @return array
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      T_FUNCTION token.
+     *                                                      T_FUNCTION or a T_CLOSURE token.
      */
     public static function getMethodProperties(File $phpcsFile, $stackPtr)
     {

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -437,6 +437,29 @@ class BCFile
      *   );
      * </code>
      *
+     * PHPCS cross-version compatible version of the File::getMethodProperties() method.
+     *
+     * Changelog for the PHPCS native function:
+     * - Introduced in PHPCS 0.0.5.
+     * - PHPCS 3.0.0: Removed the `is_closure` array index which was always `false` anyway.
+     * - PHPCS 3.0.0: The Exception thrown changed from a `PHP_CodeSniffer_Exception` to
+     *                `\PHP_CodeSniffer\Exceptions\TokenizerException`.
+     * - PHPCS 3.3.0: New `return_type`, `return_type_token` and `nullable_return_type` array indexes.
+     *                - The `return_type` index contains the return type of the function or closer,
+     *                  or a blank string if not specified.
+     *                - If the return type is nullable, the return type will contain the leading `?`.
+     *                - A `nullable_return_type` array index in the return value will also be set to `true`.
+     *                - If the return type contains namespace information, it will be cleaned of
+     *                  whitespace and comments.
+     *                - To access the original return value string, use the main tokens array.
+     * - PHPCS 3.4.0: New `has_body` array index.
+     *                - `false` if the method has no body (as with abstract and interface methods)
+     *                  or `true` otherwise.
+     * - PHPCS 3.5.0: The Exception thrown changed from a `TokenizerException` to
+     *                `\PHP_CodeSniffer\Exceptions\RuntimeException`.
+     *
+     * @see \PHP_CodeSniffer\Files\File::getMethodProperties() Original source.
+     *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -555,6 +555,8 @@ class BCFile
                 T_SELF         => T_SELF,
                 T_PARENT       => T_PARENT,
                 T_NS_SEPARATOR => T_NS_SEPARATOR,
+                T_RETURN_TYPE  => T_RETURN_TYPE, // PHPCS 2.4.0 < 3.3.0.
+                T_ARRAY_HINT   => T_ARRAY_HINT, // PHPCS < 2.8.0.
             ];
 
             for ($i = $tokens[$stackPtr]['parenthesis_closer']; $i < $phpcsFile->numTokens; $i++) {
@@ -565,7 +567,10 @@ class BCFile
                     break;
                 }
 
-                if ($tokens[$i]['code'] === T_NULLABLE) {
+                if ($tokens[$i]['type'] === 'T_NULLABLE'
+                    // Handle nullable tokens in PHPCS < 2.8.0.
+                    || (defined('T_NULLABLE') === false && $tokens[$i]['code'] === T_INLINE_THEN)
+                ) {
                     $nullableReturnType = true;
                 }
 

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -282,6 +282,7 @@ class BCFile
                     $variableLength = true;
                     $variadicToken  = $i;
                     break;
+                case T_ARRAY_HINT: // PHPCS < 3.3.0.
                 case T_CALLABLE:
                     if ($typeHintToken === false) {
                         $typeHintToken = $i;

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -36,6 +36,7 @@ namespace PHPCSUtils\BackCompat;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\BCTokens;
 
 /**
  * PHPCS native utility functions.
@@ -936,7 +937,7 @@ class BCFile
             return true;
         }
 
-        if (isset(Tokens::$assignmentTokens[$tokens[$tokenBefore]['code']]) === true) {
+        if (isset(BCTokens::assignmentTokens()[$tokens[$tokenBefore]['code']]) === true) {
             // This is directly after an assignment. It's a reference. Even if
             // it is part of an operation, the other tests will handle it.
             return true;

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1299,15 +1299,14 @@ class BCFile
     /**
      * Return the position of the condition for the passed token.
      *
-     * Returns FALSE if the token does not have the condition.
-     *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the token we are checking.
      * @param int|string                  $type      The type of token to search for.
      *
-     * @return int
+     * @return int|false Integer stack pointer to the condition or FALSE if the token
+     *                   does not have the condition.
      */
     public static function getCondition(File $phpcsFile, $stackPtr, $type)
     {

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1299,6 +1299,14 @@ class BCFile
     /**
      * Return the position of the condition for the passed token.
      *
+     * PHPCS cross-version compatible version of the File::getCondition() method.
+     *
+     * Changelog for the PHPCS native function:
+     * - Introduced in PHPCS 1.3.0.
+     * - This method has received no significant code updates since PHPCS 2.6.0.
+     *
+     * @see \PHP_CodeSniffer\Files\File::getCondition() Original source.
+     *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1344,6 +1344,17 @@ class BCFile
      * Returns the name of the class that the specified class extends.
      * (works for classes, anonymous classes and interfaces)
      *
+     * PHPCS cross-version compatible version of the File::findExtendedClassName() method.
+     *
+     * Changelog for the PHPCS native function:
+     * - Introduced in PHPCS 1.2.0.
+     * - PHPCS 2.8.0: Now supports anonymous classes.
+     * - PHPCS 3.1.0: Now supports interfaces extending interfaces (incorrectly, only supporting
+     *                single interface extension).
+     * - PHPCS 3.3.2: Fixed bug causing bleed through with nested classes, PHPCS#2127.
+     *
+     * @see \PHP_CodeSniffer\Files\File::findExtendedClassName() Original source.
+     *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1344,14 +1344,13 @@ class BCFile
      * Returns the name of the class that the specified class extends.
      * (works for classes, anonymous classes and interfaces)
      *
-     * Returns FALSE on error or if there is no extended class name.
-     *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The stack position of the class.
+     * @param int                         $stackPtr  The stack position of the class or interface.
      *
-     * @return string|false
+     * @return string|false The extended class name or FALSE on error or if there
+     *                      is no extended class name.
      */
     public static function findExtendedClassName(File $phpcsFile, $stackPtr)
     {

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1253,6 +1253,14 @@ class BCFile
     /**
      * Determine if the passed token has a condition of one of the passed types.
      *
+     * PHPCS cross-version compatible version of the File::hasCondition() method.
+     *
+     * Changelog for the PHPCS native function:
+     * - Introduced in PHPCS 0.0.5.
+     * - This method has received no significant code updates since PHPCS 2.6.0.
+     *
+     * @see \PHP_CodeSniffer\Files\File::hasCondition() Original source.
+     *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -883,6 +883,21 @@ class BCFile
     /**
      * Determine if the passed token is a reference operator.
      *
+     * PHPCS cross-version compatible version of the File::isReference() method.
+     *
+     * Changelog for the PHPCS native function:
+     * - Introduced in PHPCS 0.0.5.
+     * - PHPCS 3.1.1: Bug fix: misidentification of reference vs bitwise operator, PHPCS#1604/#1609.
+     *                - An array assignment of a calculated value with a bitwise and operator in it,
+     *                  was being misidentified as a reference.
+     *                - A calculated default value for a function parameter with a bitwise and operator
+     *                  in it, was being misidentified as a reference.
+     *                - New by reference was not recognized as a reference.
+     *                - References to class properties with `self::`, `parent::`, `static::`,
+     *                  `namespace\ClassName::`, `classname::` were not recognized as references.
+     *
+     * @see \PHP_CodeSniffer\Files\File::isReference() Original source.
+     *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1,0 +1,1201 @@
+<?php
+/**
+ * Represents a piece of content being checked during the run.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Files;
+
+use PHP_CodeSniffer\Util;
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+
+class File
+{
+
+    /**
+     * Returns the declaration names for classes, interfaces, traits, and functions.
+     *
+     * @param int $stackPtr The position of the declaration token which
+     *                      declared the class, interface, trait, or function.
+     *
+     * @return string|null The name of the class, interface, trait, or function;
+     *                     or NULL if the function or class is anonymous.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified token is not of type
+     *                                                      T_FUNCTION, T_CLASS, T_ANON_CLASS,
+     *                                                      T_CLOSURE, T_TRAIT, or T_INTERFACE.
+     */
+    public function getDeclarationName($stackPtr)
+    {
+        $tokenCode = $this->tokens[$stackPtr]['code'];
+
+        if ($tokenCode === T_ANON_CLASS || $tokenCode === T_CLOSURE) {
+            return null;
+        }
+
+        if ($tokenCode !== T_FUNCTION
+            && $tokenCode !== T_CLASS
+            && $tokenCode !== T_INTERFACE
+            && $tokenCode !== T_TRAIT
+        ) {
+            throw new RuntimeException('Token type "'.$this->tokens[$stackPtr]['type'].'" is not T_FUNCTION, T_CLASS, T_INTERFACE or T_TRAIT');
+        }
+
+        if ($tokenCode === T_FUNCTION
+            && strtolower($this->tokens[$stackPtr]['content']) !== 'function'
+        ) {
+            // This is a function declared without the "function" keyword.
+            // So this token is the function name.
+            return $this->tokens[$stackPtr]['content'];
+        }
+
+        $content = null;
+        for ($i = $stackPtr; $i < $this->numTokens; $i++) {
+            if ($this->tokens[$i]['code'] === T_STRING) {
+                $content = $this->tokens[$i]['content'];
+                break;
+            }
+        }
+
+        return $content;
+
+    }//end getDeclarationName()
+
+
+    /**
+     * Returns the method parameters for the specified function token.
+     *
+     * Also supports passing in a USE token for a closure use group.
+     *
+     * Each parameter is in the following format:
+     *
+     * <code>
+     *   0 => array(
+     *         'name'                => '$var',  // The variable name.
+     *         'token'               => integer, // The stack pointer to the variable name.
+     *         'content'             => string,  // The full content of the variable definition.
+     *         'pass_by_reference'   => boolean, // Is the variable passed by reference?
+     *         'reference_token'     => integer, // The stack pointer to the reference operator
+     *                                           // or FALSE if the param is not passed by reference.
+     *         'variable_length'     => boolean, // Is the param of variable length through use of `...` ?
+     *         'variadic_token'      => integer, // The stack pointer to the ... operator
+     *                                           // or FALSE if the param is not variable length.
+     *         'type_hint'           => string,  // The type hint for the variable.
+     *         'type_hint_token'     => integer, // The stack pointer to the start of the type hint
+     *                                           // or FALSE if there is no type hint.
+     *         'type_hint_end_token' => integer, // The stack pointer to the end of the type hint
+     *                                           // or FALSE if there is no type hint.
+     *         'nullable_type'       => boolean, // TRUE if the var type is nullable.
+     *         'comma_token'         => integer, // The stack pointer to the comma after the param
+     *                                           // or FALSE if this is the last param.
+     *        )
+     * </code>
+     *
+     * Parameters with default values have an additional array indexs of:
+     *         'default'             => string,  // The full content of the default value.
+     *         'default_token'       => integer, // The stack pointer to the start of the default value.
+     *         'default_equal_token' => integer, // The stack pointer to the equals sign.
+     *
+     * @param int $stackPtr The position in the stack of the function token
+     *                      to acquire the parameters for.
+     *
+     * @return array
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified $stackPtr is not of
+     *                                                      type T_FUNCTION, T_CLOSURE, or T_USE.
+     */
+    public function getMethodParameters($stackPtr)
+    {
+        if ($this->tokens[$stackPtr]['code'] !== T_FUNCTION
+            && $this->tokens[$stackPtr]['code'] !== T_CLOSURE
+            && $this->tokens[$stackPtr]['code'] !== T_USE
+        ) {
+            throw new RuntimeException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_USE');
+        }
+
+        if ($this->tokens[$stackPtr]['code'] === T_USE) {
+            $opener = $this->findNext(T_OPEN_PARENTHESIS, ($stackPtr + 1));
+            if ($opener === false || isset($this->tokens[$opener]['parenthesis_owner']) === true) {
+                throw new RuntimeException('$stackPtr was not a valid T_USE');
+            }
+        } else {
+            if (isset($this->tokens[$stackPtr]['parenthesis_opener']) === false) {
+                // Live coding or syntax error, so no params to find.
+                return [];
+            }
+
+            $opener = $this->tokens[$stackPtr]['parenthesis_opener'];
+        }
+
+        if (isset($this->tokens[$opener]['parenthesis_closer']) === false) {
+            // Live coding or syntax error, so no params to find.
+            return [];
+        }
+
+        $closer = $this->tokens[$opener]['parenthesis_closer'];
+
+        $vars            = [];
+        $currVar         = null;
+        $paramStart      = ($opener + 1);
+        $defaultStart    = null;
+        $equalToken      = null;
+        $paramCount      = 0;
+        $passByReference = false;
+        $referenceToken  = false;
+        $variableLength  = false;
+        $variadicToken   = false;
+        $typeHint        = '';
+        $typeHintToken   = false;
+        $typeHintEndToken = false;
+        $nullableType     = false;
+
+        for ($i = $paramStart; $i <= $closer; $i++) {
+            // Check to see if this token has a parenthesis or bracket opener. If it does
+            // it's likely to be an array which might have arguments in it. This
+            // could cause problems in our parsing below, so lets just skip to the
+            // end of it.
+            if (isset($this->tokens[$i]['parenthesis_opener']) === true) {
+                // Don't do this if it's the close parenthesis for the method.
+                if ($i !== $this->tokens[$i]['parenthesis_closer']) {
+                    $i = ($this->tokens[$i]['parenthesis_closer'] + 1);
+                }
+            }
+
+            if (isset($this->tokens[$i]['bracket_opener']) === true) {
+                // Don't do this if it's the close parenthesis for the method.
+                if ($i !== $this->tokens[$i]['bracket_closer']) {
+                    $i = ($this->tokens[$i]['bracket_closer'] + 1);
+                }
+            }
+
+            switch ($this->tokens[$i]['code']) {
+            case T_BITWISE_AND:
+                if ($defaultStart === null) {
+                    $passByReference = true;
+                    $referenceToken  = $i;
+                }
+                break;
+            case T_VARIABLE:
+                $currVar = $i;
+                break;
+            case T_ELLIPSIS:
+                $variableLength = true;
+                $variadicToken  = $i;
+                break;
+            case T_CALLABLE:
+                if ($typeHintToken === false) {
+                    $typeHintToken = $i;
+                }
+
+                $typeHint        .= $this->tokens[$i]['content'];
+                $typeHintEndToken = $i;
+                break;
+            case T_SELF:
+            case T_PARENT:
+            case T_STATIC:
+                // Self and parent are valid, static invalid, but was probably intended as type hint.
+                if (isset($defaultStart) === false) {
+                    if ($typeHintToken === false) {
+                        $typeHintToken = $i;
+                    }
+
+                    $typeHint        .= $this->tokens[$i]['content'];
+                    $typeHintEndToken = $i;
+                }
+                break;
+            case T_STRING:
+                // This is a string, so it may be a type hint, but it could
+                // also be a constant used as a default value.
+                $prevComma = false;
+                for ($t = $i; $t >= $opener; $t--) {
+                    if ($this->tokens[$t]['code'] === T_COMMA) {
+                        $prevComma = $t;
+                        break;
+                    }
+                }
+
+                if ($prevComma !== false) {
+                    $nextEquals = false;
+                    for ($t = $prevComma; $t < $i; $t++) {
+                        if ($this->tokens[$t]['code'] === T_EQUAL) {
+                            $nextEquals = $t;
+                            break;
+                        }
+                    }
+
+                    if ($nextEquals !== false) {
+                        break;
+                    }
+                }
+
+                if ($defaultStart === null) {
+                    if ($typeHintToken === false) {
+                        $typeHintToken = $i;
+                    }
+
+                    $typeHint        .= $this->tokens[$i]['content'];
+                    $typeHintEndToken = $i;
+                }
+                break;
+            case T_NS_SEPARATOR:
+                // Part of a type hint or default value.
+                if ($defaultStart === null) {
+                    if ($typeHintToken === false) {
+                        $typeHintToken = $i;
+                    }
+
+                    $typeHint        .= $this->tokens[$i]['content'];
+                    $typeHintEndToken = $i;
+                }
+                break;
+            case T_NULLABLE:
+                if ($defaultStart === null) {
+                    $nullableType     = true;
+                    $typeHint        .= $this->tokens[$i]['content'];
+                    $typeHintEndToken = $i;
+                }
+                break;
+            case T_CLOSE_PARENTHESIS:
+            case T_COMMA:
+                // If it's null, then there must be no parameters for this
+                // method.
+                if ($currVar === null) {
+                    continue 2;
+                }
+
+                $vars[$paramCount]            = [];
+                $vars[$paramCount]['token']   = $currVar;
+                $vars[$paramCount]['name']    = $this->tokens[$currVar]['content'];
+                $vars[$paramCount]['content'] = trim($this->getTokensAsString($paramStart, ($i - $paramStart)));
+
+                if ($defaultStart !== null) {
+                    $vars[$paramCount]['default']       = trim($this->getTokensAsString($defaultStart, ($i - $defaultStart)));
+                    $vars[$paramCount]['default_token'] = $defaultStart;
+                    $vars[$paramCount]['default_equal_token'] = $equalToken;
+                }
+
+                $vars[$paramCount]['pass_by_reference']   = $passByReference;
+                $vars[$paramCount]['reference_token']     = $referenceToken;
+                $vars[$paramCount]['variable_length']     = $variableLength;
+                $vars[$paramCount]['variadic_token']      = $variadicToken;
+                $vars[$paramCount]['type_hint']           = $typeHint;
+                $vars[$paramCount]['type_hint_token']     = $typeHintToken;
+                $vars[$paramCount]['type_hint_end_token'] = $typeHintEndToken;
+                $vars[$paramCount]['nullable_type']       = $nullableType;
+
+                if ($this->tokens[$i]['code'] === T_COMMA) {
+                    $vars[$paramCount]['comma_token'] = $i;
+                } else {
+                    $vars[$paramCount]['comma_token'] = false;
+                }
+
+                // Reset the vars, as we are about to process the next parameter.
+                $defaultStart    = null;
+                $equalToken      = null;
+                $paramStart      = ($i + 1);
+                $passByReference = false;
+                $referenceToken  = false;
+                $variableLength  = false;
+                $variadicToken   = false;
+                $typeHint        = '';
+                $typeHintToken   = false;
+                $nullableType    = false;
+
+                $paramCount++;
+                break;
+            case T_EQUAL:
+                $defaultStart = $this->findNext(Util\Tokens::$emptyTokens, ($i + 1), null, true);
+                $equalToken   = $i;
+                break;
+            }//end switch
+        }//end for
+
+        return $vars;
+
+    }//end getMethodParameters()
+
+
+    /**
+     * Returns the visibility and implementation properties of a method.
+     *
+     * The format of the return value is:
+     * <code>
+     *   array(
+     *    'scope'                => 'public', // Public, private, or protected
+     *    'scope_specified'      => true,     // TRUE if the scope keyword was found.
+     *    'return_type'          => '',       // The return type of the method.
+     *    'return_type_token'    => integer,  // The stack pointer to the start of the return type
+     *                                        // or FALSE if there is no return type.
+     *    'nullable_return_type' => false,    // TRUE if the return type is nullable.
+     *    'is_abstract'          => false,    // TRUE if the abstract keyword was found.
+     *    'is_final'             => false,    // TRUE if the final keyword was found.
+     *    'is_static'            => false,    // TRUE if the static keyword was found.
+     *    'has_body'             => false,    // TRUE if the method has a body
+     *   );
+     * </code>
+     *
+     * @param int $stackPtr The position in the stack of the function token to
+     *                      acquire the properties for.
+     *
+     * @return array
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
+     *                                                        T_FUNCTION token.
+     */
+    public function getMethodProperties($stackPtr)
+    {
+        if ($this->tokens[$stackPtr]['code'] !== T_FUNCTION
+            && $this->tokens[$stackPtr]['code'] !== T_CLOSURE
+        ) {
+            throw new RuntimeException('$stackPtr must be of type T_FUNCTION or T_CLOSURE');
+        }
+
+        if ($this->tokens[$stackPtr]['code'] === T_FUNCTION) {
+            $valid = [
+                T_PUBLIC      => T_PUBLIC,
+                T_PRIVATE     => T_PRIVATE,
+                T_PROTECTED   => T_PROTECTED,
+                T_STATIC      => T_STATIC,
+                T_FINAL       => T_FINAL,
+                T_ABSTRACT    => T_ABSTRACT,
+                T_WHITESPACE  => T_WHITESPACE,
+                T_COMMENT     => T_COMMENT,
+                T_DOC_COMMENT => T_DOC_COMMENT,
+            ];
+        } else {
+            $valid = [
+                T_STATIC      => T_STATIC,
+                T_WHITESPACE  => T_WHITESPACE,
+                T_COMMENT     => T_COMMENT,
+                T_DOC_COMMENT => T_DOC_COMMENT,
+            ];
+        }
+
+        $scope          = 'public';
+        $scopeSpecified = false;
+        $isAbstract     = false;
+        $isFinal        = false;
+        $isStatic       = false;
+
+        for ($i = ($stackPtr - 1); $i > 0; $i--) {
+            if (isset($valid[$this->tokens[$i]['code']]) === false) {
+                break;
+            }
+
+            switch ($this->tokens[$i]['code']) {
+            case T_PUBLIC:
+                $scope          = 'public';
+                $scopeSpecified = true;
+                break;
+            case T_PRIVATE:
+                $scope          = 'private';
+                $scopeSpecified = true;
+                break;
+            case T_PROTECTED:
+                $scope          = 'protected';
+                $scopeSpecified = true;
+                break;
+            case T_ABSTRACT:
+                $isAbstract = true;
+                break;
+            case T_FINAL:
+                $isFinal = true;
+                break;
+            case T_STATIC:
+                $isStatic = true;
+                break;
+            }//end switch
+        }//end for
+
+        $returnType         = '';
+        $returnTypeToken    = false;
+        $nullableReturnType = false;
+        $hasBody            = true;
+
+        if (isset($this->tokens[$stackPtr]['parenthesis_closer']) === true) {
+            $scopeOpener = null;
+            if (isset($this->tokens[$stackPtr]['scope_opener']) === true) {
+                $scopeOpener = $this->tokens[$stackPtr]['scope_opener'];
+            }
+
+            $valid = [
+                T_STRING       => T_STRING,
+                T_CALLABLE     => T_CALLABLE,
+                T_SELF         => T_SELF,
+                T_PARENT       => T_PARENT,
+                T_NS_SEPARATOR => T_NS_SEPARATOR,
+            ];
+
+            for ($i = $this->tokens[$stackPtr]['parenthesis_closer']; $i < $this->numTokens; $i++) {
+                if (($scopeOpener === null && $this->tokens[$i]['code'] === T_SEMICOLON)
+                    || ($scopeOpener !== null && $i === $scopeOpener)
+                ) {
+                    // End of function definition.
+                    break;
+                }
+
+                if ($this->tokens[$i]['code'] === T_NULLABLE) {
+                    $nullableReturnType = true;
+                }
+
+                if (isset($valid[$this->tokens[$i]['code']]) === true) {
+                    if ($returnTypeToken === false) {
+                        $returnTypeToken = $i;
+                    }
+
+                    $returnType .= $this->tokens[$i]['content'];
+                }
+            }
+
+            $end     = $this->findNext([T_OPEN_CURLY_BRACKET, T_SEMICOLON], $this->tokens[$stackPtr]['parenthesis_closer']);
+            $hasBody = $this->tokens[$end]['code'] === T_OPEN_CURLY_BRACKET;
+        }//end if
+
+        if ($returnType !== '' && $nullableReturnType === true) {
+            $returnType = '?'.$returnType;
+        }
+
+        return [
+            'scope'                => $scope,
+            'scope_specified'      => $scopeSpecified,
+            'return_type'          => $returnType,
+            'return_type_token'    => $returnTypeToken,
+            'nullable_return_type' => $nullableReturnType,
+            'is_abstract'          => $isAbstract,
+            'is_final'             => $isFinal,
+            'is_static'            => $isStatic,
+            'has_body'             => $hasBody,
+        ];
+
+    }//end getMethodProperties()
+
+
+    /**
+     * Returns the visibility and implementation properties of a class member var.
+     *
+     * The format of the return value is:
+     *
+     * <code>
+     *   array(
+     *    'scope'           => string,  // Public, private, or protected.
+     *    'scope_specified' => boolean, // TRUE if the scope was explicitly specified.
+     *    'is_static'       => boolean, // TRUE if the static keyword was found.
+     *    'type'            => string,  // The type of the var (empty if no type specifed).
+     *    'type_token'      => integer, // The stack pointer to the start of the type
+     *                                  // or FALSE if there is no type.
+     *    'type_end_token'  => integer, // The stack pointer to the end of the type
+     *                                  // or FALSE if there is no type.
+     *    'nullable_type'   => boolean, // TRUE if the type is nullable.
+     *   );
+     * </code>
+     *
+     * @param int $stackPtr The position in the stack of the T_VARIABLE token to
+     *                      acquire the properties for.
+     *
+     * @return array
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
+     *                                                        T_VARIABLE token, or if the position is not
+     *                                                        a class member variable.
+     */
+    public function getMemberProperties($stackPtr)
+    {
+        if ($this->tokens[$stackPtr]['code'] !== T_VARIABLE) {
+            throw new RuntimeException('$stackPtr must be of type T_VARIABLE');
+        }
+
+        $conditions = array_keys($this->tokens[$stackPtr]['conditions']);
+        $ptr        = array_pop($conditions);
+        if (isset($this->tokens[$ptr]) === false
+            || ($this->tokens[$ptr]['code'] !== T_CLASS
+            && $this->tokens[$ptr]['code'] !== T_ANON_CLASS
+            && $this->tokens[$ptr]['code'] !== T_TRAIT)
+        ) {
+            if (isset($this->tokens[$ptr]) === true
+                && $this->tokens[$ptr]['code'] === T_INTERFACE
+            ) {
+                // T_VARIABLEs in interfaces can actually be method arguments
+                // but they wont be seen as being inside the method because there
+                // are no scope openers and closers for abstract methods. If it is in
+                // parentheses, we can be pretty sure it is a method argument.
+                if (isset($this->tokens[$stackPtr]['nested_parenthesis']) === false
+                    || empty($this->tokens[$stackPtr]['nested_parenthesis']) === true
+                ) {
+                    $error = 'Possible parse error: interfaces may not include member vars';
+                    $this->addWarning($error, $stackPtr, 'Internal.ParseError.InterfaceHasMemberVar');
+                    return [];
+                }
+            } else {
+                throw new RuntimeException('$stackPtr is not a class member var');
+            }
+        }
+
+        // Make sure it's not a method parameter.
+        if (empty($this->tokens[$stackPtr]['nested_parenthesis']) === false) {
+            $parenthesis = array_keys($this->tokens[$stackPtr]['nested_parenthesis']);
+            $deepestOpen = array_pop($parenthesis);
+            if ($deepestOpen > $ptr
+                && isset($this->tokens[$deepestOpen]['parenthesis_owner']) === true
+                && $this->tokens[$this->tokens[$deepestOpen]['parenthesis_owner']]['code'] === T_FUNCTION
+            ) {
+                throw new RuntimeException('$stackPtr is not a class member var');
+            }
+        }
+
+        $valid = [
+            T_PUBLIC    => T_PUBLIC,
+            T_PRIVATE   => T_PRIVATE,
+            T_PROTECTED => T_PROTECTED,
+            T_STATIC    => T_STATIC,
+            T_VAR       => T_VAR,
+        ];
+
+        $valid += Util\Tokens::$emptyTokens;
+
+        $scope          = 'public';
+        $scopeSpecified = false;
+        $isStatic       = false;
+
+        $startOfStatement = $this->findPrevious(
+            [
+                T_SEMICOLON,
+                T_OPEN_CURLY_BRACKET,
+                T_CLOSE_CURLY_BRACKET,
+            ],
+            ($stackPtr - 1)
+        );
+
+        for ($i = ($startOfStatement + 1); $i < $stackPtr; $i++) {
+            if (isset($valid[$this->tokens[$i]['code']]) === false) {
+                break;
+            }
+
+            switch ($this->tokens[$i]['code']) {
+            case T_PUBLIC:
+                $scope          = 'public';
+                $scopeSpecified = true;
+                break;
+            case T_PRIVATE:
+                $scope          = 'private';
+                $scopeSpecified = true;
+                break;
+            case T_PROTECTED:
+                $scope          = 'protected';
+                $scopeSpecified = true;
+                break;
+            case T_STATIC:
+                $isStatic = true;
+                break;
+            }
+        }//end for
+
+        $type         = '';
+        $typeToken    = false;
+        $typeEndToken = false;
+        $nullableType = false;
+
+        if ($i < $stackPtr) {
+            // We've found a type.
+            $valid = [
+                T_STRING       => T_STRING,
+                T_CALLABLE     => T_CALLABLE,
+                T_SELF         => T_SELF,
+                T_PARENT       => T_PARENT,
+                T_NS_SEPARATOR => T_NS_SEPARATOR,
+            ];
+
+            for ($i; $i < $stackPtr; $i++) {
+                if ($this->tokens[$i]['code'] === T_VARIABLE) {
+                    // Hit another variable in a group definition.
+                    break;
+                }
+
+                if ($this->tokens[$i]['code'] === T_NULLABLE) {
+                    $nullableType = true;
+                }
+
+                if (isset($valid[$this->tokens[$i]['code']]) === true) {
+                    $typeEndToken = $i;
+                    if ($typeToken === false) {
+                        $typeToken = $i;
+                    }
+
+                    $type .= $this->tokens[$i]['content'];
+                }
+            }
+
+            if ($type !== '' && $nullableType === true) {
+                $type = '?'.$type;
+            }
+        }//end if
+
+        return [
+            'scope'           => $scope,
+            'scope_specified' => $scopeSpecified,
+            'is_static'       => $isStatic,
+            'type'            => $type,
+            'type_token'      => $typeToken,
+            'type_end_token'  => $typeEndToken,
+            'nullable_type'   => $nullableType,
+        ];
+
+    }//end getMemberProperties()
+
+
+    /**
+     * Returns the visibility and implementation properties of a class.
+     *
+     * The format of the return value is:
+     * <code>
+     *   array(
+     *    'is_abstract' => false, // true if the abstract keyword was found.
+     *    'is_final'    => false, // true if the final keyword was found.
+     *   );
+     * </code>
+     *
+     * @param int $stackPtr The position in the stack of the T_CLASS token to
+     *                      acquire the properties for.
+     *
+     * @return array
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
+     *                                                      T_CLASS token.
+     */
+    public function getClassProperties($stackPtr)
+    {
+        if ($this->tokens[$stackPtr]['code'] !== T_CLASS) {
+            throw new RuntimeException('$stackPtr must be of type T_CLASS');
+        }
+
+        $valid = [
+            T_FINAL       => T_FINAL,
+            T_ABSTRACT    => T_ABSTRACT,
+            T_WHITESPACE  => T_WHITESPACE,
+            T_COMMENT     => T_COMMENT,
+            T_DOC_COMMENT => T_DOC_COMMENT,
+        ];
+
+        $isAbstract = false;
+        $isFinal    = false;
+
+        for ($i = ($stackPtr - 1); $i > 0; $i--) {
+            if (isset($valid[$this->tokens[$i]['code']]) === false) {
+                break;
+            }
+
+            switch ($this->tokens[$i]['code']) {
+            case T_ABSTRACT:
+                $isAbstract = true;
+                break;
+
+            case T_FINAL:
+                $isFinal = true;
+                break;
+            }
+        }//end for
+
+        return [
+            'is_abstract' => $isAbstract,
+            'is_final'    => $isFinal,
+        ];
+
+    }//end getClassProperties()
+
+
+    /**
+     * Determine if the passed token is a reference operator.
+     *
+     * Returns true if the specified token position represents a reference.
+     * Returns false if the token represents a bitwise operator.
+     *
+     * @param int $stackPtr The position of the T_BITWISE_AND token.
+     *
+     * @return boolean
+     */
+    public function isReference($stackPtr)
+    {
+        if ($this->tokens[$stackPtr]['code'] !== T_BITWISE_AND) {
+            return false;
+        }
+
+        $tokenBefore = $this->findPrevious(
+            Util\Tokens::$emptyTokens,
+            ($stackPtr - 1),
+            null,
+            true
+        );
+
+        if ($this->tokens[$tokenBefore]['code'] === T_FUNCTION) {
+            // Function returns a reference.
+            return true;
+        }
+
+        if ($this->tokens[$tokenBefore]['code'] === T_DOUBLE_ARROW) {
+            // Inside a foreach loop or array assignment, this is a reference.
+            return true;
+        }
+
+        if ($this->tokens[$tokenBefore]['code'] === T_AS) {
+            // Inside a foreach loop, this is a reference.
+            return true;
+        }
+
+        if (isset(Util\Tokens::$assignmentTokens[$this->tokens[$tokenBefore]['code']]) === true) {
+            // This is directly after an assignment. It's a reference. Even if
+            // it is part of an operation, the other tests will handle it.
+            return true;
+        }
+
+        $tokenAfter = $this->findNext(
+            Util\Tokens::$emptyTokens,
+            ($stackPtr + 1),
+            null,
+            true
+        );
+
+        if ($this->tokens[$tokenAfter]['code'] === T_NEW) {
+            return true;
+        }
+
+        if (isset($this->tokens[$stackPtr]['nested_parenthesis']) === true) {
+            $brackets    = $this->tokens[$stackPtr]['nested_parenthesis'];
+            $lastBracket = array_pop($brackets);
+            if (isset($this->tokens[$lastBracket]['parenthesis_owner']) === true) {
+                $owner = $this->tokens[$this->tokens[$lastBracket]['parenthesis_owner']];
+                if ($owner['code'] === T_FUNCTION
+                    || $owner['code'] === T_CLOSURE
+                ) {
+                    $params = $this->getMethodParameters($this->tokens[$lastBracket]['parenthesis_owner']);
+                    foreach ($params as $param) {
+                        $varToken = $tokenAfter;
+                        if ($param['variable_length'] === true) {
+                            $varToken = $this->findNext(
+                                (Util\Tokens::$emptyTokens + [T_ELLIPSIS]),
+                                ($stackPtr + 1),
+                                null,
+                                true
+                            );
+                        }
+
+                        if ($param['token'] === $varToken
+                            && $param['pass_by_reference'] === true
+                        ) {
+                            // Function parameter declared to be passed by reference.
+                            return true;
+                        }
+                    }
+                }//end if
+            } else {
+                $prev = false;
+                for ($t = ($this->tokens[$lastBracket]['parenthesis_opener'] - 1); $t >= 0; $t--) {
+                    if ($this->tokens[$t]['code'] !== T_WHITESPACE) {
+                        $prev = $t;
+                        break;
+                    }
+                }
+
+                if ($prev !== false && $this->tokens[$prev]['code'] === T_USE) {
+                    // Closure use by reference.
+                    return true;
+                }
+            }//end if
+        }//end if
+
+        // Pass by reference in function calls and assign by reference in arrays.
+        if ($this->tokens[$tokenBefore]['code'] === T_OPEN_PARENTHESIS
+            || $this->tokens[$tokenBefore]['code'] === T_COMMA
+            || $this->tokens[$tokenBefore]['code'] === T_OPEN_SHORT_ARRAY
+        ) {
+            if ($this->tokens[$tokenAfter]['code'] === T_VARIABLE) {
+                return true;
+            } else {
+                $skip   = Util\Tokens::$emptyTokens;
+                $skip[] = T_NS_SEPARATOR;
+                $skip[] = T_SELF;
+                $skip[] = T_PARENT;
+                $skip[] = T_STATIC;
+                $skip[] = T_STRING;
+                $skip[] = T_NAMESPACE;
+                $skip[] = T_DOUBLE_COLON;
+
+                $nextSignificantAfter = $this->findNext(
+                    $skip,
+                    ($stackPtr + 1),
+                    null,
+                    true
+                );
+                if ($this->tokens[$nextSignificantAfter]['code'] === T_VARIABLE) {
+                    return true;
+                }
+            }//end if
+        }//end if
+
+        return false;
+
+    }//end isReference()
+
+
+    /**
+     * Returns the content of the tokens from the specified start position in
+     * the token stack for the specified length.
+     *
+     * @param int  $start       The position to start from in the token stack.
+     * @param int  $length      The length of tokens to traverse from the start pos.
+     * @param bool $origContent Whether the original content or the tab replaced
+     *                          content should be used.
+     *
+     * @return string The token contents.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position does not exist.
+     */
+    public function getTokensAsString($start, $length, $origContent=false)
+    {
+        if (is_int($start) === false || isset($this->tokens[$start]) === false) {
+            throw new RuntimeException('The $start position for getTokensAsString() must exist in the token stack');
+        }
+
+        if (is_int($length) === false || $length <= 0) {
+            return '';
+        }
+
+        $str = '';
+        $end = ($start + $length);
+        if ($end > $this->numTokens) {
+            $end = $this->numTokens;
+        }
+
+        for ($i = $start; $i < $end; $i++) {
+            // If tabs are being converted to spaces by the tokeniser, the
+            // original content should be used instead of the converted content.
+            if ($origContent === true && isset($this->tokens[$i]['orig_content']) === true) {
+                $str .= $this->tokens[$i]['orig_content'];
+            } else {
+                $str .= $this->tokens[$i]['content'];
+            }
+        }
+
+        return $str;
+
+    }//end getTokensAsString()
+
+
+    /**
+     * Returns the position of the first non-whitespace token in a statement.
+     *
+     * @param int       $start  The position to start searching from in the token stack.
+     * @param int|array $ignore Token types that should not be considered stop points.
+     *
+     * @return int
+     */
+    public function findStartOfStatement($start, $ignore=null)
+    {
+        $endTokens = Util\Tokens::$blockOpeners;
+
+        $endTokens[T_COLON]            = true;
+        $endTokens[T_COMMA]            = true;
+        $endTokens[T_DOUBLE_ARROW]     = true;
+        $endTokens[T_SEMICOLON]        = true;
+        $endTokens[T_OPEN_TAG]         = true;
+        $endTokens[T_CLOSE_TAG]        = true;
+        $endTokens[T_OPEN_SHORT_ARRAY] = true;
+
+        if ($ignore !== null) {
+            $ignore = (array) $ignore;
+            foreach ($ignore as $code) {
+                unset($endTokens[$code]);
+            }
+        }
+
+        $lastNotEmpty = $start;
+
+        for ($i = $start; $i >= 0; $i--) {
+            if (isset($endTokens[$this->tokens[$i]['code']]) === true) {
+                // Found the end of the previous statement.
+                return $lastNotEmpty;
+            }
+
+            if (isset($this->tokens[$i]['scope_opener']) === true
+                && $i === $this->tokens[$i]['scope_closer']
+            ) {
+                // Found the end of the previous scope block.
+                return $lastNotEmpty;
+            }
+
+            // Skip nested statements.
+            if (isset($this->tokens[$i]['bracket_opener']) === true
+                && $i === $this->tokens[$i]['bracket_closer']
+            ) {
+                $i = $this->tokens[$i]['bracket_opener'];
+            } else if (isset($this->tokens[$i]['parenthesis_opener']) === true
+                && $i === $this->tokens[$i]['parenthesis_closer']
+            ) {
+                $i = $this->tokens[$i]['parenthesis_opener'];
+            }
+
+            if (isset(Util\Tokens::$emptyTokens[$this->tokens[$i]['code']]) === false) {
+                $lastNotEmpty = $i;
+            }
+        }//end for
+
+        return 0;
+
+    }//end findStartOfStatement()
+
+
+    /**
+     * Returns the position of the last non-whitespace token in a statement.
+     *
+     * @param int       $start  The position to start searching from in the token stack.
+     * @param int|array $ignore Token types that should not be considered stop points.
+     *
+     * @return int
+     */
+    public function findEndOfStatement($start, $ignore=null)
+    {
+        $endTokens = [
+            T_COLON                => true,
+            T_COMMA                => true,
+            T_DOUBLE_ARROW         => true,
+            T_SEMICOLON            => true,
+            T_CLOSE_PARENTHESIS    => true,
+            T_CLOSE_SQUARE_BRACKET => true,
+            T_CLOSE_CURLY_BRACKET  => true,
+            T_CLOSE_SHORT_ARRAY    => true,
+            T_OPEN_TAG             => true,
+            T_CLOSE_TAG            => true,
+        ];
+
+        if ($ignore !== null) {
+            $ignore = (array) $ignore;
+            foreach ($ignore as $code) {
+                unset($endTokens[$code]);
+            }
+        }
+
+        $lastNotEmpty = $start;
+
+        for ($i = $start; $i < $this->numTokens; $i++) {
+            if ($i !== $start && isset($endTokens[$this->tokens[$i]['code']]) === true) {
+                // Found the end of the statement.
+                if ($this->tokens[$i]['code'] === T_CLOSE_PARENTHESIS
+                    || $this->tokens[$i]['code'] === T_CLOSE_SQUARE_BRACKET
+                    || $this->tokens[$i]['code'] === T_CLOSE_CURLY_BRACKET
+                    || $this->tokens[$i]['code'] === T_CLOSE_SHORT_ARRAY
+                    || $this->tokens[$i]['code'] === T_OPEN_TAG
+                    || $this->tokens[$i]['code'] === T_CLOSE_TAG
+                ) {
+                    return $lastNotEmpty;
+                }
+
+                return $i;
+            }
+
+            // Skip nested statements.
+            if (isset($this->tokens[$i]['scope_closer']) === true
+                && ($i === $this->tokens[$i]['scope_opener']
+                || $i === $this->tokens[$i]['scope_condition'])
+            ) {
+                if ($i === $start && isset(Util\Tokens::$scopeOpeners[$this->tokens[$i]['code']]) === true) {
+                    return $this->tokens[$i]['scope_closer'];
+                }
+
+                $i = $this->tokens[$i]['scope_closer'];
+            } else if (isset($this->tokens[$i]['bracket_closer']) === true
+                && $i === $this->tokens[$i]['bracket_opener']
+            ) {
+                $i = $this->tokens[$i]['bracket_closer'];
+            } else if (isset($this->tokens[$i]['parenthesis_closer']) === true
+                && $i === $this->tokens[$i]['parenthesis_opener']
+            ) {
+                $i = $this->tokens[$i]['parenthesis_closer'];
+            } else if ($this->tokens[$i]['code'] === T_OPEN_USE_GROUP) {
+                $end = $this->findNext(T_CLOSE_USE_GROUP, ($i + 1));
+                if ($end !== false) {
+                    $i = $end;
+                }
+            }
+
+            if (isset(Util\Tokens::$emptyTokens[$this->tokens[$i]['code']]) === false) {
+                $lastNotEmpty = $i;
+            }
+        }//end for
+
+        return ($this->numTokens - 1);
+
+    }//end findEndOfStatement()
+
+
+    /**
+     * Determine if the passed token has a condition of one of the passed types.
+     *
+     * @param int              $stackPtr The position of the token we are checking.
+     * @param int|string|array $types    The type(s) of tokens to search for.
+     *
+     * @return boolean
+     */
+    public function hasCondition($stackPtr, $types)
+    {
+        // Check for the existence of the token.
+        if (isset($this->tokens[$stackPtr]) === false) {
+            return false;
+        }
+
+        // Make sure the token has conditions.
+        if (isset($this->tokens[$stackPtr]['conditions']) === false) {
+            return false;
+        }
+
+        $types      = (array) $types;
+        $conditions = $this->tokens[$stackPtr]['conditions'];
+
+        foreach ($types as $type) {
+            if (in_array($type, $conditions, true) === true) {
+                // We found a token with the required type.
+                return true;
+            }
+        }
+
+        return false;
+
+    }//end hasCondition()
+
+
+    /**
+     * Return the position of the condition for the passed token.
+     *
+     * Returns FALSE if the token does not have the condition.
+     *
+     * @param int        $stackPtr The position of the token we are checking.
+     * @param int|string $type     The type of token to search for.
+     *
+     * @return int
+     */
+    public function getCondition($stackPtr, $type)
+    {
+        // Check for the existence of the token.
+        if (isset($this->tokens[$stackPtr]) === false) {
+            return false;
+        }
+
+        // Make sure the token has conditions.
+        if (isset($this->tokens[$stackPtr]['conditions']) === false) {
+            return false;
+        }
+
+        $conditions = $this->tokens[$stackPtr]['conditions'];
+        foreach ($conditions as $token => $condition) {
+            if ($condition === $type) {
+                return $token;
+            }
+        }
+
+        return false;
+
+    }//end getCondition()
+
+
+    /**
+     * Returns the name of the class that the specified class extends.
+     * (works for classes, anonymous classes and interfaces)
+     *
+     * Returns FALSE on error or if there is no extended class name.
+     *
+     * @param int $stackPtr The stack position of the class.
+     *
+     * @return string|false
+     */
+    public function findExtendedClassName($stackPtr)
+    {
+        // Check for the existence of the token.
+        if (isset($this->tokens[$stackPtr]) === false) {
+            return false;
+        }
+
+        if ($this->tokens[$stackPtr]['code'] !== T_CLASS
+            && $this->tokens[$stackPtr]['code'] !== T_ANON_CLASS
+            && $this->tokens[$stackPtr]['code'] !== T_INTERFACE
+        ) {
+            return false;
+        }
+
+        if (isset($this->tokens[$stackPtr]['scope_opener']) === false) {
+            return false;
+        }
+
+        $classOpenerIndex = $this->tokens[$stackPtr]['scope_opener'];
+        $extendsIndex     = $this->findNext(T_EXTENDS, $stackPtr, $classOpenerIndex);
+        if (false === $extendsIndex) {
+            return false;
+        }
+
+        $find = [
+            T_NS_SEPARATOR,
+            T_STRING,
+            T_WHITESPACE,
+        ];
+
+        $end  = $this->findNext($find, ($extendsIndex + 1), ($classOpenerIndex + 1), true);
+        $name = $this->getTokensAsString(($extendsIndex + 1), ($end - $extendsIndex - 1));
+        $name = trim($name);
+
+        if ($name === '') {
+            return false;
+        }
+
+        return $name;
+
+    }//end findExtendedClassName()
+
+
+    /**
+     * Returns the names of the interfaces that the specified class implements.
+     *
+     * Returns FALSE on error or if there are no implemented interface names.
+     *
+     * @param int $stackPtr The stack position of the class.
+     *
+     * @return array|false
+     */
+    public function findImplementedInterfaceNames($stackPtr)
+    {
+        // Check for the existence of the token.
+        if (isset($this->tokens[$stackPtr]) === false) {
+            return false;
+        }
+
+        if ($this->tokens[$stackPtr]['code'] !== T_CLASS
+            && $this->tokens[$stackPtr]['code'] !== T_ANON_CLASS
+        ) {
+            return false;
+        }
+
+        if (isset($this->tokens[$stackPtr]['scope_closer']) === false) {
+            return false;
+        }
+
+        $classOpenerIndex = $this->tokens[$stackPtr]['scope_opener'];
+        $implementsIndex  = $this->findNext(T_IMPLEMENTS, $stackPtr, $classOpenerIndex);
+        if ($implementsIndex === false) {
+            return false;
+        }
+
+        $find = [
+            T_NS_SEPARATOR,
+            T_STRING,
+            T_WHITESPACE,
+            T_COMMA,
+        ];
+
+        $end  = $this->findNext($find, ($implementsIndex + 1), ($classOpenerIndex + 1), true);
+        $name = $this->getTokensAsString(($implementsIndex + 1), ($end - $implementsIndex - 1));
+        $name = trim($name);
+
+        if ($name === '') {
+            return false;
+        } else {
+            $names = explode(',', $name);
+            $names = array_map('trim', $names);
+            return $names;
+        }
+
+    }//end findImplementedInterfaceNames()
+
+
+}//end class

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -186,6 +186,8 @@ class BCFile
      *                  will be set in a "reference_token" array index.
      *                - If the param is variable length, the position of the variadic operator will
      *                  be set in a "variadic_token" array index.
+     * - PHPCS 3.5.3: Fixed a bug where the "type_hint_end_token" array index for a type hinted
+     *                parameter would bleed through to the next (non-type hinted) parameter.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodParameters() Original source.
      *
@@ -388,16 +390,18 @@ class BCFile
                     }
 
                     // Reset the vars, as we are about to process the next parameter.
-                    $defaultStart    = null;
-                    $equalToken      = null;
-                    $paramStart      = ($i + 1);
-                    $passByReference = false;
-                    $referenceToken  = false;
-                    $variableLength  = false;
-                    $variadicToken   = false;
-                    $typeHint        = '';
-                    $typeHintToken   = false;
-                    $nullableType    = false;
+                    $currVar          = null;
+                    $paramStart       = ($i + 1);
+                    $defaultStart     = null;
+                    $equalToken       = null;
+                    $passByReference  = false;
+                    $referenceToken   = false;
+                    $variableLength   = false;
+                    $variadicToken    = false;
+                    $typeHint         = '';
+                    $typeHintToken    = false;
+                    $typeHintEndToken = false;
+                    $nullableType     = false;
 
                     $paramCount++;
                     break;

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -152,6 +152,43 @@ class BCFile
      *         'default_token'       => integer, // The stack pointer to the start of the default value.
      *         'default_equal_token' => integer, // The stack pointer to the equals sign.
      *
+     * PHPCS cross-version compatible version of the File::getMethodParameters() method.
+     *
+     * Changelog for the PHPCS native function:
+     * - Introduced in PHPCS 0.0.5.
+     * - PHPCS 2.8.0: Now recognises `self` as a valid type declaration.
+     * - PHPCS 2.8.0: The return array now contains a new "token" index containing the stack pointer
+     *                to the variable.
+     * - PHPCS 2.8.0: The return array now contains a new "content" index containing the raw content
+     *                of the param definition.
+     * - PHPCS 2.8.0: Added support for nullable types.
+     *                - The return array now contains a new "nullable_type" index set to true or false
+     *                  for each method parameter.
+     * - PHPCS 2.8.0: Added support for closures.
+     * - PHPCS 3.0.0: The Exception thrown changed from a `PHP_CodeSniffer_Exception` to
+     *                `\PHP_CodeSniffer\Exceptions\TokenizerException`.
+     * - PHPCS 3.3.0: The return array now contains a new "type_hint_token" array index.
+     *                - Provides the position in the token stack of the first token in the type declaration.
+     * - PHPCS 3.3.1: Fixed incompatibility with PHP 7.3.
+     * - PHPCS 3.5.0: The Exception thrown changed from a `TokenizerException` to
+     *                `\PHP_CodeSniffer\Exceptions\RuntimeException`.
+     * - PHPCS 3.5.0: Added support for closure USE groups.
+     * - PHPCS 3.5.0: The return array now contains yet more more information.
+     *                - If a type hint is specified, the position of the last token in the hint will be
+     *                  set in a "type_hint_end_token" array index.
+     *                - If a default is specified, the position of the first token in the default value
+     *                  will be set in a "default_token" array index.
+     *                - If a default is specified, the position of the equals sign will be set in a
+     *                  "default_equal_token" array index.
+     *                - If the param is not the last, the position of the comma will be set in a
+     *                  "comma_token" array index.
+     *                - If the param is passed by reference, the position of the reference operator
+     *                  will be set in a "reference_token" array index.
+     *                - If the param is variable length, the position of the variadic operator will
+     *                  be set in a "variadic_token" array index.
+     *
+     * @see \PHP_CodeSniffer\Files\File::getMethodParameters() Original source.
+     *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -807,7 +807,7 @@ class BCFile
     }
 
     /**
-     * Returns the visibility and implementation properties of a class.
+     * Returns the implementation properties of a class.
      *
      * The format of the return value is:
      * <code>

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -62,11 +62,11 @@ class BCFile
      *                                               trait, or function.
      *
      * @return string|null The name of the class, interface, trait, or function;
-     *                     or NULL if the function or class is anonymous.
+     *                     or NULL if the function or class is anonymous or
+     *                     in case of a parse error/live coding.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified token is not of type
-     *                                                      T_FUNCTION, T_CLASS, T_ANON_CLASS,
-     *                                                      T_CLOSURE, T_TRAIT, or T_INTERFACE.
+     *                                                      T_FUNCTION, T_CLASS, T_TRAIT, or T_INTERFACE.
      */
     public static function getDeclarationName(File $phpcsFile, $stackPtr)
     {

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -623,6 +623,29 @@ class BCFile
      *   );
      * </code>
      *
+     * PHPCS cross-version compatible version of the File::getMemberProperties() method.
+     *
+     * Changelog for the PHPCS native function:
+     * - Introduced in PHPCS 0.0.5.
+     * - PHPCS 3.0.0: The Exception thrown changed from a `PHP_CodeSniffer_Exception` to
+     *                `\PHP_CodeSniffer\Exceptions\TokenizerException`.
+     * - PHPCS 3.4.0: Fixed method params being recognized as properties, PHPCS#2214.
+     * - PHPCS 3.5.0: New `type`, `type_token`, `type_end_token` and `nullable_type` array indexes.
+     *                - The `type` index contains the type of the member var, or a blank string
+     *                  if not specified.
+     *                - If the type is nullable, `type` will contain the leading `?`.
+     *                - If a type is specified, the position of the first token in the type will
+     *                  be set in a `type_token` array index.
+     *                - If a type is specified, the position of the last token in the type will
+     *                  be set in a `type_end_token` array index.
+     *                - If the type is nullable, a `nullable_type` array index will also be set to TRUE.
+     *                - If the type contains namespace information, it will be cleaned of whitespace
+     *                  and comments in the `type` value.
+     * - PHPCS 3.5.0: The Exception thrown changed from a `TokenizerException` to
+     *                `\PHP_CodeSniffer\Exceptions\RuntimeException`.
+     *
+     * @see \PHP_CodeSniffer\Files\File::getMemberProperties() Original source.
+     *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -817,6 +817,17 @@ class BCFile
      *   );
      * </code>
      *
+     * PHPCS cross-version compatible version of the File::getClassProperties() method.
+     *
+     * Changelog for the PHPCS native function:
+     * - Introduced in PHPCS 1.3.0.
+     * - PHPCS 3.0.0: The Exception thrown changed from a `PHP_CodeSniffer_Exception` to
+     *                `\PHP_CodeSniffer\Exceptions\TokenizerException`.
+     * - PHPCS 3.5.0: The Exception thrown changed from a `TokenizerException` to
+     *                `\PHP_CodeSniffer\Exceptions\RuntimeException`.
+     *
+     * @see \PHP_CodeSniffer\Files\File::getClassProperties() Original source.
+     *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1024,6 +1024,18 @@ class BCFile
      * Returns the content of the tokens from the specified start position in
      * the token stack for the specified length.
      *
+     * PHPCS cross-version compatible version of the File::getTokensAsString() method.
+     *
+     * Changelog for the PHPCS native function:
+     * - Introduced in PHPCS 0.0.5.
+     * - PHPCS 3.3.0: New `$origContent` parameter to optionally return original
+     *                (non tab-replaced) content.
+     * - PHPCS 3.4.0: - Now throws a `RuntimeException` if the $start param is invalid.
+     *                  This stops an infinite loop when the function is passed invalid data.
+     *                - If the $length param is invalid, an empty string will be returned.
+     *
+     * @see \PHP_CodeSniffer\Files\File::getTokensAsString() Original source.
+     *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being scanned.

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -2,8 +2,27 @@
 /**
  * Represents a piece of content being checked during the run.
  *
+ * The methods in this class are imported from the PHP_CodeSniffer project.
+ * Note: this is not a one-on-one import of the `File` class!
+ *
+ * Copyright of the original code in this class as per the import:
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @author    Jaroslav Hanslík <kukulich@kukulich.cz>
+ * @author    jdavis <jdavis@bamboohr.com>
+ * @author    Klaus Purer <klaus.purer@gmail.com>
+ * @author    Juliette Reinders Folmer <jrf@phpcodesniffer.info>
+ * @author    Nick Wilde <nick@briarmoon.ca>
+ * @author    Martin Hujer <mhujer@gmail.com>
+ * @author    Chris Wilkinson <c.wilkinson@elifesciences.org>
+ *
+ * With documentation contributions from:
+ * @author    Pascal Borreli <pascal@borreli.com>
+ * @author    Diogo Oliveira de Melo <dmelo87@gmail.com>
+ * @author    Stefano Kowalke <blueduck@gmx.net>
+ * @author    George Mponos <gmponos@gmail.com>
+ * @author    Tyson Andre <tysonandre775@hotmail.com>
+ *
+ * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1156,6 +1156,17 @@ class BCFile
     /**
      * Returns the position of the last non-whitespace token in a statement.
      *
+     * PHPCS cross-version compatible version of the File::findEndOfStatement() method.
+     *
+     * Changelog for the PHPCS native function:
+     * - Introduced in PHPCS 2.1.0.
+     * - PHPCS 2.6.2: New optional `$ignore` parameter to selectively ignore stop points.
+     * - PHPCS 2.7.1: Improved handling of short arrays, PHPCS #1203.
+     * - PHPCS 3.3.0: Bug fix: end of statement detection when passed a scope opener, PHPCS #1863.
+     * - PHPCS 3.5.0: Improved handling of group use statements.
+     *
+     * @see \PHP_CodeSniffer\Files\File::findEndOfStatement() Original source.
+     *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -915,12 +915,7 @@ class BCFile
             return false;
         }
 
-        $tokenBefore = $phpcsFile->findPrevious(
-            Tokens::$emptyTokens,
-            ($stackPtr - 1),
-            null,
-            true
-        );
+        $tokenBefore = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
         if ($tokens[$tokenBefore]['code'] === T_FUNCTION) {
             // Function returns a reference.
@@ -943,12 +938,7 @@ class BCFile
             return true;
         }
 
-        $tokenAfter = $phpcsFile->findNext(
-            Tokens::$emptyTokens,
-            ($stackPtr + 1),
-            null,
-            true
-        );
+        $tokenAfter = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
         if ($tokens[$tokenAfter]['code'] === T_NEW) {
             return true;

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1409,6 +1409,14 @@ class BCFile
     /**
      * Returns the names of the interfaces that the specified class implements.
      *
+     * PHPCS cross-version compatible version of the File::findImplementedInterfaceNames() method.
+     *
+     * Changelog for the PHPCS native function:
+     * - Introduced in PHPCS 2.7.0.
+     * - PHPCS 2.8.0: Now supports anonymous classes.
+     *
+     * @see \PHP_CodeSniffer\Files\File::findImplementedInterfaceNames() Original source.
+     *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -41,9 +41,35 @@ use PHPCSUtils\BackCompat\BCTokens;
 /**
  * PHPCS native utility functions.
  *
- * Backport the latest version of PHPCS native utility functions to make them
- * available to older PHPCS version without the bugs and other quirks that the
+ * Backport of the latest versions of PHPCS native utility functions to make them
+ * available in older PHPCS versions without the bugs and other quirks that the
  * older versions of the native functions had.
+ *
+ * Additionally, this class works round the following tokenizer issues for
+ * any affected utility functions:
+ * - Array return type declarations were incorrectly tokenized to `T_ARRAY_HINT`
+ *   instead of `T_RETURN_TYPE` in some circumstances prior to PHPCS 2.8.0.
+ * - `T_NULLABLE` was not available prior to PHPCS 2.8.0 and utility functions did
+ *   not take nullability of types into account.
+ * - The PHPCS native ignore annotations were not available prior to PHPCS 3.2.0.
+ * - The way return types were tokenized has changed in PHPCS 3.3.0.
+ *   Previously a lot of them were tokenized as `T_RETURN_HINT`. For namespaced
+ *   classnames this only tokenized the classname, not the whole return type.
+ *   Now tokenization is "normalized" with most tokens being `T_STRING`, including
+ *   array return type declarations.
+ * - Typed properties were not recognized prior to PHPCS 3.5.0, including the
+ *   `?` nullability token not being converted to `T_NULLABLE`.
+ * - General PHP cross-version incompatibilities.
+ *
+ * Most functions in this class will have a related twin-function in the relevant
+ * class in the `PHPCSUtils\Utils` namespace.
+ * These will be indicated with `@see` tags in the docblock of the function.
+ *
+ * The PHPCSUtils native twin-functions will often have additional features and/or
+ * improved functionality, but will generally be fully compatible with the PHPCS
+ * native functions.
+ * The differences between the functions here and the twin functions are documented
+ * in the docblock of the respective twin-function.
  *
  * @see \PHP_CodeSniffer\Files\File Source of these utility methods.
  *

--- a/Tests/BackCompat/BCFile/FindEndOfStatementTest.inc
+++ b/Tests/BackCompat/BCFile/FindEndOfStatementTest.inc
@@ -1,0 +1,31 @@
+<?php
+
+/* testSimpleAssignment */
+$a = false;
+
+/* testControlStructure */
+while(true) {}
+$a = 1;
+
+/* testClosureAssignment */
+$a = function($b=false;){};
+
+/* testHeredocFunctionArg */
+myFunction(<<<END
+Foo
+END
+, 'bar');
+
+/* testSwitch */
+switch ($a) {
+    case 1: {break;}
+    default: {break;}
+}
+
+/* testStatementAsArrayValue */
+$a = [new Datetime];
+$a = array(new Datetime);
+$a = new Datetime;
+
+/* testUseGroup */
+use Vendor\Package\{ClassA as A, ClassB, ClassC as C};

--- a/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File:findEndOfStatement method.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\File;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+
+class FindEndOfStatementTest extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Test a simple assignment.
+     *
+     * @return void
+     */
+    public function testSimpleAssignment()
+    {
+        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testSimpleAssignment */') + 2);
+        $found = self::$phpcsFile->findEndOfStatement($start);
+
+        $tokens = self::$phpcsFile->getTokens();
+        $this->assertSame($tokens[($start + 5)], $tokens[$found]);
+
+    }//end testSimpleAssignment()
+
+
+    /**
+     * Test a direct call to a control structure.
+     *
+     * @return void
+     */
+    public function testControlStructure()
+    {
+        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testControlStructure */') + 2);
+        $found = self::$phpcsFile->findEndOfStatement($start);
+
+        $tokens = self::$phpcsFile->getTokens();
+        $this->assertSame($tokens[($start + 6)], $tokens[$found]);
+
+    }//end testControlStructure()
+
+
+    /**
+     * Test the assignment of a closure.
+     *
+     * @return void
+     */
+    public function testClosureAssignment()
+    {
+        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testClosureAssignment */') + 2);
+        $found = self::$phpcsFile->findEndOfStatement($start);
+
+        $tokens = self::$phpcsFile->getTokens();
+        $this->assertSame($tokens[($start + 13)], $tokens[$found]);
+
+    }//end testClosureAssignment()
+
+
+    /**
+     * Test using a heredoc in a function argument.
+     *
+     * @return void
+     */
+    public function testHeredocFunctionArg()
+    {
+        // Find the end of the function.
+        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testHeredocFunctionArg */') + 2);
+        $found = self::$phpcsFile->findEndOfStatement($start);
+
+        $tokens = self::$phpcsFile->getTokens();
+        $this->assertSame($tokens[($start + 10)], $tokens[$found]);
+
+        // Find the end of the heredoc.
+        $start += 2;
+        $found  = self::$phpcsFile->findEndOfStatement($start);
+
+        $tokens = self::$phpcsFile->getTokens();
+        $this->assertSame($tokens[($start + 4)], $tokens[$found]);
+
+        // Find the end of the last arg.
+        $start = ($found + 2);
+        $found = self::$phpcsFile->findEndOfStatement($start);
+
+        $tokens = self::$phpcsFile->getTokens();
+        $this->assertSame($tokens[$start], $tokens[$found]);
+
+    }//end testHeredocFunctionArg()
+
+
+    /**
+     * Test parts of a switch statement.
+     *
+     * @return void
+     */
+    public function testSwitch()
+    {
+        // Find the end of the switch.
+        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testSwitch */') + 2);
+        $found = self::$phpcsFile->findEndOfStatement($start);
+
+        $tokens = self::$phpcsFile->getTokens();
+        $this->assertSame($tokens[($start + 28)], $tokens[$found]);
+
+        // Find the end of the case.
+        $start += 9;
+        $found  = self::$phpcsFile->findEndOfStatement($start);
+
+        $tokens = self::$phpcsFile->getTokens();
+        $this->assertSame($tokens[($start + 8)], $tokens[$found]);
+
+        // Find the end of default case.
+        $start += 11;
+        $found  = self::$phpcsFile->findEndOfStatement($start);
+
+        $tokens = self::$phpcsFile->getTokens();
+        $this->assertSame($tokens[($start + 6)], $tokens[$found]);
+
+    }//end testSwitch()
+
+
+    /**
+     * Test statements that are array values.
+     *
+     * @return void
+     */
+    public function testStatementAsArrayValue()
+    {
+        // Test short array syntax.
+        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testStatementAsArrayValue */') + 7);
+        $found = self::$phpcsFile->findEndOfStatement($start);
+
+        $tokens = self::$phpcsFile->getTokens();
+        $this->assertSame($tokens[($start + 2)], $tokens[$found]);
+
+        // Test long array syntax.
+        $start += 12;
+        $found  = self::$phpcsFile->findEndOfStatement($start);
+
+        $tokens = self::$phpcsFile->getTokens();
+        $this->assertSame($tokens[($start + 2)], $tokens[$found]);
+
+        // Test same statement outside of array.
+        $start += 10;
+        $found  = self::$phpcsFile->findEndOfStatement($start);
+
+        $tokens = self::$phpcsFile->getTokens();
+        $this->assertSame($tokens[($start + 3)], $tokens[$found]);
+
+    }//end testStatementAsArrayValue()
+
+
+    /**
+     * Test a use group.
+     *
+     * @return void
+     */
+    public function testUseGroup()
+    {
+        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testUseGroup */') + 2);
+        $found = self::$phpcsFile->findEndOfStatement($start);
+
+        $tokens = self::$phpcsFile->getTokens();
+        $this->assertSame($tokens[($start + 23)], $tokens[$found]);
+
+    }//end testUseGroup()
+
+
+}//end class

--- a/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
@@ -2,7 +2,15 @@
 /**
  * Tests for the \PHP_CodeSniffer\Files\File:findEndOfStatement method.
  *
+ * This class is imported from the PHP_CodeSniffer project.
+ *
+ * Copyright of the original code in this class as per the import:
  * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Juliette Reinders Folmer <jrf@phpcodesniffer.info>
+ *
+ * With documentation contributions from:
+ * @author    Phil Davis <phil@jankaritech.com>
+
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */

--- a/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+/**
  * Tests for the \PHP_CodeSniffer\Files\File:findEndOfStatement method.
  *
  * This class is imported from the PHP_CodeSniffer project.
@@ -20,9 +27,15 @@ namespace PHPCSUtils\Tests\BackCompat\BCFile;
 use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
+/**
+ * Tests for the \PHPCSUtils\BackCompat\BCFile::findEndOfStatement method.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCFile::findEndOfStatement
+ *
+ * @since 1.0.0
+ */
 class FindEndOfStatementTest extends UtilityMethodTestCase
 {
-
 
     /**
      * Test a simple assignment.
@@ -36,9 +49,7 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 5)], $tokens[$found]);
-
-    }//end testSimpleAssignment()
-
+    }
 
     /**
      * Test a direct call to a control structure.
@@ -52,9 +63,7 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 6)], $tokens[$found]);
-
-    }//end testControlStructure()
-
+    }
 
     /**
      * Test the assignment of a closure.
@@ -68,9 +77,7 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 13)], $tokens[$found]);
-
-    }//end testClosureAssignment()
-
+    }
 
     /**
      * Test using a heredoc in a function argument.
@@ -99,9 +106,7 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[$start], $tokens[$found]);
-
-    }//end testHeredocFunctionArg()
-
+    }
 
     /**
      * Test parts of a switch statement.
@@ -130,9 +135,7 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 6)], $tokens[$found]);
-
-    }//end testSwitch()
-
+    }
 
     /**
      * Test statements that are array values.
@@ -161,9 +164,7 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 3)], $tokens[$found]);
-
-    }//end testStatementAsArrayValue()
-
+    }
 
     /**
      * Test a use group.
@@ -177,8 +178,5 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 23)], $tokens[$found]);
-
-    }//end testUseGroup()
-
-
-}//end class
+    }
+}

--- a/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
@@ -15,11 +15,12 @@
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-namespace PHP_CodeSniffer\Tests\Core\File;
+namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
-class FindEndOfStatementTest extends AbstractMethodUnitTest
+class FindEndOfStatementTest extends UtilityMethodTestCase
 {
 
 
@@ -31,7 +32,7 @@ class FindEndOfStatementTest extends AbstractMethodUnitTest
     public function testSimpleAssignment()
     {
         $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testSimpleAssignment */') + 2);
-        $found = self::$phpcsFile->findEndOfStatement($start);
+        $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 5)], $tokens[$found]);
@@ -47,7 +48,7 @@ class FindEndOfStatementTest extends AbstractMethodUnitTest
     public function testControlStructure()
     {
         $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testControlStructure */') + 2);
-        $found = self::$phpcsFile->findEndOfStatement($start);
+        $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 6)], $tokens[$found]);
@@ -63,7 +64,7 @@ class FindEndOfStatementTest extends AbstractMethodUnitTest
     public function testClosureAssignment()
     {
         $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testClosureAssignment */') + 2);
-        $found = self::$phpcsFile->findEndOfStatement($start);
+        $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 13)], $tokens[$found]);
@@ -80,21 +81,21 @@ class FindEndOfStatementTest extends AbstractMethodUnitTest
     {
         // Find the end of the function.
         $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testHeredocFunctionArg */') + 2);
-        $found = self::$phpcsFile->findEndOfStatement($start);
+        $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 10)], $tokens[$found]);
 
         // Find the end of the heredoc.
         $start += 2;
-        $found  = self::$phpcsFile->findEndOfStatement($start);
+        $found  = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 4)], $tokens[$found]);
 
         // Find the end of the last arg.
         $start = ($found + 2);
-        $found = self::$phpcsFile->findEndOfStatement($start);
+        $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[$start], $tokens[$found]);
@@ -111,21 +112,21 @@ class FindEndOfStatementTest extends AbstractMethodUnitTest
     {
         // Find the end of the switch.
         $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testSwitch */') + 2);
-        $found = self::$phpcsFile->findEndOfStatement($start);
+        $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 28)], $tokens[$found]);
 
         // Find the end of the case.
         $start += 9;
-        $found  = self::$phpcsFile->findEndOfStatement($start);
+        $found  = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 8)], $tokens[$found]);
 
         // Find the end of default case.
         $start += 11;
-        $found  = self::$phpcsFile->findEndOfStatement($start);
+        $found  = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 6)], $tokens[$found]);
@@ -142,21 +143,21 @@ class FindEndOfStatementTest extends AbstractMethodUnitTest
     {
         // Test short array syntax.
         $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testStatementAsArrayValue */') + 7);
-        $found = self::$phpcsFile->findEndOfStatement($start);
+        $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 2)], $tokens[$found]);
 
         // Test long array syntax.
         $start += 12;
-        $found  = self::$phpcsFile->findEndOfStatement($start);
+        $found  = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 2)], $tokens[$found]);
 
         // Test same statement outside of array.
         $start += 10;
-        $found  = self::$phpcsFile->findEndOfStatement($start);
+        $found  = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 3)], $tokens[$found]);
@@ -172,7 +173,7 @@ class FindEndOfStatementTest extends AbstractMethodUnitTest
     public function testUseGroup()
     {
         $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testUseGroup */') + 2);
-        $found = self::$phpcsFile->findEndOfStatement($start);
+        $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 23)], $tokens[$found]);

--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.inc
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace PHP_CodeSniffer\Tests\Core\File;
+
+class testFECNClass {}
+
+/* testExtendedClass */
+class testFECNExtendedClass extends testFECNClass {}
+
+/* testNamespacedClass */
+class testFECNNamespacedClass extends \PHP_CodeSniffer\Tests\Core\File\testFECNClass {}
+
+/* testNonExtendedClass */
+class testFECNNonExtendedClass {}
+
+/* testInterface */
+interface testFECNInterface {}
+
+/* testInterfaceThatExtendsInterface */
+interface testInterfaceThatExtendsInterface extends testFECNInterface{}
+
+/* testInterfaceThatExtendsFQCNInterface */
+interface testInterfaceThatExtendsFQCNInterface extends \PHP_CodeSniffer\Tests\Core\File\testFECNInterface{}
+
+/* testNestedExtendedClass */
+class testFECNNestedExtendedClass {
+	public function someMethod() {
+		/* testNestedExtendedAnonClass */
+		$anon = new class extends testFECNAnonClass {};
+	}
+}
+
+/* testClassThatExtendsAndImplements */
+class testFECNClassThatExtendsAndImplements extends testFECNClass implements InterfaceA, InterfaceB {}
+
+/* testClassThatImplementsAndExtends */
+class testFECNClassThatImplementsAndExtends implements InterfaceA, InterfaceB extends testFECNClass {}

--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.inc
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.inc
@@ -1,6 +1,7 @@
 <?php
 
-namespace PHP_CodeSniffer\Tests\Core\File;
+/* testNotAClass */
+function notAClass() {}
 
 class testFECNClass {}
 
@@ -24,10 +25,10 @@ interface testInterfaceThatExtendsFQCNInterface extends \PHP_CodeSniffer\Tests\C
 
 /* testNestedExtendedClass */
 class testFECNNestedExtendedClass {
-	public function someMethod() {
-		/* testNestedExtendedAnonClass */
-		$anon = new class extends testFECNAnonClass {};
-	}
+    public function someMethod() {
+        /* testNestedExtendedAnonClass */
+        $anon = new class extends testFECNAnonClass {};
+    }
 }
 
 /* testClassThatExtendsAndImplements */
@@ -35,3 +36,16 @@ class testFECNClassThatExtendsAndImplements extends testFECNClass implements Int
 
 /* testClassThatImplementsAndExtends */
 class testFECNClassThatImplementsAndExtends implements InterfaceA, InterfaceB extends testFECNClass {}
+
+/* testExtendedAnonClass */
+$anon = new class( $a, $b ) extends testFECNExtendedAnonClass {};
+
+/* testInterfaceMultiExtends */
+interface Multi extends \Package\FooInterface, \BarInterface {};
+
+/* testMissingExtendsName */
+class testMissingExtendsName extends { /* missing classname */ } // Internal parse error.
+
+// Intentional parse error. Has to be the last test in the file.
+/* testParseError */
+class testParseError extends testFECNClass

--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File:findExtendedClassName method.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\File;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+
+class FindExtendedClassNameTest extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Test retrieving the name of the class being extended by another class
+     * (or interface).
+     *
+     * @param string $identifier Comment which precedes the test case.
+     * @param bool   $expected   Expected function output.
+     *
+     * @dataProvider dataExtendedClass
+     *
+     * @return void
+     */
+    public function testFindExtendedClassName($identifier, $expected)
+    {
+        $OOToken = $this->getTargetToken($identifier, [T_CLASS, T_ANON_CLASS, T_INTERFACE]);
+        $result  = self::$phpcsFile->findExtendedClassName($OOToken);
+        $this->assertSame($expected, $result);
+
+    }//end testFindExtendedClassName()
+
+
+    /**
+     * Data provider for the FindExtendedClassName test.
+     *
+     * @see testFindExtendedClassName()
+     *
+     * @return array
+     */
+    public function dataExtendedClass()
+    {
+        return [
+            [
+                '/* testExtendedClass */',
+                'testFECNClass',
+            ],
+            [
+                '/* testNamespacedClass */',
+                '\PHP_CodeSniffer\Tests\Core\File\testFECNClass',
+            ],
+            [
+                '/* testNonExtendedClass */',
+                false,
+            ],
+            [
+                '/* testInterface */',
+                false,
+            ],
+            [
+                '/* testInterfaceThatExtendsInterface */',
+                'testFECNInterface',
+            ],
+            [
+                '/* testInterfaceThatExtendsFQCNInterface */',
+                '\PHP_CodeSniffer\Tests\Core\File\testFECNInterface',
+            ],
+            [
+                '/* testNestedExtendedClass */',
+                false,
+            ],
+            [
+                '/* testNestedExtendedAnonClass */',
+                'testFECNAnonClass',
+            ],
+            [
+                '/* testClassThatExtendsAndImplements */',
+                'testFECNClass',
+            ],
+            [
+                '/* testClassThatImplementsAndExtends */',
+                'testFECNClass',
+            ],
+        ];
+
+    }//end dataExtendedClass()
+
+
+}//end class

--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
@@ -17,11 +17,12 @@
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-namespace PHP_CodeSniffer\Tests\Core\File;
+namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
-class FindExtendedClassNameTest extends AbstractMethodUnitTest
+class FindExtendedClassNameTest extends UtilityMethodTestCase
 {
 
 
@@ -39,7 +40,7 @@ class FindExtendedClassNameTest extends AbstractMethodUnitTest
     public function testFindExtendedClassName($identifier, $expected)
     {
         $OOToken = $this->getTargetToken($identifier, [T_CLASS, T_ANON_CLASS, T_INTERFACE]);
-        $result  = self::$phpcsFile->findExtendedClassName($OOToken);
+        $result  = BCFile::findExtendedClassName(self::$phpcsFile, $OOToken);
         $this->assertSame($expected, $result);
 
     }//end testFindExtendedClassName()

--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
@@ -2,8 +2,18 @@
 /**
  * Tests for the \PHP_CodeSniffer\Files\File:findExtendedClassName method.
  *
+ * This class is imported from the PHP_CodeSniffer project.
+ *
+ * Copyright of the original code in this class as per the import:
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @author    Juliette Reinders Folmer <jrf@phpcodesniffer.info>
+ * @author    Martin Hujer <mhujer@gmail.com>
+ *
+ * With documentation contributions from:
+ * @author    George Mponos <gmponos@gmail.com>
+ * @author    Phil Davis <phil@jankaritech.com>
+ *
+ * @copyright 2016-2019 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 

--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
@@ -38,6 +38,29 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
 {
 
     /**
+     * Test getting a `false` result when a non-existent token is passed.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $result = BCFile::findExtendedClassName(self::$phpcsFile, 100000);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test getting a `false` result when a token other than one of the supported tokens is passed.
+     *
+     * @return void
+     */
+    public function testNotAClass()
+    {
+        $token  = $this->getTargetToken('/* testNotAClass */', [T_FUNCTION]);
+        $result = BCFile::findExtendedClassName(self::$phpcsFile, $token);
+        $this->assertFalse($result);
+    }
+
+    /**
      * Test retrieving the name of the class being extended by another class
      * (or interface).
      *
@@ -104,6 +127,22 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
             [
                 '/* testClassThatImplementsAndExtends */',
                 'testFECNClass',
+            ],
+            [
+                '/* testExtendedAnonClass */',
+                'testFECNExtendedAnonClass',
+            ],
+            [
+                '/* testInterfaceMultiExtends */',
+                '\Package\FooInterface',
+            ],
+            [
+                '/* testMissingExtendsName */',
+                false,
+            ],
+            [
+                '/* testParseError */',
+                false,
             ],
         ];
     }

--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
@@ -1,6 +1,11 @@
 <?php
 /**
- * Tests for the \PHP_CodeSniffer\Files\File:findExtendedClassName method.
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
  *
  * This class is imported from the PHP_CodeSniffer project.
  *
@@ -22,18 +27,24 @@ namespace PHPCSUtils\Tests\BackCompat\BCFile;
 use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
+/**
+ * Tests for the \PHPCSUtils\BackCompat\BCFile::findExtendedClassName method.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCFile::findExtendedClassName
+ *
+ * @since 1.0.0
+ */
 class FindExtendedClassNameTest extends UtilityMethodTestCase
 {
-
 
     /**
      * Test retrieving the name of the class being extended by another class
      * (or interface).
      *
+     * @dataProvider dataExtendedClass
+     *
      * @param string $identifier Comment which precedes the test case.
      * @param bool   $expected   Expected function output.
-     *
-     * @dataProvider dataExtendedClass
      *
      * @return void
      */
@@ -42,12 +53,10 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
         $OOToken = $this->getTargetToken($identifier, [T_CLASS, T_ANON_CLASS, T_INTERFACE]);
         $result  = BCFile::findExtendedClassName(self::$phpcsFile, $OOToken);
         $this->assertSame($expected, $result);
-
-    }//end testFindExtendedClassName()
-
+    }
 
     /**
-     * Data provider for the FindExtendedClassName test.
+     * Data provider.
      *
      * @see testFindExtendedClassName()
      *
@@ -97,8 +106,5 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
                 'testFECNClass',
             ],
         ];
-
-    }//end dataExtendedClass()
-
-
-}//end class
+    }
+}

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.inc
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace PHP_CodeSniffer\Tests\Core\File;
+
+interface testFIINInterface2 {}
+
+/* testInterface */
+interface testFIINInterface {}
+
+/* testImplementedClass */
+class testFIINImplementedClass implements testFIINInterface {}
+
+/* testMultiImplementedClass */
+class testFIINMultiImplementedClass implements testFIINInterface, testFIINInterface2 {}
+
+/* testNamespacedClass */
+class testFIINNamespacedClass implements \PHP_CodeSniffer\Tests\Core\File\testFIINInterface {}
+
+/* testNonImplementedClass */
+class testFIINNonImplementedClass {}
+
+/* testClassThatExtendsAndImplements */
+class testFECNClassThatExtendsAndImplements extends testFECNClass implements InterfaceA, \NameSpaced\Cat\InterfaceB {}
+
+/* testClassThatImplementsAndExtends */
+class testFECNClassThatImplementsAndExtends implements \InterfaceA, InterfaceB extends testFECNClass {}

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.inc
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.inc
@@ -1,6 +1,7 @@
 <?php
 
-namespace PHP_CodeSniffer\Tests\Core\File;
+/* testNotAClass */
+function notAClass() {}
 
 interface testFIINInterface2 {}
 
@@ -24,3 +25,13 @@ class testFECNClassThatExtendsAndImplements extends testFECNClass implements Int
 
 /* testClassThatImplementsAndExtends */
 class testFECNClassThatImplementsAndExtends implements \InterfaceA, InterfaceB extends testFECNClass {}
+
+/* testAnonClassImplements */
+$anon = class() implements testFIINInterface {}
+
+/* testMissingImplementsName */
+class testMissingExtendsName implements { /* missing interface name */  } // Internal parse error.
+
+// Intentional parse error. Has to be the last test in the file.
+/* testParseError */
+class testParseError implements testInterface

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File:findImplementedInterfaceNames method.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\File;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+
+class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Test retrieving the name(s) of the interfaces being implemented by a class.
+     *
+     * @param string $identifier Comment which precedes the test case.
+     * @param bool   $expected   Expected function output.
+     *
+     * @dataProvider dataImplementedInterface
+     *
+     * @return void
+     */
+    public function testFindImplementedInterfaceNames($identifier, $expected)
+    {
+        $OOToken = $this->getTargetToken($identifier, [T_CLASS, T_ANON_CLASS, T_INTERFACE]);
+        $result  = self::$phpcsFile->findImplementedInterfaceNames($OOToken);
+        $this->assertSame($expected, $result);
+
+    }//end testFindImplementedInterfaceNames()
+
+
+    /**
+     * Data provider for the FindImplementedInterfaceNames test.
+     *
+     * @see testFindImplementedInterfaceNames()
+     *
+     * @return array
+     */
+    public function dataImplementedInterface()
+    {
+        return [
+            [
+                '/* testImplementedClass */',
+                ['testFIINInterface'],
+            ],
+            [
+                '/* testMultiImplementedClass */',
+                [
+                    'testFIINInterface',
+                    'testFIINInterface2',
+                ],
+            ],
+            [
+                '/* testNamespacedClass */',
+                ['\PHP_CodeSniffer\Tests\Core\File\testFIINInterface'],
+            ],
+            [
+                '/* testNonImplementedClass */',
+                false,
+            ],
+            [
+                '/* testInterface */',
+                false,
+            ],
+            [
+                '/* testClassThatExtendsAndImplements */',
+                [
+                    'InterfaceA',
+                    '\NameSpaced\Cat\InterfaceB',
+                ],
+            ],
+            [
+                '/* testClassThatImplementsAndExtends */',
+                [
+                    '\InterfaceA',
+                    'InterfaceB',
+                ],
+            ],
+        ];
+
+    }//end dataImplementedInterface()
+
+
+}//end class

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
@@ -1,6 +1,11 @@
 <?php
 /**
- * Tests for the \PHP_CodeSniffer\Files\File:findImplementedInterfaceNames method.
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
  *
  * This class is imported from the PHP_CodeSniffer project.
  *
@@ -21,17 +26,23 @@ namespace PHPCSUtils\Tests\BackCompat\BCFile;
 use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
+/**
+ * Tests for the \PHPCSUtils\BackCompat\BCFile::findImplementedInterfaceNames method.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCFile::findImplementedInterfaceNames
+ *
+ * @since 1.0.0
+ */
 class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
 {
-
 
     /**
      * Test retrieving the name(s) of the interfaces being implemented by a class.
      *
+     * @dataProvider dataImplementedInterface
+     *
      * @param string $identifier Comment which precedes the test case.
      * @param bool   $expected   Expected function output.
-     *
-     * @dataProvider dataImplementedInterface
      *
      * @return void
      */
@@ -40,12 +51,10 @@ class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
         $OOToken = $this->getTargetToken($identifier, [T_CLASS, T_ANON_CLASS, T_INTERFACE]);
         $result  = BCFile::findImplementedInterfaceNames(self::$phpcsFile, $OOToken);
         $this->assertSame($expected, $result);
-
-    }//end testFindImplementedInterfaceNames()
-
+    }
 
     /**
-     * Data provider for the FindImplementedInterfaceNames test.
+     * Data provider.
      *
      * @see testFindImplementedInterfaceNames()
      *
@@ -92,8 +101,5 @@ class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
                 ],
             ],
         ];
-
-    }//end dataImplementedInterface()
-
-
-}//end class
+    }
+}

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
@@ -2,8 +2,17 @@
 /**
  * Tests for the \PHP_CodeSniffer\Files\File:findImplementedInterfaceNames method.
  *
+ * This class is imported from the PHP_CodeSniffer project.
+ *
+ * Copyright of the original code in this class as per the import:
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @author    Juliette Reinders Folmer <jrf@phpcodesniffer.info>
+ *
+ * With documentation contributions from:
+ * @author    George Mponos <gmponos@gmail.com>
+ * @author    Phil Davis <phil@jankaritech.com>
+ *
+ * @copyright 2016-2019 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
@@ -37,6 +37,29 @@ class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
 {
 
     /**
+     * Test getting a `false` result when a non-existent token is passed.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $result = BCFile::findImplementedInterfaceNames(self::$phpcsFile, 100000);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test getting a `false` result when a token other than one of the supported tokens is passed.
+     *
+     * @return void
+     */
+    public function testNotAClass()
+    {
+        $token  = $this->getTargetToken('/* testNotAClass */', [T_FUNCTION]);
+        $result = BCFile::findImplementedInterfaceNames(self::$phpcsFile, $token);
+        $this->assertFalse($result);
+    }
+
+    /**
      * Test retrieving the name(s) of the interfaces being implemented by a class.
      *
      * @dataProvider dataImplementedInterface
@@ -99,6 +122,18 @@ class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
                     '\InterfaceA',
                     'InterfaceB',
                 ],
+            ],
+            [
+                '/* testAnonClassImplements */',
+                ['testFIINInterface'],
+            ],
+            [
+                '/* testMissingImplementsName */',
+                false,
+            ],
+            [
+                '/* testParseError */',
+                false,
             ],
         ];
     }

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
@@ -16,11 +16,12 @@
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-namespace PHP_CodeSniffer\Tests\Core\File;
+namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
-class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
+class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
 {
 
 
@@ -37,7 +38,7 @@ class FindImplementedInterfaceNamesTest extends AbstractMethodUnitTest
     public function testFindImplementedInterfaceNames($identifier, $expected)
     {
         $OOToken = $this->getTargetToken($identifier, [T_CLASS, T_ANON_CLASS, T_INTERFACE]);
-        $result  = self::$phpcsFile->findImplementedInterfaceNames($OOToken);
+        $result  = BCFile::findImplementedInterfaceNames(self::$phpcsFile, $OOToken);
         $this->assertSame($expected, $result);
 
     }//end testFindImplementedInterfaceNames()

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.inc
@@ -1,0 +1,181 @@
+<?php
+
+class TestMemberProperties
+{
+    /* testVar */
+    var $varA = true;
+
+    /* testVarType */
+    var int $varA = true;
+
+    /* testPublic */
+    public $varB = true;
+
+    /* testPublicType */
+    public string $varB = true;
+
+    /* testProtected */
+    protected $varC = true;
+
+    /* testProtectedType */
+    protected bool $varC = true;
+
+    /* testPrivate */
+    private $varD = true;
+
+    /* testPrivateType */
+    private array $varD = true;
+
+    /* testStatic */
+    static $varE = true;
+
+    /* testStaticType */
+    static string $varE = true;
+
+    /* testStaticVar */
+    static var $varF = true;
+
+    /* testVarStatic */
+    var static $varG = true;
+
+    /* testPublicStatic */
+    public static $varH = true;
+
+    /* testProtectedStatic */
+    static protected $varI = true;
+
+    /* testPrivateStatic */
+    private static $varJ = true;
+
+    /* testNoPrefix */
+    $varK = true;
+
+    /* testPublicStaticWithDocblock */
+    /**
+     * Comment here.
+     *
+     * @phpcs:ignore Standard.Category.Sniff -- because
+     * @var boolean
+     */
+    public static $varH = true;
+
+    /* testProtectedStaticWithDocblock */
+    /**
+     * Comment here.
+     *
+     * @phpcs:ignore Standard.Category.Sniff -- because
+     * @var boolean
+     */
+    static protected $varI = true;
+
+    /* testPrivateStaticWithDocblock */
+    /**
+     * Comment here.
+     *
+     * @phpcs:ignore Standard.Category.Sniff -- because
+     * @var boolean
+     */
+    private static $varJ = true;
+
+    public float
+    /* testGroupType 1 */
+    $x,
+    /* testGroupType 2 */
+    $y;
+
+    public static ?string
+    /* testGroupNullableType 1 */
+    $x = null,
+    /* testGroupNullableType 2 */
+    $y = null;
+
+    protected static
+        /* testGroupProtectedStatic 1 */
+        $varL,
+        /* testGroupProtectedStatic 2 */
+        $varM,
+        /* testGroupProtectedStatic 3 */
+        $varN;
+
+    private
+        /* testGroupPrivate 1 */
+        $varO = true,
+        /* testGroupPrivate 2 */
+        $varP = array( 'a' => 'a', 'b' => 'b' ),
+        /* testGroupPrivate 3 */
+        $varQ = 'string',
+        /* testGroupPrivate 4 */
+        $varR = 123,
+        /* testGroupPrivate 5 */
+        $varS = ONE / self::THREE,
+        /* testGroupPrivate 6 */
+        $varT = [
+            'a' => 'a',
+            'b' => 'b'
+        ],
+        /* testGroupPrivate 7 */
+        $varU = __DIR__ . "/base";
+
+
+    /* testMethodParam */
+    public function methodName($param) {
+        /* testImportedGlobal */
+        global $importedGlobal = true;
+
+        /* testLocalVariable */
+        $localVariable = true;
+    }
+
+    /* testPropertyAfterMethod */
+    private static $varV = true;
+
+    /* testMessyNullableType */
+    public /* comment
+         */ ? //comment
+        array $foo = [];
+
+    /* testNamespaceType */
+    public \MyNamespace\MyClass $foo;
+
+    /* testNullableNamespaceType 1 */
+    private ?ClassName $nullableClassType;
+
+    /* testNullableNamespaceType 2 */
+    protected ?Folder\ClassName $nullableClassType2;
+
+    /* testMultilineNamespaceType */
+    public \MyNamespace /** comment *\/ comment */
+           \MyClass /* comment */
+           \Foo $foo;
+
+}
+
+interface Base
+{
+    /* testInterfaceProperty */
+    protected $anonymous;
+}
+
+/* testGlobalVariable */
+$globalVariable = true;
+
+/* testNotAVariable */
+return;
+
+$a = ( $foo == $bar ? new stdClass() :
+    new class() {
+        /* testNestedProperty 1 */
+        public $var = true;
+
+        /* testNestedMethodParam 1 */
+        public function something($var = false) {}
+    }
+);
+
+function_call( 'param', new class {
+    /* testNestedProperty 2 */
+    public $year = 2017;
+
+    /* testNestedMethodParam 2 */
+    public function __construct( $open, $post_id ) {}
+}, 10, 2 );

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.inc
@@ -39,7 +39,10 @@ class TestMemberProperties
     var static $varG = true;
 
     /* testPublicStatic */
-    public static $varH = true;
+    public // comment
+    // phpcs:ignore Stnd.Cat.Sniff -- For reasons.
+    static
+    $varH = true;
 
     /* testProtectedStatic */
     static protected $varI = true;

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -1,0 +1,524 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File::getMemberProperties method.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\File;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+
+class GetMemberPropertiesTest extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Test the getMemberProperties() method.
+     *
+     * @param string $identifier Comment which precedes the test case.
+     * @param bool   $expected   Expected function output.
+     *
+     * @dataProvider dataGetMemberProperties
+     *
+     * @return void
+     */
+    public function testGetMemberProperties($identifier, $expected)
+    {
+        $variable = $this->getTargetToken($identifier, T_VARIABLE);
+        $result   = self::$phpcsFile->getMemberProperties($variable);
+
+        $this->assertArraySubset($expected, $result, true);
+
+    }//end testGetMemberProperties()
+
+
+    /**
+     * Data provider for the GetMemberProperties test.
+     *
+     * @see testGetMemberProperties()
+     *
+     * @return array
+     */
+    public function dataGetMemberProperties()
+    {
+        return [
+            [
+                '/* testVar */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => false,
+                    'is_static'       => false,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testVarType */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => false,
+                    'is_static'       => false,
+                    'type'            => 'int',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testPublic */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testPublicType */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => 'string',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testProtected */',
+                [
+                    'scope'           => 'protected',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testProtectedType */',
+                [
+                    'scope'           => 'protected',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => 'bool',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testPrivate */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testPrivateType */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => 'array',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testStatic */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => false,
+                    'is_static'       => true,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testStaticType */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => false,
+                    'is_static'       => true,
+                    'type'            => 'string',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testStaticVar */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => false,
+                    'is_static'       => true,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testVarStatic */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => false,
+                    'is_static'       => true,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testPublicStatic */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testProtectedStatic */',
+                [
+                    'scope'           => 'protected',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testPrivateStatic */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testPublicStaticWithDocblock */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testProtectedStaticWithDocblock */',
+                [
+                    'scope'           => 'protected',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testPrivateStaticWithDocblock */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testGroupType 1 */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => 'float',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testGroupType 2 */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => 'float',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testGroupNullableType 1 */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                    'type'            => '?string',
+                    'nullable_type'   => true,
+                ],
+            ],
+            [
+                '/* testGroupNullableType 2 */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                    'type'            => '?string',
+                    'nullable_type'   => true,
+                ],
+            ],
+            [
+                '/* testNoPrefix */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => false,
+                    'is_static'       => false,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testGroupProtectedStatic 1 */',
+                [
+                    'scope'           => 'protected',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testGroupProtectedStatic 2 */',
+                [
+                    'scope'           => 'protected',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testGroupProtectedStatic 3 */',
+                [
+                    'scope'           => 'protected',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testGroupPrivate 1 */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testGroupPrivate 2 */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testGroupPrivate 3 */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testGroupPrivate 4 */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testGroupPrivate 5 */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testGroupPrivate 6 */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testGroupPrivate 7 */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testMessyNullableType */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '?array',
+                    'nullable_type'   => true,
+                ],
+            ],
+            [
+                '/* testNamespaceType */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '\MyNamespace\MyClass',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testNullableNamespaceType 1 */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '?ClassName',
+                    'nullable_type'   => true,
+                ],
+            ],
+            [
+                '/* testNullableNamespaceType 2 */',
+                [
+                    'scope'           => 'protected',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '?Folder\ClassName',
+                    'nullable_type'   => true,
+                ],
+            ],
+            [
+                '/* testMultilineNamespaceType */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '\MyNamespace\MyClass\Foo',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testPropertyAfterMethod */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testInterfaceProperty */',
+                [],
+            ],
+            [
+                '/* testNestedProperty 1 */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testNestedProperty 2 */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '',
+                    'nullable_type'   => false,
+                ],
+            ],
+        ];
+
+    }//end dataGetMemberProperties()
+
+
+    /**
+     * Test receiving an expected exception when a non property is passed.
+     *
+     * @param string $identifier Comment which precedes the test case.
+     *
+     * @expectedException        PHP_CodeSniffer\Exceptions\RuntimeException
+     * @expectedExceptionMessage $stackPtr is not a class member var
+     *
+     * @dataProvider dataNotClassProperty
+     *
+     * @return void
+     */
+    public function testNotClassPropertyException($identifier)
+    {
+        $variable = $this->getTargetToken($identifier, T_VARIABLE);
+        $result   = self::$phpcsFile->getMemberProperties($variable);
+
+    }//end testNotClassPropertyException()
+
+
+    /**
+     * Data provider for the NotClassPropertyException test.
+     *
+     * @see testNotClassPropertyException()
+     *
+     * @return array
+     */
+    public function dataNotClassProperty()
+    {
+        return [
+            ['/* testMethodParam */'],
+            ['/* testImportedGlobal */'],
+            ['/* testLocalVariable */'],
+            ['/* testGlobalVariable */'],
+            ['/* testNestedMethodParam 1 */'],
+            ['/* testNestedMethodParam 2 */'],
+        ];
+
+    }//end dataNotClassProperty()
+
+
+    /**
+     * Test receiving an expected exception when a non variable is passed.
+     *
+     * @expectedException        PHP_CodeSniffer\Exceptions\RuntimeException
+     * @expectedExceptionMessage $stackPtr must be of type T_VARIABLE
+     *
+     * @return void
+     */
+    public function testNotAVariableException()
+    {
+        $next   = $this->getTargetToken('/* testNotAVariable */', T_RETURN);
+        $result = self::$phpcsFile->getMemberProperties($next);
+
+    }//end testNotAVariableException()
+
+
+}//end class

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -2,8 +2,16 @@
 /**
  * Tests for the \PHP_CodeSniffer\Files\File::getMemberProperties method.
  *
+ * This class is imported from the PHP_CodeSniffer project.
+ *
+ * Copyright of the original code in this class as per the import:
+ * @author    Juliette Reinders Folmer <jrf@phpcodesniffer.info>
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ *
+ * With documentation contributions from:
+ * @author    Phil Davis <phil@jankaritech.com>
+ *
+ * @copyright 2017-2019 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -50,7 +50,14 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
         $variable = $this->getTargetToken($identifier, T_VARIABLE);
         $result   = BCFile::getMemberProperties(self::$phpcsFile, $variable);
 
-        $this->assertArraySubset($expected, $result, true);
+        if (isset($expected['type_token']) && $expected['type_token'] !== false) {
+            $expected['type_token'] += $variable;
+        }
+        if (isset($expected['type_end_token']) && $expected['type_end_token'] !== false) {
+            $expected['type_end_token'] += $variable;
+        }
+
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -70,6 +77,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => false,
                     'is_static'       => false,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -80,6 +89,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => false,
                     'is_static'       => false,
                     'type'            => 'int',
+                    'type_token'      => -2, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
                     'nullable_type'   => false,
                 ],
             ],
@@ -90,6 +101,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -100,6 +113,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => 'string',
+                    'type_token'      => -2, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
                     'nullable_type'   => false,
                 ],
             ],
@@ -110,6 +125,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -120,6 +137,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => 'bool',
+                    'type_token'      => -2, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
                     'nullable_type'   => false,
                 ],
             ],
@@ -130,6 +149,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -140,6 +161,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => 'array',
+                    'type_token'      => -2, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
                     'nullable_type'   => false,
                 ],
             ],
@@ -150,6 +173,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => false,
                     'is_static'       => true,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -160,6 +185,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => false,
                     'is_static'       => true,
                     'type'            => 'string',
+                    'type_token'      => -2, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
                     'nullable_type'   => false,
                 ],
             ],
@@ -170,6 +197,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => false,
                     'is_static'       => true,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -180,6 +209,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => false,
                     'is_static'       => true,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -190,6 +221,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => true,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -200,6 +233,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => true,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -210,6 +245,20 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => true,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testNoPrefix */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => false,
+                    'is_static'       => false,
+                    'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -220,6 +269,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => true,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -230,6 +281,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => true,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -240,6 +293,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => true,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -250,6 +305,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => 'float',
+                    'type_token'      => -6, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -6, // Offset from the T_VARIABLE token.
                     'nullable_type'   => false,
                 ],
             ],
@@ -260,6 +317,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => 'float',
+                    'type_token'      => -13, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -13, // Offset from the T_VARIABLE token.
                     'nullable_type'   => false,
                 ],
             ],
@@ -270,6 +329,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => true,
                     'type'            => '?string',
+                    'type_token'      => -6, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -6, // Offset from the T_VARIABLE token.
                     'nullable_type'   => true,
                 ],
             ],
@@ -280,17 +341,9 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => true,
                     'type'            => '?string',
+                    'type_token'      => -17, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -17, // Offset from the T_VARIABLE token.
                     'nullable_type'   => true,
-                ],
-            ],
-            [
-                '/* testNoPrefix */',
-                [
-                    'scope'           => 'public',
-                    'scope_specified' => false,
-                    'is_static'       => false,
-                    'type'            => '',
-                    'nullable_type'   => false,
                 ],
             ],
             [
@@ -300,6 +353,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => true,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -310,6 +365,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => true,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -320,6 +377,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => true,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -330,6 +389,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -340,6 +401,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -350,6 +413,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -360,6 +425,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -370,6 +437,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -380,6 +449,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -390,6 +461,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -400,6 +473,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '?array',
+                    'type_token'      => -2, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
                     'nullable_type'   => true,
                 ],
             ],
@@ -410,6 +485,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '\MyNamespace\MyClass',
+                    'type_token'      => -5, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
                     'nullable_type'   => false,
                 ],
             ],
@@ -420,6 +497,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '?ClassName',
+                    'type_token'      => -2, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
                     'nullable_type'   => true,
                 ],
             ],
@@ -430,6 +509,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '?Folder\ClassName',
+                    'type_token'      => -4, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
                     'nullable_type'   => true,
                 ],
             ],
@@ -440,6 +521,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '\MyNamespace\MyClass\Foo',
+                    'type_token'      => -18, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
                     'nullable_type'   => false,
                 ],
             ],
@@ -450,6 +533,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => true,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -464,6 +549,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],
@@ -474,6 +561,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
                     'nullable_type'   => false,
                 ],
             ],

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -1,6 +1,11 @@
 <?php
 /**
- * Tests for the \PHP_CodeSniffer\Files\File::getMemberProperties method.
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
  *
  * This class is imported from the PHP_CodeSniffer project.
  *
@@ -20,17 +25,23 @@ namespace PHPCSUtils\Tests\BackCompat\BCFile;
 use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
+/**
+ * Tests for the \PHPCSUtils\BackCompat\BCFile::getMemberProperties method.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCFile::getMemberProperties
+ *
+ * @since 1.0.0
+ */
 class GetMemberPropertiesTest extends UtilityMethodTestCase
 {
-
 
     /**
      * Test the getMemberProperties() method.
      *
+     * @dataProvider dataGetMemberProperties
+     *
      * @param string $identifier Comment which precedes the test case.
      * @param bool   $expected   Expected function output.
-     *
-     * @dataProvider dataGetMemberProperties
      *
      * @return void
      */
@@ -40,12 +51,10 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
         $result   = BCFile::getMemberProperties(self::$phpcsFile, $variable);
 
         $this->assertArraySubset($expected, $result, true);
-
-    }//end testGetMemberProperties()
-
+    }
 
     /**
-     * Data provider for the GetMemberProperties test.
+     * Data provider.
      *
      * @see testGetMemberProperties()
      *
@@ -469,19 +478,17 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
         ];
-
-    }//end dataGetMemberProperties()
-
+    }
 
     /**
      * Test receiving an expected exception when a non property is passed.
-     *
-     * @param string $identifier Comment which precedes the test case.
      *
      * @expectedException        PHP_CodeSniffer\Exceptions\RuntimeException
      * @expectedExceptionMessage $stackPtr is not a class member var
      *
      * @dataProvider dataNotClassProperty
+     *
+     * @param string $identifier Comment which precedes the test case.
      *
      * @return void
      */
@@ -489,12 +496,10 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
     {
         $variable = $this->getTargetToken($identifier, T_VARIABLE);
         $result   = BCFile::getMemberProperties(self::$phpcsFile, $variable);
-
-    }//end testNotClassPropertyException()
-
+    }
 
     /**
-     * Data provider for the NotClassPropertyException test.
+     * Data provider.
      *
      * @see testNotClassPropertyException()
      *
@@ -510,9 +515,7 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
             ['/* testNestedMethodParam 1 */'],
             ['/* testNestedMethodParam 2 */'],
         ];
-
-    }//end dataNotClassProperty()
-
+    }
 
     /**
      * Test receiving an expected exception when a non variable is passed.
@@ -526,8 +529,5 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
     {
         $next   = $this->getTargetToken('/* testNotAVariable */', T_RETURN);
         $result = BCFile::getMemberProperties(self::$phpcsFile, $next);
-
-    }//end testNotAVariableException()
-
-
-}//end class
+    }
+}

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -572,9 +572,6 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
     /**
      * Test receiving an expected exception when a non property is passed.
      *
-     * @expectedException        PHP_CodeSniffer\Exceptions\RuntimeException
-     * @expectedExceptionMessage $stackPtr is not a class member var
-     *
      * @dataProvider dataNotClassProperty
      *
      * @param string $identifier Comment which precedes the test case.
@@ -583,8 +580,10 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
      */
     public function testNotClassPropertyException($identifier)
     {
+        $this->expectPhpcsException('$stackPtr is not a class member var');
+
         $variable = $this->getTargetToken($identifier, T_VARIABLE);
-        $result   = BCFile::getMemberProperties(self::$phpcsFile, $variable);
+        BCFile::getMemberProperties(self::$phpcsFile, $variable);
     }
 
     /**
@@ -609,14 +608,13 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
     /**
      * Test receiving an expected exception when a non variable is passed.
      *
-     * @expectedException        PHP_CodeSniffer\Exceptions\RuntimeException
-     * @expectedExceptionMessage $stackPtr must be of type T_VARIABLE
-     *
      * @return void
      */
     public function testNotAVariableException()
     {
-        $next   = $this->getTargetToken('/* testNotAVariable */', T_RETURN);
-        $result = BCFile::getMemberProperties(self::$phpcsFile, $next);
+        $this->expectPhpcsException('$stackPtr must be of type T_VARIABLE');
+
+        $next = $this->getTargetToken('/* testNotAVariable */', T_RETURN);
+        BCFile::getMemberProperties(self::$phpcsFile, $next);
     }
 }

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -15,11 +15,12 @@
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-namespace PHP_CodeSniffer\Tests\Core\File;
+namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
-class GetMemberPropertiesTest extends AbstractMethodUnitTest
+class GetMemberPropertiesTest extends UtilityMethodTestCase
 {
 
 
@@ -36,7 +37,7 @@ class GetMemberPropertiesTest extends AbstractMethodUnitTest
     public function testGetMemberProperties($identifier, $expected)
     {
         $variable = $this->getTargetToken($identifier, T_VARIABLE);
-        $result   = self::$phpcsFile->getMemberProperties($variable);
+        $result   = BCFile::getMemberProperties(self::$phpcsFile, $variable);
 
         $this->assertArraySubset($expected, $result, true);
 
@@ -487,7 +488,7 @@ class GetMemberPropertiesTest extends AbstractMethodUnitTest
     public function testNotClassPropertyException($identifier)
     {
         $variable = $this->getTargetToken($identifier, T_VARIABLE);
-        $result   = self::$phpcsFile->getMemberProperties($variable);
+        $result   = BCFile::getMemberProperties(self::$phpcsFile, $variable);
 
     }//end testNotClassPropertyException()
 
@@ -524,7 +525,7 @@ class GetMemberPropertiesTest extends AbstractMethodUnitTest
     public function testNotAVariableException()
     {
         $next   = $this->getTargetToken('/* testNotAVariable */', T_RETURN);
-        $result = self::$phpcsFile->getMemberProperties($next);
+        $result = BCFile::getMemberProperties(self::$phpcsFile, $next);
 
     }//end testNotAVariableException()
 

--- a/Tests/BackCompat/BCFile/GetMethodParametersParseError1Test.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersParseError1Test.inc
@@ -1,0 +1,4 @@
+<?php
+
+/* testParseError */
+function missingOpenParens // Intentional parse error.

--- a/Tests/BackCompat/BCFile/GetMethodParametersParseError1Test.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersParseError1Test.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCFile;
+
+use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+
+/**
+ * Tests for the \PHPCSUtils\BackCompat\BCFile::getMethodParameters method.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCFile::getMethodParameters
+ *
+ * @group functiondeclarations
+ *
+ * @since 1.0.0
+ */
+class GetMethodParametersParseError1Test extends UtilityMethodTestCase
+{
+
+    /**
+     * Test receiving an empty array when encountering a specific parse error.
+     *
+     * @return void
+     */
+    public function testParseError()
+    {
+        $target = $this->getTargetToken('/* testParseError */', [\T_FUNCTION, \T_CLOSURE]);
+        $result = BCFile::getMethodParameters(self::$phpcsFile, $target);
+
+        $this->assertSame([], $result);
+    }
+}

--- a/Tests/BackCompat/BCFile/GetMethodParametersParseError2Test.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersParseError2Test.inc
@@ -1,0 +1,4 @@
+<?php
+
+/* testParseError */
+function missingCloseParens( // Intentional parse error.

--- a/Tests/BackCompat/BCFile/GetMethodParametersParseError2Test.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersParseError2Test.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCFile;
+
+use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+
+/**
+ * Tests for the \PHPCSUtils\BackCompat\BCFile::getMethodParameters method.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCFile::getMethodParameters
+ *
+ * @group functiondeclarations
+ *
+ * @since 1.0.0
+ */
+class GetMethodParametersParseError2Test extends UtilityMethodTestCase
+{
+
+    /**
+     * Test receiving an empty array when encountering a specific parse error.
+     *
+     * @return void
+     */
+    public function testParseError()
+    {
+        $target = $this->getTargetToken('/* testParseError */', [\T_FUNCTION, \T_CLOSURE]);
+        $result = BCFile::getMethodParameters(self::$phpcsFile, $target);
+
+        $this->assertSame([], $result);
+    }
+}

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
@@ -1,0 +1,30 @@
+<?php
+
+/* testPassByReference */
+function passByReference(&$var) {}
+
+/* testArrayHint */
+function arrayHint(array $var) {}
+
+/* testVariable */
+function variable($var) {}
+
+/* testSingleDefaultValue */
+function defaultValue($var1=self::CONSTANT) {}
+
+/* testDefaultValues */
+function defaultValues($var1=1, $var2='value') {}
+
+/* testTypeHint */
+function typeHint(foo $var1, bar $var2) {}
+
+class MyClass {
+    /* testSelfTypeHint */
+    function typeSelfHint(self $var) {}
+}
+
+/* testNullableTypeHint */
+function nullableTypeHint(?int $var1, ?\bar $var2) {}
+
+/* testBitwiseAndConstantExpressionDefaultValue */
+function myFunction($a = 10 & 20) {}

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
@@ -1,5 +1,29 @@
 <?php
 
+/* testImportUse */
+use Vendor\Package\Sub as Alias;
+
+/* testImportGroupUse */
+use Vendor\Package\Sub\{
+    ClassA,
+    ClassB as BAlias,
+};
+
+if ($foo) {}
+
+/* testTraitUse */
+class TraitUse {
+    use ImportedTrait;
+
+    function methodName() {}
+}
+
+/* testNotAFunction */
+interface NotAFunction {};
+
+/* testFunctionNoParams */
+function noParams() {}
+
 /* testPassByReference */
 function passByReference(&$var) {}
 
@@ -28,3 +52,69 @@ function defaultValues($var1=1, $var2='value') {}
 
 /* testBitwiseAndConstantExpressionDefaultValue */
 function myFunction($a = 10 & 20) {}
+
+/* testArrayDefaultValues */
+function arrayDefaultValues($var1 = [], $var2 = array(1, 2, 3) ) {}
+
+/* testConstantDefaultValueSecondParam */
+function constantDefaultValueSecondParam($var1, $var2 = M_PI) {}
+
+/* testScalarTernaryExpressionInDefault */
+function ternayInDefault( $a = FOO ? 'bar' : 10, ? bool $b ) {}
+
+/* testVariadicFunction */
+function variadicFunction( int ... $a ) {}
+
+/* testVariadicByRefFunction */
+function variadicByRefFunction( &...$a ) {}
+
+/* testVariadicFunctionClassType */
+function variableLengthArgument($unit, DateInterval ...$intervals) {}
+
+/* testNameSpacedTypeDeclaration */
+function namespacedClassType( \Package\Sub\ClassName $a, ?Sub\AnotherClass $b ) {}
+
+/* testWithAllTypes */
+class testAllTypes {
+    function allTypes(
+        ?ClassName $a,
+        self $b,
+        parent $c,
+        object $d,
+        ?int $e,
+        string &$f,
+        iterable $g,
+        bool $h = true,
+        callable $i = 'is_null',
+        float $j = 1.1,
+        array ...$k
+    ) {}
+}
+
+/* testMessyDeclaration */
+function messyDeclaration(
+    // comment
+    ?\MyNS /* comment */
+        \ SubCat // phpcs:ignore Standard.Cat.Sniff -- for reasons.
+            \  MyClass $a,
+    $b /* test */ = /* test */ 'default' /* test*/,
+    // phpcs:ignore Stnd.Cat.Sniff -- For reasons.
+    ? /*comment*/
+        bool // phpcs:disable Stnd.Cat.Sniff -- For reasons.
+        & /*test*/ ... /* phpcs:ignore */ $c
+) {}
+
+/* testClosureNoParams */
+function() {}
+
+/* testClosure */
+function( $a = 'test' ) {}
+
+/* testClosureUseNoParams */
+function() use() {}
+
+/* testClosureUse */
+function() use( $foo, $bar ) {}
+
+/* testInvalidUse */
+function() use {} // Intentional parse error.

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
@@ -6,15 +6,6 @@ function passByReference(&$var) {}
 /* testArrayHint */
 function arrayHint(array $var) {}
 
-/* testVariable */
-function variable($var) {}
-
-/* testSingleDefaultValue */
-function defaultValue($var1=self::CONSTANT) {}
-
-/* testDefaultValues */
-function defaultValues($var1=1, $var2='value') {}
-
 /* testTypeHint */
 function typeHint(foo $var1, bar $var2) {}
 
@@ -25,6 +16,15 @@ class MyClass {
 
 /* testNullableTypeHint */
 function nullableTypeHint(?int $var1, ?\bar $var2) {}
+
+/* testVariable */
+function variable($var) {}
+
+/* testSingleDefaultValue */
+function defaultValue($var1=self::CONSTANT) {}
+
+/* testDefaultValues */
+function defaultValues($var1=1, $var2='value') {}
 
 /* testBitwiseAndConstantExpressionDefaultValue */
 function myFunction($a = 10 & 20) {}

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File:getMethodParameters method.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\File;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+
+class GetMethodParametersTest extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Verify pass-by-reference parsing.
+     *
+     * @return void
+     */
+    public function testPassByReference()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var',
+            'content'           => '&$var',
+            'pass_by_reference' => true,
+            'variable_length'   => false,
+            'type_hint'         => '',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPassByReference()
+
+
+    /**
+     * Verify array hint parsing.
+     *
+     * @return void
+     */
+    public function testArrayHint()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var',
+            'content'           => 'array $var',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => 'array',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testArrayHint()
+
+
+    /**
+     * Verify type hint parsing.
+     *
+     * @return void
+     */
+    public function testTypeHint()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var1',
+            'content'           => 'foo $var1',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => 'foo',
+            'nullable_type'     => false,
+        ];
+
+        $expected[1] = [
+            'name'              => '$var2',
+            'content'           => 'bar $var2',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => 'bar',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testTypeHint()
+
+
+    /**
+     * Verify self type hint parsing.
+     *
+     * @return void
+     */
+    public function testSelfTypeHint()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var',
+            'content'           => 'self $var',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => 'self',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testSelfTypeHint()
+
+
+    /**
+     * Verify nullable type hint parsing.
+     *
+     * @return void
+     */
+    public function testNullableTypeHint()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var1',
+            'content'           => '?int $var1',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => '?int',
+            'nullable_type'     => true,
+        ];
+
+        $expected[1] = [
+            'name'              => '$var2',
+            'content'           => '?\bar $var2',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => '?\bar',
+            'nullable_type'     => true,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testNullableTypeHint()
+
+
+    /**
+     * Verify variable.
+     *
+     * @return void
+     */
+    public function testVariable()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var',
+            'content'           => '$var',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => '',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testVariable()
+
+
+    /**
+     * Verify default value parsing with a single function param.
+     *
+     * @return void
+     */
+    public function testSingleDefaultValue()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var1',
+            'content'           => '$var1=self::CONSTANT',
+            'default'           => 'self::CONSTANT',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => '',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testSingleDefaultValue()
+
+
+    /**
+     * Verify default value parsing.
+     *
+     * @return void
+     */
+    public function testDefaultValues()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$var1',
+            'content'           => '$var1=1',
+            'default'           => '1',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => '',
+            'nullable_type'     => false,
+        ];
+        $expected[1] = [
+            'name'              => '$var2',
+            'content'           => "\$var2='value'",
+            'default'           => "'value'",
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => '',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testDefaultValues()
+
+
+    /**
+     * Verify "bitwise and" in default value !== pass-by-reference.
+     *
+     * @return void
+     */
+    public function testBitwiseAndConstantExpressionDefaultValue()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'name'              => '$a',
+            'content'           => '$a = 10 & 20',
+            'default'           => '10 & 20',
+            'pass_by_reference' => false,
+            'variable_length'   => false,
+            'type_hint'         => '',
+            'nullable_type'     => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testBitwiseAndConstantExpressionDefaultValue()
+
+
+    /**
+     * Test helper.
+     *
+     * @param string $commentString The comment which preceeds the test.
+     * @param array  $expected      The expected function output.
+     *
+     * @return void
+     */
+    private function getMethodParametersTestHelper($commentString, $expected)
+    {
+        $function = $this->getTargetToken($commentString, [T_FUNCTION]);
+        $found    = self::$phpcsFile->getMethodParameters($function);
+
+        $this->assertArraySubset($expected, $found, true);
+
+    }//end getMethodParametersTestHelper()
+
+
+}//end class

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -37,6 +37,88 @@ class GetMethodParametersTest extends UtilityMethodTestCase
 {
 
     /**
+     * Test receiving an expected exception when a non function/use token is passed.
+     *
+     * @return void
+     */
+    public function testUnexpectedTokenException()
+    {
+        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_USE');
+
+        $next = $this->getTargetToken('/* testNotAFunction */', [T_INTERFACE]);
+        BCFile::getMethodParameters(self::$phpcsFile, $next);
+    }
+
+    /**
+     * Test receiving an expected exception when a non-closure use token is passed.
+     *
+     * @dataProvider dataInvalidUse
+     *
+     * @param string $identifier The comment which preceeds the test.
+     *
+     * @return void
+     */
+    public function testInvalidUse($identifier)
+    {
+        $this->expectPhpcsException('$stackPtr was not a valid T_USE');
+
+        $use = $this->getTargetToken($identifier, [T_USE]);
+        BCFile::getMethodParameters(self::$phpcsFile, $use);
+    }
+
+    /**
+     * Data Provider.
+     *
+     * @see testInvalidUse() For the array format.
+     *
+     * @return array
+     */
+    public function dataInvalidUse()
+    {
+        return [
+            'ImportUse'      => ['/* testImportUse */'],
+            'ImportGroupUse' => ['/* testImportGroupUse */'],
+            'TraitUse'       => ['/* testTraitUse */'],
+            'InvalidUse'     => ['/* testInvalidUse */'],
+        ];
+    }
+
+    /**
+     * Test receiving an empty array when there are no parameters.
+     *
+     * @dataProvider dataNoParams
+     *
+     * @param string $commentString   The comment which preceeds the test.
+     * @param array  $targetTokenType Optional. The token type to search for after $commentString.
+     *                                Defaults to the function/closure tokens.
+     *
+     * @return void
+     */
+    public function testNoParams($commentString, $targetTokenType = [T_FUNCTION, T_CLOSURE])
+    {
+        $target = $this->getTargetToken($commentString, $targetTokenType);
+        $result = BCFile::getMethodParameters(self::$phpcsFile, $target);
+
+        $this->assertSame([], $result);
+    }
+
+    /**
+     * Data Provider.
+     *
+     * @see testNoParams() For the array format.
+     *
+     * @return array
+     */
+    public function dataNoParams()
+    {
+        return [
+            'FunctionNoParams'   => ['/* testFunctionNoParams */'],
+            'ClosureNoParams'    => ['/* testClosureNoParams */'],
+            'ClosureUseNoParams' => ['/* testClosureUseNoParams */', T_USE],
+        ];
+    }
+
+    /**
      * Verify pass-by-reference parsing.
      *
      * @return void
@@ -327,17 +409,590 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     }
 
     /**
+     * Verify default value parsing with array values.
+     *
+     * @return void
+     */
+    public function testArrayDefaultValues()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 4, // Offset from the T_FUNCTION token.
+            'name'                => '$var1',
+            'content'             => '$var1 = []',
+            'default'             => '[]',
+            'default_token'       => 8, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 6, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => 10, // Offset from the T_FUNCTION token.
+        ];
+        $expected[1] = [
+            'token'               => 12, // Offset from the T_FUNCTION token.
+            'name'                => '$var2',
+            'content'             => '$var2 = array(1, 2, 3)',
+            'default'             => 'array(1, 2, 3)',
+            'default_token'       => 16, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 14, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify having a T_STRING constant as a default value for the second parameter.
+     *
+     * @return void
+     */
+    public function testConstantDefaultValueSecondParam()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 4, // Offset from the T_FUNCTION token.
+            'name'                => '$var1',
+            'content'             => '$var1',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => 5, // Offset from the T_FUNCTION token.
+        ];
+        $expected[1] = [
+            'token'               => 7, // Offset from the T_FUNCTION token.
+            'name'                => '$var2',
+            'content'             => '$var2 = M_PI',
+            'default'             => 'M_PI',
+            'default_token'       => 11, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 9, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify distinquishing between a nullable type and a ternary within a default expression.
+     *
+     * @return void
+     */
+    public function testScalarTernaryExpressionInDefault()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 5, // Offset from the T_FUNCTION token.
+            'name'                => '$a',
+            'content'             => '$a = FOO ? \'bar\' : 10',
+            'default'             => 'FOO ? \'bar\' : 10',
+            'default_token'       => 9, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 7, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => 18, // Offset from the T_FUNCTION token.
+        ];
+        $expected[1] = [
+            'token'               => 24, // Offset from the T_FUNCTION token.
+            'name'                => '$b',
+            'content'             => '? bool $b',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '?bool',
+            'type_hint_token'     => 22, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 22, // Offset from the T_FUNCTION token.
+            'nullable_type'       => true,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify a variadic parameter being recognized correctly.
+     *
+     * @return void
+     */
+    public function testVariadicFunction()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 9, // Offset from the T_FUNCTION token.
+            'name'                => '$a',
+            'content'             => 'int ... $a',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => true,
+            'variadic_token'      => 7, // Offset from the T_FUNCTION token.
+            'type_hint'           => 'int',
+            'type_hint_token'     => 5, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 5, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify a variadic parameter passed by reference being recognized correctly.
+     *
+     * @return void
+     */
+    public function testVariadicByRefFunction()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 7, // Offset from the T_FUNCTION token.
+            'name'                => '$a',
+            'content'             => '&...$a',
+            'pass_by_reference'   => true,
+            'reference_token'     => 5, // Offset from the T_FUNCTION token.
+            'variable_length'     => true,
+            'variadic_token'      => 6, // Offset from the T_FUNCTION token.
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify handling of a variadic parameter with a class based type declaration.
+     *
+     * @return void
+     */
+    public function testVariadicFunctionClassType()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 4, // Offset from the T_FUNCTION token.
+            'name'                => '$unit',
+            'content'             => '$unit',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => 5, // Offset from the T_FUNCTION token.
+        ];
+        $expected[1] = [
+            'token'               => 10, // Offset from the T_FUNCTION token.
+            'name'                => '$intervals',
+            'content'             => 'DateInterval ...$intervals',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => true,
+            'variadic_token'      => 9,
+            'type_hint'           => 'DateInterval',
+            'type_hint_token'     => 7, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 7, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify distinquishing between a nullable type and a ternary within a default expression.
+     *
+     * @return void
+     */
+    public function testNameSpacedTypeDeclaration()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 12, // Offset from the T_FUNCTION token.
+            'name'                => '$a',
+            'content'             => '\Package\Sub\ClassName $a',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '\Package\Sub\ClassName',
+            'type_hint_token'     => 5, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 10, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => 13, // Offset from the T_FUNCTION token.
+        ];
+        $expected[1] = [
+            'token'               => 20, // Offset from the T_FUNCTION token.
+            'name'                => '$b',
+            'content'             => '?Sub\AnotherClass $b',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '?Sub\AnotherClass',
+            'type_hint_token'     => 16, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 18, // Offset from the T_FUNCTION token.
+            'nullable_type'       => true,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify correctly recognizing all type declarations supported by PHP.
+     *
+     * @return void
+     */
+    public function testWithAllTypes()
+    {
+        $expected     = [];
+        $expected[0]  = [
+            'token'               => 9, // Offset from the T_FUNCTION token.
+            'name'                => '$a',
+            'content'             => '?ClassName $a',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '?ClassName',
+            'type_hint_token'     => 7, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 7, // Offset from the T_FUNCTION token.
+            'nullable_type'       => true,
+            'comma_token'         => 10, // Offset from the T_FUNCTION token.
+        ];
+        $expected[1]  = [
+            'token'               => 15, // Offset from the T_FUNCTION token.
+            'name'                => '$b',
+            'content'             => 'self $b',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'self',
+            'type_hint_token'     => 13, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 13, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => 16, // Offset from the T_FUNCTION token.
+        ];
+        $expected[2]  = [
+            'token'               => 21, // Offset from the T_FUNCTION token.
+            'name'                => '$c',
+            'content'             => 'parent $c',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'parent',
+            'type_hint_token'     => 19, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 19, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => 22, // Offset from the T_FUNCTION token.
+        ];
+        $expected[3]  = [
+            'token'               => 27, // Offset from the T_FUNCTION token.
+            'name'                => '$d',
+            'content'             => 'object $d',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'object',
+            'type_hint_token'     => 25, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 25, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => 28, // Offset from the T_FUNCTION token.
+        ];
+        $expected[4]  = [
+            'token'               => 34, // Offset from the T_FUNCTION token.
+            'name'                => '$e',
+            'content'             => '?int $e',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '?int',
+            'type_hint_token'     => 32, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 32, // Offset from the T_FUNCTION token.
+            'nullable_type'       => true,
+            'comma_token'         => 35, // Offset from the T_FUNCTION token.
+        ];
+        $expected[5]  = [
+            'token'               => 41, // Offset from the T_FUNCTION token.
+            'name'                => '$f',
+            'content'             => 'string &$f',
+            'pass_by_reference'   => true,
+            'reference_token'     => 40, // Offset from the T_FUNCTION token.
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'string',
+            'type_hint_token'     => 38, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 38, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => 42, // Offset from the T_FUNCTION token.
+        ];
+        $expected[6]  = [
+            'token'               => 47, // Offset from the T_FUNCTION token.
+            'name'                => '$g',
+            'content'             => 'iterable $g',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'iterable',
+            'type_hint_token'     => 45, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 45, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => 48, // Offset from the T_FUNCTION token.
+        ];
+        $expected[7]  = [
+            'token'               => 53, // Offset from the T_FUNCTION token.
+            'name'                => '$h',
+            'content'             => 'bool $h = true',
+            'default'             => 'true',
+            'default_token'       => 57, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 55, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'bool',
+            'type_hint_token'     => 51, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 51, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => 58, // Offset from the T_FUNCTION token.
+        ];
+        $expected[8]  = [
+            'token'               => 63, // Offset from the T_FUNCTION token.
+            'name'                => '$i',
+            'content'             => 'callable $i = \'is_null\'',
+            'default'             => "'is_null'",
+            'default_token'       => 67, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 65, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'callable',
+            'type_hint_token'     => 61, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 61, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => 68, // Offset from the T_FUNCTION token.
+        ];
+        $expected[9]  = [
+            'token'               => 73, // Offset from the T_FUNCTION token.
+            'name'                => '$j',
+            'content'             => 'float $j = 1.1',
+            'default'             => '1.1',
+            'default_token'       => 77, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 75, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'float',
+            'type_hint_token'     => 71, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 71, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => 78, // Offset from the T_FUNCTION token.
+        ];
+        $expected[10] = [
+            'token'               => 84, // Offset from the T_FUNCTION token.
+            'name'                => '$k',
+            'content'             => 'array ...$k',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => true,
+            'variadic_token'      => 83, // Offset from the T_FUNCTION token.
+            'type_hint'           => 'array',
+            'type_hint_token'     => 81, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 81, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify handling of a closure.
+     *
+     * @return void
+     */
+    public function testMessyDeclaration()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 25, // Offset from the T_FUNCTION token.
+            'name'                => '$a',
+            'content'             => '// comment
+    ?\MyNS /* comment */
+        \ SubCat // phpcs:ignore Standard.Cat.Sniff -- for reasons.
+            \  MyClass $a',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '?\MyNS\SubCat\MyClass',
+            'type_hint_token'     => 9,
+            'type_hint_end_token' => 23,
+            'nullable_type'       => true,
+            'comma_token'         => 26, // Offset from the T_FUNCTION token.
+        ];
+        $expected[1] = [
+            'token'               => 29, // Offset from the T_FUNCTION token.
+            'name'                => '$b',
+            'content'             => "\$b /* test */ = /* test */ 'default' /* test*/",
+            'default'             => "'default' /* test*/",
+            'default_token'       => 37, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 33, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => 40, // Offset from the T_FUNCTION token.
+        ];
+        $expected[2] = [
+            'token'               => 62, // Offset from the T_FUNCTION token.
+            'name'                => '$c',
+            'content'             => '// phpcs:ignore Stnd.Cat.Sniff -- For reasons.
+    ? /*comment*/
+        bool // phpcs:disable Stnd.Cat.Sniff -- For reasons.
+        & /*test*/ ... /* phpcs:ignore */ $c',
+            'pass_by_reference'   => true,
+            'reference_token'     => 54, // Offset from the T_FUNCTION token.
+            'variable_length'     => true,
+            'variadic_token'      => 58, // Offset from the T_FUNCTION token.
+            'type_hint'           => '?bool',
+            'type_hint_token'     => 50, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 50, // Offset from the T_FUNCTION token.
+            'nullable_type'       => true,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify handling of a closure.
+     *
+     * @return void
+     */
+    public function testClosure()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 3, // Offset from the T_FUNCTION token.
+            'name'                => '$a',
+            'content'             => '$a = \'test\'',
+            'default'             => "'test'",
+            'default_token'       => 7, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 5, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify handling of a closure T_USE token correctly.
+     *
+     * @return void
+     */
+    public function testClosureUse()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 3, // Offset from the T_USE token.
+            'name'                => '$foo',
+            'content'             => '$foo',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => 4, // Offset from the T_USE token.
+        ];
+        $expected[1] = [
+            'token'               => 6, // Offset from the T_USE token.
+            'name'                => '$bar',
+            'content'             => '$bar',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected, [T_USE]);
+    }
+
+    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.
      * @param array  $expected      The expected function output.
+     * @param array  $targetType    Optional. The token type to search for after $commentString.
+     *                              Defaults to the function/closure tokens.
      *
      * @return void
      */
-    private function getMethodParametersTestHelper($commentString, $expected)
+    private function getMethodParametersTestHelper($commentString, $expected, $targetType = [T_FUNCTION, T_CLOSURE])
     {
-        $function = $this->getTargetToken($commentString, [T_FUNCTION]);
-        $found    = BCFile::getMethodParameters(self::$phpcsFile, $function);
+        $target = $this->getTargetToken($commentString, $targetType);
+        $found  = BCFile::getMethodParameters(self::$phpcsFile, $target);
 
         foreach ($expected as $key => $param) {
             $expected[$key]['token'] += $target;

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -16,11 +16,12 @@
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-namespace PHP_CodeSniffer\Tests\Core\File;
+namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
-class GetMethodParametersTest extends AbstractMethodUnitTest
+class GetMethodParametersTest extends UtilityMethodTestCase
 {
 
 
@@ -263,7 +264,7 @@ class GetMethodParametersTest extends AbstractMethodUnitTest
     private function getMethodParametersTestHelper($commentString, $expected)
     {
         $function = $this->getTargetToken($commentString, [T_FUNCTION]);
-        $found    = self::$phpcsFile->getMethodParameters($function);
+        $found    = BCFile::getMethodParameters(self::$phpcsFile, $function);
 
         $this->assertArraySubset($expected, $found, true);
 

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -1,6 +1,11 @@
 <?php
 /**
- * Tests for the \PHP_CodeSniffer\Files\File:getMethodParameters method.
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
  *
  * This class is imported from the PHP_CodeSniffer project.
  *
@@ -21,9 +26,15 @@ namespace PHPCSUtils\Tests\BackCompat\BCFile;
 use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
+/**
+ * Tests for the \PHPCSUtils\BackCompat\BCFile::getMethodParameters method.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCFile::getMethodParameters
+ *
+ * @since 1.0.0
+ */
 class GetMethodParametersTest extends UtilityMethodTestCase
 {
-
 
     /**
      * Verify pass-by-reference parsing.
@@ -42,10 +53,8 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'nullable_type'     => false,
         ];
 
-        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testPassByReference()
-
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Verify array hint parsing.
@@ -64,10 +73,8 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'nullable_type'     => false,
         ];
 
-        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testArrayHint()
-
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Verify type hint parsing.
@@ -95,10 +102,8 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'nullable_type'     => false,
         ];
 
-        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testTypeHint()
-
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Verify self type hint parsing.
@@ -117,10 +122,8 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'nullable_type'     => false,
         ];
 
-        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testSelfTypeHint()
-
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Verify nullable type hint parsing.
@@ -148,10 +151,8 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'nullable_type'     => true,
         ];
 
-        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testNullableTypeHint()
-
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Verify variable.
@@ -170,10 +171,8 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'nullable_type'     => false,
         ];
 
-        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testVariable()
-
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Verify default value parsing with a single function param.
@@ -193,10 +192,8 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'nullable_type'     => false,
         ];
 
-        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testSingleDefaultValue()
-
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Verify default value parsing.
@@ -225,10 +222,8 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'nullable_type'     => false,
         ];
 
-        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testDefaultValues()
-
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Verify "bitwise and" in default value !== pass-by-reference.
@@ -248,10 +243,8 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'nullable_type'     => false,
         ];
 
-        $this->getMethodParametersTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testBitwiseAndConstantExpressionDefaultValue()
-
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Test helper.
@@ -267,8 +260,5 @@ class GetMethodParametersTest extends UtilityMethodTestCase
         $found    = BCFile::getMethodParameters(self::$phpcsFile, $function);
 
         $this->assertArraySubset($expected, $found, true);
-
-    }//end getMethodParametersTestHelper()
-
-
-}//end class
+    }
+}

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -2,8 +2,17 @@
 /**
  * Tests for the \PHP_CodeSniffer\Files\File:getMethodParameters method.
  *
+ * This class is imported from the PHP_CodeSniffer project.
+ *
+ * Copyright of the original code in this class as per the import:
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @author    Juliette Reinders Folmer <jrf@phpcodesniffer.info>
+ *
+ * With documentation contributions from:
+ * @author    Diogo Oliveira de Melo <dmelo87@gmail.com>
+ * @author    George Mponos <gmponos@gmail.com>
+ *
+ * @copyright 2010-2019 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -45,12 +45,18 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     {
         $expected    = [];
         $expected[0] = [
-            'name'              => '$var',
-            'content'           => '&$var',
-            'pass_by_reference' => true,
-            'variable_length'   => false,
-            'type_hint'         => '',
-            'nullable_type'     => false,
+            'token'               => 5, // Offset from the T_FUNCTION token.
+            'name'                => '$var',
+            'content'             => '&$var',
+            'pass_by_reference'   => true,
+            'reference_token'     => 4, // Offset from the T_FUNCTION token.
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => false,
         ];
 
         $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -65,12 +71,18 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     {
         $expected    = [];
         $expected[0] = [
-            'name'              => '$var',
-            'content'           => 'array $var',
-            'pass_by_reference' => false,
-            'variable_length'   => false,
-            'type_hint'         => 'array',
-            'nullable_type'     => false,
+            'token'               => 6, // Offset from the T_FUNCTION token.
+            'name'                => '$var',
+            'content'             => 'array $var',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'array',
+            'type_hint_token'     => 4, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 4, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => false,
         ];
 
         $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -85,21 +97,33 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     {
         $expected    = [];
         $expected[0] = [
-            'name'              => '$var1',
-            'content'           => 'foo $var1',
-            'pass_by_reference' => false,
-            'variable_length'   => false,
-            'type_hint'         => 'foo',
-            'nullable_type'     => false,
+            'token'               => 6, // Offset from the T_FUNCTION token.
+            'name'                => '$var1',
+            'content'             => 'foo $var1',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'foo',
+            'type_hint_token'     => 4, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 4, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => 7, // Offset from the T_FUNCTION token.
         ];
 
         $expected[1] = [
-            'name'              => '$var2',
-            'content'           => 'bar $var2',
-            'pass_by_reference' => false,
-            'variable_length'   => false,
-            'type_hint'         => 'bar',
-            'nullable_type'     => false,
+            'token'               => 11, // Offset from the T_FUNCTION token.
+            'name'                => '$var2',
+            'content'             => 'bar $var2',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'bar',
+            'type_hint_token'     => 9, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 9, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => false,
         ];
 
         $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -114,12 +138,18 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     {
         $expected    = [];
         $expected[0] = [
-            'name'              => '$var',
-            'content'           => 'self $var',
-            'pass_by_reference' => false,
-            'variable_length'   => false,
-            'type_hint'         => 'self',
-            'nullable_type'     => false,
+            'token'               => 6, // Offset from the T_FUNCTION token.
+            'name'                => '$var',
+            'content'             => 'self $var',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'self',
+            'type_hint_token'     => 4, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 4, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => false,
         ];
 
         $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -134,21 +164,33 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     {
         $expected    = [];
         $expected[0] = [
-            'name'              => '$var1',
-            'content'           => '?int $var1',
-            'pass_by_reference' => false,
-            'variable_length'   => false,
-            'type_hint'         => '?int',
-            'nullable_type'     => true,
+            'token'               => 7, // Offset from the T_FUNCTION token.
+            'name'                => '$var1',
+            'content'             => '?int $var1',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '?int',
+            'type_hint_token'     => 5, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 5, // Offset from the T_FUNCTION token.
+            'nullable_type'       => true,
+            'comma_token'         => 8, // Offset from the T_FUNCTION token.
         ];
 
         $expected[1] = [
-            'name'              => '$var2',
-            'content'           => '?\bar $var2',
-            'pass_by_reference' => false,
-            'variable_length'   => false,
-            'type_hint'         => '?\bar',
-            'nullable_type'     => true,
+            'token'               => 14, // Offset from the T_FUNCTION token.
+            'name'                => '$var2',
+            'content'             => '?\bar $var2',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '?\bar',
+            'type_hint_token'     => 11, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 12, // Offset from the T_FUNCTION token.
+            'nullable_type'       => true,
+            'comma_token'         => false,
         ];
 
         $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -163,12 +205,18 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     {
         $expected    = [];
         $expected[0] = [
-            'name'              => '$var',
-            'content'           => '$var',
-            'pass_by_reference' => false,
-            'variable_length'   => false,
-            'type_hint'         => '',
-            'nullable_type'     => false,
+            'token'               => 4, // Offset from the T_FUNCTION token.
+            'name'                => '$var',
+            'content'             => '$var',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => false,
         ];
 
         $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -183,13 +231,21 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     {
         $expected    = [];
         $expected[0] = [
-            'name'              => '$var1',
-            'content'           => '$var1=self::CONSTANT',
-            'default'           => 'self::CONSTANT',
-            'pass_by_reference' => false,
-            'variable_length'   => false,
-            'type_hint'         => '',
-            'nullable_type'     => false,
+            'token'               => 4, // Offset from the T_FUNCTION token.
+            'name'                => '$var1',
+            'content'             => '$var1=self::CONSTANT',
+            'default'             => 'self::CONSTANT',
+            'default_token'       => 6, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 5, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => false,
         ];
 
         $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -204,22 +260,38 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     {
         $expected    = [];
         $expected[0] = [
-            'name'              => '$var1',
-            'content'           => '$var1=1',
-            'default'           => '1',
-            'pass_by_reference' => false,
-            'variable_length'   => false,
-            'type_hint'         => '',
-            'nullable_type'     => false,
+            'token'               => 4, // Offset from the T_FUNCTION token.
+            'name'                => '$var1',
+            'content'             => '$var1=1',
+            'default'             => '1',
+            'default_token'       => 6, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 5, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => 7, // Offset from the T_FUNCTION token.
         ];
         $expected[1] = [
-            'name'              => '$var2',
-            'content'           => "\$var2='value'",
-            'default'           => "'value'",
-            'pass_by_reference' => false,
-            'variable_length'   => false,
-            'type_hint'         => '',
-            'nullable_type'     => false,
+            'token'               => 9, // Offset from the T_FUNCTION token.
+            'name'                => '$var2',
+            'content'             => "\$var2='value'",
+            'default'             => "'value'",
+            'default_token'       => 11, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 10, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => false,
         ];
 
         $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -234,13 +306,21 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     {
         $expected    = [];
         $expected[0] = [
-            'name'              => '$a',
-            'content'           => '$a = 10 & 20',
-            'default'           => '10 & 20',
-            'pass_by_reference' => false,
-            'variable_length'   => false,
-            'type_hint'         => '',
-            'nullable_type'     => false,
+            'token'               => 4, // Offset from the T_FUNCTION token.
+            'name'                => '$a',
+            'content'             => '$a = 10 & 20',
+            'default'             => '10 & 20',
+            'default_token'       => 8, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 6, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => false,
         ];
 
         $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -259,6 +339,32 @@ class GetMethodParametersTest extends UtilityMethodTestCase
         $function = $this->getTargetToken($commentString, [T_FUNCTION]);
         $found    = BCFile::getMethodParameters(self::$phpcsFile, $function);
 
-        $this->assertArraySubset($expected, $found, true);
+        foreach ($expected as $key => $param) {
+            $expected[$key]['token'] += $target;
+
+            if ($param['reference_token'] !== false) {
+                $expected[$key]['reference_token'] += $target;
+            }
+            if ($param['variadic_token'] !== false) {
+                $expected[$key]['variadic_token'] += $target;
+            }
+            if ($param['type_hint_token'] !== false) {
+                $expected[$key]['type_hint_token'] += $target;
+            }
+            if ($param['type_hint_end_token'] !== false) {
+                $expected[$key]['type_hint_end_token'] += $target;
+            }
+            if ($param['comma_token'] !== false) {
+                $expected[$key]['comma_token'] += $target;
+            }
+            if (isset($param['default_token'])) {
+                $expected[$key]['default_token'] += $target;
+            }
+            if (isset($param['default_equal_token'])) {
+                $expected[$key]['default_equal_token'] += $target;
+            }
+        }
+
+        $this->assertSame($expected, $found);
     }
 }

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
@@ -1,0 +1,62 @@
+<?php
+
+/* testBasicFunction */
+function myFunction() {}
+
+/* testReturnFunction */
+function myFunction(array ...$arrays): array
+{
+    /* testNestedClosure */
+    return array_map(function(array $array): int {
+        return array_sum($array);
+    }, $arrays);
+}
+
+class MyClass {
+    /* testBasicMethod */
+    function myFunction() {}
+
+    /* testPrivateStaticMethod */
+    private static function myFunction() {}
+
+    /* testFinalMethod */
+    final public function myFunction() {}
+
+    /* testProtectedReturnMethod */
+    protected function myFunction() : int {}
+
+    /* testPublicReturnMethod */
+    public function myFunction(): array {}
+
+    /* testNullableReturnMethod */
+    public function myFunction(): ?array {}
+
+    /* testMessyNullableReturnMethod */
+    public function myFunction() /* comment
+        */ :  
+        /* comment */ ? //comment
+        array {}
+
+    /* testReturnNamespace */
+    function myFunction(): \MyNamespace\MyClass {}
+
+    /* testReturnMultilineNamespace */
+    function myFunction(): \MyNamespace /** comment *\/ comment */
+                           \MyClass /* comment */
+                           \Foo {}
+}
+
+abstract class MyClass
+{
+    /* testAbstractMethod */
+    abstract function myFunction();
+
+    /* testAbstractReturnMethod */
+    abstract protected function myFunction(): bool;
+}
+
+interface MyInterface
+{
+    /* testInterfaceMethod */
+    function myFunction();
+}

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
@@ -34,7 +34,7 @@ class MyClass {
     /* testMessyNullableReturnMethod */
     public function myFunction() /* comment
         */ :  
-        /* comment */ ? //comment
+        /* comment */ ? // phpcs:ignore Stnd.Cat.Sniff -- For reasons.
         array {}
 
     /* testReturnNamespace */
@@ -59,4 +59,12 @@ interface MyInterface
 {
     /* testInterfaceMethod */
     function myFunction();
+}
+
+/* testNotAFunction */
+return true;
+
+/* testPhpcsIssue1264 */
+function foo() : array {
+    echo $foo;
 }

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -1,0 +1,381 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File:getMethodProperties method.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\File;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+
+class GetMethodPropertiesTest extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Test a basic function.
+     *
+     * @return void
+     */
+    public function testBasicFunction()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => '',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testBasicFunction()
+
+
+    /**
+     * Test a function with a return type.
+     *
+     * @return void
+     */
+    public function testReturnFunction()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => 'array',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testReturnFunction()
+
+
+    /**
+     * Test a closure used as a function argument.
+     *
+     * @return void
+     */
+    public function testNestedClosure()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => 'int',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testNestedClosure()
+
+
+    /**
+     * Test a basic method.
+     *
+     * @return void
+     */
+    public function testBasicMethod()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => '',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testBasicMethod()
+
+
+    /**
+     * Test a private static method.
+     *
+     * @return void
+     */
+    public function testPrivateStaticMethod()
+    {
+        $expected = [
+            'scope'                => 'private',
+            'scope_specified'      => true,
+            'return_type'          => '',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => true,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPrivateStaticMethod()
+
+
+    /**
+     * Test a basic final method.
+     *
+     * @return void
+     */
+    public function testFinalMethod()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => true,
+            'return_type'          => '',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => true,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testFinalMethod()
+
+
+    /**
+     * Test a protected method with a return type.
+     *
+     * @return void
+     */
+    public function testProtectedReturnMethod()
+    {
+        $expected = [
+            'scope'                => 'protected',
+            'scope_specified'      => true,
+            'return_type'          => 'int',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testProtectedReturnMethod()
+
+
+    /**
+     * Test a public method with a return type.
+     *
+     * @return void
+     */
+    public function testPublicReturnMethod()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => true,
+            'return_type'          => 'array',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testPublicReturnMethod()
+
+
+    /**
+     * Test a public method with a nullable return type.
+     *
+     * @return void
+     */
+    public function testNullableReturnMethod()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => true,
+            'return_type'          => '?array',
+            'nullable_return_type' => true,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testNullableReturnMethod()
+
+
+    /**
+     * Test a public method with a nullable return type.
+     *
+     * @return void
+     */
+    public function testMessyNullableReturnMethod()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => true,
+            'return_type'          => '?array',
+            'nullable_return_type' => true,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testMessyNullableReturnMethod()
+
+
+    /**
+     * Test a method with a namespaced return type.
+     *
+     * @return void
+     */
+    public function testReturnNamespace()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => '\MyNamespace\MyClass',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testReturnNamespace()
+
+
+    /**
+     * Test a method with a messy namespaces return type.
+     *
+     * @return void
+     */
+    public function testReturnMultilineNamespace()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => '\MyNamespace\MyClass\Foo',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testReturnMultilineNamespace()
+
+
+    /**
+     * Test a basic abstract method.
+     *
+     * @return void
+     */
+    public function testAbstractMethod()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => '',
+            'nullable_return_type' => false,
+            'is_abstract'          => true,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => false,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testAbstractMethod()
+
+
+    /**
+     * Test an abstract method with a return type.
+     *
+     * @return void
+     */
+    public function testAbstractReturnMethod()
+    {
+        $expected = [
+            'scope'                => 'protected',
+            'scope_specified'      => true,
+            'return_type'          => 'bool',
+            'nullable_return_type' => false,
+            'is_abstract'          => true,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => false,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testAbstractReturnMethod()
+
+
+    /**
+     * Test a basic interface method.
+     *
+     * @return void
+     */
+    public function testInterfaceMethod()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => '',
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => false,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
+
+    }//end testInterfaceMethod()
+
+
+    /**
+     * Test helper.
+     *
+     * @param string $commentString The comment which preceeds the test.
+     * @param array  $expected      The expected function output.
+     *
+     * @return void
+     */
+    private function getMethodPropertiesTestHelper($commentString, $expected)
+    {
+        $function = $this->getTargetToken($commentString, [T_FUNCTION, T_CLOSURE]);
+        $found    = self::$phpcsFile->getMethodProperties($function);
+
+        $this->assertArraySubset($expected, $found, true);
+
+    }//end getMethodPropertiesTestHelper()
+
+
+}//end class

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -2,8 +2,14 @@
 /**
  * Tests for the \PHP_CodeSniffer\Files\File:getMethodProperties method.
  *
+ * This class is imported from the PHP_CodeSniffer project.
+ *
+ * Copyright of the original code in this class as per the import:
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @author    Chris Wilkinson <c.wilkinson@elifesciences.org>
+ * @author    Juliette Reinders Folmer <jrf@phpcodesniffer.info>
+ *
+ * @copyright 2018-2019 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -34,6 +34,19 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
 {
 
     /**
+     * Test receiving an expected exception when a non function token is passed.
+     *
+     * @return void
+     */
+    public function testNotAFunctionException()
+    {
+        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION or T_CLOSURE');
+
+        $next = $this->getTargetToken('/* testNotAFunction */', T_RETURN);
+        BCFile::getMethodProperties(self::$phpcsFile, $next);
+    }
+
+    /**
      * Test a basic function.
      *
      * @return void
@@ -44,6 +57,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope'                => 'public',
             'scope_specified'      => false,
             'return_type'          => '',
+            'return_type_token'    => false,
             'nullable_return_type' => false,
             'is_abstract'          => false,
             'is_final'             => false,
@@ -65,6 +79,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope'                => 'public',
             'scope_specified'      => false,
             'return_type'          => 'array',
+            'return_type_token'    => 11, // Offset from the T_FUNCTION token.
             'nullable_return_type' => false,
             'is_abstract'          => false,
             'is_final'             => false,
@@ -86,6 +101,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope'                => 'public',
             'scope_specified'      => false,
             'return_type'          => 'int',
+            'return_type_token'    => 8, // Offset from the T_FUNCTION token.
             'nullable_return_type' => false,
             'is_abstract'          => false,
             'is_final'             => false,
@@ -107,6 +123,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope'                => 'public',
             'scope_specified'      => false,
             'return_type'          => '',
+            'return_type_token'    => false,
             'nullable_return_type' => false,
             'is_abstract'          => false,
             'is_final'             => false,
@@ -128,6 +145,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope'                => 'private',
             'scope_specified'      => true,
             'return_type'          => '',
+            'return_type_token'    => false,
             'nullable_return_type' => false,
             'is_abstract'          => false,
             'is_final'             => false,
@@ -149,6 +167,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope'                => 'public',
             'scope_specified'      => true,
             'return_type'          => '',
+            'return_type_token'    => false,
             'nullable_return_type' => false,
             'is_abstract'          => false,
             'is_final'             => true,
@@ -170,6 +189,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope'                => 'protected',
             'scope_specified'      => true,
             'return_type'          => 'int',
+            'return_type_token'    => 8, // Offset from the T_FUNCTION token.
             'nullable_return_type' => false,
             'is_abstract'          => false,
             'is_final'             => false,
@@ -191,6 +211,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope'                => 'public',
             'scope_specified'      => true,
             'return_type'          => 'array',
+            'return_type_token'    => 7, // Offset from the T_FUNCTION token.
             'nullable_return_type' => false,
             'is_abstract'          => false,
             'is_final'             => false,
@@ -212,6 +233,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope'                => 'public',
             'scope_specified'      => true,
             'return_type'          => '?array',
+            'return_type_token'    => 8, // Offset from the T_FUNCTION token.
             'nullable_return_type' => true,
             'is_abstract'          => false,
             'is_final'             => false,
@@ -233,6 +255,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope'                => 'public',
             'scope_specified'      => true,
             'return_type'          => '?array',
+            'return_type_token'    => 18, // Offset from the T_FUNCTION token.
             'nullable_return_type' => true,
             'is_abstract'          => false,
             'is_final'             => false,
@@ -254,6 +277,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope'                => 'public',
             'scope_specified'      => false,
             'return_type'          => '\MyNamespace\MyClass',
+            'return_type_token'    => 7, // Offset from the T_FUNCTION token.
             'nullable_return_type' => false,
             'is_abstract'          => false,
             'is_final'             => false,
@@ -275,6 +299,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope'                => 'public',
             'scope_specified'      => false,
             'return_type'          => '\MyNamespace\MyClass\Foo',
+            'return_type_token'    => 7, // Offset from the T_FUNCTION token.
             'nullable_return_type' => false,
             'is_abstract'          => false,
             'is_final'             => false,
@@ -296,6 +321,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope'                => 'public',
             'scope_specified'      => false,
             'return_type'          => '',
+            'return_type_token'    => false,
             'nullable_return_type' => false,
             'is_abstract'          => true,
             'is_final'             => false,
@@ -317,6 +343,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope'                => 'protected',
             'scope_specified'      => true,
             'return_type'          => 'bool',
+            'return_type_token'    => 7, // Offset from the T_FUNCTION token.
             'nullable_return_type' => false,
             'is_abstract'          => true,
             'is_final'             => false,
@@ -338,11 +365,36 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope'                => 'public',
             'scope_specified'      => false,
             'return_type'          => '',
+            'return_type_token'    => false,
             'nullable_return_type' => false,
             'is_abstract'          => false,
             'is_final'             => false,
             'is_static'            => false,
             'has_body'             => false,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Test for incorrect tokenization of array return type declarations in PHPCS < 2.8.0.
+     *
+     * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/1264
+     *
+     * @return void
+     */
+    public function testPhpcsIssue1264()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => 'array',
+            'return_type_token'    => 8, // Offset from the T_FUNCTION token.
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -361,6 +413,10 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
         $function = $this->getTargetToken($commentString, [T_FUNCTION, T_CLOSURE]);
         $found    = BCFile::getMethodProperties(self::$phpcsFile, $function);
 
-        $this->assertArraySubset($expected, $found, true);
+        if ($expected['return_type_token'] !== false) {
+            $expected['return_type_token'] += $function;
+        }
+
+        $this->assertSame($expected, $found);
     }
 }

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -13,11 +13,12 @@
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-namespace PHP_CodeSniffer\Tests\Core\File;
+namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
-class GetMethodPropertiesTest extends AbstractMethodUnitTest
+class GetMethodPropertiesTest extends UtilityMethodTestCase
 {
 
 
@@ -377,7 +378,7 @@ class GetMethodPropertiesTest extends AbstractMethodUnitTest
     private function getMethodPropertiesTestHelper($commentString, $expected)
     {
         $function = $this->getTargetToken($commentString, [T_FUNCTION, T_CLOSURE]);
-        $found    = self::$phpcsFile->getMethodProperties($function);
+        $found    = BCFile::getMethodProperties(self::$phpcsFile, $function);
 
         $this->assertArraySubset($expected, $found, true);
 

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -1,6 +1,11 @@
 <?php
 /**
- * Tests for the \PHP_CodeSniffer\Files\File:getMethodProperties method.
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
  *
  * This class is imported from the PHP_CodeSniffer project.
  *
@@ -18,9 +23,15 @@ namespace PHPCSUtils\Tests\BackCompat\BCFile;
 use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
+/**
+ * Tests for the \PHPCSUtils\BackCompat\BCFile::getMethodProperties method.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCFile::getMethodProperties
+ *
+ * @since 1.0.0
+ */
 class GetMethodPropertiesTest extends UtilityMethodTestCase
 {
-
 
     /**
      * Test a basic function.
@@ -40,10 +51,8 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => true,
         ];
 
-        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testBasicFunction()
-
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Test a function with a return type.
@@ -63,10 +72,8 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => true,
         ];
 
-        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testReturnFunction()
-
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Test a closure used as a function argument.
@@ -86,10 +93,8 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => true,
         ];
 
-        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testNestedClosure()
-
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Test a basic method.
@@ -109,10 +114,8 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => true,
         ];
 
-        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testBasicMethod()
-
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Test a private static method.
@@ -132,10 +135,8 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => true,
         ];
 
-        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testPrivateStaticMethod()
-
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Test a basic final method.
@@ -155,10 +156,8 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => true,
         ];
 
-        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testFinalMethod()
-
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Test a protected method with a return type.
@@ -178,10 +177,8 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => true,
         ];
 
-        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testProtectedReturnMethod()
-
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Test a public method with a return type.
@@ -201,10 +198,8 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => true,
         ];
 
-        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testPublicReturnMethod()
-
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Test a public method with a nullable return type.
@@ -224,10 +219,8 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => true,
         ];
 
-        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testNullableReturnMethod()
-
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Test a public method with a nullable return type.
@@ -247,10 +240,8 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => true,
         ];
 
-        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testMessyNullableReturnMethod()
-
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Test a method with a namespaced return type.
@@ -270,10 +261,8 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => true,
         ];
 
-        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testReturnNamespace()
-
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Test a method with a messy namespaces return type.
@@ -293,10 +282,8 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => true,
         ];
 
-        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testReturnMultilineNamespace()
-
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Test a basic abstract method.
@@ -316,10 +303,8 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => false,
         ];
 
-        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testAbstractMethod()
-
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Test an abstract method with a return type.
@@ -339,10 +324,8 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => false,
         ];
 
-        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testAbstractReturnMethod()
-
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Test a basic interface method.
@@ -362,10 +345,8 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => false,
         ];
 
-        $this->getMethodPropertiesTestHelper('/* '.__FUNCTION__.' */', $expected);
-
-    }//end testInterfaceMethod()
-
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
 
     /**
      * Test helper.
@@ -381,8 +362,5 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
         $found    = BCFile::getMethodProperties(self::$phpcsFile, $function);
 
         $this->assertArraySubset($expected, $found, true);
-
-    }//end getMethodPropertiesTestHelper()
-
-
-}//end class
+    }
+}

--- a/Tests/BackCompat/BCFile/IsReferenceTest.inc
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.inc
@@ -1,0 +1,138 @@
+<?php
+
+namespace PHP_CodeSniffer\Tests\Core\File;
+
+/* testBitwiseAndA */
+error_reporting( E_NOTICE & E_STRICT );
+
+/* testBitwiseAndB */
+$a = [ $something & $somethingElse ];
+
+/* testBitwiseAndC */
+$a = [ $first, $something & self::$somethingElse ];
+
+/* testBitwiseAndD */
+$a = array $first, $something & $somethingElse );
+
+/* testBitwiseAndE */
+$a = [ 'a' => $first, 'b' => $something & $somethingElse ];
+
+/* testBitwiseAndF */
+$a = array( 'a' => $first, 'b' => $something & \MyClass::$somethingElse );
+
+/* testBitwiseAndG */
+$a = $something & $somethingElse;
+
+/* testBitwiseAndH */
+function myFunction($a = 10 & 20) {}
+
+/* testBitwiseAndI */
+$closure = function ($a = MY_CONSTANT & parent::OTHER_CONSTANT) {};
+
+/* testFunctionReturnByReference */
+function &myFunction() {}
+
+/* testFunctionPassByReferenceA */
+function myFunction( &$a ) {}
+
+/* testFunctionPassByReferenceB */
+function myFunction( $a, &$b ) {}
+
+/* testFunctionPassByReferenceC */
+$closure = function ( &$a ) {};
+
+/* testFunctionPassByReferenceD */
+$closure = function ( $a, &$b ) {};
+
+/* testFunctionPassByReferenceE */
+function myFunction(array &$one) {}
+
+/* testFunctionPassByReferenceF */
+$closure = function (\MyClass &$one) {};
+
+/* testFunctionPassByReferenceG */
+$closure = function myFunc($param, &...$moreParams) {};
+
+/* testForeachValueByReference */
+foreach( $array as $key => &$value ) {}
+
+/* testForeachKeyByReference */
+foreach( $array as &$key => $value ) {}
+
+/* testArrayValueByReferenceA */
+$a = [ 'a' => &$something ];
+
+/* testArrayValueByReferenceB */
+$a = [ 'a' => $something, 'b' => &$somethingElse ];
+
+/* testArrayValueByReferenceC */
+$a = [ &$something ];
+
+/* testArrayValueByReferenceD */
+$a = [ $something, &$somethingElse ];
+
+/* testArrayValueByReferenceE */
+$a = array( 'a' => &$something );
+
+/* testArrayValueByReferenceF */
+$a = array( 'a' => $something, 'b' => &$somethingElse );
+
+/* testArrayValueByReferenceG */
+$a = array( &$something );
+
+/* testArrayValueByReferenceH */
+$a = array( $something, &$somethingElse );
+
+/* testAssignByReferenceA */
+$b = &$something;
+
+/* testAssignByReferenceB */
+$b =& $something;
+
+/* testAssignByReferenceC */
+$b .= &$something;
+
+/* testAssignByReferenceD */
+$myValue = &$obj->getValue();
+
+/* testAssignByReferenceE */
+$collection = &collector();
+
+/* testPassByReferenceA */
+functionCall(&$something, $somethingElse);
+
+/* testPassByReferenceB */
+functionCall($something, &$somethingElse);
+
+/* testPassByReferenceC */
+functionCall($something, &$this->somethingElse);
+
+/* testPassByReferenceD */
+functionCall($something, &self::$somethingElse);
+
+/* testPassByReferenceE */
+functionCall($something, &parent::$somethingElse);
+
+/* testPassByReferenceF */
+functionCall($something, &static::$somethingElse);
+
+/* testPassByReferenceG */
+functionCall($something, &SomeClass::$somethingElse);
+
+/* testPassByReferenceH */
+functionCall(&\SomeClass::$somethingElse);
+
+/* testPassByReferenceI */
+functionCall($something, &\SomeNS\SomeClass::$somethingElse);
+
+/* testPassByReferenceJ */
+functionCall($something, &namespace\SomeClass::$somethingElse);
+
+/* testNewByReferenceA */
+$foobar2 = &new Foobar();
+
+/* testNewByReferenceB */
+functionCall( $something , &new Foobar() );
+
+/* testUseByReference */
+$closure = function() use (&$var){};

--- a/Tests/BackCompat/BCFile/IsReferenceTest.inc
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.inc
@@ -12,7 +12,7 @@ $a = [ $something & $somethingElse ];
 $a = [ $first, $something & self::$somethingElse ];
 
 /* testBitwiseAndD */
-$a = array $first, $something & $somethingElse );
+$a = array( $first, $something & $somethingElse );
 
 /* testBitwiseAndE */
 $a = [ 'a' => $first, 'b' => $something & $somethingElse ];
@@ -51,7 +51,7 @@ function myFunction(array &$one) {}
 $closure = function (\MyClass &$one) {};
 
 /* testFunctionPassByReferenceG */
-$closure = function myFunc($param, &...$moreParams) {};
+$closure = function ($param, &...$moreParams) {};
 
 /* testForeachValueByReference */
 foreach( $array as $key => &$value ) {}

--- a/Tests/BackCompat/BCFile/IsReferenceTest.inc
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.inc
@@ -101,6 +101,29 @@ $collection = &collector();
 /* testAssignByReferenceF */
 $collection ??= &collector();
 
+/* testShortListAssignByReferenceNoKeyA */
+[
+    &$a,
+    /* testShortListAssignByReferenceNoKeyB */
+    &$b,
+    /* testNestedShortListAssignByReferenceNoKey */
+    [$c, &$d]
+] = $array;
+
+/* testLongListAssignByReferenceNoKeyA */
+list($a, &$b, list(/* testLongListAssignByReferenceNoKeyB */ &$c, /* testLongListAssignByReferenceNoKeyC */ &$d)) = $array;
+
+[
+    /* testNestedShortListAssignByReferenceWithKeyA */
+    'a' => [&$a, $b],
+    /* testNestedShortListAssignByReferenceWithKeyB */
+    'b' => [$c, &$d]
+] = $array;
+
+
+/* testLongListAssignByReferenceWithKeyA */
+list(get_key()[1] => &$e) = [1, 2, 3];
+
 /* testPassByReferenceA */
 functionCall(&$something, $somethingElse);
 

--- a/Tests/BackCompat/BCFile/IsReferenceTest.inc
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.inc
@@ -98,6 +98,9 @@ $myValue = &$obj->getValue();
 /* testAssignByReferenceE */
 $collection = &collector();
 
+/* testAssignByReferenceF */
+$collection ??= &collector();
+
 /* testPassByReferenceA */
 functionCall(&$something, $somethingElse);
 

--- a/Tests/BackCompat/BCFile/IsReferenceTest.php
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Tests for the \PHP_CodeSniffer\Files\File:isReference method.
+ *
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ */
+
+namespace PHP_CodeSniffer\Tests\Core\File;
+
+use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+
+class IsReferenceTest extends AbstractMethodUnitTest
+{
+
+
+    /**
+     * Test a class that extends another.
+     *
+     * @param string $identifier Comment which precedes the test case.
+     * @param bool   $expected   Expected function output.
+     *
+     * @dataProvider dataIsReference
+     *
+     * @return void
+     */
+    public function testIsReference($identifier, $expected)
+    {
+        $bitwiseAnd = $this->getTargetToken($identifier, T_BITWISE_AND);
+        $result     = self::$phpcsFile->isReference($bitwiseAnd);
+        $this->assertSame($expected, $result);
+
+    }//end testIsReference()
+
+
+    /**
+     * Data provider for the IsReference test.
+     *
+     * @see testIsReference()
+     *
+     * @return array
+     */
+    public function dataIsReference()
+    {
+        return [
+            [
+                '/* testBitwiseAndA */',
+                false,
+            ],
+            [
+                '/* testBitwiseAndB */',
+                false,
+            ],
+            [
+                '/* testBitwiseAndC */',
+                false,
+            ],
+            [
+                '/* testBitwiseAndD */',
+                false,
+            ],
+            [
+                '/* testBitwiseAndE */',
+                false,
+            ],
+            [
+                '/* testBitwiseAndF */',
+                false,
+            ],
+            [
+                '/* testBitwiseAndG */',
+                false,
+            ],
+            [
+                '/* testBitwiseAndH */',
+                false,
+            ],
+            [
+                '/* testBitwiseAndI */',
+                false,
+            ],
+            [
+                '/* testFunctionReturnByReference */',
+                true,
+            ],
+            [
+                '/* testFunctionPassByReferenceA */',
+                true,
+            ],
+            [
+                '/* testFunctionPassByReferenceB */',
+                true,
+            ],
+            [
+                '/* testFunctionPassByReferenceC */',
+                true,
+            ],
+            [
+                '/* testFunctionPassByReferenceD */',
+                true,
+            ],
+            [
+                '/* testFunctionPassByReferenceE */',
+                true,
+            ],
+            [
+                '/* testFunctionPassByReferenceF */',
+                true,
+            ],
+            [
+                '/* testFunctionPassByReferenceG */',
+                true,
+            ],
+            [
+                '/* testForeachValueByReference */',
+                true,
+            ],
+            [
+                '/* testForeachKeyByReference */',
+                true,
+            ],
+            [
+                '/* testArrayValueByReferenceA */',
+                true,
+            ],
+            [
+                '/* testArrayValueByReferenceB */',
+                true,
+            ],
+            [
+                '/* testArrayValueByReferenceC */',
+                true,
+            ],
+            [
+                '/* testArrayValueByReferenceD */',
+                true,
+            ],
+            [
+                '/* testArrayValueByReferenceE */',
+                true,
+            ],
+            [
+                '/* testArrayValueByReferenceF */',
+                true,
+            ],
+            [
+                '/* testArrayValueByReferenceG */',
+                true,
+            ],
+            [
+                '/* testArrayValueByReferenceH */',
+                true,
+            ],
+            [
+                '/* testAssignByReferenceA */',
+                true,
+            ],
+            [
+                '/* testAssignByReferenceB */',
+                true,
+            ],
+            [
+                '/* testAssignByReferenceC */',
+                true,
+            ],
+            [
+                '/* testAssignByReferenceD */',
+                true,
+            ],
+            [
+                '/* testAssignByReferenceE */',
+                true,
+            ],
+            [
+                '/* testPassByReferenceA */',
+                true,
+            ],
+            [
+                '/* testPassByReferenceB */',
+                true,
+            ],
+            [
+                '/* testPassByReferenceC */',
+                true,
+            ],
+            [
+                '/* testPassByReferenceD */',
+                true,
+            ],
+            [
+                '/* testPassByReferenceE */',
+                true,
+            ],
+            [
+                '/* testPassByReferenceF */',
+                true,
+            ],
+            [
+                '/* testPassByReferenceG */',
+                true,
+            ],
+            [
+                '/* testPassByReferenceH */',
+                true,
+            ],
+            [
+                '/* testPassByReferenceI */',
+                true,
+            ],
+            [
+                '/* testPassByReferenceJ */',
+                true,
+            ],
+            [
+                '/* testNewByReferenceA */',
+                true,
+            ],
+            [
+                '/* testNewByReferenceB */',
+                true,
+            ],
+            [
+                '/* testUseByReference */',
+                true,
+            ],
+        ];
+
+    }//end dataIsReference()
+
+
+}//end class

--- a/Tests/BackCompat/BCFile/IsReferenceTest.php
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.php
@@ -2,8 +2,16 @@
 /**
  * Tests for the \PHP_CodeSniffer\Files\File:isReference method.
  *
+ * This class is imported from the PHP_CodeSniffer project.
+ *
+ * Copyright of the original code in this class as per the import:
+ * @author    Juliette Reinders Folmer <jrf@phpcodesniffer.info>
  * @author    Greg Sherwood <gsherwood@squiz.net>
- * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ *
+ * With documentation contributions from:
+ * @author    Phil Davis <phil@jankaritech.com>
+ *
+ * @copyright 2017-2019 Squiz Pty Ltd (ABN 77 084 670 600)
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 

--- a/Tests/BackCompat/BCFile/IsReferenceTest.php
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.php
@@ -15,11 +15,12 @@
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
-namespace PHP_CodeSniffer\Tests\Core\File;
+namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
-use PHP_CodeSniffer\Tests\Core\AbstractMethodUnitTest;
+use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
-class IsReferenceTest extends AbstractMethodUnitTest
+class IsReferenceTest extends UtilityMethodTestCase
 {
 
 
@@ -36,7 +37,7 @@ class IsReferenceTest extends AbstractMethodUnitTest
     public function testIsReference($identifier, $expected)
     {
         $bitwiseAnd = $this->getTargetToken($identifier, T_BITWISE_AND);
-        $result     = self::$phpcsFile->isReference($bitwiseAnd);
+        $result     = BCFile::isReference(self::$phpcsFile, $bitwiseAnd);
         $this->assertSame($expected, $result);
 
     }//end testIsReference()

--- a/Tests/BackCompat/BCFile/IsReferenceTest.php
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.php
@@ -36,7 +36,7 @@ class IsReferenceTest extends UtilityMethodTestCase
 {
 
     /**
-     * Test a class that extends another.
+     * Test correctly identifying that whether a "bitwise and" token is a reference or not.
      *
      * @dataProvider dataIsReference
      *

--- a/Tests/BackCompat/BCFile/IsReferenceTest.php
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.php
@@ -36,6 +36,17 @@ class IsReferenceTest extends UtilityMethodTestCase
 {
 
     /**
+     * Test that false is returned when a non-"bitwise and" token is passed.
+     *
+     * @return void
+     */
+    public function testNotBitwiseAndToken()
+    {
+        $target = $this->getTargetToken('/* testBitwiseAndA */', T_STRING);
+        $this->assertFalse(BCFile::isReference(self::$phpcsFile, $target));
+    }
+
+    /**
      * Test correctly identifying that whether a "bitwise and" token is a reference or not.
      *
      * @dataProvider dataIsReference
@@ -188,6 +199,10 @@ class IsReferenceTest extends UtilityMethodTestCase
             ],
             [
                 '/* testAssignByReferenceE */',
+                true,
+            ],
+            [
+                '/* testAssignByReferenceF */',
                 true,
             ],
             [

--- a/Tests/BackCompat/BCFile/IsReferenceTest.php
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.php
@@ -1,6 +1,11 @@
 <?php
 /**
- * Tests for the \PHP_CodeSniffer\Files\File:isReference method.
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
  *
  * This class is imported from the PHP_CodeSniffer project.
  *
@@ -20,17 +25,23 @@ namespace PHPCSUtils\Tests\BackCompat\BCFile;
 use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
+/**
+ * Tests for the \PHPCSUtils\BackCompat\BCFile::isReference method.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCFile::isReference
+ *
+ * @since 1.0.0
+ */
 class IsReferenceTest extends UtilityMethodTestCase
 {
-
 
     /**
      * Test a class that extends another.
      *
+     * @dataProvider dataIsReference
+     *
      * @param string $identifier Comment which precedes the test case.
      * @param bool   $expected   Expected function output.
-     *
-     * @dataProvider dataIsReference
      *
      * @return void
      */
@@ -39,12 +50,10 @@ class IsReferenceTest extends UtilityMethodTestCase
         $bitwiseAnd = $this->getTargetToken($identifier, T_BITWISE_AND);
         $result     = BCFile::isReference(self::$phpcsFile, $bitwiseAnd);
         $this->assertSame($expected, $result);
-
-    }//end testIsReference()
-
+    }
 
     /**
-     * Data provider for the IsReference test.
+     * Data provider.
      *
      * @see testIsReference()
      *
@@ -234,8 +243,5 @@ class IsReferenceTest extends UtilityMethodTestCase
                 true,
             ],
         ];
-
-    }//end dataIsReference()
-
-
-}//end class
+    }
+}

--- a/Tests/BackCompat/BCFile/IsReferenceTest.php
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.php
@@ -206,6 +206,42 @@ class IsReferenceTest extends UtilityMethodTestCase
                 true,
             ],
             [
+                '/* testShortListAssignByReferenceNoKeyA */',
+                true,
+            ],
+            [
+                '/* testShortListAssignByReferenceNoKeyB */',
+                true,
+            ],
+            [
+                '/* testNestedShortListAssignByReferenceNoKey */',
+                true,
+            ],
+            [
+                '/* testLongListAssignByReferenceNoKeyA */',
+                true,
+            ],
+            [
+                '/* testLongListAssignByReferenceNoKeyB */',
+                true,
+            ],
+            [
+                '/* testLongListAssignByReferenceNoKeyC */',
+                true,
+            ],
+            [
+                '/* testNestedShortListAssignByReferenceWithKeyA */',
+                true,
+            ],
+            [
+                '/* testNestedShortListAssignByReferenceWithKeyB */',
+                true,
+            ],
+            [
+                '/* testLongListAssignByReferenceWithKeyA */',
+                true,
+            ],
+            [
                 '/* testPassByReferenceA */',
                 true,
             ],

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -72,21 +72,27 @@
     </rule>
     <rule ref="Generic.Commenting.DocComment.TagsNotGrouped">
         <exclude-pattern>/PHPCSUtils/BackCompat/BCFile\.php$</exclude-pattern>
+        <exclude-pattern>/Tests/BackCompat/BCFile/*Test\.php$</exclude-pattern>
     </rule>
     <rule ref="PEAR.Commenting.FileComment.AuthorTagOrder">
         <exclude-pattern>/PHPCSUtils/BackCompat/BCFile\.php$</exclude-pattern>
+        <exclude-pattern>/Tests/BackCompat/BCFile/*Test\.php$</exclude-pattern>
     </rule>
     <rule ref="PEAR.Commenting.FileComment.CopyrightTagOrder">
         <exclude-pattern>/PHPCSUtils/BackCompat/BCFile\.php$</exclude-pattern>
+        <exclude-pattern>/Tests/BackCompat/BCFile/*Test\.php$</exclude-pattern>
     </rule>
     <rule ref="PEAR.Commenting.FileComment.DuplicateLicenseTag">
         <exclude-pattern>/PHPCSUtils/BackCompat/BCFile\.php$</exclude-pattern>
+        <exclude-pattern>/Tests/BackCompat/BCFile/*Test\.php$</exclude-pattern>
     </rule>
     <rule ref="PEAR.Commenting.FileComment.LicenseTagOrder">
         <exclude-pattern>/PHPCSUtils/BackCompat/BCFile\.php$</exclude-pattern>
+        <exclude-pattern>/Tests/BackCompat/BCFile/*Test\.php$</exclude-pattern>
     </rule>
     <rule ref="PEAR.Commenting.FileComment.LinkTagOrder">
         <exclude-pattern>/PHPCSUtils/BackCompat/BCFile\.php$</exclude-pattern>
+        <exclude-pattern>/Tests/BackCompat/BCFile/*Test\.php$</exclude-pattern>
     </rule>
 
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -66,4 +66,27 @@
         <exclude-pattern>/Tests/*Test\.php$</exclude-pattern>
     </rule>
 
+    <!-- Allow slightly different code style and file docblocks for classes imported from PHPCS. -->
+    <rule ref="Generic.Files.LineLength.TooLong">
+        <exclude-pattern>/PHPCSUtils/BackCompat/BCFile\.php$</exclude-pattern>
+    </rule>
+    <rule ref="Generic.Commenting.DocComment.TagsNotGrouped">
+        <exclude-pattern>/PHPCSUtils/BackCompat/BCFile\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PEAR.Commenting.FileComment.AuthorTagOrder">
+        <exclude-pattern>/PHPCSUtils/BackCompat/BCFile\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PEAR.Commenting.FileComment.CopyrightTagOrder">
+        <exclude-pattern>/PHPCSUtils/BackCompat/BCFile\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PEAR.Commenting.FileComment.DuplicateLicenseTag">
+        <exclude-pattern>/PHPCSUtils/BackCompat/BCFile\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PEAR.Commenting.FileComment.LicenseTagOrder">
+        <exclude-pattern>/PHPCSUtils/BackCompat/BCFile\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PEAR.Commenting.FileComment.LinkTagOrder">
+        <exclude-pattern>/PHPCSUtils/BackCompat/BCFile\.php$</exclude-pattern>
+    </rule>
+
 </ruleset>


### PR DESCRIPTION
## BackCompat\BCFile: import from PHPCS 3.5.0

Import the PHPCS native utility methods from the `File` class as per PHPCS 3.5.0, as well as any associated unit tests.

These methods will be improved upon further and - in so far possible - made backward-compatible to allow using the most recent PHPCS versions of these utility methods in older PHPCS version as well.

Copyright of the original code here is held by Squizlabs and the [respective contributors to PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer/graphs/contributors).

_Contributors to the specific code imported have been credited and added as co-authors to this commit._

### BackCompat\BCFile: give credit where credit is due

Add author and copyright information for all the imported code.

Note: the names and email addresses used are per the commits made by the contributors to `PHP_CodeSniffer`, which is information in the public domain.

### BackCompat\BCFile: adjust to work within PHPCSUtils

* Adjust namespace.
* Minor adjustments to import use statements.
* Adjust class name.
    The class is named `BCFile` instead of `File` on purpose to more easily allow sniffs to use both the PHPCS native File class as well as this class without always having to alias one of the two.
* Adjust method signatures
    - Make all methods `static`.
    - Add `$phpcsFile` as first parameter to all methods.
* Adjust code within methods:
    - Add calls to `File::getTokens()` and use local `$tokens` variable.
    - Adjust function calls and property access to use `$phpcsFile`.
    - Remove `Utils\` from uses of the `Tokens` class.

### BackCompat\BCFile: adjust to work within PHPCSUtils (unit tests)

Adjust namespace statement, import use statements and the calls to the functions being tested to point to the PHPCSUtils versions of the classes/methods.

### BackCompat\BCFile: adjust docs & CS

Minimal adjustments to the docs and code style to make the class fit into PHPCSUtils properly.

* Add standard PHPCSUtils file docblock info.
* Add class docblock.
* Add function `@since` tags for PHPCSUtils.
* Remove extraneous blank lines between methods.
* Remove function, class, control structure `//end` comments.

### BackCompat\BCFile: adjust docs & CS (unit tests)

Minimal adjustments to the docs and code style to make the classes fit into PHPCSUtils properly.

* Add standard PHPCSUtils file docblock info.
* Add class docblock.
* Remove extraneous blank lines between methods.
* Remove function and class `//end` comments.

### BackCompat\BCFile: document work-arounds added

Add documentation about which Tokenizer changes are being accounted for in the utility methods in this class.

## Method specific changes

### BCFile::getDeclarationName()

* Improve documentation.
* Add changelog for PHPCS changes between PHPCS 2.6.0 and now.

### BCFile::getMethodParameters()

* Add changelog for PHPCS changes between PHPCS 2.6.0 and now.
* Re-order unit tests.
    List the unit tests in the order they are run.
* Make the existing unit tests feature complete. [1]
    Test the correct determination of the token position for the various `...token` index keys.
* Make the existing unit tests feature complete. [2]
    * Test the situations in which the method returns an empty array.
    * Add a significant number of additional unit tests:
        - Cover all situations this method handles, i.e. test closures and closure use statements.
        - Test variadic functions.
        - Test handling of _all_ type declarations supported by PHP.
        - Test handling of the PHPCS 3.2.0+ ignore annotations.
        - Test (document) the behaviour of the function with fully qualified class names as type declaration, including when such a type declaration is interlaced with comments and whitespace.
        - Verify that a ternary in a default expression will not be confused with nullability.
    * Test the `Exceptions` being thrown by the method.
* Fix "type_hint_end_token" bleed through.
    Fixed a bug where a subsequent parameter without type declaration would get the `type_hint_end_token` from the end of the type declaration from a previous parameter.
    This bug fix is included in PHPCS 3.5.3 upstream.
    Ref: squizlabs/PHP_CodeSniffer#2685
* Fix compatibility with PHPCS < 3.3.0.
    * Between PHPCS 2.4.0 and 3.2.3, array type declaration were tokenized as `T_ARRAY_HINT`.
        This has been changed to "normalized" tokenization in PHPCS 3.3.0.
* Fix compatibility with PHPCS < 2.8.0.
    * The `T_NULLABLE` token was only introduced in PHPCS 2.8.0, so the constant may not exist.
        For PHPCS < 2.8.0, the token will be `T_INLINE_THEN`.

### BCFile::getMethodProperties()

* Improve documentation.
* Add changelog for PHPCS changes between PHPCS 2.6.0 and now.
* Make the existing unit tests feature complete.
    * Test the correct determination of the token position for the `return_type_token` index key.
    * Test the `Exception` being thrown by the method.
    * Test recognition of array return type declaration with a code sample which will be incorrectly tokenized in PHPCS < 2.8.0.
* Fix compatibility with PHPCS < 3.3.0.
    * Between PHPCS 2.4.0 and 3.2.3, return types were tokenized as `T_RETURN_TYPE`.
        This has been changed to "normalized" tokenization in PHPCS 3.3.0.
    * A bug existed with the tokenization of return types to `T_RETURN_TYPE` which would cause `array` return type declarations to be tokenized as `T_ARRAY_HINT` in certain circumstances.
        This bug was fixed in PHPCS 2.8.0.
    * The `T_NULLABLE` token was only introduced in PHPCS 2.8.0, so the constant may not exist.
        For PHPCS < 2.8.0, the token will be `T_INLINE_THEN`.

### BCFile::getMemberProperties()

* Improve documentation.
* Add changelog for PHPCS changes between PHPCS 2.6.0 and now.
* Make the existing unit tests feature complete.
    * Test the correct determination of the token position for the `type_token` and the `type_end_token` index keys.
    * Test handling of the PHPCS 3.2.0+ ignore annotations.
* Make the existing unit tests compatible with PHPUnit 8+.
* Fix compatibility with PHPCS < 3.5.0.
    * The `T_NULLABLE` token was only introduced in PHPCS 2.8.0, so the constant may not exist.
    * Prior to PHPCS 3.5.0, even when the `T_NULLABLE` token _does_ exist, the nullable indicator for typed property declarations would not be corrected to `T_NULLABLE` by the Tokenizer and would still be a `T_INLINE_THEN` token.
        See:  PHPCS issue https://github.com/squizlabs/PHP_CodeSniffer/issues/2413
    * Prior to PHPCS 3.3.0, the array keyword when not used to declare an array would be tokenized as `T_ARRAY_HINT`.
        This has been changed to "normalized" tokenization in PHPCS 3.3.0 and it will now be tokenized as a `T_STRING`.

### BCFile::getClassProperties()

* Improve documentation.
* Add changelog for PHPCS changes between PHPCS 2.6.0 and now.

### BCFile::isReference()

* Improve documentation.
* Add changelog for PHPCS changes between PHPCS 2.6.0 and now.
* Fix minor parse errors in the unit test case file.
* Fix test documentation.
* Make the existing unit tests feature complete.
    * Test passing an unexpected token.
    * Test assignment using null coalesce equals.
* Add tests for list assignments by reference (PHP 7.3+).
* Fix compatibility with PHPCS 2.8.1.
    ... as while the `T_COALESCE_EQUAL` was introduced in PHPCS 2.8.1, it wasn't added to the `Tokens::$assignmentTokens` array until PHPCS 2.9.0.
* Fix code coverage not correctly registering.

### BCFile::getTokensAsString()

* Improve documentation.
* Add changelog for PHPCS changes between PHPCS 2.6.0 and now.

### BCFile::findStartOfStatement()

* Add changelog for PHPCS changes between PHPCS 2.6.0 and now.

### BCFile::findEndOfStatement()

* Add changelog for PHPCS changes between PHPCS 2.6.0 and now.

### BCFile::hasCondition()

* Add changelog for PHPCS changes between PHPCS 2.6.0 and now.

### BCFile::getCondition()

* Improve documentation.
* Add changelog for PHPCS changes between PHPCS 2.6.0 and now.

### BCFile::findExtendedClassName()

* Improve documentation.
* Add changelog for PHPCS changes between PHPCS 2.6.0 and now.
* Make the existing unit tests feature complete.
    * Test support of anonymous classes.
    * Test the situations in which the method returns `false`.
    * Confirm non-support of multi-extended interfaces.

### BCFile::findImplementedInterfaceNames()

* Improve documentation.
* Add changelog for PHPCS changes between PHPCS 2.6.0 and now.
* Make the existing unit tests feature complete.
    * Test support of anonymous classes.
    * Test handling of the PHPCS 3.2.0+ ignore annotations.
    * Test the situations in which the method returns `false`.
