### PR TITLE
New Utils\GetTokensAsString class

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1061,6 +1061,7 @@ class BCFile
      *                - If the $length param is invalid, an empty string will be returned.
      *
      * @see \PHP_CodeSniffer\Files\File::getTokensAsString() Original source.
+     * @see \PHPCSUtils\Utils\GetTokensAsString              Related set of functions.
      *
      * @since 1.0.0
      *

--- a/PHPCSUtils/Utils/GetTokensAsString.php
+++ b/PHPCSUtils/Utils/GetTokensAsString.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Utils;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Utility functions to retrieve the content of a set of tokens as a string.
+ *
+ * In contrast to the PHPCS native {@see \PHP_CodeSniffer\Files\File::getTokensAsString()} method,
+ * which has `$length` as the third parameter, all methods in this class expect a stack pointer to
+ * an `$end` token (inclusive) as the third parameter.
+ *
+ * @since 1.0.0 The principle of this class is loosely based on and inspired by the
+ *              {@see \PHP_CodeSniffer\Files\File::getTokensAsString()} method in the
+ *              PHPCS native `File` class.
+ *              Also see {@see \PHPCSUtils\BackCompat\BCFile::getTokensAsString()}.
+ */
+class GetTokensAsString
+{
+
+    /**
+     * Retrieve the tab-replaced content of the tokens from the specified start position in
+     * the token stack to the specified end position (inclusive).
+     *
+     * This is the default behaviour for PHPCS.
+     *
+     * If the tab width is set, either via a (custom) ruleset, the config file or by passing it
+     * on the command-line, PHPCS will automatically replace tabs with spaces.
+     * The `'content'` index key in the `$tokens` array will contain the tab-replaced content.
+     * The `'orig_content'` index key in the `$tokens` array will contain the original content.
+     *
+     * @see \PHP_CodeSniffer\Files\File::getTokensAsString()   Similar length-based function.
+     * @see \PHPCSUtils\BackCompat\BCFile::getTokensAsString() Cross-version compatible version of the original.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $start     The position to start from in the token stack.
+     * @param int                         $end       The position to end at in the token stack (inclusive).
+     *
+     * @return string The token contents.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified start position does not exist.
+     */
+    public static function normal(File $phpcsFile, $start, $end)
+    {
+        return self::getString($phpcsFile, $start, $end);
+    }
+
+    /**
+     * Retrieve the tab-replaced content of the tokens from the specified start position in
+     * the token stack to the specified end position (inclusive).
+     *
+     * Alias for the {@see \PHPCSUtils\Utils\GetTokensAsString::normal()} method.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $start     The position to start from in the token stack.
+     * @param int                         $end       The position to end at in the token stack (inclusive).
+     *
+     * @return string The token contents.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified start position does not exist.
+     */
+    public static function tabReplaced(File $phpcsFile, $start, $end)
+    {
+        return self::normal($phpcsFile, $start, $end);
+    }
+
+    /**
+     * Retrieve the original content of the tokens from the specified start position in
+     * the token stack to the specified end position (inclusive).
+     *
+     * If the original content contained tabs, the return value of this function will
+     * also contain tabs.
+     *
+     * @see \PHP_CodeSniffer\Files\File::getTokensAsString()   Similar length-based function.
+     * @see \PHPCSUtils\BackCompat\BCFile::getTokensAsString() Cross-version compatible version of the original.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $start     The position to start from in the token stack.
+     * @param int                         $end       The position to end at in the token stack (inclusive).
+     *
+     * @return string The token contents.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified start position does not exist.
+     */
+    public static function origContent(File $phpcsFile, $start, $end)
+    {
+        return self::getString($phpcsFile, $start, $end, true);
+    }
+
+    /**
+     * Retrieve the content of the tokens from the specified start position in the token
+     * stack to the specified end position (inclusive) without comments.
+     *
+     * @see \PHP_CodeSniffer\Files\File::getTokensAsString() Loosely related function.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $start     The position to start from in the token stack.
+     * @param int                         $end       The position to end at in the token stack (inclusive).
+     *
+     * @return string The token contents.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified start position does not exist.
+     */
+    public static function noComments(File $phpcsFile, $start, $end)
+    {
+        return self::getString($phpcsFile, $start, $end, false, true);
+    }
+
+    /**
+     * Retrieve the code-tokens only content of the tokens from the specified start position
+     * in the token stack to the specified end position (inclusive) without whitespace or comments.
+     *
+     * This is, for instance, useful to retrieve a namespace name without stray whitespace or comments.
+     * Use this function selectively and with care!
+     *
+     * @see \PHP_CodeSniffer\Files\File::getTokensAsString() Loosely related function.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $start     The position to start from in the token stack.
+     * @param int                         $end       The position to end at in the token stack (inclusive).
+     *
+     * @return string The token contents.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified start position does not exist.
+     */
+    public static function noEmpties(File $phpcsFile, $start, $end)
+    {
+        return self::getString($phpcsFile, $start, $end, false, true, true);
+    }
+
+    /**
+     * Retrieve the content of the tokens from the specified start position in the token
+     * stack to the specified end position (inclusive) with all whitespace tokens - tabs,
+     * new lines, multiple spaces - replaced by a single space and optionally without comments.
+     *
+     * @see \PHP_CodeSniffer\Files\File::getTokensAsString() Loosely related function.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile     The file being scanned.
+     * @param int                         $start         The position to start from in the token stack.
+     * @param int                         $end           The position to end at in the token stack (inclusive).
+     * @param bool                        $stripComments Whether comments should be stripped from the contents.
+     *                                                   Defaults to false.
+     *
+     * @return string The token contents.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified start position does not exist.
+     */
+    public static function compact(File $phpcsFile, $start, $end, $stripComments = false)
+    {
+        return self::getString($phpcsFile, $start, $end, false, $stripComments, false, true);
+    }
+
+    /**
+     * Retrieve the content of the tokens from the specified start position in the token stack
+     * to the specified end position (inclusive).
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile       The file being scanned.
+     * @param int                         $start           The position to start from in the token stack.
+     * @param int                         $end             The position to end at in the token stack (inclusive).
+     * @param bool                        $origContent     Whether the original content or the tab replaced
+     *                                                     content should be used.
+     *                                                     Defaults to false (= tabs replaced with spaces).
+     * @param bool                        $stripComments   Whether comments should be stripped from the contents.
+     *                                                     Defaults to false.
+     * @param bool                        $stripWhitespace Whether whitespace should be stripped from the contents.
+     *                                                     Defaults to false.
+     * @param bool                        $compact         Whether all whitespace tokens should be replaced with a
+     *                                                     single space. Defaults to false.
+     *
+     * @return string The token contents.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified start position does not exist.
+     */
+    protected static function getString(
+        File $phpcsFile,
+        $start,
+        $end,
+        $origContent = false,
+        $stripComments = false,
+        $stripWhitespace = false,
+        $compact = false
+    ) {
+        $tokens = $phpcsFile->getTokens();
+
+        if (\is_int($start) === false || isset($tokens[$start]) === false) {
+            throw new RuntimeException(
+                'The $start position for GetTokensAsString methods must exist in the token stack'
+            );
+        }
+
+        if (\is_int($end) === false || $end < $start) {
+            return '';
+        }
+
+        $str = '';
+        if ($end >= $phpcsFile->numTokens) {
+            $end = ($phpcsFile->numTokens - 1);
+        }
+
+        $lastAdded = null;
+        for ($i = $start; $i <= $end; $i++) {
+            if ($stripComments === true && isset(Tokens::$commentTokens[$tokens[$i]['code']])) {
+                continue;
+            }
+
+            if ($stripWhitespace === true && $tokens[$i]['code'] === \T_WHITESPACE) {
+                continue;
+            }
+
+            if ($compact === true && $tokens[$i]['code'] === \T_WHITESPACE) {
+                if (isset($lastAdded) === false || $tokens[$lastAdded]['code'] !== \T_WHITESPACE) {
+                    $str      .= ' ';
+                    $lastAdded = $i;
+                }
+                continue;
+            }
+
+            // If tabs are being converted to spaces by the tokenizer, the
+            // original content should be used instead of the converted content.
+            if ($origContent === true && isset($tokens[$i]['orig_content']) === true) {
+                $str .= $tokens[$i]['orig_content'];
+            } else {
+                $str .= $tokens[$i]['content'];
+            }
+
+            $lastAdded = $i;
+        }
+
+        return $str;
+    }
+}

--- a/Tests/BackCompat/BCFile/GetTokensAsStringTest.php
+++ b/Tests/BackCompat/BCFile/GetTokensAsStringTest.php
@@ -18,6 +18,8 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @covers \PHPCSUtils\BackCompat\BCFile::getTokensAsString
  *
+ * @group gettokensasstring
+ *
  * @since 1.0.0
  */
 class GetTokensAsStringTest extends UtilityMethodTestCase

--- a/Tests/Utils/GetTokensAsString/GetTokensAsStringTest.php
+++ b/Tests/Utils/GetTokensAsString/GetTokensAsStringTest.php
@@ -1,0 +1,309 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\GetTokensAsString;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\GetTokensAsString;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\GetTokensAsString class.
+ *
+ * @covers \PHPCSUtils\Utils\GetTokensAsString
+ *
+ * @group gettokensasstring
+ *
+ * @since 1.0.0
+ */
+class GetTokensAsStringTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Full path to the test case file associated with this test class.
+     *
+     * @var string
+     */
+    protected static $caseFile = '';
+
+    /**
+     * Initialize PHPCS & tokenize the test case file.
+     *
+     * Overloaded to re-use the `$caseFile` from the BCFile test.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        self::$caseFile = \dirname(\dirname(__DIR__)) . '/BackCompat/BCFile/GetTokensAsStringTest.inc';
+        parent::setUpTestFile();
+    }
+
+    /**
+     * Test passing a non-existent $start token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentStart()
+    {
+        $this->expectPhpcsException('The $start position for GetTokensAsString methods must exist in the token stack');
+
+        GetTokensAsString::normal(self::$phpcsFile, 100000, 100010);
+    }
+
+    /**
+     * Test passing a non integer `$start`, like the result of a failed $phpcsFile->findNext().
+     *
+     * @return void
+     */
+    public function testNonIntegerStart()
+    {
+        $this->expectPhpcsException('The $start position for GetTokensAsString methods must exist in the token stack');
+
+        GetTokensAsString::noEmpties(self::$phpcsFile, false, 10);
+    }
+
+    /**
+     * Test passing a non integer `$end`, like the result of a failed $phpcsFile->findNext().
+     *
+     * @return void
+     */
+    public function testNonIntegerEnd()
+    {
+        $result = GetTokensAsString::tabReplaced(self::$phpcsFile, 10, false);
+        $this->assertSame('', $result);
+
+        $result = GetTokensAsString::origContent(self::$phpcsFile, 10, 11.5);
+        $this->assertSame('', $result);
+    }
+
+    /**
+     * Test passing a token pointer to $end which is less than $start.
+     *
+     * @return void
+     */
+    public function testEndBeforeStart()
+    {
+        $result = GetTokensAsString::noComments(self::$phpcsFile, 10, 5);
+        $this->assertSame('', $result);
+    }
+
+    /**
+     * Test passing a `$end` beyond the end of the file.
+     *
+     * @return void
+     */
+    public function testLengthBeyondEndOfFile()
+    {
+        $semicolon = $this->getTargetToken('/* testEndOfFile */', \T_SEMICOLON);
+        $result    = GetTokensAsString::origContent(self::$phpcsFile, $semicolon, 1000);
+        $this->assertSame(';
+', $result);
+    }
+
+    /**
+     * Test getting a token set as a string.
+     *
+     * @dataProvider dataGetTokensAsString()
+     *
+     * @param string           $testMarker     The comment which prefaces the target token in the test file.
+     * @param int|string|array $startTokenType The type of token(s) to look for for the start of the string.
+     * @param array            $expected       The expected function's return values.
+     *
+     * @return void
+     */
+    public function testNormal($testMarker, $startTokenType, $expected)
+    {
+        $start = $this->getTargetToken($testMarker, $startTokenType);
+        $end   = $this->getTargetToken($testMarker, \T_SEMICOLON);
+
+        $result = GetTokensAsString::normal(self::$phpcsFile, $start, $end);
+        $this->assertSame($expected['normal'], $result);
+    }
+
+    /**
+     * Test getting a token set as a string with the original content.
+     *
+     * @dataProvider dataGetTokensAsString()
+     *
+     * @param string           $testMarker     The comment which prefaces the target token in the test file.
+     * @param int|string|array $startTokenType The type of token(s) to look for for the start of the string.
+     * @param array            $expected       The expected function's return values.
+     *
+     * @return void
+     */
+    public function testOrigContent($testMarker, $startTokenType, $expected)
+    {
+        $start = $this->getTargetToken($testMarker, $startTokenType);
+        $end   = $this->getTargetToken($testMarker, \T_SEMICOLON);
+
+        $result = GetTokensAsString::origContent(self::$phpcsFile, $start, $end);
+        $this->assertSame($expected['orig'], $result);
+    }
+
+    /**
+     * Test getting a token set as a string without comments.
+     *
+     * @dataProvider dataGetTokensAsString()
+     *
+     * @param string           $testMarker     The comment which prefaces the target token in the test file.
+     * @param int|string|array $startTokenType The type of token(s) to look for for the start of the string.
+     * @param array            $expected       The expected function's return values.
+     *
+     * @return void
+     */
+    public function testNoComments($testMarker, $startTokenType, $expected)
+    {
+        $start = $this->getTargetToken($testMarker, $startTokenType);
+        $end   = $this->getTargetToken($testMarker, \T_SEMICOLON);
+
+        $result = GetTokensAsString::noComments(self::$phpcsFile, $start, $end);
+        $this->assertSame($expected['no_comments'], $result);
+    }
+
+    /**
+     * Test getting a token set as a string without comments or whitespace.
+     *
+     * @dataProvider dataGetTokensAsString()
+     *
+     * @param string           $testMarker     The comment which prefaces the target token in the test file.
+     * @param int|string|array $startTokenType The type of token(s) to look for for the start of the string.
+     * @param array            $expected       The expected function's return values.
+     *
+     * @return void
+     */
+    public function testNoEmpties($testMarker, $startTokenType, $expected)
+    {
+        $start = $this->getTargetToken($testMarker, $startTokenType);
+        $end   = $this->getTargetToken($testMarker, \T_SEMICOLON);
+
+        $result = GetTokensAsString::noEmpties(self::$phpcsFile, $start, $end);
+        $this->assertSame($expected['no_empties'], $result);
+    }
+
+    /**
+     * Test getting a token set as a string with compacted whitespace.
+     *
+     * @dataProvider dataGetTokensAsString()
+     *
+     * @param string           $testMarker     The comment which prefaces the target token in the test file.
+     * @param int|string|array $startTokenType The type of token(s) to look for for the start of the string.
+     * @param array            $expected       The expected function's return values.
+     *
+     * @return void
+     */
+    public function testCompact($testMarker, $startTokenType, $expected)
+    {
+        $start = $this->getTargetToken($testMarker, $startTokenType);
+        $end   = $this->getTargetToken($testMarker, \T_SEMICOLON);
+
+        $result = GetTokensAsString::compact(self::$phpcsFile, $start, $end);
+        $this->assertSame($expected['compact'], $result);
+    }
+
+    /**
+     * Test getting a token set as a string without comments and with compacted whitespace.
+     *
+     * @dataProvider dataGetTokensAsString()
+     *
+     * @param string           $testMarker     The comment which prefaces the target token in the test file.
+     * @param int|string|array $startTokenType The type of token(s) to look for for the start of the string.
+     * @param array            $expected       The expected function's return values.
+     *
+     * @return void
+     */
+    public function testCompactNoComments($testMarker, $startTokenType, $expected)
+    {
+        $start = $this->getTargetToken($testMarker, $startTokenType);
+        $end   = $this->getTargetToken($testMarker, \T_SEMICOLON);
+
+        $result = GetTokensAsString::compact(self::$phpcsFile, $start, $end, true);
+        $this->assertSame($expected['compact_nc'], $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNormal()            For the array format.
+     * @see testOrigContent()       For the array format.
+     * @see testNoComments()        For the array format.
+     * @see testNoEmpties()         For the array format.
+     * @see testCompact()           For the array format.
+     * @see testCompactNoComments() For the array format.
+     *
+     * @return array
+     */
+    public function dataGetTokensAsString()
+    {
+        return [
+            'namespace' => [
+                'marker'   => '/* testNamespace */',
+                'type'     => \T_NAMESPACE,
+                'expected' => [
+                    'normal'      => 'namespace Foo\Bar\Baz;',
+                    'orig'        => 'namespace Foo\Bar\Baz;',
+                    'no_comments' => 'namespace Foo\Bar\Baz;',
+                    'no_empties'  => 'namespaceFoo\Bar\Baz;',
+                    'compact'     => 'namespace Foo\Bar\Baz;',
+                    'compact_nc'  => 'namespace Foo\Bar\Baz;',
+                ],
+            ],
+            'use-with-comments' => [
+                'marker'   => '/* testUseWithComments */',
+                'type'     => \T_STRING,
+                'expected' => [
+                    'normal'      => 'Foo /*comment*/ \ Bar
+    // phpcs:ignore Stnd.Cat.Sniff --    For reasons.
+    \ Bah;',
+                    'orig'        => 'Foo /*comment*/ \ Bar
+	// phpcs:ignore Stnd.Cat.Sniff --	 For reasons.
+	\ Bah;',
+                    'no_comments' => 'Foo  \ Bar
+        \ Bah;',
+                    'no_empties'  => 'Foo\Bar\Bah;',
+                    'compact'     => 'Foo /*comment*/ \ Bar // phpcs:ignore Stnd.Cat.Sniff --    For reasons.
+ \ Bah;',
+                    'compact_nc'  => 'Foo \ Bar \ Bah;',
+                ],
+            ],
+            'echo-with-tabs' => [
+                'marker'   => '/* testEchoWithTabs */',
+                'type'     => \T_ECHO,
+                'expected' => [
+                    'normal'      => 'echo \'foo\',
+    \'bar\'   ,
+        \'baz\';',
+                    'orig'        => 'echo \'foo\',
+	\'bar\'	,
+		\'baz\';',
+                    'no_comments' => 'echo \'foo\',
+    \'bar\'   ,
+        \'baz\';',
+                    'no_empties'  => 'echo\'foo\',\'bar\',\'baz\';',
+                    'compact'     => 'echo \'foo\', \'bar\' , \'baz\';',
+                    'compact_nc'  => 'echo \'foo\', \'bar\' , \'baz\';',
+                ],
+            ],
+            'end-of-file' => [
+                'marker'   => '/* testEndOfFile */',
+                'type'     => \T_ECHO,
+                'expected' => [
+                    'normal'      => 'echo   $foo;',
+                    'orig'        => 'echo   $foo;',
+                    'no_comments' => 'echo   $foo;',
+                    'no_empties'  => 'echo$foo;',
+                    'compact'     => 'echo $foo;',
+                    'compact_nc'  => 'echo $foo;',
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This adds five new utility/convenience methods which are closely related to the PHPCS native `File::getTokensAsString()` method.

In contrast to the PHPCS native `File::getTokensAsString()` method, which has `$length` as the third parameter, all methods in this class expect a stack pointer to an `$end` token (inclusive) as the third parameter.

Methods:
* `normal()` - to retrieve the tab-replaced content of the tokens from the specified start position in the token stack to the specified end position (inclusive). Returns string.
    If the tab width is set, either via a (custom) ruleset, the config file or by passing it on the command-line, PHPCS will automatically replace tabs with spaces.
    The `'content'` index key in the `$tokens` array will contain the tab-replaced content.
    The `'orig_content'` index key in the `$tokens` array will contain the original content.
    This method returns the tokens as string based on the tab-replaced `content` value.
    This method basically behaves the same as the PHPCS native `File::getTokensAsString()` method.
* `tabReplaced()` - alias for the `normal()` method.
* `origContent()` - to retrieve the original content of the tokens from the specified start position in the token stack to the specified end position (inclusive). Returns string.
    This method returns the tokens as string based on the `orig_content` value.
* `noComments()` - to retrieve the code-tokens only content of the tokens from the specified start position in the token stack to the specified end position (inclusive) without comments. Returns string.
* `noEmpties()` - to retrieve the code-tokens only content of the tokens from the specified start position in the token stack to the specified end position (inclusive) without whitespace or comments. Returns string.
    This is, for instance, useful to retrieve a namespace name without stray whitespace or comments.
    Use this function selectively and with care!.
* `compact` - to retrieve the content of the tokens from the specified start position in the token stack to the specified end position (inclusive) with all whitespace tokens - tabs, new lines, multiple spaces - replaced by a single space and optionally without comments. Returns string.

All methods with throw a `PHP_CodeSniffer\Exceptions\RuntimeException` if the specified `$start` position does not exist and will return an empty string when an invalid `$end` position has been passed.
This emulates the behaviour of the PHPCS native `File::getTokensAsString()` method.

All the methods in the class use the `protected` `getString()` helper method under the hood.

Includes dedicated unit tests.