### PR TITLE
Objectdeclarations::getName(): various improvements

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -99,6 +99,7 @@ class BCFile
      * Note: support for JS ES6 method syntax has not been back-filled for PHPCS < 3.0.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getDeclarationName() Original source.
+     * @see \PHPCSUtils\Utils\ObjectDeclarations::getName()   PHPCSUtils native improved version.
      *
      * @since 1.0.0
      *

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -32,6 +32,9 @@ class ObjectDeclarations
      *       this method will be accepted for JS files.
      * Note: support for JS ES6 method syntax has not (yet) been back-filled for PHPCS < 3.0.0.
      *
+     * Main differences with the PHPCS version:
+     * - Defensive coding against incorrect calls to this method.
+     *
      * @see \PHP_CodeSniffer\Files\File::getDeclarationName()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getDeclarationName() Cross-version compatible version of the original.
      *
@@ -43,20 +46,23 @@ class ObjectDeclarations
      *                                               trait, or function.
      *
      * @return string|null The name of the class, interface, trait, or function;
-     *                     or NULL if the function or class is anonymous or
-     *                     in case of a parse error/live coding.
+     *                     or NULL if the passed token doesn't exist, the function or
+     *                     class is anonymous or in case of a parse error/live coding.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified token is not of type
      *                                                      T_FUNCTION, T_CLASS, T_TRAIT, or T_INTERFACE.
      */
     public static function getName(File $phpcsFile, $stackPtr)
     {
-        $tokens    = $phpcsFile->getTokens();
-        $tokenCode = $tokens[$stackPtr]['code'];
+        $tokens = $phpcsFile->getTokens();
 
-        if ($tokenCode === \T_ANON_CLASS || $tokenCode === \T_CLOSURE) {
+        if (isset($tokens[$stackPtr]) === false
+            || ($tokens[$stackPtr]['code'] === \T_ANON_CLASS || $tokens[$stackPtr]['code'] === \T_CLOSURE)
+        ) {
             return null;
         }
+
+        $tokenCode = $tokens[$stackPtr]['code'];
 
         /*
          * BC: Work-around JS ES6 classes not being tokenized as T_CLASS in PHPCS < 3.0.0.

--- a/Tests/Utils/ObjectDeclarations/GetNameDiffTest.inc
+++ b/Tests/Utils/ObjectDeclarations/GetNameDiffTest.inc
@@ -1,0 +1,3 @@
+<?php
+
+// No PHPCSUtils native test cases yet.

--- a/Tests/Utils/ObjectDeclarations/GetNameDiffTest.inc
+++ b/Tests/Utils/ObjectDeclarations/GetNameDiffTest.inc
@@ -1,3 +1,17 @@
 <?php
 
-// No PHPCSUtils native test cases yet.
+/* testTraitStartingWithNumber */
+trait 5InvalidNameStartingWithNumber {
+}
+
+/* testInterfaceFullyNumeric */
+interface 12345 {}
+
+/* testInvalidInterfaceName */
+interface switch{ // Intentional parse error.
+    public function someFunction();
+}
+
+/* testLiveCoding */
+// Intentional parse error. Redundancy testing.
+abstract class

--- a/Tests/Utils/ObjectDeclarations/GetNameDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameDiffTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\ObjectDeclarations::getName() method.
+ *
+ * The tests in this class cover the differences between the PHPCS native method and the PHPCSUtils
+ * version. These tests would fail when using the BCFile `getDeclarationName()` method.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getName
+ *
+ * @group objectdeclarations
+ *
+ * @since 1.0.0
+ */
+class GetNameDiffTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $result = ObjectDeclarations::getName(self::$phpcsFile, 10000);
+        $this->assertNull($result);
+    }
+}

--- a/Tests/Utils/ObjectDeclarations/GetNameDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameDiffTest.php
@@ -38,4 +38,85 @@ class GetNameDiffTest extends UtilityMethodTestCase
         $result = ObjectDeclarations::getName(self::$phpcsFile, 10000);
         $this->assertNull($result);
     }
+
+    /**
+     * Test receiving "null" when passed an anonymous construct or in case of a parse error.
+     *
+     * @dataProvider dataGetNameNull
+     *
+     * @param string     $testMarker The comment which prefaces the target token in the test file.
+     * @param int|string $targetType Token type of the token to get as stackPtr.
+     *
+     * @return void
+     */
+    public function testGetNameNull($testMarker, $targetType)
+    {
+        $target = $this->getTargetToken($testMarker, $targetType);
+        $result = ObjectDeclarations::getName(self::$phpcsFile, $target);
+        $this->assertNull($result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetNameNull() For the array format.
+     *
+     * @return array
+     */
+    public function dataGetNameNull()
+    {
+        return [
+            'live-coding' => [
+                '/* testLiveCoding */',
+                \T_CLASS,
+            ],
+        ];
+    }
+
+    /**
+     * Test retrieving the name of a function or OO structure.
+     *
+     * @dataProvider dataGetName
+     *
+     * @param string     $testMarker The comment which prefaces the target token in the test file.
+     * @param string     $expected   Expected function output.
+     * @param int|string $targetType Token type of the token to get as stackPtr.
+     *
+     * @return void
+     */
+    public function testGetName($testMarker, $expected, $targetType = null)
+    {
+        if (isset($targetType) === false) {
+            $targetType = [\T_CLASS, \T_INTERFACE, \T_TRAIT, \T_FUNCTION];
+        }
+
+        $target = $this->getTargetToken($testMarker, $targetType);
+        $result = ObjectDeclarations::getName(self::$phpcsFile, $target);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetName() For the array format.
+     *
+     * @return array
+     */
+    public function dataGetName()
+    {
+        return [
+            'trait-name-starts-with-number' => [
+                '/* testTraitStartingWithNumber */',
+                '5InvalidNameStartingWithNumber',
+            ],
+            'interface-fully-numeric-name' => [
+                '/* testInterfaceFullyNumeric */',
+                '12345',
+            ],
+            'using-reserved-keyword-as-name' => [
+                '/* testInvalidInterfaceName */',
+                'switch',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
## ObjectDeclarations::getName(): improve defensive coding

Includes unit test.

## ObjectDeclarations::getName(): improved handling of parse errors

While certain names may be invalid, such as construct names starting with a number, for the purpose of alerting users to these invalid names, the `getName()` method should be able to pick up on them.

The `getName()` method has now been adjusted to allow for such names.

The way this has been implemented also improves the parse error resilience for the `getName()` method.

The `getName()` method could previously inadvertently misidentify the name of a structure in the case of parse errors/live coding as it looked for the first `T_STRING` after the keyword without limiting it to the declaration statement. This has now also been fixed.

The method will now return `null`, both when passed  an anonymous class/function as well as in case of a parse error.

Included additional unit tests.