### PR TITLE
New Utils\Parentheses class

### DIFF
--- a/PHPCSUtils/Utils/Parentheses.php
+++ b/PHPCSUtils/Utils/Parentheses.php
@@ -1,0 +1,366 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Utils;
+
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Utility functions for use when examining parenthesis tokens and arbitrary tokens wrapped in
+ * parentheses.
+ *
+ * @since 1.0.0
+ */
+class Parentheses
+{
+
+    /**
+     * Get the pointer to the parentheses owner of an open/close parenthesis.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The position of `T_OPEN/CLOSE_PARENTHESIS` token.
+     *
+     * @return int|false Integer stack pointer to the parentheses owner or false if the
+     *                   parenthesis does not have a (direct) owner or if the token passed
+     *                   was not a parenthesis.
+     */
+    public static function getOwner(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        if (isset($tokens[$stackPtr], $tokens[$stackPtr]['parenthesis_owner']) === false) {
+            return false;
+        }
+
+        return $tokens[$stackPtr]['parenthesis_owner'];
+    }
+
+    /**
+     * Check whether the parenthesis owner of an open/close parenthesis is within a limited
+     * set of valid owners.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
+     * @param int                         $stackPtr    The position of `T_OPEN/CLOSE_PARENTHESIS` token.
+     * @param int|string|array            $validOwners Array of token constants for the owners
+     *                                                 which should be considered valid.
+     *
+     * @return bool True if the owner is within the list of `$validOwners`, false if not and
+     *              if the parenthesis does not have a (direct) owner.
+     */
+    public static function isOwnerIn(File $phpcsFile, $stackPtr, $validOwners)
+    {
+        $owner = self::getOwner($phpcsFile, $stackPtr);
+        if ($owner === false) {
+            return false;
+        }
+
+        $tokens      = $phpcsFile->getTokens();
+        $validOwners = (array) $validOwners;
+        return \in_array($tokens[$owner]['code'], $validOwners, true);
+    }
+
+    /**
+     * Check whether the passed token is nested within parentheses owned by one of the valid owners.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
+     * @param int                         $stackPtr    The position of the token we are checking.
+     * @param int|string|array            $validOwners Array of token constants for the owners
+     *                                                 which should be considered valid.
+     *
+     * @return bool
+     */
+    public static function hasOwner(File $phpcsFile, $stackPtr, $validOwners)
+    {
+        return (self::nestedParensWalker($phpcsFile, $stackPtr, $validOwners) !== false);
+    }
+
+    /**
+     * Retrieve the position of the opener to the first (outer) set of parentheses an arbitrary
+     * token is wrapped in, where the parentheses owner is within the set of valid owners.
+     *
+     * If no `$validOwners` are specified, the opener to the first set of parentheses surrounding
+     * the token will be returned.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
+     * @param int                         $stackPtr    The position of the token we are checking.
+     * @param int|string|array            $validOwners Array of token constants for the owners
+     *                                                 which should be considered valid.
+     *
+     * @return int|false Integer stack pointer to the parentheses opener or false if the token
+     *                   does not have parentheses owned by any of the valid owners or if
+     *                   the token is not nested in parentheses at all.
+     */
+    public static function getFirstOpener(File $phpcsFile, $stackPtr, $validOwners = [])
+    {
+        return self::nestedParensWalker($phpcsFile, $stackPtr, $validOwners, false);
+    }
+
+    /**
+     * Retrieve the position of the closer to the first (outer) set of parentheses an arbitrary
+     * token is wrapped in, where the parentheses owner is within the set of valid owners.
+     *
+     * If no `$validOwners` are specified, the closer to the first set of parentheses surrounding
+     * the token will be returned.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
+     * @param int                         $stackPtr    The position of the token we are checking.
+     * @param int|string|array            $validOwners Array of token constants for the owners
+     *                                                 which should be considered valid.
+     *
+     * @return int|false Integer stack pointer to the parentheses closer or false if the token
+     *                   does not have parentheses owned by any of the valid owners or if
+     *                   the token is not nested in parentheses at all.
+     */
+    public static function getFirstCloser(File $phpcsFile, $stackPtr, $validOwners = [])
+    {
+        $opener = self::getFirstOpener($phpcsFile, $stackPtr, $validOwners);
+        $tokens = $phpcsFile->getTokens();
+        if ($opener !== false && isset($tokens[$opener]['parenthesis_closer']) === true) {
+            return $tokens[$opener]['parenthesis_closer'];
+        }
+
+        return false;
+    }
+
+    /**
+     * Retrieve the position of the parentheses owner to the first (outer) set of parentheses an
+     * arbitrary token is wrapped in, where the parentheses owner is within the set of valid owners.
+     *
+     * If no `$validOwners` are specified, the owner to the first set of parentheses surrounding
+     * the token will be returned or false if the first set of parentheses does not have an owner.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
+     * @param int                         $stackPtr    The position of the token we are checking.
+     * @param int|string|array            $validOwners Array of token constants for the owners
+     *                                                 which should be considered valid.
+     *
+     * @return int|false Integer stack pointer  to the parentheses owner or false if the token
+     *                   does not have parentheses owned by any of the valid owners or if
+     *                   the token is not nested in parentheses at all.
+     */
+    public static function getFirstOwner(File $phpcsFile, $stackPtr, $validOwners = [])
+    {
+        $opener = self::getFirstOpener($phpcsFile, $stackPtr, $validOwners);
+        if ($opener !== false) {
+            return self::getOwner($phpcsFile, $opener);
+        }
+
+        return false;
+    }
+
+    /**
+     * Retrieve the position of the opener to the last (inner) set of parentheses an arbitrary
+     * token is wrapped in, where the parentheses owner is within the set of valid owners.
+     *
+     * If no `$validOwners` are specified, the opener to the last set of parentheses surrounding
+     * the token will be returned.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
+     * @param int                         $stackPtr    The position of the token we are checking.
+     * @param int|string|array            $validOwners Array of token constants for the owners
+     *                                                 which should be considered valid.
+     *
+     * @return int|false Integer stack pointer to the parentheses opener or false if the token
+     *                   does not have parentheses owned by any of the valid owners or if
+     *                   the token is not nested in parentheses at all.
+     */
+    public static function getLastOpener(File $phpcsFile, $stackPtr, $validOwners = [])
+    {
+        return self::nestedParensWalker($phpcsFile, $stackPtr, $validOwners, true);
+    }
+
+    /**
+     * Retrieve the position of the closer to the last (inner) set of parentheses an arbitrary
+     * token is wrapped in, where the parentheses owner is within the set of valid owners.
+     *
+     * If no `$validOwners` are specified, the closer to the last set of parentheses surrounding
+     * the token will be returned.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
+     * @param int                         $stackPtr    The position of the token we are checking.
+     * @param int|string|array            $validOwners Array of token constants for the owners
+     *                                                 which should be considered valid.
+     *
+     * @return int|false Integer stack pointer to the parentheses closer or false if the token
+     *                   does not have parentheses owned by any of the valid owners or if
+     *                   the token is not nested in parentheses at all.
+     */
+    public static function getLastCloser(File $phpcsFile, $stackPtr, $validOwners = [])
+    {
+        $opener = self::getLastOpener($phpcsFile, $stackPtr, $validOwners);
+        $tokens = $phpcsFile->getTokens();
+        if ($opener !== false && isset($tokens[$opener]['parenthesis_closer']) === true) {
+            return $tokens[$opener]['parenthesis_closer'];
+        }
+
+        return false;
+    }
+
+    /**
+     * Retrieve the position of the parentheses owner to the last (inner) set of parentheses an
+     * arbitrary token is wrapped in where the parentheses owner is within the set of valid owners.
+     *
+     * If no `$validOwners` are specified, the owner to the last set of parentheses surrounding
+     * the token will be returned or false if the last set of parentheses does not have an owner.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
+     * @param int                         $stackPtr    The position of the token we are checking.
+     * @param int|string|array            $validOwners Array of token constants for the owners
+     *                                                 which should be considered valid.
+     *
+     * @return int|false Integer stack pointer to the parentheses owner or false if the token
+     *                   does not have parentheses owned by any of the valid owners or if
+     *                   the token is not nested in parentheses at all.
+     */
+    public static function getLastOwner(File $phpcsFile, $stackPtr, $validOwners = [])
+    {
+        $opener = self::getLastOpener($phpcsFile, $stackPtr, $validOwners);
+        if ($opener !== false) {
+            return self::getOwner($phpcsFile, $opener);
+        }
+
+        return false;
+    }
+
+    /**
+     * Check whether the owner of a outermost wrapping set of parentheses of an arbitrary token
+     * is within a limited set of acceptable token types.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
+     * @param int                         $stackPtr    The position in the stack of the
+     *                                                 token to verify.
+     * @param int|string|array            $validOwners Array of token constants for the owners
+     *                                                 which should be considered valid.
+     *
+     * @return int|false Integer stack pointer to the valid parentheses owner or false if
+     *                   the token was not wrapped in parentheses or if the outermost set
+     *                   of parentheses in which the token is wrapped does not have an owner
+     *                   within the set of owners considered valid.
+     */
+    public static function firstOwnerIn(File $phpcsFile, $stackPtr, $validOwners)
+    {
+        $opener = self::getFirstOpener($phpcsFile, $stackPtr);
+
+        if ($opener !== false && self::isOwnerIn($phpcsFile, $opener, $validOwners) === true) {
+            return self::getOwner($phpcsFile, $opener);
+        }
+
+        return false;
+    }
+
+    /**
+     * Check whether the owner of a innermost wrapping set of parentheses of an arbitrary token
+     * is within a limited set of acceptable token types.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
+     * @param int                         $stackPtr    The position in the stack of the
+     *                                                 token to verify.
+     * @param int|string|array            $validOwners Array of token constants for the owners
+     *                                                 which should be considered valid.
+     *
+     * @return int|false Integer stack pointer to the valid parentheses owner or false if
+     *                   the token was not wrapped in parentheses or if the innermost set
+     *                   of parentheses in which the token is wrapped does not have an owner
+     *                   within the set of owners considered valid.
+     */
+    public static function lastOwnerIn(File $phpcsFile, $stackPtr, $validOwners)
+    {
+        $opener = self::getLastOpener($phpcsFile, $stackPtr);
+
+        if ($opener !== false && self::isOwnerIn($phpcsFile, $opener, $validOwners) === true) {
+            return self::getOwner($phpcsFile, $opener);
+        }
+
+        return false;
+    }
+
+    /**
+     * Helper method. Retrieve the position of a parentheses opener for an arbitrary passed token.
+     *
+     * If no `$validOwners` are specified, the opener to the first set of parentheses surrounding
+     * the token - or if `$reverse=true`, the last set of parentheses - will be returned.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
+     * @param int                         $stackPtr    The position of the token we are checking.
+     * @param int|string|array            $validOwners Optional. Array of token constants for the owners
+     *                                                 which should be considered valid.
+     * @param bool                        $reverse     Optional. Whether to search for the first/outermost
+     *                                                 (false) or the last/innermost (true) set of
+     *                                                 parentheses with the specified owner(s).
+     *
+     * @return int|false Integer stack pointer to the parentheses opener or false if the token
+     *                   does not have parentheses owned by any of the valid owners or if
+     *                   the token is not nested in parentheses at all.
+     */
+    private static function nestedParensWalker(File $phpcsFile, $stackPtr, $validOwners = [], $reverse = false)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Check for the existence of the token.
+        if (isset($tokens[$stackPtr]) === false) {
+            return false;
+        }
+
+        // Make sure the token is nested in parenthesis.
+        if (empty($tokens[$stackPtr]['nested_parenthesis']) === true) {
+            return false;
+        }
+
+        $validOwners = (array) $validOwners;
+        $parentheses = $tokens[$stackPtr]['nested_parenthesis'];
+
+        if (empty($validOwners) === true) {
+            // No owners specified, just return the first/last parentheses opener.
+            if ($reverse === true) {
+                \end($parentheses);
+            } else {
+                \reset($parentheses);
+            }
+
+            return \key($parentheses);
+        }
+
+        if ($reverse === true) {
+            $parentheses = \array_reverse($parentheses, true);
+        }
+
+        foreach ($parentheses as $opener => $closer) {
+            if (self::isOwnerIn($phpcsFile, $opener, $validOwners) === true) {
+                // We found a token with a valid owner.
+                return $opener;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Tests/Utils/Parentheses/ParenthesesTest.inc
+++ b/Tests/Utils/Parentheses/ParenthesesTest.inc
@@ -35,6 +35,12 @@ $anonClass = new class(
 ) extends DateTime {
 };
 
+/* testListOnCloseParens */
+list($a, $b) = $array;
+
+/* testNoOwnerOnCloseParens */
+$a = ($b + $c);
+
 // Intentional parse error. This has to be the last test in the file.
 /* testParseError */
 declare(ticks=1

--- a/Tests/Utils/Parentheses/ParenthesesTest.inc
+++ b/Tests/Utils/Parentheses/ParenthesesTest.inc
@@ -1,0 +1,40 @@
+<?php
+
+/* testNoParentheses */
+$a = 1;
+
+/* testIfWithArray */
+if (($a + $b) === function_call(array($c, $d))) {
+
+/* testElseIfWithClosure */
+} elseif ( array_map( function( $a ) {}, $array) ) {}
+
+/* testForeach */
+foreach( array(array(1, array(2, 3)), array(23, array(45, 67))) as list /* comment */ ( $a, list($b, $c) ) ) {}
+
+/* testFunctionwithArray */
+function test($param, $array = array(1, 2, 3)) {}
+
+/* testForWithTernary */
+for ($i = ( $a ? get_a($b) : get_b($c) ); $i < count($array); $i++ ) {}
+
+/* testWhileWithClosure */
+while (($result = function_call( $a )) > 0 && ((function($p) {/* do something */})($result) === true)) {}
+
+/* testAnonClass */
+$anonClass = new class(
+    new class implements Countable {
+		function test($param) {
+			do {
+				try {
+				} catch( Exception $e ) {
+				}
+			} while($a === true);
+		}
+    }
+) extends DateTime {
+};
+
+// Intentional parse error. This has to be the last test in the file.
+/* testParseError */
+declare(ticks=1

--- a/Tests/Utils/Parentheses/ParenthesesTest.php
+++ b/Tests/Utils/Parentheses/ParenthesesTest.php
@@ -1,0 +1,1030 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Parentheses;
+
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Parentheses;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Parentheses class.
+ *
+ * @covers \PHPCSUtils\Utils\Parentheses
+ *
+ * @group parentheses
+ *
+ * @since 1.0.0
+ */
+class ParenthesesTest extends UtilityMethodTestCase
+{
+
+    /**
+     * List of all the test markers with their target token info in the test case file.
+     *
+     * @var array
+     */
+    public static $testTargets = [
+        'testIfWithArray-$a' => [
+            'marker'  => '/* testIfWithArray */',
+            'code'    => \T_VARIABLE,
+            'content' => '$a',
+        ],
+        'testIfWithArray-array' => [
+            'marker' => '/* testIfWithArray */',
+            'code'   => \T_ARRAY,
+        ],
+        'testIfWithArray-$c' => [
+            'marker'  => '/* testIfWithArray */',
+            'code'    => \T_VARIABLE,
+            'content' => '$c',
+        ],
+        'testElseIfWithClosure-$a' => [
+            'marker'  => '/* testElseIfWithClosure */',
+            'code'    => \T_VARIABLE,
+            'content' => '$a',
+        ],
+        'testElseIfWithClosure-closure' => [
+            'marker' => '/* testElseIfWithClosure */',
+            'code'   => \T_CLOSURE,
+        ],
+        'testElseIfWithClosure-$array' => [
+            'marker'  => '/* testElseIfWithClosure */',
+            'code'    => \T_VARIABLE,
+            'content' => '$array',
+        ],
+        'testForeach-45' => [
+            'marker'  => '/* testForeach */',
+            'code'    => \T_LNUMBER,
+            'content' => '45',
+        ],
+        'testForeach-$a' => [
+            'marker'  => '/* testForeach */',
+            'code'    => \T_VARIABLE,
+            'content' => '$a',
+        ],
+        'testForeach-$c' => [
+            'marker'  => '/* testForeach */',
+            'code'    => \T_VARIABLE,
+            'content' => '$c',
+        ],
+        'testFunctionwithArray-$param' => [
+            'marker'  => '/* testFunctionwithArray */',
+            'code'    => \T_VARIABLE,
+            'content' => '$param',
+        ],
+        'testFunctionwithArray-2' => [
+            'marker'  => '/* testFunctionwithArray */',
+            'code'    => \T_LNUMBER,
+            'content' => '2',
+        ],
+        'testForWithTernary-$a' => [
+            'marker'  => '/* testForWithTernary */',
+            'code'    => \T_VARIABLE,
+            'content' => '$a',
+        ],
+        'testForWithTernary-$c' => [
+            'marker'  => '/* testForWithTernary */',
+            'code'    => \T_VARIABLE,
+            'content' => '$c',
+        ],
+        'testForWithTernary-$array' => [
+            'marker'  => '/* testForWithTernary */',
+            'code'    => \T_VARIABLE,
+            'content' => '$array',
+        ],
+        'testWhileWithClosure-$a' => [
+            'marker'  => '/* testWhileWithClosure */',
+            'code'    => \T_VARIABLE,
+            'content' => '$a',
+        ],
+        'testWhileWithClosure-$p' => [
+            'marker'  => '/* testWhileWithClosure */',
+            'code'    => \T_VARIABLE,
+            'content' => '$p',
+        ],
+        'testWhileWithClosure-$result' => [
+            'marker'  => '/* testWhileWithClosure */',
+            'code'    => \T_VARIABLE,
+            'content' => '$result',
+        ],
+        'testAnonClass-implements' => [
+            'marker' => '/* testAnonClass */',
+            'code'   => \T_IMPLEMENTS,
+        ],
+        'testAnonClass-$param' => [
+            'marker'  => '/* testAnonClass */',
+            'code'    => \T_VARIABLE,
+            'content' => '$param',
+        ],
+        'testAnonClass-$e' => [
+            'marker'  => '/* testAnonClass */',
+            'code'    => \T_VARIABLE,
+            'content' => '$e',
+        ],
+        'testAnonClass-$a' => [
+            'marker'  => '/* testAnonClass */',
+            'code'    => \T_VARIABLE,
+            'content' => '$a',
+        ],
+        'testParseError-1' => [
+            'marker'  => '/* testParseError */',
+            'code'    => \T_LNUMBER,
+            'content' => '1',
+        ],
+    ];
+
+    /**
+     * Cache for the test token stack pointers.
+     *
+     * @var array <string> => <int>
+     */
+    private static $testTokens = [];
+
+    /**
+     * Base array with all the tokens which are assigned parenthesis owners.
+     *
+     * This array is merged with expected result arrays for various unit tests
+     * to make sure all possible parentheses owners are tested.
+     *
+     * This array should be kept in sync with the Tokens::$parenthesisOpeners array.
+     * This array isn't auto-generated based on the array in Tokens as for these
+     * tests we want to have access to the token constant names, not just their values.
+     *
+     * @var array <string> => <bool>
+     */
+    private $ownerDefaults = [
+        'T_ARRAY'      => false,
+        'T_LIST'       => false,
+        'T_FUNCTION'   => false,
+        'T_CLOSURE'    => false,
+        'T_ANON_CLASS' => false,
+        'T_WHILE'      => false,
+        'T_FOR'        => false,
+        'T_FOREACH'    => false,
+        'T_SWITCH'     => false,
+        'T_IF'         => false,
+        'T_ELSEIF'     => false,
+        'T_CATCH'      => false,
+        'T_DECLARE'    => false,
+    ];
+
+    /**
+     * Set up the token position caches for the tests.
+     *
+     * Retrieves the test tokens and marker token stack pointer positions
+     * only once and caches them as they won't change between the tests anyway.
+     *
+     * @before
+     *
+     * @return void
+     */
+    protected function setUpCaches()
+    {
+        if (empty(self::$testTokens) === true) {
+            foreach (self::$testTargets as $testName => $targetDetails) {
+                if (isset($targetDetails['content']) === true) {
+                    self::$testTokens[$testName] = $this->getTargetToken(
+                        $targetDetails['marker'],
+                        $targetDetails['code'],
+                        $targetDetails['content']
+                    );
+                } else {
+                    self::$testTokens[$testName] = $this->getTargetToken(
+                        $targetDetails['marker'],
+                        $targetDetails['code']
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Test passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $result = Parentheses::getOwner(self::$phpcsFile, 100000);
+        $this->assertFalse($result);
+
+        $result = Parentheses::isOwnerIn(self::$phpcsFile, 100000, \T_FUNCTION);
+        $this->assertFalse($result);
+
+        $result = Parentheses::hasOwner(self::$phpcsFile, 100000, \T_FOR);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test passing a token which isn't in parentheses.
+     *
+     * @return void
+     */
+    public function testNoParentheses()
+    {
+        $stackPtr = $this->getTargetToken('/* testNoParentheses */', \T_VARIABLE);
+
+        $result = Parentheses::getOwner(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result);
+
+        $result = Parentheses::isOwnerIn(self::$phpcsFile, $stackPtr, \T_IF);
+        $this->assertFalse($result);
+
+        $result = Parentheses::hasOwner(self::$phpcsFile, $stackPtr, \T_FOREACH);
+        $this->assertFalse($result);
+
+        $result = Parentheses::getFirstOpener(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result);
+
+        $result = Parentheses::getFirstCloser(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result);
+
+        $result = Parentheses::getFirstOwner(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result);
+
+        $result = Parentheses::firstOwnerIn(self::$phpcsFile, $stackPtr, [\T_FUNCTION, \T_CLOSURE]);
+        $this->assertFalse($result);
+
+        $result = Parentheses::getLastOpener(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result);
+
+        $result = Parentheses::getLastCloser(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result);
+
+        $result = Parentheses::getLastOwner(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result);
+
+        $result = Parentheses::lastOwnerIn(self::$phpcsFile, $stackPtr, [\T_FUNCTION, \T_CLOSURE]);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test passing a non-parenthesis token to methods which expect to receive an open/close parenthesis.
+     *
+     * @return void
+     */
+    public function testPassingNonParenthesisTokenToMethodsWhichExpectParenthesis()
+    {
+        $stackPtr = self::$testTokens['testIfWithArray-$a'];
+
+        $result = Parentheses::getOwner(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result);
+
+        $result = Parentheses::isOwnerIn(self::$phpcsFile, $stackPtr, \T_IF);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test passing an open parenthesis token to methods which expect to receive an open/close parenthesis.
+     *
+     * @return void
+     */
+    public function testPassingParenthesisTokenToMethodsWhichExpectParenthesisOpen()
+    {
+        $stackPtr = (self::$testTokens['testIfWithArray-$c'] - 1);
+
+        $result = Parentheses::getOwner(self::$phpcsFile, $stackPtr);
+        $this->assertSame(($stackPtr - 1), $result);
+
+        $result = Parentheses::isOwnerIn(self::$phpcsFile, $stackPtr, \T_IF);
+        $this->assertFalse($result);
+
+        $result = Parentheses::isOwnerIn(self::$phpcsFile, $stackPtr, \T_ARRAY);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test passing a close parenthesis token to methods which expect to receive an open/close parenthesis.
+     *
+     * @return void
+     */
+    public function testPassingParenthesisTokenToMethodsWhichExpectParenthesisClose()
+    {
+        $stackPtr = (self::$testTokens['testForeach-$c'] + 1);
+
+        $result = Parentheses::getOwner(self::$phpcsFile, $stackPtr);
+        $this->assertSame(($stackPtr - 6), $result);
+
+        $result = Parentheses::isOwnerIn(self::$phpcsFile, $stackPtr, \T_IF);
+        $this->assertFalse($result);
+
+        $result = Parentheses::isOwnerIn(self::$phpcsFile, $stackPtr, \T_LIST);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test correctly retrieving the first parenthesis opener for an arbitrary token.
+     *
+     * @dataProvider dataWalkParentheses
+     *
+     * @param string $testName        The name of this test as set in the cached $testTokens array.
+     * @param array  $expectedResults Expected function output for the various functions.
+     *
+     * @return void
+     */
+    public function testGetFirstOpener($testName, $expectedResults)
+    {
+        $stackPtr = self::$testTokens[$testName];
+
+        $result   = Parentheses::getFirstOpener(self::$phpcsFile, $stackPtr);
+        $expected = $expectedResults['firstOpener'];
+        if ($expected !== false) {
+            $expected += $stackPtr;
+        }
+
+        $this->assertSame($expected, $result, 'Assertion without owners failed');
+
+        $result   = Parentheses::getFirstOpener(self::$phpcsFile, $stackPtr, BCTokens::scopeOpeners());
+        $expected = $expectedResults['firstScopeOwnerOpener'];
+        if ($expected !== false) {
+            $expected += $stackPtr;
+        }
+
+        $this->assertSame($expected, $result, 'Assertion with $validOwners failed');
+    }
+
+    /**
+     * Test correctly retrieving the first parenthesis closer for an arbitrary token.
+     *
+     * @dataProvider dataWalkParentheses
+     *
+     * @param string $testName        The name of this test as set in the cached $testTokens array.
+     * @param array  $expectedResults Expected function output for the various functions.
+     *
+     * @return void
+     */
+    public function testGetFirstCloser($testName, $expectedResults)
+    {
+        $stackPtr = self::$testTokens[$testName];
+
+        $result   = Parentheses::getFirstCloser(self::$phpcsFile, $stackPtr);
+        $expected = $expectedResults['firstCloser'];
+        if ($expected !== false) {
+            $expected += $stackPtr;
+        }
+
+        $this->assertSame($expected, $result, 'Assertion without owners failed');
+
+        $result   = Parentheses::getFirstCloser(self::$phpcsFile, $stackPtr, BCTokens::scopeOpeners());
+        $expected = $expectedResults['firstScopeOwnerCloser'];
+        if ($expected !== false) {
+            $expected += $stackPtr;
+        }
+
+        $this->assertSame($expected, $result, 'Assertion with $validOwners failed');
+    }
+
+    /**
+     * Test correctly retrieving the first parenthesis owner for an arbitrary token.
+     *
+     * @dataProvider dataWalkParentheses
+     *
+     * @param string $testName        The name of this test as set in the cached $testTokens array.
+     * @param array  $expectedResults Expected function output for the various functions.
+     *
+     * @return void
+     */
+    public function testGetFirstOwner($testName, $expectedResults)
+    {
+        $stackPtr = self::$testTokens[$testName];
+
+        $result   = Parentheses::getFirstOwner(self::$phpcsFile, $stackPtr);
+        $expected = $expectedResults['firstOwner'];
+        if ($expected !== false) {
+            $expected += $stackPtr;
+        }
+
+        $this->assertSame($expected, $result, 'Assertion without owners failed');
+
+        $result   = Parentheses::getFirstOwner(self::$phpcsFile, $stackPtr, BCTokens::scopeOpeners());
+        $expected = $expectedResults['firstScopeOwnerOwner'];
+        if ($expected !== false) {
+            $expected += $stackPtr;
+        }
+
+        $this->assertSame($expected, $result, 'Assertion with $validOwners failed');
+    }
+
+    /**
+     * Test correctly retrieving the last parenthesis opener for an arbitrary token.
+     *
+     * @dataProvider dataWalkParentheses
+     *
+     * @param string $testName        The name of this test as set in the cached $testTokens array.
+     * @param array  $expectedResults Expected function output for the various functions.
+     *
+     * @return void
+     */
+    public function testGetLastOpener($testName, $expectedResults)
+    {
+        $stackPtr = self::$testTokens[$testName];
+
+        $result   = Parentheses::getLastOpener(self::$phpcsFile, $stackPtr);
+        $expected = $expectedResults['lastOpener'];
+        if ($expected !== false) {
+            $expected += $stackPtr;
+        }
+
+        $this->assertSame($expected, $result, 'Assertion without owners failed');
+
+        $result   = Parentheses::getLastOpener(self::$phpcsFile, $stackPtr, [\T_ARRAY]);
+        $expected = $expectedResults['lastArrayOpener'];
+        if ($expected !== false) {
+            $expected += $stackPtr;
+        }
+
+        $this->assertSame($expected, $result, 'Assertion with $validOwners failed');
+    }
+
+    /**
+     * Test correctly retrieving the last parenthesis closer for an arbitrary token.
+     *
+     * @dataProvider dataWalkParentheses
+     *
+     * @param string $testName        The name of this test as set in the cached $testTokens array.
+     * @param array  $expectedResults Expected function output for the various functions.
+     *
+     * @return void
+     */
+    public function testGetLastCloser($testName, $expectedResults)
+    {
+        $stackPtr = self::$testTokens[$testName];
+
+        $result   = Parentheses::getLastCloser(self::$phpcsFile, $stackPtr);
+        $expected = $expectedResults['lastCloser'];
+        if ($expected !== false) {
+            $expected += $stackPtr;
+        }
+
+        $this->assertSame($expected, $result, 'Assertion without owners failed');
+
+        $result   = Parentheses::getLastCloser(self::$phpcsFile, $stackPtr, [\T_FUNCTION, \T_CLOSURE]);
+        $expected = $expectedResults['lastFunctionCloser'];
+        if ($expected !== false) {
+            $expected += $stackPtr;
+        }
+
+        $this->assertSame($expected, $result, 'Assertion with $validOwners failed');
+    }
+
+    /**
+     * Test correctly retrieving the last parenthesis owner for an arbitrary token.
+     *
+     * @dataProvider dataWalkParentheses
+     *
+     * @param string $testName        The name of this test as set in the cached $testTokens array.
+     * @param array  $expectedResults Expected function output for the various functions.
+     *
+     * @return void
+     */
+    public function testGetLastOwner($testName, $expectedResults)
+    {
+        $stackPtr = self::$testTokens[$testName];
+
+        $result   = Parentheses::getLastOwner(self::$phpcsFile, $stackPtr);
+        $expected = $expectedResults['lastOwner'];
+        if ($expected !== false) {
+            $expected += $stackPtr;
+        }
+
+        $this->assertSame($expected, $result, 'Assertion without owners failed');
+
+        $result   = Parentheses::getLastOwner(self::$phpcsFile, $stackPtr, [\T_IF, \T_ELSEIF, \T_ELSE]);
+        $expected = $expectedResults['lastIfElseOwner'];
+        if ($expected !== false) {
+            $expected += $stackPtr;
+        }
+
+        $this->assertSame($expected, $result, 'Assertion with $validOwners failed');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetFirstOpener()  For the array format.
+     * @see testGetFirstCloser(() For the array format.
+     * @see testGetFirstOwner()   For the array format.
+     * @see testGetLastOpener()   For the array format.
+     * @see testGetLastCloser()   For the array format.
+     * @see testGetLastOwner()    For the array format.
+     *
+     * @return array
+     */
+    public function dataWalkParentheses()
+    {
+        $data = [
+            'testIfWithArray-$a' => [
+                'testIfWithArray-$a',
+                [
+                    'firstOpener'           => -2,
+                    'firstCloser'           => 19,
+                    'firstOwner'            => -4,
+                    'firstScopeOwnerOpener' => -2,
+                    'firstScopeOwnerCloser' => 19,
+                    'firstScopeOwnerOwner'  => -4,
+                    'lastOpener'            => -1,
+                    'lastCloser'            => 5,
+                    'lastOwner'             => false,
+                    'lastArrayOpener'       => false,
+                    'lastFunctionCloser'    => false,
+                    'lastIfElseOwner'       => -4,
+                ],
+            ],
+            'testIfWithArray-array' => [
+                'testIfWithArray-array',
+                [
+                    'firstOpener'           => -13,
+                    'firstCloser'           => 8,
+                    'firstOwner'            => -15,
+                    'firstScopeOwnerOpener' => -13,
+                    'firstScopeOwnerCloser' => 8,
+                    'firstScopeOwnerOwner'  => -15,
+                    'lastOpener'            => -1,
+                    'lastCloser'            => 7,
+                    'lastOwner'             => false,
+                    'lastArrayOpener'       => false,
+                    'lastFunctionCloser'    => false,
+                    'lastIfElseOwner'       => -15,
+                ],
+            ],
+            'testIfWithArray-$c' => [
+                'testIfWithArray-$c',
+                [
+                    'firstOpener'           => -15,
+                    'firstCloser'           => 6,
+                    'firstOwner'            => -17,
+                    'firstScopeOwnerOpener' => -15,
+                    'firstScopeOwnerCloser' => 6,
+                    'firstScopeOwnerOwner'  => -17,
+                    'lastOpener'            => -1,
+                    'lastCloser'            => 4,
+                    'lastOwner'             => -2,
+                    'lastArrayOpener'       => -1,
+                    'lastFunctionCloser'    => false,
+                    'lastIfElseOwner'       => -17,
+                ],
+            ],
+            'testWhileWithClosure-$a' => [
+                'testWhileWithClosure-$a',
+                [
+                    'firstOpener'           => -9,
+                    'firstCloser'           => 30,
+                    'firstOwner'            => -11,
+                    'firstScopeOwnerOpener' => -9,
+                    'firstScopeOwnerCloser' => 30,
+                    'firstScopeOwnerOwner'  => -11,
+                    'lastOpener'            => -2,
+                    'lastCloser'            => 2,
+                    'lastOwner'             => false,
+                    'lastArrayOpener'       => false,
+                    'lastFunctionCloser'    => false,
+                    'lastIfElseOwner'       => false,
+                ],
+            ],
+            'testWhileWithClosure-$p' => [
+                'testWhileWithClosure-$p',
+                [
+                    'firstOpener'           => -24,
+                    'firstCloser'           => 15,
+                    'firstOwner'            => -26,
+                    'firstScopeOwnerOpener' => -24,
+                    'firstScopeOwnerCloser' => 15,
+                    'firstScopeOwnerOwner'  => -26,
+                    'lastOpener'            => -1,
+                    'lastCloser'            => 1,
+                    'lastOwner'             => -2,
+                    'lastArrayOpener'       => false,
+                    'lastFunctionCloser'    => 1,
+                    'lastIfElseOwner'       => false,
+                ],
+            ],
+            'testWhileWithClosure-$result' => [
+                'testWhileWithClosure-$result',
+                [
+                    'firstOpener'           => -2,
+                    'firstCloser'           => 37,
+                    'firstOwner'            => -4,
+                    'firstScopeOwnerOpener' => -2,
+                    'firstScopeOwnerCloser' => 37,
+                    'firstScopeOwnerOwner'  => -4,
+                    'lastOpener'            => -1,
+                    'lastCloser'            => 10,
+                    'lastOwner'             => false,
+                    'lastArrayOpener'       => false,
+                    'lastFunctionCloser'    => false,
+                    'lastIfElseOwner'       => false,
+                ],
+            ],
+            'testParseError-1' => [
+                'testParseError-1',
+                [
+                    'firstOpener'           => false,
+                    'firstCloser'           => false,
+                    'firstOwner'            => false,
+                    'firstScopeOwnerOpener' => false,
+                    'firstScopeOwnerCloser' => false,
+                    'firstScopeOwnerOwner'  => false,
+                    'lastOpener'            => false,
+                    'lastCloser'            => false,
+                    'lastOwner'             => false,
+                    'lastArrayOpener'       => false,
+                    'lastFunctionCloser'    => false,
+                    'lastIfElseOwner'       => false,
+                ],
+            ],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Test correctly determining whether a token has an owner of a certain type.
+     *
+     * @dataProvider dataHasOwner
+     *
+     * @param string $testName        The name of this test as set in the cached $testTokens array.
+     * @param array  $expectedResults Array with the owner token type to search for as key
+     *                                and the expected result as a value.
+     *
+     * @return void
+     */
+    public function testHasOwner($testName, $expectedResults)
+    {
+        $stackPtr = self::$testTokens[$testName];
+
+        // Add expected results for all owner types not listed in the data provider.
+        $expectedResults += $this->ownerDefaults;
+
+        foreach ($expectedResults as $ownerType => $expected) {
+            $result = Parentheses::hasOwner(self::$phpcsFile, $stackPtr, \constant($ownerType));
+            $this->assertSame(
+                $expected,
+                $result,
+                "Assertion failed for test marker '{$testName}' with owner {$ownerType}"
+            );
+        }
+    }
+
+    /**
+     * Data Provider.
+     *
+     * Only list the "true" owners in the $results array.
+     * All other potential owners will automatically also be tested
+     * and will expect "false" as a result.
+     *
+     * @see testHasOwner() For the array format.
+     *
+     * @return array
+     */
+    public function dataHasOwner()
+    {
+        return [
+            'testIfWithArray-$a' => [
+                'testIfWithArray-$a',
+                ['T_IF' => true],
+            ],
+
+            'testIfWithArray-array' => [
+                'testIfWithArray-array',
+                ['T_IF' => true],
+            ],
+            'testIfWithArray-$c' => [
+                'testIfWithArray-$c',
+                [
+                    'T_ARRAY' => true,
+                    'T_IF'    => true,
+                ],
+            ],
+            'testElseIfWithClosure-$a' => [
+                'testElseIfWithClosure-$a',
+                [
+                    'T_CLOSURE' => true,
+                    'T_ELSEIF'  => true,
+                ],
+            ],
+            'testElseIfWithClosure-closure' => [
+                'testElseIfWithClosure-closure',
+                ['T_ELSEIF' => true],
+            ],
+            'testElseIfWithClosure-$array' => [
+                'testElseIfWithClosure-$array',
+                ['T_ELSEIF' => true],
+            ],
+            'testForeach-45' => [
+                'testForeach-45',
+                [
+                    'T_ARRAY'   => true,
+                    'T_FOREACH' => true,
+                ],
+            ],
+            'testForeach-$a' => [
+                'testForeach-$a',
+                [
+                    'T_LIST'    => true,
+                    'T_FOREACH' => true,
+                ],
+            ],
+            'testForeach-$c' => [
+                'testForeach-$c',
+                [
+                    'T_LIST'    => true,
+                    'T_FOREACH' => true,
+                ],
+            ],
+            'testFunctionwithArray-$param' => [
+                'testFunctionwithArray-$param',
+                ['T_FUNCTION' => true],
+            ],
+            'testFunctionwithArray-2' => [
+                'testFunctionwithArray-2',
+                [
+                    'T_ARRAY'    => true,
+                    'T_FUNCTION' => true,
+                ],
+            ],
+            'testForWithTernary-$a' => [
+                'testForWithTernary-$a',
+                ['T_FOR' => true],
+            ],
+            'testForWithTernary-$c' => [
+                'testForWithTernary-$c',
+                ['T_FOR' => true],
+            ],
+            'testForWithTernary-$array' => [
+                'testForWithTernary-$array',
+                ['T_FOR' => true],
+            ],
+            'testWhileWithClosure-$a' => [
+                'testWhileWithClosure-$a',
+                ['T_WHILE' => true],
+            ],
+            'testWhileWithClosure-$p' => [
+                'testWhileWithClosure-$p',
+                [
+                    'T_CLOSURE' => true,
+                    'T_WHILE'   => true,
+                ],
+            ],
+            'testWhileWithClosure-$result' => [
+                'testWhileWithClosure-$result',
+                ['T_WHILE' => true],
+            ],
+            'testAnonClass-implements' => [
+                'testAnonClass-implements',
+                ['T_ANON_CLASS' => true],
+            ],
+            'testAnonClass-$param' => [
+                'testAnonClass-$param',
+                [
+                    'T_ANON_CLASS' => true,
+                    'T_FUNCTION'   => true,
+                ],
+            ],
+            'testAnonClass-$e' => [
+                'testAnonClass-$e',
+                [
+                    'T_ANON_CLASS' => true,
+                    'T_CATCH'      => true,
+                ],
+            ],
+            'testAnonClass-$a' => [
+                'testAnonClass-$a',
+                [
+                    'T_ANON_CLASS' => true,
+                    'T_WHILE'      => true,
+                ],
+            ],
+            'testParseError-1' => [
+                'testParseError-1',
+                [],
+            ],
+        ];
+    }
+
+    /**
+     * Test correctly determining whether a token is nested in parentheses with an owner
+     * of a certain type, with multiple allowed possibilities.
+     *
+     * @return void
+     */
+    public function testHasOwnerMultipleTypes()
+    {
+        $stackPtr = self::$testTokens['testElseIfWithClosure-$array'];
+
+        $result = Parentheses::hasOwner(self::$phpcsFile, $stackPtr, [\T_FUNCTION, \T_CLOSURE]);
+        $this->assertFalse(
+            $result,
+            'Failed asserting that $array in "testElseIfWithClosure" does not have a "function" nor a "closure" owner'
+        );
+
+        $result = Parentheses::hasOwner(self::$phpcsFile, $stackPtr, [\T_IF, \T_ELSEIF, \T_ELSE]);
+        $this->assertTrue(
+            $result,
+            'Failed asserting that $array in "testElseIfWithClosure" has an "if", "elseif" or "else" owner'
+        );
+
+        $stackPtr = self::$testTokens['testForWithTernary-$array'];
+
+        $result = Parentheses::hasOwner(self::$phpcsFile, $stackPtr, [\T_ARRAY, \T_LIST]);
+        $this->assertFalse(
+            $result,
+            'Failed asserting that $array in "testForWithTernary" does not have an array or list condition'
+        );
+
+        $result = Parentheses::hasOwner(self::$phpcsFile, $stackPtr, BCTokens::scopeOpeners());
+        $this->assertTrue(
+            $result,
+            'Failed asserting that $array in "testForWithTernary" has an owner which is also a scope opener'
+        );
+    }
+
+    /**
+     * Test correctly determining whether the first set of parenthesis around an arbitrary token
+     * has an owner of a certain type.
+     *
+     * @dataProvider dataFirstOwnerIn
+     *
+     * @param string    $testName    The name of this test as set in the cached $testTokens array.
+     * @param array     $validOwners Valid owners to test against.
+     * @param int|false $expected    Expected function output
+     *
+     * @return void
+     */
+    public function testFirstOwnerIn($testName, $validOwners, $expected)
+    {
+        $stackPtr = self::$testTokens[$testName];
+        if ($expected !== false) {
+            $expected += $stackPtr;
+        }
+
+        $result = Parentheses::firstOwnerIn(self::$phpcsFile, $stackPtr, $validOwners);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testFirstOwnerIn() For the array format.
+     *
+     * @return array
+     */
+    public function dataFirstOwnerIn()
+    {
+        return [
+            'testElseIfWithClosure-$a-elseif' => [
+                'testElseIfWithClosure-$a',
+                [\T_ELSEIF],
+                -10,
+            ],
+            'testElseIfWithClosure-$a-array' => [
+                'testElseIfWithClosure-$a',
+                [\T_ARRAY],
+                false,
+            ],
+            'testForeach-45-foreach-for' => [
+                'testForeach-45',
+                [\T_FOREACH, \T_FOR],
+                -27,
+            ],
+            'testForeach-45-array' => [
+                'testForeach-45',
+                [\T_ARRAY],
+                false,
+            ],
+            'testForeach-$a-foreach-for' => [
+                'testForeach-$a',
+                [\T_FOREACH, \T_FOR],
+                -43,
+            ],
+            'testForeach-$a-list' => [
+                'testForeach-$a',
+                [\T_LIST],
+                false,
+            ],
+            'testFunctionwithArray-$param-function-closure' => [
+                'testFunctionwithArray-$param',
+                [\T_FUNCTION, \T_CLOSURE],
+                -4,
+            ],
+            'testFunctionwithArray-$param-if-elseif-else' => [
+                'testFunctionwithArray-$param',
+                [\T_IF, \T_ELSEIF, \T_ELSE],
+                false,
+            ],
+            'testAnonClass-implements-anon-class' => [
+                'testAnonClass-implements',
+                [\T_ANON_CLASS],
+                -8,
+            ],
+            'testAnonClass-$e-function' => [
+                'testAnonClass-$e',
+                [\T_FUNCTION],
+                false,
+            ],
+            'testAnonClass-$e-catch' => [
+                'testAnonClass-$e',
+                [\T_CATCH],
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * Test correctly determining whether the last set of parenthesis around an arbitrary token
+     * has an owner of a certain type.
+     *
+     * @dataProvider dataLastOwnerIn
+     *
+     * @param string    $testName    The name of this test as set in the cached $testTokens array.
+     * @param array     $validOwners Valid owners to test against.
+     * @param int|false $expected    Expected function output
+     *
+     * @return void
+     */
+    public function testLastOwnerIn($testName, $validOwners, $expected)
+    {
+        $stackPtr = self::$testTokens[$testName];
+        if ($expected !== false) {
+            $expected += $stackPtr;
+        }
+
+        $result = Parentheses::lastOwnerIn(self::$phpcsFile, $stackPtr, $validOwners);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testLastOwnerIn() For the array format.
+     *
+     * @return array
+     */
+    public function dataLastOwnerIn()
+    {
+        return [
+            'testElseIfWithClosure-$a-closure' => [
+                'testElseIfWithClosure-$a',
+                [\T_CLOSURE],
+                -3,
+            ],
+            'testElseIfWithClosure-$a-array' => [
+                'testElseIfWithClosure-$a',
+                [\T_ARRAY],
+                false,
+            ],
+            'testForeach-45-array' => [
+                'testForeach-45',
+                [\T_ARRAY],
+                -2,
+            ],
+            'testForeach-45-foreach-for' => [
+                'testForeach-45',
+                [\T_FOREACH, \T_FOR],
+                false,
+            ],
+            'testForeach-$a-foreach-for' => [
+                'testForeach-$a',
+                [\T_FOREACH, \T_FOR],
+                false,
+            ],
+            'testForeach-$a-list' => [
+                'testForeach-$a',
+                [\T_LIST],
+                -6,
+            ],
+            'testFunctionwithArray-$param-function-closure' => [
+                'testFunctionwithArray-$param',
+                [\T_FUNCTION, \T_CLOSURE],
+                -4,
+            ],
+            'testFunctionwithArray-$param-if-elseif-else' => [
+                'testFunctionwithArray-$param',
+                [\T_IF, \T_ELSEIF, \T_ELSE],
+                false,
+            ],
+            'testAnonClass-implements-anon-class' => [
+                'testAnonClass-implements',
+                [\T_ANON_CLASS],
+                -8,
+            ],
+            'testAnonClass-$e-function' => [
+                'testAnonClass-$e',
+                [\T_FUNCTION],
+                false,
+            ],
+            'testAnonClass-$e-catch' => [
+                'testAnonClass-$e',
+                [\T_CATCH],
+                -5,
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/Parentheses/ParenthesesTest.php
+++ b/Tests/Utils/Parentheses/ParenthesesTest.php
@@ -321,6 +321,35 @@ class ParenthesesTest extends UtilityMethodTestCase
     }
 
     /**
+     * Test passing a close parenthesis token to methods which expect to receive an open/close parenthesis.
+     *
+     * This specifically tests the BC-layer for lists and anon classes.
+     *
+     * @return void
+     */
+    public function testPassingParenthesisCloseHandlinginBCLayer()
+    {
+        $stackPtr = $this->getTargetToken('/* testListOnCloseParens */', \T_CLOSE_PARENTHESIS);
+
+        $result = Parentheses::getOwner(self::$phpcsFile, $stackPtr);
+        $this->assertSame(($stackPtr - 6), $result);
+
+        $result = Parentheses::isOwnerIn(self::$phpcsFile, $stackPtr, \T_LIST);
+        $this->assertTrue($result);
+
+        $result = Parentheses::isOwnerIn(self::$phpcsFile, $stackPtr, \T_IF);
+        $this->assertFalse($result);
+
+        $stackPtr = $this->getTargetToken('/* testNoOwnerOnCloseParens */', \T_CLOSE_PARENTHESIS);
+
+        $result = Parentheses::getOwner(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result);
+
+        $result = Parentheses::isOwnerIn(self::$phpcsFile, $stackPtr, BCTokens::scopeOpeners());
+        $this->assertFalse($result);
+    }
+
+    /**
      * Test correctly retrieving the first parenthesis opener for an arbitrary token.
      *
      * @dataProvider dataWalkParentheses


### PR DESCRIPTION
## :sparkles: New Utils\Parentheses class

This adds eleven new utility/convenience methods.

The first two are targeted at open/close parentheses tokens:
* `getOwner()` - to retrieve the stack pointer to the parentheses owner of an open/close parenthesis. Returns int or false if the parenthesis does not have an owner.
* `isOwnerIn()` - to check whether the parenthesis owner of an open/close parenthesis is within a limited set of valid owners. Returns bool.

The other eight methods are targeted at arbitrary tokens:
* `hasOwner()` - to check whether the passed token is nested within parentheses owned by one of the valid owners. Returns bool.
* `firstOwnerIn()` - to check whether the owner of the outermost set of parentheses is within a limited set of acceptable tokens. Returns int/false.
* `lastOwnerIn()` - to check whether the owner of the innermost set of parentheses is within a limited set of acceptable tokens. Returns int/false.
* `getFirstOpener()` - to retrieve the position of the opener to the first (outer) set of parentheses an arbitrary token is wrapped in where the parentheses owner is within the set of valid owners. Returns int/false.
* `getFirstCloser()` - to retrieve the position of the closer to the first (outer) set of parentheses an arbitrary token is wrapped in where the parentheses owner is within the set of valid owners. Returns int/false.
* `getFirstOwner()` - to retrieve the position of the parentheses owner to the first (outer) set of parentheses an arbitrary token is wrapped in where the parentheses owner is within the set of valid owners. Returns int/false.
* `getLastOpener()` - to retrieve the position of the opener to the last (inner) set of parentheses an arbitrary token is wrapped in where the parentheses owner is within the set of valid owners. Returns int/false.
* `getLastCloser()` - to retrieve the position of the closer to the last (inner) set of parentheses an arbitrary token is wrapped in where the parentheses owner is within the set of valid owners. Returns int/false.
* `getLastOwner()` - to retrieve the position of the parentheses owner to the last (inner) set of parentheses an arbitrary token is wrapped in where the parentheses owner is within the set of valid owners. Returns int/false.

These last nine, all use the private `nestedParensWalker()` helper method under the hood.

Where the return value is of the type `int|false`, the integer stack pointer to the parentheses opener/closer/owner will be returned or `false` when:
* the token is not wrapped in parentheses;
* the parentheses owner is not within the set of `$validOwners` passed;
* and in the case of `owner`: when the desired set of parenthesis does not have an owner.

Includes dedicated unit tests.

### Utils\Parentheses: fix compatibility with PHPCS < 3.5.0

For this class to be compatible with PHPCS 2.6.0 - `master`, two work-arounds need to be added:
1. Parentheses associated with `list()` constructs and anonymous classes, i.e. `new class() {}` would not be assigned a `parenthesis_owner` prior to PHPCS 3.5.0.
2. For certain nested anonymous class code patterns, the `class` keyword would incorrectly be tokenized as `T_CLASS` instead of `T_ANON_CLASS` prior to PHPCS 3.4.0.

The relevant methods in this class which need to take these issues into account have received fixes to do so.

