### PR TITLE
ObjectDeclarations::findExtendedClassName/findImplementedInterfaceNames(): various improvements

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1363,7 +1363,8 @@ class BCFile
      *                single interface extension).
      * - PHPCS 3.3.2: Fixed bug causing bleed through with nested classes, PHPCS#2127.
      *
-     * @see \PHP_CodeSniffer\Files\File::findExtendedClassName() Original source.
+     * @see \PHP_CodeSniffer\Files\File::findExtendedClassName()          Original source.
+     * @see \PHPCSUtils\Utils\ObjectDeclarations::findExtendedClassName() PHPCSUtils native improved version.
      *
      * @since 1.0.0
      *

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1426,7 +1426,8 @@ class BCFile
      * - Introduced in PHPCS 2.7.0.
      * - PHPCS 2.8.0: Now supports anonymous classes.
      *
-     * @see \PHP_CodeSniffer\Files\File::findImplementedInterfaceNames() Original source.
+     * @see \PHP_CodeSniffer\Files\File::findImplementedInterfaceNames()          Original source.
+     * @see \PHPCSUtils\Utils\ObjectDeclarations::findImplementedInterfaceNames() PHPCSUtils native improved version.
      *
      * @since 1.0.0
      *

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -47,6 +47,31 @@ class Collections
     ];
 
     /**
+     * OO structures which can use the `extends` keyword.
+     *
+     * @since 1.0.0
+     *
+     * @var array <int|string> => <int|string>
+     */
+    public static $OOCanExtend = [
+        \T_CLASS      => \T_CLASS,
+        \T_ANON_CLASS => \T_ANON_CLASS,
+        \T_INTERFACE  => \T_INTERFACE,
+    ];
+
+    /**
+     * OO structures which can use the `implements` keyword.
+     *
+     * @since 1.0.0
+     *
+     * @var array <int|string> => <int|string>
+     */
+    public static $OOCanImplement = [
+        \T_CLASS      => \T_CLASS,
+        \T_ANON_CLASS => \T_ANON_CLASS,
+    ];
+
+    /**
      * OO scopes in which constants can be declared.
      *
      * Note: traits can not declare constants.

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -277,6 +277,11 @@ class ObjectDeclarations
     /**
      * Retrieves the names of the interfaces that the specified class implements.
      *
+     * Main differences with the PHPCS version:
+     * - Bugs fixed:
+     *   - Handling of PHPCS annotations.
+     *   - Handling of comments.
+     *
      * @see \PHP_CodeSniffer\Files\File::findImplementedInterfaceNames()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::findImplementedInterfaceNames() Cross-version compatible version of
      *                                                                     the original.
@@ -314,12 +319,12 @@ class ObjectDeclarations
             return false;
         }
 
-        $find = [
+        $find  = [
             \T_NS_SEPARATOR,
             \T_STRING,
-            \T_WHITESPACE,
             \T_COMMA,
         ];
+        $find += Tokens::$emptyTokens;
 
         $end  = $phpcsFile->findNext($find, ($implementsIndex + 1), ($classOpenerIndex + 1), true);
         $name = $phpcsFile->getTokensAsString(($implementsIndex + 1), ($end - $implementsIndex - 1));

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -215,6 +215,11 @@ class ObjectDeclarations
      * Retrieves the name of the class that the specified class extends.
      * (works for classes, anonymous classes and interfaces)
      *
+     * Main differences with the PHPCS version:
+     * - Bugs fixed:
+     *   - Handling of PHPCS annotations.
+     *   - Handling of comments.
+     *
      * @see \PHP_CodeSniffer\Files\File::findExtendedClassName()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::findExtendedClassName() Cross-version compatible version of the original.
      *
@@ -252,11 +257,11 @@ class ObjectDeclarations
             return false;
         }
 
-        $find = [
+        $find  = [
             \T_NS_SEPARATOR,
             \T_STRING,
-            \T_WHITESPACE,
         ];
+        $find += Tokens::$emptyTokens;
 
         $end  = $phpcsFile->findNext($find, ($extendsIndex + 1), ($classOpenerIndex + 1), true);
         $name = $phpcsFile->getTokensAsString(($extendsIndex + 1), ($end - $extendsIndex - 1));

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -221,6 +221,7 @@ class ObjectDeclarations
      *   - Handling of PHPCS annotations.
      *   - Handling of comments.
      * - Improved handling of parse errors.
+     * - The returned name will be clean of superfluous whitespace and/or comments.
      *
      * @see \PHP_CodeSniffer\Files\File::findExtendedClassName()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::findExtendedClassName() Cross-version compatible version of the original.
@@ -252,6 +253,7 @@ class ObjectDeclarations
      *   - Handling of PHPCS annotations.
      *   - Handling of comments.
      * - Improved handling of parse errors.
+     * - The returned name(s) will be clean of superfluous whitespace and/or comments.
      *
      * @see \PHP_CodeSniffer\Files\File::findImplementedInterfaceNames()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::findImplementedInterfaceNames() Cross-version compatible version of
@@ -315,7 +317,7 @@ class ObjectDeclarations
         do {
             $start = ($end + 1);
             $end   = $phpcsFile->findNext($find, $start, ($scopeOpener + 1), true);
-            $name  = \trim(GetTokensAsString::normal($phpcsFile, $start, ($end - 1)));
+            $name  = GetTokensAsString::noEmpties($phpcsFile, $start, ($end - 1));
 
             if (\trim($name) !== '') {
                 $names[] = $name;

--- a/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.inc
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.inc
@@ -1,0 +1,7 @@
+<?php
+
+/* testDeclarationWithComments */
+class testDeclarationWithComments
+    extends
+    // phpcs:ignore Stnd.Cat.Sniff -- For reasons.
+    \Package\SubDir /* comment */ \ /* comment */ SomeClass /* comment */ {}

--- a/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.inc
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.inc
@@ -5,3 +5,6 @@ class testDeclarationWithComments
     extends
     // phpcs:ignore Stnd.Cat.Sniff -- For reasons.
     \Package\SubDir /* comment */ \ /* comment */ SomeClass /* comment */ {}
+
+/* testExtendedClassStrayComma */
+class testExtendedClassStrayComma extends , testClass {} // Intentional parse error.

--- a/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\ObjectDeclarations::findExtendedClassName() method.
+ *
+ * The tests in this class cover the differences between the PHPCS native method and the PHPCSUtils
+ * version. These tests would fail when using the BCFile `findExtendedClassName()` method.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::findExtendedClassName
+ *
+ * @group objectdeclarations
+ *
+ * @since 1.0.0
+ */
+class FindExtendedClassNameDiffTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test retrieving the name of the class being extended by another class (or interface).
+     *
+     * @dataProvider dataFindExtendedClassName
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param bool   $expected   Expected function output.
+     *
+     * @return void
+     */
+    public function testFindExtendedClassName($testMarker, $expected)
+    {
+        $OOToken = $this->getTargetToken($testMarker, [\T_CLASS, \T_ANON_CLASS, \T_INTERFACE]);
+        $result  = ObjectDeclarations::findExtendedClassName(self::$phpcsFile, $OOToken);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testFindExtendedClassName() For the array format.
+     *
+     * @return array
+     */
+    public function dataFindExtendedClassName()
+    {
+        return [
+            'phpcs-annotation-and-comments' => [
+                '/* testDeclarationWithComments */',
+                '// phpcs:ignore Stnd.Cat.Sniff -- For reasons.
+    \Package\SubDir /* comment */ \ /* comment */ SomeClass /* comment */',
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.php
@@ -20,6 +20,7 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  * version. These tests would fail when using the BCFile `findExtendedClassName()` method.
  *
  * @covers \PHPCSUtils\Utils\ObjectDeclarations::findExtendedClassName
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::findNames
  *
  * @group objectdeclarations
  *
@@ -59,6 +60,10 @@ class FindExtendedClassNameDiffTest extends UtilityMethodTestCase
                 '/* testDeclarationWithComments */',
                 '// phpcs:ignore Stnd.Cat.Sniff -- For reasons.
     \Package\SubDir /* comment */ \ /* comment */ SomeClass /* comment */',
+            ],
+            'parse-error-stray-comma' => [
+                '/* testExtendedClassStrayComma */',
+                'testClass',
             ],
         ];
     }

--- a/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.php
@@ -58,8 +58,7 @@ class FindExtendedClassNameDiffTest extends UtilityMethodTestCase
         return [
             'phpcs-annotation-and-comments' => [
                 '/* testDeclarationWithComments */',
-                '// phpcs:ignore Stnd.Cat.Sniff -- For reasons.
-    \Package\SubDir /* comment */ \ /* comment */ SomeClass /* comment */',
+                '\Package\SubDir\SomeClass',
             ],
             'parse-error-stray-comma' => [
                 '/* testExtendedClassStrayComma */',

--- a/Tests/Utils/ObjectDeclarations/FindExtendedClassNameTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedClassNameTest.php
@@ -16,6 +16,7 @@ use PHPCSUtils\Tests\BackCompat\BCFile\FindExtendedClassNameTest as BCFile_FindE
  * Tests for the \PHPCSUtils\Utils\ObjectDeclarations::findExtendedClassName() method.
  *
  * @covers \PHPCSUtils\Utils\ObjectDeclarations::findExtendedClassName
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::findNames
  *
  * @group objectdeclarations
  *

--- a/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.inc
+++ b/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.inc
@@ -1,0 +1,14 @@
+<?php
+
+/* testDeclarationWithComments */
+class testDeclarationWithComments
+    /* comment */
+    implements
+        //phpcs:ignore Standard.Cat.Sniff -- For reasons
+        \Vendor
+        /* comment */
+        \Package\Core
+        //phpcs:disable Standard.Cat.Sniff -- For reasons
+        \SubDir         \         SomeInterface,
+        // comment
+        InterfaceB {}

--- a/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.inc
+++ b/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.inc
@@ -12,3 +12,6 @@ class testDeclarationWithComments
         \SubDir         \         SomeInterface,
         // comment
         InterfaceB {}
+
+/* testMultiImplementedStrayComma */
+class testMultiImplementedStrayComma implements testInterfaceA, , testInterfaceB {} // Intentional parse error.

--- a/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\ObjectDeclarations::findImplementedInterfaceNames() method.
+ *
+ * The tests in this class cover the differences between the PHPCS native method and the PHPCSUtils
+ * version. These tests would fail when using the BCFile `findImplementedInterfaceNames()` method.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::findImplementedInterfaceNames
+ *
+ * @group objectdeclarations
+ *
+ * @since 1.0.0
+ */
+class FindImplementedInterfaceNamesDiffTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test retrieving the name(s) of the interfaces being implemented by a class.
+     *
+     * @dataProvider dataFindImplementedInterfaceNames
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param bool   $expected   Expected function output.
+     *
+     * @return void
+     */
+    public function testFindImplementedInterfaceNames($testMarker, $expected)
+    {
+        $OOToken = $this->getTargetToken($testMarker, [\T_CLASS, \T_ANON_CLASS, \T_INTERFACE]);
+        $result  = ObjectDeclarations::findImplementedInterfaceNames(self::$phpcsFile, $OOToken);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testFindImplementedInterfaceNames() For the array format.
+     *
+     * @return array
+     */
+    public function dataFindImplementedInterfaceNames()
+    {
+        return [
+            'phpcs-annotation-and-comments' => [
+                '/* testDeclarationWithComments */',
+                [
+                    '//phpcs:ignore Standard.Cat.Sniff -- For reasons
+        \Vendor
+        /* comment */
+        \Package\Core
+        //phpcs:disable Standard.Cat.Sniff -- For reasons
+        \SubDir         \         SomeInterface',
+                    '// comment
+        InterfaceB',
+                ],
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.php
@@ -20,6 +20,7 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  * version. These tests would fail when using the BCFile `findImplementedInterfaceNames()` method.
  *
  * @covers \PHPCSUtils\Utils\ObjectDeclarations::findImplementedInterfaceNames
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::findNames
  *
  * @group objectdeclarations
  *
@@ -66,6 +67,13 @@ class FindImplementedInterfaceNamesDiffTest extends UtilityMethodTestCase
         \SubDir         \         SomeInterface',
                     '// comment
         InterfaceB',
+                ],
+            ],
+            'parse-error-stray-comma' => [
+                '/* testMultiImplementedStrayComma */',
+                [
+                    0 => 'testInterfaceA',
+                    1 => 'testInterfaceB',
                 ],
             ],
         ];

--- a/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.php
@@ -59,14 +59,8 @@ class FindImplementedInterfaceNamesDiffTest extends UtilityMethodTestCase
             'phpcs-annotation-and-comments' => [
                 '/* testDeclarationWithComments */',
                 [
-                    '//phpcs:ignore Standard.Cat.Sniff -- For reasons
-        \Vendor
-        /* comment */
-        \Package\Core
-        //phpcs:disable Standard.Cat.Sniff -- For reasons
-        \SubDir         \         SomeInterface',
-                    '// comment
-        InterfaceB',
+                    '\Vendor\Package\Core\SubDir\SomeInterface',
+                    'InterfaceB',
                 ],
             ],
             'parse-error-stray-comma' => [

--- a/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesTest.php
@@ -16,6 +16,7 @@ use PHPCSUtils\Tests\BackCompat\BCFile\FindImplementedInterfaceNamesTest as BCFi
  * Tests for the \PHPCSUtils\Utils\ObjectDeclarations::findImplementedInterfaceNames() method.
  *
  * @covers \PHPCSUtils\Utils\ObjectDeclarations::findImplementedInterfaceNames
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::findNames
  *
  * @group objectdeclarations
  *


### PR DESCRIPTION
## ObjectDeclarations::findExtendedClassName(): fix handling of PHPCS annotations

... as well as handling of comments within the class declaration.

While probably unlikely to come across in the wild, the utility should handle this type of code correctly.

Includes a separate set of unit tests for this method.

These additional tests would fail when using the BCFile version of the method.


## ObjectDeclarations::findImplementedInterfaceNames(): fix handling of PHPCS annotations

... as well as handling of comments within the class declaration.

While probably unlikely to come across in the wild, the utility should handle this type of code correctly.

Includes a separate set of unit tests for this method.

These additional tests would fail when using the BCFile version of the method.

## ObjectDeclarations::findExtendedClassName/findImplementedInterfaceNames(): refactor

As the logic needed for these two methods, as well as for the (upcoming) `findImplementedInterfaces()` method, is basically the same, I've extracted the logic out to a private `ObjectDeclarations::findNames()` method which is now called by both methods to DRY out the code (remove code duplication).

This refactor includes some minor hardening of the methods for the handling of parse errors.

Includes additional unit test covering the parse error hardening.
Includes introducing two new properties to the `PHPCSUtils\Tokens\Collections` class.

## ObjectDeclarations::findNames(): return cleaned up names

Previously, the method would use the `GetTokensAsString::normal()` method to retrieve the name of extended/implemented classes/interfaces.

Other than to just check that a class/interface _does_ extend/implement, the most common use case for using these methods is for comparing the returned class/interface name against a list of names.

The name, however, may contain superfluous whitespace and/or comments which would invalidate any such name comparison against the name.

To that end, the name is now returned "clean", i.e. stripped of all whitespace and/or comments.

Includes updating the existing unit tests to reflect the changed behaviour.