### PR TITLE
New Utils\Scopes class

### DIFF
--- a/PHPCSUtils/Utils/Scopes.php
+++ b/PHPCSUtils/Utils/Scopes.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Utils;
+
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Conditions;
+use PHPCSUtils\Utils\Parentheses;
+
+/**
+ * Utility functions for use when examining token scopes.
+ *
+ * @since 1.0.0
+ */
+class Scopes
+{
+
+    /**
+     * Check whether the direct wrapping scope of a token is within a limited set of
+     * acceptable tokens.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
+     * @param int                         $stackPtr    The position in the stack of the
+     *                                                 token to verify.
+     * @param int|string|array            $validScopes Array of token constants representing
+     *                                                 the scopes considered valid.
+     *
+     * @return int|false Integer stack pointer to the valid direct scope or false if
+     *                   no valid direct scope was found.
+     */
+    public static function validDirectScope(File $phpcsFile, $stackPtr, $validScopes)
+    {
+        $ptr = Conditions::getLastCondition($phpcsFile, $stackPtr);
+
+        if ($ptr !== false) {
+            $tokens      = $phpcsFile->getTokens();
+            $validScopes = (array) $validScopes;
+
+            if (\in_array($tokens[$ptr]['code'], $validScopes, true) === true) {
+                return $ptr;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check whether a `T_CONST` token is a class/interface constant declaration.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The position in the stack of the
+     *                                               `T_CONST` token to verify.
+     *
+     * @return bool
+     */
+    public static function isOOConstant(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== \T_CONST) {
+            return false;
+        }
+
+        if (self::validDirectScope($phpcsFile, $stackPtr, Collections::$OOConstantScopes) !== false) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check whether a `T_VARIABLE` token is a class/trait property declaration.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The position in the stack of the
+     *                                               `T_VARIABLE` token to verify.
+     *
+     * @return bool
+     */
+    public static function isOOProperty(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== \T_VARIABLE) {
+            return false;
+        }
+
+        $scopePtr = self::validDirectScope($phpcsFile, $stackPtr, Collections::$OOPropertyScopes);
+        if ($scopePtr !== false) {
+            // Make sure it's not a method parameter.
+            $deepestOpen = Parentheses::getLastOpener($phpcsFile, $stackPtr);
+            if ($deepestOpen === false
+                || $deepestOpen < $scopePtr
+                || Parentheses::isOwnerIn($phpcsFile, $deepestOpen, \T_FUNCTION) === false
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check whether a `T_FUNCTION` token is a class/interface/trait method declaration.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The position in the stack of the
+     *                                               `T_FUNCTION` token to verify.
+     *
+     * @return bool
+     */
+    public static function isOOMethod(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== \T_FUNCTION) {
+            return false;
+        }
+
+        if (self::validDirectScope($phpcsFile, $stackPtr, BCTokens::ooScopeTokens()) !== false) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Tests/Utils/Scopes/IsOOConstantTest.inc
+++ b/Tests/Utils/Scopes/IsOOConstantTest.inc
@@ -1,0 +1,39 @@
+<?php
+
+/* testGlobalConst */
+const BAR = false;
+
+function something()
+{
+    /* testFunctionConst */
+    // Intentional parse error. Constants cannot be declared using the const keyword from within functions.
+    const BAR = false;
+}
+
+class MyClass {
+    /* testClassConst */
+    const FOO = true;
+
+    public function something()
+    {
+        /* testClassMethodConst */
+        // Intentional parse error. Constants cannot be declared using the const keyword from within functions.
+        const BAR = false;
+    }
+}
+
+$a = new class {
+    /* testAnonClassConst */
+    public const FOO = true;
+};
+
+interface MyInterface {
+    /* testInterfaceConst */
+    const FOO = true;
+}
+
+trait MyTrait {
+    // Intentional parse error. Constants are not allowed in traits.
+    /* testTraitConst */
+    const BAR = false;
+}

--- a/Tests/Utils/Scopes/IsOOConstantTest.php
+++ b/Tests/Utils/Scopes/IsOOConstantTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Scopes;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Scopes;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Scopes::isOOConstant() method.
+ *
+ * @group scopes
+ *
+ * @since 1.0.0
+ */
+class IsOOConstantTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test passing a non-existent token pointer.
+     *
+     * @covers \PHPCSUtils\Utils\Scopes::isOOConstant
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $result = Scopes::isOOConstant(self::$phpcsFile, 10000);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test passing a non const token.
+     *
+     * @covers \PHPCSUtils\Utils\Scopes::isOOConstant
+     *
+     * @return void
+     */
+    public function testNonConstToken()
+    {
+        $result = Scopes::isOOConstant(self::$phpcsFile, 0);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test correctly identifying whether a T_CONST token is a class constant.
+     *
+     * @dataProvider dataIsOOConstant
+     *
+     * @covers \PHPCSUtils\Utils\Scopes::isOOConstant
+     * @covers \PHPCSUtils\Utils\Scopes::validDirectScope
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param bool   $expected   The expected function return value.
+     *
+     * @return void
+     */
+    public function testIsOOConstant($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, \T_CONST);
+        $result   = Scopes::isOOConstant(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsOOConstant() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsOOConstant()
+    {
+        return [
+            'global-const' => [
+                '/* testGlobalConst */',
+                false,
+            ],
+            'function-const' => [
+                '/* testFunctionConst */',
+                false,
+            ],
+            'class-const' => [
+                '/* testClassConst */',
+                true,
+            ],
+            'method-const' => [
+                '/* testClassMethodConst */',
+                false,
+            ],
+            'anon-class-const' => [
+                '/* testAnonClassConst */',
+                true,
+            ],
+            'interface-const' => [
+                '/* testInterfaceConst */',
+                true,
+            ],
+            'trait-const' => [
+                '/* testTraitConst */',
+                false,
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/Scopes/IsOOMethodTest.inc
+++ b/Tests/Utils/Scopes/IsOOMethodTest.inc
@@ -1,0 +1,40 @@
+<?php
+
+/* testGlobalFunction */
+function something()
+{
+    /* testNestedFunction */
+    function nested() {}
+
+    /* testNestedClosure */
+    $c = function() {};
+}
+
+abstract class MyClass {
+    /* testClassMethod */
+    public function something() {
+        /* testClassNestedFunction */
+        function nested() {}
+
+        /* testClassNestedClosure */
+        $c = function() {};
+    }
+
+    /* testClassAbstractMethod */
+    abstract protected function somethingAbstract();
+}
+
+$a = new class {
+    /* testAnonClassMethod */
+    final public function something() {}
+};
+
+interface MyInterface {
+    /* testInterfaceMethod */
+    function something();
+}
+
+trait MyTrait {
+    /* testTraitMethod */
+    public function something() {}
+}

--- a/Tests/Utils/Scopes/IsOOMethodTest.php
+++ b/Tests/Utils/Scopes/IsOOMethodTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Scopes;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Scopes;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Scopes::isOOMethod() method.
+ *
+ * @group scopes
+ *
+ * @since 1.0.0
+ */
+class IsOOMethodTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test passing a non-existent token pointer.
+     *
+     * @covers \PHPCSUtils\Utils\Scopes::isOOMethod
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $result = Scopes::isOOMethod(self::$phpcsFile, 10000);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test passing a non function token.
+     *
+     * @covers \PHPCSUtils\Utils\Scopes::isOOMethod
+     *
+     * @return void
+     */
+    public function testNonFunctionToken()
+    {
+        $result = Scopes::isOOMethod(self::$phpcsFile, 0);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test correctly identifying whether a T_FUNCTION token is a class method declaration.
+     *
+     * @dataProvider dataIsOOMethod
+     *
+     * @covers \PHPCSUtils\Utils\Scopes::isOOMethod
+     * @covers \PHPCSUtils\Utils\Scopes::validDirectScope
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param bool   $expected   The expected function return value.
+     *
+     * @return void
+     */
+    public function testIsOOMethod($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, [\T_FUNCTION, \T_CLOSURE]);
+        $result   = Scopes::isOOMethod(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsOOMethod() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsOOMethod()
+    {
+        return [
+            'global-function' => [
+                '/* testGlobalFunction */',
+                false,
+            ],
+            'nested-function' => [
+                '/* testNestedFunction */',
+                false,
+            ],
+            'nested-closure' => [
+                '/* testNestedClosure */',
+                false,
+            ],
+            'class-method' => [
+                '/* testClassMethod */',
+                true,
+            ],
+            'class-nested-function' => [
+                '/* testClassNestedFunction */',
+                false,
+            ],
+            'class-nested-closure' => [
+                '/* testClassNestedClosure */',
+                false,
+            ],
+            'class-abstract-method' => [
+                '/* testClassAbstractMethod */',
+                true,
+            ],
+            'anon-class-method' => [
+                '/* testAnonClassMethod */',
+                true,
+            ],
+            'interface-method' => [
+                '/* testInterfaceMethod */',
+                true,
+            ],
+            'trait-method' => [
+                '/* testTraitMethod */',
+                true,
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/Scopes/IsOOPropertyTest.inc
+++ b/Tests/Utils/Scopes/IsOOPropertyTest.inc
@@ -1,0 +1,89 @@
+<?php
+
+/* testGlobalVar */
+$var = false;
+
+/* testFunctionParameter */
+function something($param = false)
+{
+    /* testFunctionLocalVar */
+    $var = false;
+}
+
+class MyClass {
+    /* testClassPropPublic */
+    public $publicProp = true;
+
+    /* testClassPropVar */
+    var $varPHP4style = true;
+
+    /* testClassPropStaticProtected */
+    static protected $staticProtected = true;
+
+    /* testMethodParameter */
+    public function something($param = false)
+    {
+        /* testMethodLocalVar */
+        $var = false;
+    }
+}
+
+$a = new class {
+    /* testAnonClassPropPrivate */
+    private $privateProp = true;
+
+    /* testAnonMethodParameter */
+    public function something($param = false)
+    {
+        /* testAnonMethodLocalVar */
+        $var = false;
+    }
+};
+
+interface MyInterface {
+    // Intentional parse error. Properties are not allowed in interfaces.
+    /* testInterfaceProp */
+    public $interfaceProp = false;
+
+    /* testInterfaceMethodParameter */
+    public function something($param = false);
+}
+
+trait MyTrait {
+    /* testTraitProp */
+    public $traitProp = true;
+
+    /* testTraitMethodParameter */
+    function something($param = false) {}
+}
+
+// Multi-property declarations.
+class MultiPropClass {
+    /* testClassMultiProp1 */
+    public $varA = true,
+        /* testClassMultiProp2 */
+        $varB = false,
+        /* testClassMultiProp3 */
+        $varC = 'string';
+}
+
+/* testGlobalVarObj */
+$util->setLogger(
+    new class {
+        /* testNestedAnonClassProp */
+        private $varName  = 'hello';
+});
+
+if ( has_filter( 'comments_open' ) === false ) {
+    add_filter( 'comments_open', new class {
+        /* testDoubleNestedAnonClassProp */
+        public $year = 2017; // Ok.
+
+        /* testDoubleNestedAnonClassMethodParameter */
+        public function __construct( $open, $post_id ) {
+            /* testDoubleNestedAnonClassMethodLocalVar */
+            global $page;
+        }
+    /* testFunctionCallParameter */
+    }, $priority, 2 );
+}

--- a/Tests/Utils/Scopes/IsOOPropertyTest.php
+++ b/Tests/Utils/Scopes/IsOOPropertyTest.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Scopes;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Scopes;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Scopes::isOOProperty method.
+ *
+ * @group scopes
+ *
+ * @since 1.0.0
+ */
+class IsOOPropertyTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test passing a non-existent token pointer.
+     *
+     * @covers \PHPCSUtils\Utils\Scopes::isOOProperty
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $result = Scopes::isOOProperty(self::$phpcsFile, 10000);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test passing a non variable token.
+     *
+     * @covers \PHPCSUtils\Utils\Scopes::isOOProperty
+     *
+     * @return void
+     */
+    public function testNonVariableToken()
+    {
+        $result = Scopes::isOOProperty(self::$phpcsFile, 0);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test correctly identifying whether a T_VARIABLE token is a class property declaration.
+     *
+     * @dataProvider dataIsOOProperty
+     *
+     * @covers \PHPCSUtils\Utils\Scopes::isOOProperty
+     * @covers \PHPCSUtils\Utils\Scopes::validDirectScope
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param bool   $expected   The expected function return value.
+     *
+     * @return void
+     */
+    public function testIsOOProperty($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, \T_VARIABLE);
+        $result   = Scopes::isOOProperty(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsOOProperty() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsOOProperty()
+    {
+        return [
+            'global-var' => [
+                '/* testGlobalVar */',
+                false,
+            ],
+            'function-param' => [
+                '/* testFunctionParameter */',
+                false,
+            ],
+            'function-local-var' => [
+                '/* testFunctionLocalVar */',
+                false,
+            ],
+            'class-property-public' => [
+                '/* testClassPropPublic */',
+                true,
+            ],
+            'class-property-var' => [
+                '/* testClassPropVar */',
+                true,
+            ],
+            'class-property-static-protected' => [
+                '/* testClassPropStaticProtected */',
+                true,
+            ],
+            'method-param' => [
+                '/* testMethodParameter */',
+                false,
+            ],
+            'method-local-var' => [
+                '/* testMethodLocalVar */',
+                false,
+            ],
+            'anon-class-property-private' => [
+                '/* testAnonClassPropPrivate */',
+                true,
+            ],
+            'anon-class-method-param' => [
+                '/* testAnonMethodParameter */',
+                false,
+            ],
+            'anon-class-method-local-var' => [
+                '/* testAnonMethodLocalVar */',
+                false,
+            ],
+            'interface-property' => [
+                '/* testInterfaceProp */',
+                false,
+            ],
+            'interface-method-param' => [
+                '/* testInterfaceMethodParameter */',
+                false,
+            ],
+            'trait-property' => [
+                '/* testTraitProp */',
+                true,
+            ],
+            'trait-method-param' => [
+                '/* testTraitMethodParameter */',
+                false,
+            ],
+            'class-multi-property-1' => [
+                '/* testClassMultiProp1 */',
+                true,
+            ],
+            'class-multi-property-2' => [
+                '/* testClassMultiProp2 */',
+                true,
+            ],
+            'class-multi-property-3' => [
+                '/* testClassMultiProp3 */',
+                true,
+            ],
+            'global-var-obj-access' => [
+                '/* testGlobalVarObj */',
+                false,
+            ],
+            'nested-anon-class-property' => [
+                '/* testNestedAnonClassProp */',
+                true,
+            ],
+            'double-nested-anon-class-property' => [
+                '/* testDoubleNestedAnonClassProp */',
+                true,
+            ],
+            'double-nested-anon-class-method-param' => [
+                '/* testDoubleNestedAnonClassMethodParameter */',
+                false,
+            ],
+            'double-nested-anon-class-method-local-var' => [
+                '/* testDoubleNestedAnonClassMethodLocalVar */',
+                false,
+            ],
+            'function-call-param' => [
+                '/* testFunctionCallParameter */',
+                false,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
New `PHPCSUtils\Utils\Scopes` class which will hold methods related to the scoping of tokens.
This class is closely related to the `PHPCSUtils\Utils\Conditions` class in that it uses the `$tokens[$stackPtr]['conditions']` index.

This class initially contains the following four utility methods:
* `isOOProperty()` - to check if a `T_VARIABLE` token is a class/trait property. Returns true/false.
* `isOOConstant()` - to check if a `T_CONSTANT` token is a class/interface constant.  Returns true/false.
* `isOOMethod()` - to check if a `T_FUNCTION` token is a class/interface/trait method.  Returns true/false.
* `validDirectScope()` - to check the direct condition of an arbitrary token against a set of valid scope conditions. Returns the integer stackPtr to the direct condition if valid or false otherwise.

These methods were written by me and have been battle-tested in the past year or two in the PHPCompatibility standard.

Includes dedicated unit tests.