### PR TITLE
BCFile::getDeclarationName(): add unit tests and fix compatibility with older PHPCS versions

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -94,6 +94,9 @@ class BCFile
      * - PHPCS 3.0.0: The Exception thrown changed from a `PHP_CodeSniffer_Exception` to
      *                `\PHP_CodeSniffer\Exceptions\RuntimeException`.
      *
+     * Note: For ES6 classes in combination with PHPCS 2.x, passing a `T_STRING` token to
+     *       this method will be accepted for JS files.
+     *
      * @see \PHP_CodeSniffer\Files\File::getDeclarationName() Original source.
      *
      * @since 1.0.0
@@ -119,6 +122,16 @@ class BCFile
             return null;
         }
 
+        /*
+         * BC: Work-around JS ES6 classes not being tokenized as T_CLASS in PHPCS < 3.0.0.
+         */
+        if ($phpcsFile->tokenizerType === 'JS'
+            && $tokenCode === T_STRING
+            && $tokens[$stackPtr]['content'] === 'class'
+        ) {
+            $tokenCode = T_CLASS;
+        }
+
         if ($tokenCode !== T_FUNCTION
             && $tokenCode !== T_CLASS
             && $tokenCode !== T_INTERFACE
@@ -136,7 +149,7 @@ class BCFile
         }
 
         $content = null;
-        for ($i = $stackPtr; $i < $phpcsFile->numTokens; $i++) {
+        for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
             if ($tokens[$i]['code'] === T_STRING) {
                 $content = $tokens[$i]['content'];
                 break;

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -152,7 +152,13 @@ class BCFile
         $content = null;
         for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
             if ($tokens[$i]['code'] === T_STRING) {
-                $content = $tokens[$i]['content'];
+                /*
+                 * BC: In PHPCS 2.6.0, in case of live coding, the last token in a file will be tokenized
+                 * as T_STRING, but won't have the `content` index set.
+                 */
+                if (isset($tokens[$i]['content'])) {
+                    $content = $tokens[$i]['content'];
+                }
                 break;
             }
         }

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -96,6 +96,7 @@ class BCFile
      *
      * Note: For ES6 classes in combination with PHPCS 2.x, passing a `T_STRING` token to
      *       this method will be accepted for JS files.
+     * Note: support for JS ES6 method syntax has not been back-filled for PHPCS < 3.0.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getDeclarationName() Original source.
      *

--- a/Tests/BackCompat/BCFile/GetDeclarationNameJSTest.js
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameJSTest.js
@@ -1,0 +1,23 @@
+/* testInvalidTokenPassed */
+print something;
+
+var object =
+{
+    /* testClosure */
+    propertyName: function ()  {}
+}
+
+/* testFunction */
+function functionName() {}
+
+/* testClass */
+class ClassName
+{
+    /* testMethod */
+    methodName() {
+       return false;
+    }
+}
+
+/* testFunctionUnicode */
+function π() {}

--- a/Tests/BackCompat/BCFile/GetDeclarationNameJSTest.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameJSTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCFile;
+
+use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+
+/**
+ * Tests for the \PHPCSUtils\BackCompat\BCFile::getDeclarationName() method.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCFile::getDeclarationName
+ *
+ * @since 1.0.0
+ */
+class GetDeclarationNameJSTest extends UtilityMethodTestCase
+{
+
+    /**
+     * The file extension of the test case file (without leading dot).
+     *
+     * @var string
+     */
+    protected static $fileExtension = 'js';
+
+    /**
+     * Test receiving an expected exception when a non-supported token is passed.
+     *
+     * @return void
+     */
+    public function testInvalidTokenPassed()
+    {
+        $this->expectPhpcsException('Token type "T_STRING" is not T_FUNCTION, T_CLASS, T_INTERFACE or T_TRAIT');
+
+        $target = $this->getTargetToken('/* testInvalidTokenPassed */', \T_STRING);
+        BCFile::getDeclarationName(self::$phpcsFile, $target);
+    }
+
+    /**
+     * Test receiving "null" when passed an anonymous construct or in case of a parse error.
+     *
+     * @dataProvider dataGetDeclarationNameNull
+     *
+     * @param string     $testMarker The comment which prefaces the target token in the test file.
+     * @param int|string $targetType Token type of the token to get as stackPtr.
+     *
+     * @return void
+     */
+    public function testGetDeclarationNameNull($testMarker, $targetType)
+    {
+        $target = $this->getTargetToken($testMarker, $targetType);
+        $result = BCFile::getDeclarationName(self::$phpcsFile, $target);
+        $this->assertNull($result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see GetDeclarationNameTest::testGetDeclarationNameNull()
+     *
+     * @return array
+     */
+    public function dataGetDeclarationNameNull()
+    {
+        return [
+            'closure' => [
+                '/* testClosure */',
+                \T_CLOSURE,
+            ],
+        ];
+    }
+
+    /**
+     * Test retrieving the name of a function or OO structure.
+     *
+     * @dataProvider dataGetDeclarationName
+     *
+     * @param string     $testMarker The comment which prefaces the target token in the test file.
+     * @param string     $expected   Expected function output.
+     * @param int|string $targetType Token type of the token to get as stackPtr.
+     *
+     * @return void
+     */
+    public function testGetDeclarationName($testMarker, $expected, $targetType = null)
+    {
+        if (isset($targetType) === false) {
+            $targetType = [\T_CLASS, \T_INTERFACE, \T_TRAIT, \T_FUNCTION];
+        }
+
+        $target = $this->getTargetToken($testMarker, $targetType);
+        $result = BCFile::getDeclarationName(self::$phpcsFile, $target);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see GetDeclarationNameTest::testGetDeclarationName()
+     *
+     * @return array
+     */
+    public function dataGetDeclarationName()
+    {
+        return [
+            'function' => [
+                '/* testFunction */',
+                'functionName',
+            ],
+            'class' => [
+                '/* testClass */',
+                'ClassName',
+            ],
+            'method' => [
+                '/* testMethod */',
+                'methodName',
+            ],
+            'function-unicode-name' => [
+                '/* testFunctionUnicode */',
+                'π',
+            ],
+        ];
+    }
+}

--- a/Tests/BackCompat/BCFile/GetDeclarationNameJSTest.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameJSTest.php
@@ -11,6 +11,7 @@
 namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
 use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
 /**
@@ -118,14 +119,26 @@ class GetDeclarationNameJSTest extends UtilityMethodTestCase
                 'ClassName',
                 [\T_CLASS, \T_STRING],
             ],
-            'method' => [
-                '/* testMethod */',
-                'methodName',
-            ],
             'function-unicode-name' => [
                 '/* testFunctionUnicode */',
                 'π',
             ],
         ];
+    }
+
+    /**
+     * Test retrieving the name of JS ES6 class method.
+     *
+     * @return void
+     */
+    public function testGetDeclarationNameES6Method()
+    {
+        if (\version_compare(Helper::getVersion(), '3.0.0', '<') === true) {
+            $this->markTestSkipped('Support for JS ES6 method has not been backfilled for PHPCS 2.x (yet)');
+        }
+
+        $target = $this->getTargetToken('/* testMethod */', [\T_CLASS, \T_INTERFACE, \T_TRAIT, \T_FUNCTION]);
+        $result = BCFile::getDeclarationName(self::$phpcsFile, $target);
+        $this->assertSame('methodName', $result);
     }
 }

--- a/Tests/BackCompat/BCFile/GetDeclarationNameJSTest.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameJSTest.php
@@ -116,6 +116,7 @@ class GetDeclarationNameJSTest extends UtilityMethodTestCase
             'class' => [
                 '/* testClass */',
                 'ClassName',
+                [\T_CLASS, \T_STRING],
             ],
             'method' => [
                 '/* testMethod */',

--- a/Tests/BackCompat/BCFile/GetDeclarationNameTest.inc
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameTest.inc
@@ -1,0 +1,65 @@
+<?php
+
+/* testInvalidTokenPassed */
+echo MY_CONSTANT;
+
+/* testClosure */
+$closure = function() {};
+
+/* testAnonClassWithParens */
+$anonClass = new class() {};
+
+/* testAnonClassWithParens2 */
+$class = new class() {
+    private $property = 'test';
+    public function test() {}
+};
+
+/* testAnonClassWithoutParens */
+$anonClass = new class {};
+
+/* testAnonClassExtendsWithoutParens */
+$class = new class extends SomeClass {
+    private $property = 'test';
+    public function test() {}
+};
+
+/* testFunction */
+function functionName() {}
+
+/* testClass */
+abstract class ClassName {
+    /* testMethod */
+    public function methodName() {}
+
+    /* testAbstractMethod */
+    abstract protected function abstractMethodName();
+}
+
+/* testExtendedClass */
+class ExtendedClass extends Foo {}
+
+/* testInterface */
+interface InterfaceName {}
+
+/* testTrait */
+trait TraitName {
+    /* testFunctionEndingWithNumber */
+    function ValidNameEndingWithNumber5(){}
+}
+
+/* testClassWithNumber */
+class ClassWith1Number implements SomeInterface {}
+
+/* testInterfaceWithNumbers */
+interface InterfaceWith12345Numbers extends AnotherInterface {}
+
+/* testClassWithCommentsAndNewLines */
+class /* comment */
+
+// phpcs:ignore Standard.Cat.SniffName -- for reasons
+    ClassWithCommentsAndNewLines {}
+
+/* testLiveCoding */
+// Intentional parse error. This has to be the last test in the file.
+function // Comment.

--- a/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCFile;
+
+use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+
+/**
+ * Tests for the \PHPCSUtils\BackCompat\BCFile::getDeclarationName() method.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCFile::getDeclarationName
+ *
+ * @since 1.0.0
+ */
+class GetDeclarationNameTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test receiving an expected exception when a non-supported token is passed.
+     *
+     * @return void
+     */
+    public function testInvalidTokenPassed()
+    {
+        $this->expectPhpcsException('Token type "T_STRING" is not T_FUNCTION, T_CLASS, T_INTERFACE or T_TRAIT');
+
+        $target = $this->getTargetToken('/* testInvalidTokenPassed */', \T_STRING);
+        BCFile::getDeclarationName(self::$phpcsFile, $target);
+    }
+
+    /**
+     * Test receiving "null" when passed an anonymous construct or in case of a parse error.
+     *
+     * @dataProvider dataGetDeclarationNameNull
+     *
+     * @param string     $testMarker The comment which prefaces the target token in the test file.
+     * @param int|string $targetType Token type of the token to get as stackPtr.
+     *
+     * @return void
+     */
+    public function testGetDeclarationNameNull($testMarker, $targetType)
+    {
+        $target = $this->getTargetToken($testMarker, $targetType);
+        $result = BCFile::getDeclarationName(self::$phpcsFile, $target);
+        $this->assertNull($result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetDeclarationNameNull() For the array format.
+     *
+     * @return array
+     */
+    public function dataGetDeclarationNameNull()
+    {
+        return [
+            'closure' => [
+                '/* testClosure */',
+                \T_CLOSURE,
+            ],
+            'anon-class-with-parentheses' => [
+                '/* testAnonClassWithParens */',
+                \T_ANON_CLASS,
+            ],
+            'anon-class-with-parentheses-2' => [
+                '/* testAnonClassWithParens2 */',
+                \T_ANON_CLASS,
+            ],
+            'anon-class-without-parentheses' => [
+                '/* testAnonClassWithoutParens */',
+                \T_ANON_CLASS,
+            ],
+            'anon-class-extends-without-parentheses' => [
+                '/* testAnonClassExtendsWithoutParens */',
+                \T_ANON_CLASS,
+            ],
+            'live-coding' => [
+                '/* testLiveCoding */',
+                \T_FUNCTION,
+            ],
+        ];
+    }
+
+    /**
+     * Test retrieving the name of a function or OO structure.
+     *
+     * @dataProvider dataGetDeclarationName
+     *
+     * @param string     $testMarker The comment which prefaces the target token in the test file.
+     * @param string     $expected   Expected function output.
+     * @param int|string $targetType Token type of the token to get as stackPtr.
+     *
+     * @return void
+     */
+    public function testGetDeclarationName($testMarker, $expected, $targetType = null)
+    {
+        if (isset($targetType) === false) {
+            $targetType = [\T_CLASS, \T_INTERFACE, \T_TRAIT, \T_FUNCTION];
+        }
+
+        $target = $this->getTargetToken($testMarker, $targetType);
+        $result = BCFile::getDeclarationName(self::$phpcsFile, $target);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetDeclarationName() For the array format.
+     *
+     * @return array
+     */
+    public function dataGetDeclarationName()
+    {
+        return [
+            'function' => [
+                '/* testFunction */',
+                'functionName',
+            ],
+            'class' => [
+                '/* testClass */',
+                'ClassName',
+            ],
+            'method' => [
+                '/* testMethod */',
+                'methodName',
+            ],
+            'abstract-method' => [
+                '/* testAbstractMethod */',
+                'abstractMethodName',
+            ],
+            'extended-class' => [
+                '/* testExtendedClass */',
+                'ExtendedClass',
+            ],
+            'interface' => [
+                '/* testInterface */',
+                'InterfaceName',
+            ],
+            'trait' => [
+                '/* testTrait */',
+                'TraitName',
+            ],
+            'function-name-ends-with-number' => [
+                '/* testFunctionEndingWithNumber */',
+                'ValidNameEndingWithNumber5',
+            ],
+            'class-with-numbers-in-name' => [
+                '/* testClassWithNumber */',
+                'ClassWith1Number',
+            ],
+            'interface-with-numbers-in-name' => [
+                '/* testInterfaceWithNumbers */',
+                'InterfaceWith12345Numbers',
+            ],
+            'class-with-comments-and-new-lines' => [
+                '/* testClassWithCommentsAndNewLines */',
+                'ClassWithCommentsAndNewLines',
+            ],
+        ];
+    }
+}

--- a/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
@@ -83,6 +83,11 @@ class GetDeclarationNameTest extends UtilityMethodTestCase
                 '/* testAnonClassExtendsWithoutParens */',
                 \T_ANON_CLASS,
             ],
+
+            /*
+             * Note: this particular test *will* throw tokenizer "undefined offset" notices on PHPCS 2.6.0,
+             * but the test will pass.
+             */
             'live-coding' => [
                 '/* testLiveCoding */',
                 \T_FUNCTION,


### PR DESCRIPTION
## BCFile::getDeclarationName(): add unit tests

## BCFile::getDeclarationName(): fix JS ES6 class compatibility with PHPCS < 3.0.0 [1]

In PHPCS 2.x, for JS files, ES6 classes were not tokenized as `T_CLASS`.

This commit adds work-arounds to the utility method to handle the situation correctly.

Ref: squizlabs/PHP_CodeSniffer#1251

## BCFile::getDeclarationName(): exclude JS ES6 method support for PHPCS < 3.0.0 [2]

In PHPCS 2.x, for JS files, ES6 method were not tokenized as `T_FUNCTION`.

As the `class` condition is not available either in PHPCS 2.x, it will be hard to back-fill this reliably.

For now, I'm making the choice to explicitly **NOT** backfill support for JS ES6 methods in PHPCS < 3.0.0 for the `BCFile::getDeclarationName()` method.

If enough support requests are opened about it, I may reconsider.

Ref: squizlabs/PHP_CodeSniffer#1251

## BCFile::getDeclarationName(): fix compatibility with PHPCS < 2.6.1 [3]

In PHPCS 2.6.0, when live coding, the last token in a file can be tokenized as `T_STRING`, but without having the `content` index key set.

This commit adds a work-around to the utility method to handle the situation correctly.