### PR TITLE
New Utils\Conditions class

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1285,7 +1285,8 @@ class BCFile
      * - Introduced in PHPCS 0.0.5.
      * - This method has received no significant code updates since PHPCS 2.6.0.
      *
-     * @see \PHP_CodeSniffer\Files\File::hasCondition() Original source.
+     * @see \PHP_CodeSniffer\Files\File::hasCondition()  Original source.
+     * @see \PHPCSUtils\Utils\Conditions::hasCondition() PHPCSUtils native alternative.
      *
      * @since 1.0.0
      *
@@ -1309,7 +1310,8 @@ class BCFile
      * - Introduced in PHPCS 1.3.0.
      * - This method has received no significant code updates since PHPCS 2.6.0.
      *
-     * @see \PHP_CodeSniffer\Files\File::getCondition() Original source.
+     * @see \PHP_CodeSniffer\Files\File::getCondition()  Original source.
+     * @see \PHPCSUtils\Utils\Conditions::getCondition() More versatile alternative.
      *
      * @since 1.0.0
      *

--- a/PHPCSUtils/Utils/Conditions.php
+++ b/PHPCSUtils/Utils/Conditions.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Utils;
+
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Utility functions for use when examining token conditions.
+ *
+ * @since 1.0.0 The `getCondition()` and `hasCondition()` methods are based
+ *              on and inspired by the methods of the same name in the
+ *              PHPCS native `File` class.
+ *              Also see {@see \PHPCSUtils\BackCompat\BCFile}.
+ */
+class Conditions
+{
+
+    /**
+     * Retrieve the position of the condition for the passed token.
+     *
+     * @see \PHP_CodeSniffer\Files\File::getCondition()   Original source.
+     * @see \PHPCSUtils\BackCompat\BCFile::getCondition() Cross-version compatible version of the original.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the token we are checking.
+     * @param int|string                  $type      The type of token to search for.
+     *
+     * @return int|false Integer stack pointer to the condition or FALSE if the token
+     *                   does not have the condition.
+     */
+    public static function getCondition(File $phpcsFile, $stackPtr, $type)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Check for the existence of the token.
+        if (isset($tokens[$stackPtr]) === false) {
+            return false;
+        }
+
+        // Make sure the token has conditions.
+        if (isset($tokens[$stackPtr]['conditions']) === false) {
+            return false;
+        }
+
+        $conditions = $tokens[$stackPtr]['conditions'];
+        foreach ($conditions as $token => $condition) {
+            if ($condition === $type) {
+                return $token;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if the passed token has a condition of one of the passed types.
+     *
+     * @see \PHP_CodeSniffer\Files\File::hasCondition()   Original source.
+     * @see \PHPCSUtils\BackCompat\BCFile::hasCondition() Cross-version compatible version of the original.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the token we are checking.
+     * @param int|string|array            $types     The type(s) of tokens to search for.
+     *
+     * @return bool
+     */
+    public static function hasCondition(File $phpcsFile, $stackPtr, $types)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Check for the existence of the token.
+        if (isset($tokens[$stackPtr]) === false) {
+            return false;
+        }
+
+        // Make sure the token has conditions.
+        if (isset($tokens[$stackPtr]['conditions']) === false) {
+            return false;
+        }
+
+        $types      = (array) $types;
+        $conditions = $tokens[$stackPtr]['conditions'];
+
+        foreach ($types as $type) {
+            if (\in_array($type, $conditions, true) === true) {
+                // We found a token with the required type.
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/PHPCSUtils/Utils/Conditions.php
+++ b/PHPCSUtils/Utils/Conditions.php
@@ -114,4 +114,42 @@ class Conditions
     {
         return (self::getCondition($phpcsFile, $stackPtr, $types) !== false);
     }
+
+    /**
+     * Return the position of the first (outermost) condition of a certain type for the passed token.
+     *
+     * If no types are specified, the first condition for the token, independently of type,
+     * will be returned.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The position of the token we are checking.
+     * @param int|string|array            $types     Optional. The type(s) of tokens to search for.
+     *
+     * @return int|false StackPtr to the condition or false if the token does not have the condition.
+     */
+    public static function getFirstCondition(File $phpcsFile, $stackPtr, $types = [])
+    {
+        return self::getCondition($phpcsFile, $stackPtr, $types, false);
+    }
+
+    /**
+     * Return the position of the last (innermost) condition of a certain type for the passed token.
+     *
+     * If no types are specified, the last condition for the token, independently of type,
+     * will be returned.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The position of the token we are checking.
+     * @param int|string|array            $types     Optional. The type(s) of tokens to search for.
+     *
+     * @return int|false StackPtr to the condition or false if the token does not have the condition.
+     */
+    public static function getLastCondition(File $phpcsFile, $stackPtr, $types = [])
+    {
+        return self::getCondition($phpcsFile, $stackPtr, $types, true);
+    }
 }

--- a/Tests/BackCompat/BCFile/GetConditionTest.php
+++ b/Tests/BackCompat/BCFile/GetConditionTest.php
@@ -21,6 +21,8 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  * @covers \PHPCSUtils\BackCompat\BCFile::getCondition
  * @covers \PHPCSUtils\BackCompat\BCFile::hasCondition
  *
+ * @group conditions
+ *
  * @since 1.0.0
  */
 class GetConditionTest extends UtilityMethodTestCase

--- a/Tests/Utils/Conditions/GetConditionTest.php
+++ b/Tests/Utils/Conditions/GetConditionTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Conditions;
+
+use PHPCSUtils\Tests\BackCompat\BCFile\GetConditionTest as BCFile_GetConditionTest;
+
+/**
+ * Tests for various methods in the \PHPCSUtils\Utils\Conditions class.
+ *
+ * @covers \PHPCSUtils\Utils\Conditions::getCondition
+ * @covers \PHPCSUtils\Utils\Conditions::hasCondition
+ *
+ * @group conditions
+ *
+ * @since 1.0.0
+ */
+class GetConditionTest extends BCFile_GetConditionTest
+{
+
+    /**
+     * The fully qualified name of the class being tested.
+     *
+     * This allows for the same unit tests to be run for both the BCFile functions
+     * as well as for the related PHPCSUtils functions.
+     *
+     * @var string
+     */
+    const TEST_CLASS = '\PHPCSUtils\Utils\Conditions';
+
+    /**
+     * Full path to the test case file associated with this test class.
+     *
+     * @var string
+     */
+    protected static $caseFile = '';
+
+    /**
+     * Initialize PHPCS & tokenize the test case file.
+     *
+     * Overloaded to re-use the `$caseFile` from the BCFile test.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        self::$caseFile = \dirname(\dirname(__DIR__)) . '/BackCompat/BCFile/GetConditionTest.inc';
+        parent::setUpTestFile();
+    }
+}

--- a/Tests/Utils/Conditions/GetConditionTest.php
+++ b/Tests/Utils/Conditions/GetConditionTest.php
@@ -11,6 +11,7 @@
 namespace PHPCSUtils\Tests\Utils\Conditions;
 
 use PHPCSUtils\Tests\BackCompat\BCFile\GetConditionTest as BCFile_GetConditionTest;
+use PHPCSUtils\Utils\Conditions;
 
 /**
  * Tests for various methods in the \PHPCSUtils\Utils\Conditions class.
@@ -55,5 +56,106 @@ class GetConditionTest extends BCFile_GetConditionTest
     {
         self::$caseFile = \dirname(\dirname(__DIR__)) . '/BackCompat/BCFile/GetConditionTest.inc';
         parent::setUpTestFile();
+    }
+
+    /**
+     * Test retrieving a specific condition from a tokens "conditions" array.
+     *
+     * @dataProvider dataGetConditionReversed
+     *
+     * @param string $testMarker      The comment which prefaces the target token in the test file.
+     * @param array  $expectedResults Array with the condition token type to search for as key
+     *                                and the marker for the expected stack pointer result as a value.
+     *
+     * @return void
+     */
+    public function testGetConditionReversed($testMarker, $expectedResults)
+    {
+        $stackPtr = self::$testTokens[$testMarker];
+
+        // Add expected results for all test markers not listed in the data provider.
+        $expectedResults += $this->conditionDefaults;
+
+        foreach ($expectedResults as $conditionType => $expected) {
+            if ($expected !== false) {
+                $expected = self::$markerTokens[$expected];
+            }
+
+            $result = Conditions::getCondition(self::$phpcsFile, $stackPtr, \constant($conditionType), true);
+            $this->assertSame(
+                $expected,
+                $result,
+                "Assertion failed for test marker '{$testMarker}' with condition {$conditionType} (reversed)"
+            );
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * Only the conditions which are expected to be *found* need to be listed here.
+     * All other potential conditions will automatically also be tested and will expect
+     * `false` as a result.
+     *
+     * @see testGetConditionReversed() For the array format.
+     *
+     * @return array
+     */
+    public static function dataGetConditionReversed()
+    {
+        $data = self::dataGetCondition();
+
+        // Set up the data for the reversed results.
+        $data['testSeriouslyNestedMethod'][1]['T_IF'] = '/* condition 4: if */';
+
+        $data['testDeepestNested'][1]['T_FUNCTION'] = '/* condition 12: nested anonymous class method */';
+        $data['testDeepestNested'][1]['T_IF']       = '/* condition 10-1: if */';
+
+        $data['testInException'][1]['T_FUNCTION'] = '/* condition 6: class method */';
+        $data['testInException'][1]['T_IF']       = '/* condition 4: if */';
+
+        $data['testInDefault'][1]['T_FUNCTION'] = '/* condition 6: class method */';
+        $data['testInDefault'][1]['T_IF']       = '/* condition 4: if */';
+
+        return $data;
+    }
+
+    /**
+     * Test retrieving a specific condition from a token's "conditions" array,
+     * with multiple allowed possibilities.
+     *
+     * @return void
+     */
+    public function testGetConditionMultipleTypes()
+    {
+        $stackPtr = self::$testTokens['/* testInException */'];
+
+        $result = Conditions::getCondition(self::$phpcsFile, $stackPtr, [\T_DO, \T_FOR]);
+        $this->assertFalse(
+            $result,
+            'Failed asserting that "testInException" does not have a "do" nor a "for" condition'
+        );
+
+        $result = Conditions::getCondition(self::$phpcsFile, $stackPtr, [\T_DO, \T_FOR, \T_FOREACH]);
+        $this->assertSame(
+            self::$markerTokens['/* condition 10-3: foreach */'],
+            $result,
+            'Failed asserting that "testInException" has a condition based on the types "do", "for" and "foreach"'
+        );
+
+        $stackPtr = self::$testTokens['/* testDeepestNested */'];
+
+        $result = Conditions::getCondition(self::$phpcsFile, $stackPtr, [\T_INTERFACE, \T_TRAIT]);
+        $this->assertFalse(
+            $result,
+            'Failed asserting that "testDeepestNested" does not have an interface nor a trait condition'
+        );
+
+        $result = Conditions::getCondition(self::$phpcsFile, $stackPtr, $this->ooScopeTokens);
+        $this->assertSame(
+            self::$markerTokens['/* condition 5: nested class */'],
+            $result,
+            'Failed asserting that "testDeepestNested" has a class condition based on the OO Scope token types'
+        );
     }
 }


### PR DESCRIPTION
## :sparkles: New Utils\Conditions class

New `PHPCSUtils\Utils\Conditions` class which will hold improved versions of the `File::hasCondition()` and the `File::getCondition()` methods as well as additional methods related to examining a `$tokens[$stackPtr]['conditions']` array.

For the initial functions in this class, the unit tests for the `PHPCSUtils\BackCompat\BCFile::getCondition()` and the `PHPCSUtils\BackCompat\BCFile::hasCondition()` functions are re-used to ensure that the improved functions in this class stay compatible with the original functions.

## Conditions::getCondition(): refactor the method to be more versatile

This refactors the `PHPCSUtils\Utils\Conditions::getCondition()` method to be more versatile with an eye on additional methods to be added later.

It also removes duplicate code and will allow the new methods to be added without code duplication.

Includes additional unit tests covering the new functionality added to the `Conditions::getCondition()` method.

## Utils\Conditions: add getFirstCondition() and getLastCondition() methods

This adds two additional utility methods:
* `getFirstCondition()` - to retrieve the first condition of a type passed in `$types` for a token or the first condition for a token if no types are specified.
    This is effectively just an alias for the `getCondition()` method.
* `getLastCondition()` - to retrieve the last condition of a type passed in `$types` for a token or the last condition for a token if no types are specified.

Includes dedicated unit tests.

