### PR TITLE
ObjectDeclarations::getClassProperties(): various improvements

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -875,7 +875,8 @@ class BCFile
      * - PHPCS 3.5.0: The Exception thrown changed from a `TokenizerException` to
      *                `\PHP_CodeSniffer\Exceptions\RuntimeException`.
      *
-     * @see \PHP_CodeSniffer\Files\File::getClassProperties() Original source.
+     * @see \PHP_CodeSniffer\Files\File::getClassProperties()          Original source.
+     * @see \PHPCSUtils\Utils\ObjectDeclarations::getClassProperties() PHPCSUtils native improved version.
      *
      * @since 1.0.0
      *

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -25,6 +25,18 @@ class Collections
 {
 
     /**
+     * Modifier keywords which can be used for a class declaration.
+     *
+     * @since 1.0.0
+     *
+     * @var array <int|string> => <int|string>
+     */
+    public static $classModifierKeywords = [
+        \T_FINAL    => \T_FINAL,
+        \T_ABSTRACT => \T_ABSTRACT,
+    ];
+
+    /**
      * List of tokens which represent "closed" scopes.
      *
      * I.e. anything declared within that scope - except for other closed scopes - is

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -161,6 +161,7 @@ class ObjectDeclarations
      *   - Handling of PHPCS annotations.
      *   - Handling of unorthodox docblock placement.
      *   - A class cannot both be abstract as well as final, so this utility should not allow for that.
+     * - Defensive coding against incorrect calls to this method.
      *
      * @see \PHP_CodeSniffer\Files\File::getClassProperties()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getClassProperties() Cross-version compatible version of the original.
@@ -180,7 +181,7 @@ class ObjectDeclarations
     {
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[$stackPtr]['code'] !== \T_CLASS) {
+        if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== \T_CLASS) {
             throw new RuntimeException('$stackPtr must be of type T_CLASS');
         }
 

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -160,6 +160,7 @@ class ObjectDeclarations
      * - Bugs fixed:
      *   - Handling of PHPCS annotations.
      *   - Handling of unorthodox docblock placement.
+     *   - A class cannot both be abstract as well as final, so this utility should not allow for that.
      *
      * @see \PHP_CodeSniffer\Files\File::getClassProperties()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getClassProperties() Cross-version compatible version of the original.
@@ -200,11 +201,11 @@ class ObjectDeclarations
             switch ($tokens[$i]['code']) {
                 case \T_ABSTRACT:
                     $isAbstract = true;
-                    break;
+                    break 2;
 
                 case \T_FINAL:
                     $isFinal = true;
-                    break;
+                    break 2;
             }
         }
 

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -156,6 +156,11 @@ class ObjectDeclarations
      *   );
      * </code>
      *
+     * Main differences with the PHPCS version:
+     * - Bugs fixed:
+     *   - Handling of PHPCS annotations.
+     *   - Handling of unorthodox docblock placement.
+     *
      * @see \PHP_CodeSniffer\Files\File::getClassProperties()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getClassProperties() Cross-version compatible version of the original.
      *
@@ -178,13 +183,11 @@ class ObjectDeclarations
             throw new RuntimeException('$stackPtr must be of type T_CLASS');
         }
 
-        $valid = [
-            \T_FINAL       => \T_FINAL,
-            \T_ABSTRACT    => \T_ABSTRACT,
-            \T_WHITESPACE  => \T_WHITESPACE,
-            \T_COMMENT     => \T_COMMENT,
-            \T_DOC_COMMENT => \T_DOC_COMMENT,
+        $valid  = [
+            \T_FINAL    => \T_FINAL,
+            \T_ABSTRACT => \T_ABSTRACT,
         ];
+        $valid += Tokens::$emptyTokens;
 
         $isAbstract = false;
         $isFinal    = false;

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -13,6 +13,7 @@ namespace PHPCSUtils\Utils;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\GetTokensAsString;
 
 /**
@@ -185,14 +186,11 @@ class ObjectDeclarations
             throw new RuntimeException('$stackPtr must be of type T_CLASS');
         }
 
-        $valid  = [
-            \T_FINAL    => \T_FINAL,
-            \T_ABSTRACT => \T_ABSTRACT,
+        $valid      = Collections::$classModifierKeywords + Tokens::$emptyTokens;
+        $properties = [
+            'is_abstract' => false,
+            'is_final'    => false,
         ];
-        $valid += Tokens::$emptyTokens;
-
-        $isAbstract = false;
-        $isFinal    = false;
 
         for ($i = ($stackPtr - 1); $i > 0; $i--) {
             if (isset($valid[$tokens[$i]['code']]) === false) {
@@ -201,19 +199,16 @@ class ObjectDeclarations
 
             switch ($tokens[$i]['code']) {
                 case \T_ABSTRACT:
-                    $isAbstract = true;
+                    $properties['is_abstract'] = true;
                     break 2;
 
                 case \T_FINAL:
-                    $isFinal = true;
+                    $properties['is_final'] = true;
                     break 2;
             }
         }
 
-        return [
-            'is_abstract' => $isAbstract,
-            'is_final'    => $isFinal,
-        ];
+        return $properties;
     }
 
     /**

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.inc
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.inc
@@ -1,0 +1,18 @@
+<?php
+
+/* testPHPCSAnnotations */
+final
+    // phpcs:ignore Standard.Cat.SniffName -- Just because.
+    class PHPCSAnnotation {}
+
+/* testWithDocblockWithWeirdlyPlacedProperty */
+final
+
+/**
+ * Class docblock.
+ *
+ * @package SomePackage
+ *
+ * @phpcs:disable Standard.Cat.SniffName -- Just because.
+ */
+class ClassWithPropertyBeforeDocblock {}

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.inc
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.inc
@@ -16,3 +16,10 @@ final
  * @phpcs:disable Standard.Cat.SniffName -- Just because.
  */
 class ClassWithPropertyBeforeDocblock {}
+
+/* testParseErrorAbstractFinal */
+final /* comment */
+
+    abstract // Intentional parse error, class cannot both be final and abstract.
+
+        class AbstractFinal {}

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
@@ -29,6 +29,18 @@ class GetClassPropertiesDiffTest extends UtilityMethodTestCase
 {
 
     /**
+     * Test passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->expectPhpcsException('$stackPtr must be of type T_CLASS');
+
+        ObjectDeclarations::getClassProperties(self::$phpcsFile, 10000);
+    }
+
+    /**
      * Test retrieving the properties for a class declaration.
      *
      * @dataProvider dataGetClassProperties

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
@@ -69,6 +69,13 @@ class GetClassPropertiesDiffTest extends UtilityMethodTestCase
                     'is_final'    => true,
                 ],
             ],
+            'abstract-final-parse-error' => [
+                '/* testParseErrorAbstractFinal */',
+                [
+                    'is_abstract' => true,
+                    'is_final'    => false,
+                ],
+            ],
         ];
     }
 }

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\ObjectDeclarations::getClassProperties() method.
+ *
+ * The tests in this class cover the differences between the PHPCS native method and the PHPCSUtils
+ * version. These tests would fail when using the BCFile `getClassProperties()` method.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getClassProperties
+ *
+ * @group objectdeclarations
+ *
+ * @since 1.0.0
+ */
+class GetClassPropertiesDiffTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test retrieving the properties for a class declaration.
+     *
+     * @dataProvider dataGetClassProperties
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   Expected function output.
+     *
+     * @return void
+     */
+    public function testGetClassProperties($testMarker, $expected)
+    {
+        $class  = $this->getTargetToken($testMarker, \T_CLASS);
+        $result = ObjectDeclarations::getClassProperties(self::$phpcsFile, $class);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetClassProperties() For the array format.
+     *
+     * @return array
+     */
+    public function dataGetClassProperties()
+    {
+        return [
+            'phpcs-annotation' => [
+                '/* testPHPCSAnnotations */',
+                [
+                    'is_abstract' => false,
+                    'is_final'    => true,
+                ],
+            ],
+            'unorthodox-docblock-placement' => [
+                '/* testWithDocblockWithWeirdlyPlacedProperty */',
+                [
+                    'is_abstract' => false,
+                    'is_final'    => true,
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## ObjectDeclarations::getClassProperties(): fix handling of PHPCS annotations

... as well as handling of unorthodox placement of DocBlocks.

While probably unlikely to come across in the wild, the utility should handle this type of code correctly.

Includes a separate set of unit tests for this method.

These additional tests would fail when using the BCFile version of the method.

## ObjectDeclarations::getClassProperties(): don't allow for both abstract + final (parse error)

A class cannot both be `abstract` as well as `final`, so the utility method should not have to allow for it.

Fixing this makes the utility method more efficient.

Includes unit test.

## ObjectDeclarations::getClassProperties(): improve defensive coding

Includes unit test.

## ObjectDeclarations::getClassProperties(): minor code reorganization

* Move the class modifier keywords array to a class property in the `PHPCSUtils\Tokens\Collections` class.
* Declare the `$properties` results array before looping through the tokens.