### PR TITLE
New Tokens\Collections class

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tokens;
+
+/**
+ * Collections of related tokens as often used and needed for sniffs.
+ *
+ * These are additional "token groups" to compliment the ones available through the PHPCS
+ * native {@see \PHP_CodeSniffer\Util\Tokens} class.
+ *
+ * @see \PHP_CodeSniffer\Util\Tokens    PHPCS native token groups.
+ * @see \PHPCSUtils\BackCompat\BCTokens Backward compatible version of the PHPCS native token groups.
+ *
+ * @since 1.0.0
+ */
+class Collections
+{
+
+    /**
+     * List of tokens which represent "closed" scopes.
+     *
+     * I.e. anything declared within that scope - except for other closed scopes - is
+     * outside of the global namespace.
+     *
+     * This list doesn't contain `T_NAMESPACE` on purpose as variables declared
+     * within a namespace scope are still global and not limited to that namespace.
+     *
+     * @since 1.0.0
+     *
+     * @var array <int|string> => <int|string>
+     */
+    public static $closedScopes = [
+        \T_CLASS      => \T_CLASS,
+        \T_ANON_CLASS => \T_ANON_CLASS,
+        \T_INTERFACE  => \T_INTERFACE,
+        \T_TRAIT      => \T_TRAIT,
+        \T_FUNCTION   => \T_FUNCTION,
+        \T_CLOSURE    => \T_CLOSURE,
+    ];
+
+    /**
+     * OO scopes in which constants can be declared.
+     *
+     * Note: traits can not declare constants.
+     *
+     * @since 1.0.0
+     *
+     * @var array <int|string> => <int|string>
+     */
+    public static $OOConstantScopes = [
+        \T_CLASS      => \T_CLASS,
+        \T_ANON_CLASS => \T_ANON_CLASS,
+        \T_INTERFACE  => \T_INTERFACE,
+    ];
+
+    /**
+     * OO scopes in which properties can be declared.
+     *
+     * Note: interfaces can not declare properties.
+     *
+     * @since 1.0.0
+     *
+     * @var array <int|string> => <int|string>
+     */
+    public static $OOPropertyScopes = [
+        \T_CLASS      => \T_CLASS,
+        \T_ANON_CLASS => \T_ANON_CLASS,
+        \T_TRAIT      => \T_TRAIT,
+    ];
+}


### PR DESCRIPTION
New `PHPCSUtils\Tokens\Collections` class which will hold "collections" of related tokens in static properties.

These are additional "token groups" to compliment the ones available through the PHPCS native `\PHP_CodeSniffer\Util\Tokens` class.

These properties are often needed for `register()` methods and/or to disseminate the results of calls to `$phpcsFile->findNext()`/`$phpcsFile->findPrevious()`.

To start off the class, it currently holds the following properties:
* `$closedScopes` - List of tokens which represent "closed" scopes.
* `$OOConstantScopes` - OO scopes in which constants can be declared.
* `$OOPropertyScopes` - OO scopes in which properties can be declared.

The available token collections will grow once more classes get added.