### PR TITLE
FunctionDeclarations::getParameters(): various improvements

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -239,7 +239,8 @@ class BCFile
      * - PHPCS 3.5.3: Fixed a bug where the "type_hint_end_token" array index for a type hinted
      *                parameter would bleed through to the next (non-type hinted) parameter.
      *
-     * @see \PHP_CodeSniffer\Files\File::getMethodParameters() Original source.
+     * @see \PHP_CodeSniffer\Files\File::getMethodParameters()      Original source.
+     * @see \PHPCSUtils\Utils\FunctionDeclarations::getParameters() PHPCSUtils native improved version.
      *
      * @since 1.0.0
      *

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -247,6 +247,9 @@ class FunctionDeclarations
      *         'default_token'       => integer, // The stack pointer to the start of the default value.
      *         'default_equal_token' => integer, // The stack pointer to the equals sign.
      *
+     * Main differences with the PHPCS version:
+     * - Defensive coding against incorrect calls to this method.
+     *
      * @see \PHP_CodeSniffer\Files\File::getMethodParameters()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getMethodParameters() Cross-version compatible version of the original.
      *
@@ -265,9 +268,10 @@ class FunctionDeclarations
     {
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[$stackPtr]['code'] !== \T_FUNCTION
-            && $tokens[$stackPtr]['code'] !== \T_CLOSURE
-            && $tokens[$stackPtr]['code'] !== \T_USE
+        if (isset($tokens[$stackPtr]) === false
+            || ($tokens[$stackPtr]['code'] !== \T_FUNCTION
+                && $tokens[$stackPtr]['code'] !== \T_CLOSURE
+                && $tokens[$stackPtr]['code'] !== \T_USE)
         ) {
             throw new RuntimeException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_USE');
         }

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -251,6 +251,7 @@ class FunctionDeclarations
      * Main differences with the PHPCS version:
      * - Defensive coding against incorrect calls to this method.
      * - More efficient checking whether a T_USE token is a closure use.
+     * - More efficient and more stable looping of the default value.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodParameters()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getMethodParameters() Cross-version compatible version of the original.
@@ -318,31 +319,11 @@ class FunctionDeclarations
         $nullableType     = false;
 
         for ($i = $paramStart; $i <= $closer; $i++) {
-            // Check to see if this token has a parenthesis or bracket opener. If it does
-            // it's likely to be an array which might have arguments in it. This
-            // could cause problems in our parsing below, so lets just skip to the
-            // end of it.
-            if (isset($tokens[$i]['parenthesis_opener']) === true) {
-                // Don't do this if it's the close parenthesis for the method.
-                if ($i !== $tokens[$i]['parenthesis_closer']) {
-                    $i = ($tokens[$i]['parenthesis_closer'] + 1);
-                }
-            }
-
-            if (isset($tokens[$i]['bracket_opener']) === true) {
-                // Don't do this if it's the close parenthesis for the method.
-                if ($i !== $tokens[$i]['bracket_closer']) {
-                    $i = ($tokens[$i]['bracket_closer'] + 1);
-                }
-            }
-
             // Changed from checking 'code' to 'type' to allow for T_NULLABLE not existing in PHPCS < 2.8.0.
             switch ($tokens[$i]['type']) {
                 case 'T_BITWISE_AND':
-                    if ($defaultStart === null) {
-                        $passByReference = true;
-                        $referenceToken  = $i;
-                    }
+                    $passByReference = true;
+                    $referenceToken  = $i;
                     break;
 
                 case 'T_VARIABLE':
@@ -356,6 +337,11 @@ class FunctionDeclarations
 
                 case 'T_ARRAY_HINT': // PHPCS < 3.3.0.
                 case 'T_CALLABLE':
+                case 'T_SELF':
+                case 'T_PARENT':
+                case 'T_STATIC': // Self and parent are valid, static invalid, but was probably intended as type hint.
+                case 'T_STRING':
+                case 'T_NS_SEPARATOR':
                     if ($typeHintToken === false) {
                         $typeHintToken = $i;
                     }
@@ -364,74 +350,11 @@ class FunctionDeclarations
                     $typeHintEndToken = $i;
                     break;
 
-                case 'T_SELF':
-                case 'T_PARENT':
-                case 'T_STATIC':
-                    // Self and parent are valid, static invalid, but was probably intended as type hint.
-                    if (isset($defaultStart) === false) {
-                        if ($typeHintToken === false) {
-                            $typeHintToken = $i;
-                        }
-
-                        $typeHint        .= $tokens[$i]['content'];
-                        $typeHintEndToken = $i;
-                    }
-                    break;
-
-                case 'T_STRING':
-                    // This is a string, so it may be a type hint, but it could
-                    // also be a constant used as a default value.
-                    $prevComma = false;
-                    for ($t = $i; $t >= $opener; $t--) {
-                        if ($tokens[$t]['code'] === \T_COMMA) {
-                            $prevComma = $t;
-                            break;
-                        }
-                    }
-
-                    if ($prevComma !== false) {
-                        $nextEquals = false;
-                        for ($t = $prevComma; $t < $i; $t++) {
-                            if ($tokens[$t]['code'] === \T_EQUAL) {
-                                $nextEquals = $t;
-                                break;
-                            }
-                        }
-
-                        if ($nextEquals !== false) {
-                            break;
-                        }
-                    }
-
-                    if ($defaultStart === null) {
-                        if ($typeHintToken === false) {
-                            $typeHintToken = $i;
-                        }
-
-                        $typeHint        .= $tokens[$i]['content'];
-                        $typeHintEndToken = $i;
-                    }
-                    break;
-
-                case 'T_NS_SEPARATOR':
-                    // Part of a type hint or default value.
-                    if ($defaultStart === null) {
-                        if ($typeHintToken === false) {
-                            $typeHintToken = $i;
-                        }
-
-                        $typeHint        .= $tokens[$i]['content'];
-                        $typeHintEndToken = $i;
-                    }
-                    break;
-
                 case 'T_NULLABLE':
                 case 'T_INLINE_THEN': // PHPCS < 2.8.0.
-                    if ($defaultStart === null) {
-                        $nullableType     = true;
-                        $typeHint        .= $tokens[$i]['content'];
-                        $typeHintEndToken = $i;
-                    }
+                    $nullableType     = true;
+                    $typeHint        .= $tokens[$i]['content'];
+                    $typeHintEndToken = $i;
                     break;
 
                 case 'T_CLOSE_PARENTHESIS':
@@ -492,6 +415,33 @@ class FunctionDeclarations
                 case 'T_EQUAL':
                     $defaultStart = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
                     $equalToken   = $i;
+
+                    // Skip past everything in the default value before going into the next switch loop.
+                    for ($j = ($i + 1); $j <= $closer; $j++) {
+                        // Skip past array()'s et al as default values.
+                        if (isset($tokens[$j]['parenthesis_opener'], $tokens[$j]['parenthesis_closer'])) {
+                            $j = $tokens[$j]['parenthesis_closer'];
+
+                            if ($j === $closer) {
+                                // Found the end of the parameter.
+                                break;
+                            }
+
+                            continue;
+                        }
+
+                        // Skip past short arrays et al as default values.
+                        if (isset($tokens[$j]['bracket_opener'])) {
+                            $j = $tokens[$j]['bracket_closer'];
+                            continue;
+                        }
+
+                        if ($tokens[$j]['code'] === \T_COMMA) {
+                            break;
+                        }
+                    }
+
+                    $i = ($j - 1);
                     break;
             }
         }

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -214,11 +214,11 @@ class FunctionDeclarations
     }
 
     /**
-     * Returns the method parameters for the specified function token.
+     * Retrieves the method parameters for the specified function token.
      *
      * Also supports passing in a USE token for a closure use group.
      *
-     * Each parameter is in the following format:
+     * The returned array will contain the following information for each parameter:
      *
      * <code>
      *   0 => array(
@@ -242,7 +242,7 @@ class FunctionDeclarations
      *        )
      * </code>
      *
-     * Parameters with default values have an additional array indexs of:
+     * Parameters with default values have the following additional array indexes:
      *         'default'             => string,  // The full content of the default value.
      *         'default_token'       => integer, // The stack pointer to the start of the default value.
      *         'default_equal_token' => integer, // The stack pointer to the equals sign.

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\ObjectDeclarations;
 
 /**
@@ -441,12 +442,12 @@ class FunctionDeclarations
                     $vars[$paramCount]['token']   = $currVar;
                     $vars[$paramCount]['name']    = $tokens[$currVar]['content'];
                     $vars[$paramCount]['content'] = \trim(
-                        $phpcsFile->getTokensAsString($paramStart, ($i - $paramStart))
+                        GetTokensAsString::normal($phpcsFile, $paramStart, ($i - 1))
                     );
 
                     if ($defaultStart !== null) {
                         $vars[$paramCount]['default']             = \trim(
-                            $phpcsFile->getTokensAsString($defaultStart, ($i - $defaultStart))
+                            GetTokensAsString::normal($phpcsFile, $defaultStart, ($i - 1))
                         );
                         $vars[$paramCount]['default_token']       = $defaultStart;
                         $vars[$paramCount]['default_equal_token'] = $equalToken;

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -250,6 +250,7 @@ class FunctionDeclarations
      *
      * Main differences with the PHPCS version:
      * - Defensive coding against incorrect calls to this method.
+     * - More efficient checking whether a T_USE token is a closure use.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodParameters()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getMethodParameters() Cross-version compatible version of the original.
@@ -278,8 +279,11 @@ class FunctionDeclarations
         }
 
         if ($tokens[$stackPtr]['code'] === \T_USE) {
-            $opener = $phpcsFile->findNext(\T_OPEN_PARENTHESIS, ($stackPtr + 1));
-            if ($opener === false || isset($tokens[$opener]['parenthesis_owner']) === true) {
+            $opener = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            if ($opener === false
+                || $tokens[$opener]['code'] !== \T_OPEN_PARENTHESIS
+                || isset($tokens[$opener]['parenthesis_owner']) === true
+            ) {
                 throw new RuntimeException('$stackPtr was not a valid T_USE');
             }
         } else {

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.inc
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.inc
@@ -1,0 +1,3 @@
+<?php
+
+// No PHPCSUtils native test cases yet.

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\FunctionDeclarations;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\FunctionDeclarations;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\FunctionDeclarations::getParameters method.
+ *
+ * The tests in this class cover the differences between the PHPCS native method and the PHPCSUtils
+ * version. These tests would fail when using the BCFile `getParameters()` method.
+ *
+ * @covers \PHPCSUtils\Utils\FunctionDeclarations::getParameters
+ *
+ * @group functiondeclarations
+ *
+ * @since 1.0.0
+ */
+class GetParametersDiffTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_USE');
+
+        FunctionDeclarations::getParameters(self::$phpcsFile, 10000);
+    }
+}


### PR DESCRIPTION
## FunctionDeclarations::getParameters(): improve documentation

## FunctionDeclarations::getParameters(): improve defensive coding

Includes unit test.

## FunctionDeclarations::getParameters(): switch over to using `GetTokensAsString` class

No change in behaviour.

## FunctionDeclarations::getParameters(): efficiency fix / use type determination

Prevent the method from walking far, far ahead if it would have been passed an import `use` or a trait `use` token.

## FunctionDeclarations::getParameters(): code simplification and efficiency fix

Once the equal sign has been found, we know that everything else until the end of the parameter is part of the default value.

So instead of looping through each token individually after the equal sign, go straight to the end of the parameter.

This allows for greatly simplifying the code within various `case`s in the `switch` as well as for merging a lot of the `case`s together.