### PR TITLE
New Utils\ObjectDeclarations class

### DIFF
--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -1,0 +1,289 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Utils;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Utility functions for use when examining object declaration statements.
+ *
+ * @since 1.0.0 The `get(Declaration)Name()`, `getClassProperties()`, `findExtendedClassName()`
+ *              and `findImplementedInterfaceNames()` methods are based on and
+ *              inspired by the methods of the same name in the PHPCS native
+ *              `File` class.
+ *              Also see {@see \PHPCSUtils\BackCompat\BCFile}.
+ */
+class ObjectDeclarations
+{
+
+    /**
+     * Retrieves the declaration name for classes, interfaces, traits, and functions.
+     *
+     * Note: For ES6 classes in combination with PHPCS 2.x, passing a `T_STRING` token to
+     *       this method will be accepted for JS files.
+     * Note: support for JS ES6 method syntax has not (yet) been back-filled for PHPCS < 3.0.0.
+     *
+     * @see \PHP_CodeSniffer\Files\File::getDeclarationName()   Original source.
+     * @see \PHPCSUtils\BackCompat\BCFile::getDeclarationName() Cross-version compatible version of the original.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the declaration token
+     *                                               which declared the class, interface,
+     *                                               trait, or function.
+     *
+     * @return string|null The name of the class, interface, trait, or function;
+     *                     or NULL if the function or class is anonymous or
+     *                     in case of a parse error/live coding.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified token is not of type
+     *                                                      T_FUNCTION, T_CLASS, T_TRAIT, or T_INTERFACE.
+     */
+    public static function getName(File $phpcsFile, $stackPtr)
+    {
+        $tokens    = $phpcsFile->getTokens();
+        $tokenCode = $tokens[$stackPtr]['code'];
+
+        if ($tokenCode === \T_ANON_CLASS || $tokenCode === \T_CLOSURE) {
+            return null;
+        }
+
+        /*
+         * BC: Work-around JS ES6 classes not being tokenized as T_CLASS in PHPCS < 3.0.0.
+         */
+        if ($phpcsFile->tokenizerType === 'JS'
+            && $tokenCode === \T_STRING
+            && $tokens[$stackPtr]['content'] === 'class'
+        ) {
+            $tokenCode = \T_CLASS;
+        }
+
+        if ($tokenCode !== \T_FUNCTION
+            && $tokenCode !== \T_CLASS
+            && $tokenCode !== \T_INTERFACE
+            && $tokenCode !== \T_TRAIT
+        ) {
+            throw new RuntimeException(
+                'Token type "' . $tokens[$stackPtr]['type'] . '" is not T_FUNCTION, T_CLASS, T_INTERFACE or T_TRAIT'
+            );
+        }
+
+        if ($tokenCode === \T_FUNCTION
+            && \strtolower($tokens[$stackPtr]['content']) !== 'function'
+        ) {
+            // This is a function declared without the "function" keyword.
+            // So this token is the function name.
+            return $tokens[$stackPtr]['content'];
+        }
+
+        $content = null;
+        for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
+            if ($tokens[$i]['code'] === \T_STRING) {
+                /*
+                 * BC: In PHPCS 2.6.0, in case of live coding, the last token in a file will be tokenized
+                 * as T_STRING, but won't have the `content` index set.
+                 */
+                if (isset($tokens[$i]['content'])) {
+                    $content = $tokens[$i]['content'];
+                }
+                break;
+            }
+        }
+
+        return $content;
+    }
+
+    /**
+     * Retrieves the implementation properties of a class.
+     *
+     * The format of the return value is:
+     * <code>
+     *   array(
+     *    'is_abstract' => false, // true if the abstract keyword was found.
+     *    'is_final'    => false, // true if the final keyword was found.
+     *   );
+     * </code>
+     *
+     * @see \PHP_CodeSniffer\Files\File::getClassProperties()   Original source.
+     * @see \PHPCSUtils\BackCompat\BCFile::getClassProperties() Cross-version compatible version of the original.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position in the stack of the T_CLASS
+     *                                               token to acquire the properties for.
+     *
+     * @return array
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
+     *                                                      T_CLASS token.
+     */
+    public static function getClassProperties(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['code'] !== \T_CLASS) {
+            throw new RuntimeException('$stackPtr must be of type T_CLASS');
+        }
+
+        $valid = [
+            \T_FINAL       => \T_FINAL,
+            \T_ABSTRACT    => \T_ABSTRACT,
+            \T_WHITESPACE  => \T_WHITESPACE,
+            \T_COMMENT     => \T_COMMENT,
+            \T_DOC_COMMENT => \T_DOC_COMMENT,
+        ];
+
+        $isAbstract = false;
+        $isFinal    = false;
+
+        for ($i = ($stackPtr - 1); $i > 0; $i--) {
+            if (isset($valid[$tokens[$i]['code']]) === false) {
+                break;
+            }
+
+            switch ($tokens[$i]['code']) {
+                case \T_ABSTRACT:
+                    $isAbstract = true;
+                    break;
+
+                case \T_FINAL:
+                    $isFinal = true;
+                    break;
+            }
+        }
+
+        return [
+            'is_abstract' => $isAbstract,
+            'is_final'    => $isFinal,
+        ];
+    }
+
+    /**
+     * Retrieves the name of the class that the specified class extends.
+     * (works for classes, anonymous classes and interfaces)
+     *
+     * @see \PHP_CodeSniffer\Files\File::findExtendedClassName()   Original source.
+     * @see \PHPCSUtils\BackCompat\BCFile::findExtendedClassName() Cross-version compatible version of the original.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The stack position of the class.
+     *
+     * @return string|false The extended class name or FALSE on error or if there
+     *                      is no extended class name.
+     */
+    public static function findExtendedClassName(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Check for the existence of the token.
+        if (isset($tokens[$stackPtr]) === false) {
+            return false;
+        }
+
+        if ($tokens[$stackPtr]['code'] !== \T_CLASS
+            && $tokens[$stackPtr]['code'] !== \T_ANON_CLASS
+            && $tokens[$stackPtr]['code'] !== \T_INTERFACE
+        ) {
+            return false;
+        }
+
+        if (isset($tokens[$stackPtr]['scope_opener']) === false) {
+            return false;
+        }
+
+        $classOpenerIndex = $tokens[$stackPtr]['scope_opener'];
+        $extendsIndex     = $phpcsFile->findNext(\T_EXTENDS, $stackPtr, $classOpenerIndex);
+        if ($extendsIndex === false) {
+            return false;
+        }
+
+        $find = [
+            \T_NS_SEPARATOR,
+            \T_STRING,
+            \T_WHITESPACE,
+        ];
+
+        $end  = $phpcsFile->findNext($find, ($extendsIndex + 1), ($classOpenerIndex + 1), true);
+        $name = $phpcsFile->getTokensAsString(($extendsIndex + 1), ($end - $extendsIndex - 1));
+        $name = \trim($name);
+
+        if ($name === '') {
+            return false;
+        }
+
+        return $name;
+    }
+
+    /**
+     * Retrieves the names of the interfaces that the specified class implements.
+     *
+     * @see \PHP_CodeSniffer\Files\File::findImplementedInterfaceNames()   Original source.
+     * @see \PHPCSUtils\BackCompat\BCFile::findImplementedInterfaceNames() Cross-version compatible version of
+     *                                                                     the original.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The stack position of the class.
+     *
+     * @return array|false Array with names of the implemented interfaces or FALSE on
+     *                     error or if there are no implemented interface names.
+     */
+    public static function findImplementedInterfaceNames(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Check for the existence of the token.
+        if (isset($tokens[$stackPtr]) === false) {
+            return false;
+        }
+
+        if ($tokens[$stackPtr]['code'] !== \T_CLASS
+            && $tokens[$stackPtr]['code'] !== \T_ANON_CLASS
+        ) {
+            return false;
+        }
+
+        if (isset($tokens[$stackPtr]['scope_closer']) === false) {
+            return false;
+        }
+
+        $classOpenerIndex = $tokens[$stackPtr]['scope_opener'];
+        $implementsIndex  = $phpcsFile->findNext(\T_IMPLEMENTS, $stackPtr, $classOpenerIndex);
+        if ($implementsIndex === false) {
+            return false;
+        }
+
+        $find = [
+            \T_NS_SEPARATOR,
+            \T_STRING,
+            \T_WHITESPACE,
+            \T_COMMA,
+        ];
+
+        $end  = $phpcsFile->findNext($find, ($implementsIndex + 1), ($classOpenerIndex + 1), true);
+        $name = $phpcsFile->getTokensAsString(($implementsIndex + 1), ($end - $implementsIndex - 1));
+        $name = \trim($name);
+
+        if ($name === '') {
+            return false;
+        } else {
+            $names = \explode(',', $name);
+            $names = \array_map('trim', $names);
+            return $names;
+        }
+    }
+}

--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
@@ -24,7 +24,6 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
-use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
 /**
@@ -32,10 +31,22 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @covers \PHPCSUtils\BackCompat\BCFile::findExtendedClassName
  *
+ * @group objectdeclarations
+ *
  * @since 1.0.0
  */
 class FindExtendedClassNameTest extends UtilityMethodTestCase
 {
+
+    /**
+     * The fully qualified name of the class being tested.
+     *
+     * This allows for the same unit tests to be run for both the BCFile functions
+     * as well as for the related PHPCSUtils functions.
+     *
+     * @var string
+     */
+    const TEST_CLASS = '\PHPCSUtils\BackCompat\BCFile';
 
     /**
      * Test getting a `false` result when a non-existent token is passed.
@@ -44,7 +55,9 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
      */
     public function testNonExistentToken()
     {
-        $result = BCFile::findExtendedClassName(self::$phpcsFile, 100000);
+        $testClass = static::TEST_CLASS;
+
+        $result = $testClass::findExtendedClassName(self::$phpcsFile, 100000);
         $this->assertFalse($result);
     }
 
@@ -55,8 +68,10 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
      */
     public function testNotAClass()
     {
+        $testClass = static::TEST_CLASS;
+
         $token  = $this->getTargetToken('/* testNotAClass */', [T_FUNCTION]);
-        $result = BCFile::findExtendedClassName(self::$phpcsFile, $token);
+        $result = $testClass::findExtendedClassName(self::$phpcsFile, $token);
         $this->assertFalse($result);
     }
 
@@ -73,8 +88,10 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
      */
     public function testFindExtendedClassName($identifier, $expected)
     {
+        $testClass = static::TEST_CLASS;
+
         $OOToken = $this->getTargetToken($identifier, [T_CLASS, T_ANON_CLASS, T_INTERFACE]);
-        $result  = BCFile::findExtendedClassName(self::$phpcsFile, $OOToken);
+        $result  = $testClass::findExtendedClassName(self::$phpcsFile, $OOToken);
         $this->assertSame($expected, $result);
     }
 

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
@@ -23,7 +23,6 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
-use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
 /**
@@ -31,10 +30,22 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @covers \PHPCSUtils\BackCompat\BCFile::findImplementedInterfaceNames
  *
+ * @group objectdeclarations
+ *
  * @since 1.0.0
  */
 class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
 {
+
+    /**
+     * The fully qualified name of the class being tested.
+     *
+     * This allows for the same unit tests to be run for both the BCFile functions
+     * as well as for the related PHPCSUtils functions.
+     *
+     * @var string
+     */
+    const TEST_CLASS = '\PHPCSUtils\BackCompat\BCFile';
 
     /**
      * Test getting a `false` result when a non-existent token is passed.
@@ -43,7 +54,9 @@ class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
      */
     public function testNonExistentToken()
     {
-        $result = BCFile::findImplementedInterfaceNames(self::$phpcsFile, 100000);
+        $testClass = static::TEST_CLASS;
+
+        $result = $testClass::findImplementedInterfaceNames(self::$phpcsFile, 100000);
         $this->assertFalse($result);
     }
 
@@ -54,8 +67,10 @@ class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
      */
     public function testNotAClass()
     {
+        $testClass = static::TEST_CLASS;
+
         $token  = $this->getTargetToken('/* testNotAClass */', [T_FUNCTION]);
-        $result = BCFile::findImplementedInterfaceNames(self::$phpcsFile, $token);
+        $result = $testClass::findImplementedInterfaceNames(self::$phpcsFile, $token);
         $this->assertFalse($result);
     }
 
@@ -71,8 +86,10 @@ class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
      */
     public function testFindImplementedInterfaceNames($identifier, $expected)
     {
+        $testClass = static::TEST_CLASS;
+
         $OOToken = $this->getTargetToken($identifier, [T_CLASS, T_ANON_CLASS, T_INTERFACE]);
-        $result  = BCFile::findImplementedInterfaceNames(self::$phpcsFile, $OOToken);
+        $result  = $testClass::findImplementedInterfaceNames(self::$phpcsFile, $OOToken);
         $this->assertSame($expected, $result);
     }
 

--- a/Tests/BackCompat/BCFile/GetClassPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetClassPropertiesTest.php
@@ -17,6 +17,8 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @covers \PHPCSUtils\BackCompat\BCFile::getClassProperties
  *
+ * @group objectdeclarations
+ *
  * @since 1.0.0
  */
 class GetClassPropertiesTest extends UtilityMethodTestCase

--- a/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
@@ -18,6 +18,8 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @covers \PHPCSUtils\BackCompat\BCFile::getDeclarationName
  *
+ * @group objectdeclarations
+ *
  * @since 1.0.0
  */
 class GetDeclarationNameTest extends UtilityMethodTestCase

--- a/Tests/Utils/ObjectDeclarations/FindExtendedClassNameTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedClassNameTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations;
+
+use PHPCSUtils\Tests\BackCompat\BCFile\FindExtendedClassNameTest as BCFile_FindExtendedClassNameTest;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\ObjectDeclarations::findExtendedClassName() method.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::findExtendedClassName
+ *
+ * @group objectdeclarations
+ *
+ * @since 1.0.0
+ */
+class FindExtendedClassNameTest extends BCFile_FindExtendedClassNameTest
+{
+
+    /**
+     * The fully qualified name of the class being tested.
+     *
+     * This allows for the same unit tests to be run for both the BCFile functions
+     * as well as for the related PHPCSUtils functions.
+     *
+     * @var string
+     */
+    const TEST_CLASS = '\PHPCSUtils\Utils\ObjectDeclarations';
+
+    /**
+     * Full path to the test case file associated with this test class.
+     *
+     * @var string
+     */
+    protected static $caseFile = '';
+
+    /**
+     * Initialize PHPCS & tokenize the test case file.
+     *
+     * Overloaded to re-use the `$caseFile` from the BCFile test.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        self::$caseFile = \dirname(\dirname(__DIR__)) . '/BackCompat/BCFile/FindExtendedClassNameTest.inc';
+        parent::setUpTestFile();
+    }
+}

--- a/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations;
+
+use PHPCSUtils\Tests\BackCompat\BCFile\FindImplementedInterfaceNamesTest as BCFile_FindImplInterfaceNamesTest;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\ObjectDeclarations::findImplementedInterfaceNames() method.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::findImplementedInterfaceNames
+ *
+ * @group objectdeclarations
+ *
+ * @since 1.0.0
+ */
+class FindImplementedInterfaceNamesTest extends BCFile_FindImplInterfaceNamesTest
+{
+
+    /**
+     * The fully qualified name of the class being tested.
+     *
+     * This allows for the same unit tests to be run for both the BCFile functions
+     * as well as for the related PHPCSUtils functions.
+     *
+     * @var string
+     */
+    const TEST_CLASS = '\PHPCSUtils\Utils\ObjectDeclarations';
+
+    /**
+     * Full path to the test case file associated with this test class.
+     *
+     * @var string
+     */
+    protected static $caseFile = '';
+
+    /**
+     * Initialize PHPCS & tokenize the test case file.
+     *
+     * Overloaded to re-use the `$caseFile` from the BCFile test.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        self::$caseFile = \dirname(\dirname(__DIR__)) . '/BackCompat/BCFile/FindImplementedInterfaceNamesTest.inc';
+        parent::setUpTestFile();
+    }
+}

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations;
+
+use PHPCSUtils\Tests\BackCompat\BCFile\GetClassPropertiesTest as BCFile_GetClassPropertiesTest;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\ObjectDeclarations::getClassProperties() method.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getClassProperties
+ *
+ * @group objectdeclarations
+ *
+ * @since 1.0.0
+ */
+class GetClassPropertiesTest extends BCFile_GetClassPropertiesTest
+{
+
+    /**
+     * The fully qualified name of the class being tested.
+     *
+     * This allows for the same unit tests to be run for both the BCFile functions
+     * as well as for the related PHPCSUtils functions.
+     *
+     * @var string
+     */
+    const TEST_CLASS = '\PHPCSUtils\Utils\ObjectDeclarations';
+
+    /**
+     * Full path to the test case file associated with this test class.
+     *
+     * @var string
+     */
+    protected static $caseFile = '';
+
+    /**
+     * Initialize PHPCS & tokenize the test case file.
+     *
+     * Overloaded to re-use the `$caseFile` from the BCFile test.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        self::$caseFile = \dirname(\dirname(__DIR__)) . '/BackCompat/BCFile/GetClassPropertiesTest.inc';
+        parent::setUpTestFile();
+    }
+}

--- a/Tests/Utils/ObjectDeclarations/GetNameJSTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameJSTest.php
@@ -8,30 +8,45 @@
  * @link      https://github.com/PHPCSStandards/PHPCSUtils
  */
 
-namespace PHPCSUtils\Tests\BackCompat\BCFile;
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations;
 
-use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\BackCompat\Helper;
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\BackCompat\BCFile\GetDeclarationNameJSTest as BCFile_GetDeclarationNameJSTest;
+use PHPCSUtils\Utils\ObjectDeclarations;
 
 /**
- * Tests for the \PHPCSUtils\BackCompat\BCFile::getDeclarationName() method.
+ * Tests for the \PHPCSUtils\Utils\ObjectDeclarations::getName() method.
  *
- * @covers \PHPCSUtils\BackCompat\BCFile::getDeclarationName
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getName
  *
  * @group objectdeclarations
  *
  * @since 1.0.0
  */
-class GetDeclarationNameJSTest extends UtilityMethodTestCase
+class GetNameJSTest extends BCFile_GetDeclarationNameJSTest
 {
 
     /**
-     * The file extension of the test case file (without leading dot).
+     * Full path to the test case file associated with this test class.
      *
      * @var string
      */
-    protected static $fileExtension = 'js';
+    protected static $caseFile = '';
+
+    /**
+     * Initialize PHPCS & tokenize the test case file.
+     *
+     * Overloaded to re-use the `$caseFile` from the BCFile test.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        self::$caseFile = \dirname(\dirname(__DIR__)) . '/BackCompat/BCFile/GetDeclarationNameJSTest.js';
+        parent::setUpTestFile();
+    }
 
     /**
      * Test receiving an expected exception when a non-supported token is passed.
@@ -43,11 +58,13 @@ class GetDeclarationNameJSTest extends UtilityMethodTestCase
         $this->expectPhpcsException('Token type "T_STRING" is not T_FUNCTION, T_CLASS, T_INTERFACE or T_TRAIT');
 
         $target = $this->getTargetToken('/* testInvalidTokenPassed */', \T_STRING);
-        BCFile::getDeclarationName(self::$phpcsFile, $target);
+        ObjectDeclarations::getName(self::$phpcsFile, $target);
     }
 
     /**
      * Test receiving "null" when passed an anonymous construct or in case of a parse error.
+     *
+     * {@internal Method name not adjusted as otherwise it wouldn't overload the parent method.}
      *
      * @dataProvider dataGetDeclarationNameNull
      *
@@ -59,29 +76,14 @@ class GetDeclarationNameJSTest extends UtilityMethodTestCase
     public function testGetDeclarationNameNull($testMarker, $targetType)
     {
         $target = $this->getTargetToken($testMarker, $targetType);
-        $result = BCFile::getDeclarationName(self::$phpcsFile, $target);
+        $result = ObjectDeclarations::getName(self::$phpcsFile, $target);
         $this->assertNull($result);
     }
 
     /**
-     * Data provider.
-     *
-     * @see GetDeclarationNameTest::testGetDeclarationNameNull()
-     *
-     * @return array
-     */
-    public function dataGetDeclarationNameNull()
-    {
-        return [
-            'closure' => [
-                '/* testClosure */',
-                \T_CLOSURE,
-            ],
-        ];
-    }
-
-    /**
      * Test retrieving the name of a function or OO structure.
+     *
+     * {@internal Method name not adjusted as otherwise it wouldn't overload the parent method.}
      *
      * @dataProvider dataGetDeclarationName
      *
@@ -98,38 +100,14 @@ class GetDeclarationNameJSTest extends UtilityMethodTestCase
         }
 
         $target = $this->getTargetToken($testMarker, $targetType);
-        $result = BCFile::getDeclarationName(self::$phpcsFile, $target);
+        $result = ObjectDeclarations::getName(self::$phpcsFile, $target);
         $this->assertSame($expected, $result);
     }
 
     /**
-     * Data provider.
-     *
-     * @see GetDeclarationNameTest::testGetDeclarationName()
-     *
-     * @return array
-     */
-    public function dataGetDeclarationName()
-    {
-        return [
-            'function' => [
-                '/* testFunction */',
-                'functionName',
-            ],
-            'class' => [
-                '/* testClass */',
-                'ClassName',
-                [\T_CLASS, \T_STRING],
-            ],
-            'function-unicode-name' => [
-                '/* testFunctionUnicode */',
-                'π',
-            ],
-        ];
-    }
-
-    /**
      * Test retrieving the name of JS ES6 class method.
+     *
+     * {@internal Method name not adjusted as otherwise it wouldn't overload the parent method.}
      *
      * @return void
      */
@@ -140,7 +118,7 @@ class GetDeclarationNameJSTest extends UtilityMethodTestCase
         }
 
         $target = $this->getTargetToken('/* testMethod */', [\T_CLASS, \T_INTERFACE, \T_TRAIT, \T_FUNCTION]);
-        $result = BCFile::getDeclarationName(self::$phpcsFile, $target);
+        $result = ObjectDeclarations::getName(self::$phpcsFile, $target);
         $this->assertSame('methodName', $result);
     }
 }

--- a/Tests/Utils/ObjectDeclarations/GetNameTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations;
+
+use PHPCSUtils\Tests\BackCompat\BCFile\GetDeclarationNameTest as BCFile_GetDeclarationNameTest;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\ObjectDeclarations::getName() method.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getName
+ *
+ * @group objectdeclarations
+ *
+ * @since 1.0.0
+ */
+class GetNameTest extends BCFile_GetDeclarationNameTest
+{
+
+    /**
+     * Full path to the test case file associated with this test class.
+     *
+     * @var string
+     */
+    protected static $caseFile = '';
+
+    /**
+     * Initialize PHPCS & tokenize the test case file.
+     *
+     * Overloaded to re-use the `$caseFile` from the BCFile test.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        self::$caseFile = \dirname(\dirname(__DIR__)) . '/BackCompat/BCFile/GetDeclarationNameTest.inc';
+        parent::setUpTestFile();
+    }
+
+    /**
+     * Test receiving an expected exception when a non-supported token is passed.
+     *
+     * @return void
+     */
+    public function testInvalidTokenPassed()
+    {
+        $this->expectPhpcsException('Token type "T_STRING" is not T_FUNCTION, T_CLASS, T_INTERFACE or T_TRAIT');
+
+        $target = $this->getTargetToken('/* testInvalidTokenPassed */', \T_STRING);
+        ObjectDeclarations::getName(self::$phpcsFile, $target);
+    }
+
+    /**
+     * Test receiving "null" when passed an anonymous construct or in case of a parse error.
+     *
+     * {@internal Method name not adjusted as otherwise it wouldn't overload the parent method.}
+     *
+     * @dataProvider dataGetDeclarationNameNull
+     *
+     * @param string     $testMarker The comment which prefaces the target token in the test file.
+     * @param int|string $targetType Token type of the token to get as stackPtr.
+     *
+     * @return void
+     */
+    public function testGetDeclarationNameNull($testMarker, $targetType)
+    {
+        $target = $this->getTargetToken($testMarker, $targetType);
+        $result = ObjectDeclarations::getName(self::$phpcsFile, $target);
+        $this->assertNull($result);
+    }
+
+    /**
+     * Test retrieving the name of a function or OO structure.
+     *
+     * {@internal Method name not adjusted as otherwise it wouldn't overload the parent method.}
+     *
+     * @dataProvider dataGetDeclarationName
+     *
+     * @param string     $testMarker The comment which prefaces the target token in the test file.
+     * @param string     $expected   Expected function output.
+     * @param int|string $targetType Token type of the token to get as stackPtr.
+     *
+     * @return void
+     */
+    public function testGetDeclarationName($testMarker, $expected, $targetType = null)
+    {
+        if (isset($targetType) === false) {
+            $targetType = [\T_CLASS, \T_INTERFACE, \T_TRAIT, \T_FUNCTION];
+        }
+
+        $target = $this->getTargetToken($testMarker, $targetType);
+        $result = ObjectDeclarations::getName(self::$phpcsFile, $target);
+        $this->assertSame($expected, $result);
+    }
+}


### PR DESCRIPTION
New `PHPCSUtils\Utils\ObjectDeclarations` class which will hold improved versions of the `File::getDeclarationName()`, `File::getClassProperties()`, `File::findExtendedClassName()` and the `File::findImplementedInterfaceNames()` methods as well as additional methods related to examining object declaration statements.

For the initial functions in this class, the unit tests for the `PHPCSUtils\BackCompat\BCFile` versions of these functions are re-used to ensure that the improved functions in this class stay compatible with the original functions.

To this end, the pre-existing unit test classes for the `findExtendedClassName()` and `findImplementedInterfaceNames()` methods have been adjusted.