### PR TITLE
FunctionDeclarations::getProperties(): various improvements

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -38,6 +38,7 @@ use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\Tokens\Collections;
 
 /**
  * PHPCS native utility functions.
@@ -599,16 +600,6 @@ class BCFile
                 $scopeOpener = $tokens[$stackPtr]['scope_opener'];
             }
 
-            $valid = [
-                T_STRING       => T_STRING,
-                T_CALLABLE     => T_CALLABLE,
-                T_SELF         => T_SELF,
-                T_PARENT       => T_PARENT,
-                T_NS_SEPARATOR => T_NS_SEPARATOR,
-                T_RETURN_TYPE  => T_RETURN_TYPE, // PHPCS 2.4.0 < 3.3.0.
-                T_ARRAY_HINT   => T_ARRAY_HINT, // PHPCS < 2.8.0.
-            ];
-
             for ($i = $tokens[$stackPtr]['parenthesis_closer']; $i < $phpcsFile->numTokens; $i++) {
                 if (($scopeOpener === null && $tokens[$i]['code'] === T_SEMICOLON)
                     || ($scopeOpener !== null && $i === $scopeOpener)
@@ -624,7 +615,7 @@ class BCFile
                     $nullableReturnType = true;
                 }
 
-                if (isset($valid[$tokens[$i]['code']]) === true) {
+                if (isset(Collections::$returnTypeTokens[$tokens[$i]['code']]) === true) {
                     if ($returnTypeToken === false) {
                         $returnTypeToken = $i;
                     }

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -507,7 +507,8 @@ class BCFile
      * - PHPCS 3.5.0: The Exception thrown changed from a `TokenizerException` to
      *                `\PHP_CodeSniffer\Exceptions\RuntimeException`.
      *
-     * @see \PHP_CodeSniffer\Files\File::getMethodProperties() Original source.
+     * @see \PHP_CodeSniffer\Files\File::getMethodProperties()      Original source.
+     * @see \PHPCSUtils\Utils\FunctionDeclarations::getProperties() PHPCSUtils native improved version.
      *
      * @since 1.0.0
      *

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -112,4 +112,21 @@ class Collections
         \T_ANON_CLASS => \T_ANON_CLASS,
         \T_TRAIT      => \T_TRAIT,
     ];
+
+    /**
+     * Token types which can be encountered in a return type declaration.
+     *
+     * @since 1.0.0
+     *
+     * @var array <int|string> => <int|string>
+     */
+    public static $returnTypeTokens = [
+        \T_STRING       => \T_STRING,
+        \T_CALLABLE     => \T_CALLABLE,
+        \T_SELF         => \T_SELF,
+        \T_PARENT       => \T_PARENT,
+        \T_NS_SEPARATOR => \T_NS_SEPARATOR,
+        \T_RETURN_TYPE  => \T_RETURN_TYPE, // PHPCS 2.4.0 < 3.3.0.
+        \T_ARRAY_HINT   => \T_ARRAY_HINT, // PHPCS < 2.8.0.
+    ];
 }

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -60,16 +60,18 @@ class FunctionDeclarations
      * The format of the return value is:
      * <code>
      *   array(
-     *    'scope'                => 'public', // Public, private, or protected
-     *    'scope_specified'      => true,     // TRUE if the scope keyword was found.
-     *    'return_type'          => '',       // The return type of the method.
-     *    'return_type_token'    => integer,  // The stack pointer to the start of the return type
-     *                                        // or FALSE if there is no return type.
-     *    'nullable_return_type' => false,    // TRUE if the return type is nullable.
-     *    'is_abstract'          => false,    // TRUE if the abstract keyword was found.
-     *    'is_final'             => false,    // TRUE if the final keyword was found.
-     *    'is_static'            => false,    // TRUE if the static keyword was found.
-     *    'has_body'             => false,    // TRUE if the method has a body
+     *    'scope'                 => 'public', // Public, private, or protected
+     *    'scope_specified'       => true,     // TRUE if the scope keyword was found.
+     *    'return_type'           => '',       // The return type of the method.
+     *    'return_type_token'     => integer,  // The stack pointer to the start of the return type
+     *                                         // or FALSE if there is no return type.
+     *    'return_type_end_token' => integer,  // The stack pointer to the end of the return type
+     *                                         // or FALSE if there is no return type.
+     *    'nullable_return_type'  => false,    // TRUE if the return type is nullable.
+     *    'is_abstract'           => false,    // TRUE if the abstract keyword was found.
+     *    'is_final'              => false,    // TRUE if the final keyword was found.
+     *    'is_static'             => false,    // TRUE if the static keyword was found.
+     *    'has_body'              => false,    // TRUE if the method has a body
      *   );
      * </code>
      *
@@ -80,6 +82,7 @@ class FunctionDeclarations
      *      parse errors or live coding.
      * - Defensive coding against incorrect calls to this method.
      * - More efficient checking whether a function has a body.
+     * - New `return_type_end_token` (int|false) array index.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodProperties()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getMethodProperties() Cross-version compatible version of the original.
@@ -152,6 +155,7 @@ class FunctionDeclarations
 
         $returnType         = '';
         $returnTypeToken    = false;
+        $returnTypeEndToken = false;
         $nullableReturnType = false;
         $hasBody            = false;
 
@@ -185,7 +189,8 @@ class FunctionDeclarations
                         $returnTypeToken = $i;
                     }
 
-                    $returnType .= $tokens[$i]['content'];
+                    $returnType        .= $tokens[$i]['content'];
+                    $returnTypeEndToken = $i;
                 }
             }
         }
@@ -195,15 +200,16 @@ class FunctionDeclarations
         }
 
         return [
-            'scope'                => $scope,
-            'scope_specified'      => $scopeSpecified,
-            'return_type'          => $returnType,
-            'return_type_token'    => $returnTypeToken,
-            'nullable_return_type' => $nullableReturnType,
-            'is_abstract'          => $isAbstract,
-            'is_final'             => $isFinal,
-            'is_static'            => $isStatic,
-            'has_body'             => $hasBody,
+            'scope'                 => $scope,
+            'scope_specified'       => $scopeSpecified,
+            'return_type'           => $returnType,
+            'return_type_token'     => $returnTypeToken,
+            'return_type_end_token' => $returnTypeEndToken,
+            'nullable_return_type'  => $nullableReturnType,
+            'is_abstract'           => $isAbstract,
+            'is_final'              => $isFinal,
+            'is_static'             => $isStatic,
+            'has_body'              => $hasBody,
         ];
     }
 

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -13,6 +13,7 @@ namespace PHPCSUtils\Utils;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\ObjectDeclarations;
 
 /**
@@ -103,18 +104,9 @@ class FunctionDeclarations
         }
 
         if ($tokens[$stackPtr]['code'] === \T_FUNCTION) {
-            $valid = [
-                \T_PUBLIC    => \T_PUBLIC,
-                \T_PRIVATE   => \T_PRIVATE,
-                \T_PROTECTED => \T_PROTECTED,
-                \T_STATIC    => \T_STATIC,
-                \T_FINAL     => \T_FINAL,
-                \T_ABSTRACT  => \T_ABSTRACT,
-            ];
+            $valid = Tokens::$methodPrefixes;
         } else {
-            $valid = [
-                \T_STATIC => \T_STATIC,
-            ];
+            $valid = [\T_STATIC => \T_STATIC];
         }
 
         $valid += Tokens::$emptyTokens;
@@ -166,16 +158,6 @@ class FunctionDeclarations
                 $scopeOpener = $tokens[$stackPtr]['scope_opener'];
             }
 
-            $valid = [
-                \T_STRING       => \T_STRING,
-                \T_CALLABLE     => \T_CALLABLE,
-                \T_SELF         => \T_SELF,
-                \T_PARENT       => \T_PARENT,
-                \T_NS_SEPARATOR => \T_NS_SEPARATOR,
-                \T_RETURN_TYPE  => \T_RETURN_TYPE, // PHPCS 2.4.0 < 3.3.0.
-                \T_ARRAY_HINT   => \T_ARRAY_HINT, // PHPCS < 2.8.0.
-            ];
-
             for ($i = $tokens[$stackPtr]['parenthesis_closer']; $i < $phpcsFile->numTokens; $i++) {
                 if (($scopeOpener === null && $tokens[$i]['code'] === \T_SEMICOLON)
                     || ($scopeOpener !== null && $i === $scopeOpener)
@@ -191,7 +173,7 @@ class FunctionDeclarations
                     $nullableReturnType = true;
                 }
 
-                if (isset($valid[$tokens[$i]['code']]) === true) {
+                if (isset(Collections::$returnTypeTokens[$tokens[$i]['code']]) === true) {
                     if ($returnTypeToken === false) {
                         $returnTypeToken = $i;
                     }

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -72,6 +72,10 @@ class FunctionDeclarations
      *   );
      * </code>
      *
+     * Main differences with the PHPCS version:
+     * - Bugs fixed:
+     *   - Handling of PHPCS annotations.
+     *
      * @see \PHP_CodeSniffer\Files\File::getMethodProperties()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getMethodProperties() Cross-version compatible version of the original.
      *
@@ -98,24 +102,20 @@ class FunctionDeclarations
 
         if ($tokens[$stackPtr]['code'] === \T_FUNCTION) {
             $valid = [
-                \T_PUBLIC      => \T_PUBLIC,
-                \T_PRIVATE     => \T_PRIVATE,
-                \T_PROTECTED   => \T_PROTECTED,
-                \T_STATIC      => \T_STATIC,
-                \T_FINAL       => \T_FINAL,
-                \T_ABSTRACT    => \T_ABSTRACT,
-                \T_WHITESPACE  => \T_WHITESPACE,
-                \T_COMMENT     => \T_COMMENT,
-                \T_DOC_COMMENT => \T_DOC_COMMENT,
+                \T_PUBLIC    => \T_PUBLIC,
+                \T_PRIVATE   => \T_PRIVATE,
+                \T_PROTECTED => \T_PROTECTED,
+                \T_STATIC    => \T_STATIC,
+                \T_FINAL     => \T_FINAL,
+                \T_ABSTRACT  => \T_ABSTRACT,
             ];
         } else {
             $valid = [
-                \T_STATIC      => \T_STATIC,
-                \T_WHITESPACE  => \T_WHITESPACE,
-                \T_COMMENT     => \T_COMMENT,
-                \T_DOC_COMMENT => \T_DOC_COMMENT,
+                \T_STATIC => \T_STATIC,
             ];
         }
+
+        $valid += Tokens::$emptyTokens;
 
         $scope          = 'public';
         $scopeSpecified = false;

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -75,6 +75,7 @@ class FunctionDeclarations
      * Main differences with the PHPCS version:
      * - Bugs fixed:
      *   - Handling of PHPCS annotations.
+     * - Defensive coding against incorrect calls to this method.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodProperties()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getMethodProperties() Cross-version compatible version of the original.
@@ -94,8 +95,9 @@ class FunctionDeclarations
     {
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[$stackPtr]['code'] !== \T_FUNCTION
-            && $tokens[$stackPtr]['code'] !== \T_CLOSURE
+        if (isset($tokens[$stackPtr]) === false
+            || ($tokens[$stackPtr]['code'] !== \T_FUNCTION
+                && $tokens[$stackPtr]['code'] !== \T_CLOSURE)
         ) {
             throw new RuntimeException('$stackPtr must be of type T_FUNCTION or T_CLOSURE');
         }

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.inc
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.inc
@@ -1,0 +1,19 @@
+<?php
+
+/* testMessyPhpcsAnnotationsMethod */
+trait FooTrait {
+    /**
+     * Method doc.
+     */
+    public // phpcs:disable Stnd.Cat.Sniff
+        abstract // phpcs:ignore Stnd.Cat.Sniff
+/*comment*/ function foo() {
+
+        /* testMessyPhpcsAnnotationsStaticClosure */
+        $closure = static // phpcs:ignore Stnd.Cat.Sniff
+            function ( $foo ) {
+                var_dump($foo);
+            };
+            $func();
+    }
+}

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.inc
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.inc
@@ -17,3 +17,8 @@ trait FooTrait {
             $func();
     }
 }
+
+/* testReturnTypeEndTokenIndex */
+function myFunction(): ?\MyNamespace /* comment */
+                        \MyClass // comment
+                        \Foo {}

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\FunctionDeclarations;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\FunctionDeclarations;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\FunctionDeclarations::getProperties method.
+ *
+ * The tests in this class cover the differences between the PHPCS native method and the PHPCSUtils
+ * version. These tests would fail when using the BCFile `getMethodProperties()` method.
+ *
+ * @covers \PHPCSUtils\Utils\FunctionDeclarations::getProperties
+ *
+ * @group functiondeclarations
+ *
+ * @since 1.0.0
+ */
+class GetPropertiesDiffTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test handling of the PHPCS 3.2.0+ annotations between the keywords.
+     *
+     * @return void
+     */
+    public function testMessyPhpcsAnnotationsMethod()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => true,
+            'return_type'          => '',
+            'return_type_token'    => false,
+            'nullable_return_type' => false,
+            'is_abstract'          => true,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Test handling of the PHPCS 3.2.0+ annotations between the keywords with a static closure.
+     *
+     * @return void
+     */
+    public function testMessyPhpcsAnnotationsStaticClosure()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => '',
+            'return_type_token'    => false,
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => true,
+            'has_body'             => true,
+        ];
+
+        $this->getPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Test helper.
+     *
+     * @param string $commentString The comment which preceeds the test.
+     * @param array  $expected      The expected function output.
+     *
+     * @return void
+     */
+    protected function getPropertiesTestHelper($commentString, $expected)
+    {
+        $function = $this->getTargetToken($commentString, [\T_FUNCTION, \T_CLOSURE]);
+        $found    = FunctionDeclarations::getProperties(self::$phpcsFile, $function);
+
+        if ($expected['return_type_token'] !== false) {
+            $expected['return_type_token'] += $function;
+        }
+
+        $this->assertSame($expected, $found);
+    }
+}

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
@@ -29,6 +29,18 @@ class GetPropertiesDiffTest extends UtilityMethodTestCase
 {
 
     /**
+     * Test passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION or T_CLOSURE');
+
+        FunctionDeclarations::getProperties(self::$phpcsFile, 10000);
+    }
+
+    /**
      * Test handling of the PHPCS 3.2.0+ annotations between the keywords.
      *
      * @return void

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
@@ -48,15 +48,16 @@ class GetPropertiesDiffTest extends UtilityMethodTestCase
     public function testMessyPhpcsAnnotationsMethod()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => true,
-            'return_type'          => '',
-            'return_type_token'    => false,
-            'nullable_return_type' => false,
-            'is_abstract'          => true,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => true,
+            'return_type'           => '',
+            'return_type_token'     => false,
+            'return_type_end_token' => false,
+            'nullable_return_type'  => false,
+            'is_abstract'           => true,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -70,15 +71,39 @@ class GetPropertiesDiffTest extends UtilityMethodTestCase
     public function testMessyPhpcsAnnotationsStaticClosure()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '',
-            'return_type_token'    => false,
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => true,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '',
+            'return_type_token'     => false,
+            'return_type_end_token' => false,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => true,
+            'has_body'              => true,
+        ];
+
+        $this->getPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Test that the new "return_type_end_token" index is set correctly.
+     *
+     * @return void
+     */
+    public function testReturnTypeEndTokenIndex()
+    {
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '?\MyNamespace\MyClass\Foo',
+            'return_type_token'     => 8, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 20, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -99,6 +124,9 @@ class GetPropertiesDiffTest extends UtilityMethodTestCase
 
         if ($expected['return_type_token'] !== false) {
             $expected['return_type_token'] += $function;
+        }
+        if ($expected['return_type_end_token'] !== false) {
+            $expected['return_type_end_token'] += $function;
         }
 
         $this->assertSame($expected, $found);

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesTest.php
@@ -77,6 +77,15 @@ class GetPropertiesTest extends BCFile_GetMethodPropertiesTest
             $expected['return_type_token'] += $function;
         }
 
+        /*
+         * Test the new `return_type_end_token` key which is not in the original datasets.
+         */
+        $this->assertArrayHasKey('return_type_end_token', $found);
+        $this->assertTrue($found['return_type_end_token'] === false || \is_int($found['return_type_end_token']));
+
+        // Remove the array key before doing the compare against the original dataset.
+        unset($found['return_type_end_token']);
+
         $this->assertSame($expected, $found);
     }
 }


### PR DESCRIPTION
## FunctionDeclarations::getProperties(): fix handling of PHPCS annotations

While probably unlikely to come across in the wild, the utility should handle this type of code correctly.

Includes a separate set of unit tests for this method.

These additional tests would fail when using the BCFile version of the method.

## FunctionDeclarations::getProperties(): improve defensive coding

Includes unit test.

## FunctionDeclarations::getProperties(): minor code reorganization

* Move the return type tokens array to a class property in the `PHPCSUtils\Tokens\Collections` class.
* Use the existing `Tokens::$methodPrefixes` token array.

## FunctionDeclarations::getProperties(): `has_body` determination - efficiency fix + bug fix

No need to walk the same set of tokens twice to determine whether a function has a body.
We already have the necessary information. Use it.

Also prevents the `has_body` index key from being set to `true` in certain cases of parse errors/live coding.

## FunctionDeclarations::getProperties(): add `return_type_end_token` to the array

The `getParameters()` method already returns stack pointers to both the "start" and "end" of a parameter type declaration.

The `getProperties()` method only returned the stack pointer to the _start_ of the return type declaration.

For feature completeness, a new `return_type_end_token` array index has been added to the array which is returned by this method.
The value will be `false` if there is no return type declaration; or the integer stack pointer to the last token of the return type declaration if there is.

Includes a new unit test for this feature, as well as some adjustments to the existing unit tests to allow for this feature.