### PR TITLE
Util\FunctionDeclarations: add new reserved name related utility methods

### DIFF
--- a/Tests/Utils/FunctionDeclarations/IsMagicFunctionNameTest.php
+++ b/Tests/Utils/FunctionDeclarations/IsMagicFunctionNameTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\FunctionDeclarations;
+
+use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\FunctionDeclarations::isMagicFunctionName() method.
+ *
+ * @covers \PHPCSUtils\Utils\FunctionDeclarations::isMagicFunctionName
+ *
+ * @group functiondeclarations
+ *
+ * @since 1.0.0
+ */
+class IsMagicFunctionNameTest extends TestCase
+{
+
+    /**
+     * Test valid PHP magic function names.
+     *
+     * @dataProvider dataIsMagicFunctionName
+     *
+     * @param string $name The function name to test.
+     *
+     * @return void
+     */
+    public function testIsMagicFunctionName($name)
+    {
+        $this->assertTrue(FunctionDeclarations::isMagicFunctionName($name));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsMagicFunctionName() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsMagicFunctionName()
+    {
+        return [
+            'lowercase' => ['__autoload'],
+            'uppercase' => ['__AUTOLOAD'],
+            'mixedcase' => ['__AutoLoad'],
+        ];
+    }
+
+    /**
+     * Test non-magic function names.
+     *
+     * @dataProvider dataIsNotMagicFunctionName
+     *
+     * @param string $name The function name to test.
+     *
+     * @return void
+     */
+    public function testIsNotMagicFunctionName($name)
+    {
+        $this->assertFalse(FunctionDeclarations::isMagicFunctionName($name));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsNotMagicFunctionName() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsNotMagicFunctionName()
+    {
+        return [
+            'no_underscore'           => ['noDoubleUnderscore'],
+            'single_underscore'       => ['_autoload'],
+            'triple_underscore'       => ['___autoload'],
+            'not_magic_function_name' => ['__notAutoload'],
+        ];
+    }
+}

--- a/Tests/Utils/FunctionDeclarations/IsMagicMethodNameTest.php
+++ b/Tests/Utils/FunctionDeclarations/IsMagicMethodNameTest.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\FunctionDeclarations;
+
+use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\FunctionDeclarations::isMagicMethodName() method.
+ *
+ * @group functiondeclarations
+ *
+ * @since 1.0.0
+ */
+class IsMagicMethodNameTest extends TestCase
+{
+
+    /**
+     * Test valid PHP magic method names.
+     *
+     * @dataProvider dataIsMagicMethodName
+     * @covers       \PHPCSUtils\Utils\FunctionDeclarations::isMagicMethodName
+     *
+     * @param string $name The function name to test.
+     *
+     * @return void
+     */
+    public function testIsMagicMethodName($name)
+    {
+        $this->assertTrue(FunctionDeclarations::isMagicMethodName($name));
+    }
+
+    /**
+     * Test valid PHP magic method names.
+     *
+     * @dataProvider dataIsMagicMethodName
+     * @covers       \PHPCSUtils\Utils\FunctionDeclarations::isSpecialMethodName
+     *
+     * @param string $name The function name to test.
+     *
+     * @return void
+     */
+    public function testIsSpecialMethodName($name)
+    {
+        $this->assertTrue(FunctionDeclarations::isSpecialMethodName($name));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsMagicMethodName()   For the array format.
+     * @see testIsSpecialMethodName() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsMagicMethodName()
+    {
+        return [
+            // Normal case.
+            'construct-defined-case'   => ['__construct'],
+            'destruct-defined-case'    => ['__destruct'],
+            'call-defined-case'        => ['__call'],
+            'callStatic-defined-case'  => ['__callStatic'],
+            'get-defined-case'         => ['__get'],
+            'set-defined-case'         => ['__set'],
+            'isset-defined-case'       => ['__isset'],
+            'unset-defined-case'       => ['__unset'],
+            'sleep-defined-case'       => ['__sleep'],
+            'wakeup-defined-case'      => ['__wakeup'],
+            'toString-defined-case'    => ['__toString'],
+            'set_state-defined-case'   => ['__set_state'],
+            'clone-defined-case'       => ['__clone'],
+            'invoke-defined-case'      => ['__invoke'],
+            'debugInfo-defined-case'   => ['__debugInfo'],
+            'serialize-defined-case'   => ['__serialize'],
+            'unserialize-defined-case' => ['__unserialize'],
+
+            // Uppercase et al.
+            'construct-changed-case'   => ['__CONSTRUCT'],
+            'destruct-changed-case'    => ['__Destruct'],
+            'call-changed-case'        => ['__Call'],
+            'callStatic-changed-case'  => ['__callstatic'],
+            'get-changed-case'         => ['__GET'],
+            'set-changed-case'         => ['__SeT'],
+            'isset-changed-case'       => ['__isSet'],
+            'unset-changed-case'       => ['__unSet'],
+            'sleep-changed-case'       => ['__SleeP'],
+            'wakeup-changed-case'      => ['__wakeUp'],
+            'toString-changed-case'    => ['__TOString'],
+            'set_state-changed-case'   => ['__Set_State'],
+            'clone-changed-case'       => ['__CLONE'],
+            'invoke-changed-case'      => ['__Invoke'],
+            'debugInfo-changed-case'   => ['__Debuginfo'],
+            'serialize-changed-case'   => ['__SERIALIZE'],
+            'unserialize-changed-case' => ['__unSerialize'],
+        ];
+    }
+
+    /**
+     * Test non-magic method names.
+     *
+     * @dataProvider dataIsNotMagicMethodName
+     * @covers       \PHPCSUtils\Utils\FunctionDeclarations::isMagicMethodName
+     *
+     * @param string $name The function name to test.
+     *
+     * @return void
+     */
+    public function testIsNotMagicMethodName($name)
+    {
+        $this->assertFalse(FunctionDeclarations::isMagicMethodName($name));
+    }
+
+    /**
+     * Test non-magic method names.
+     *
+     * @dataProvider dataIsNotMagicMethodName
+     * @covers       \PHPCSUtils\Utils\FunctionDeclarations::isSpecialMethodName
+     *
+     * @param string $name The function name to test.
+     *
+     * @return void
+     */
+    public function testIsNotSpecialMethodName($name)
+    {
+        $this->assertFalse(FunctionDeclarations::isSpecialMethodName($name));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsNotMagicMethodName()   For the array format.
+     * @see testIsNotSpecialMethodName() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsNotMagicMethodName()
+    {
+        return [
+            'no_underscore'         => ['construct'],
+            'single_underscore'     => ['_destruct'],
+            'triple_underscore'     => ['___call'],
+            'not_magic_method_name' => ['__myFunction'],
+        ];
+    }
+}

--- a/Tests/Utils/FunctionDeclarations/IsPHPDoubleUnderscoreMethodNameTest.php
+++ b/Tests/Utils/FunctionDeclarations/IsPHPDoubleUnderscoreMethodNameTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\FunctionDeclarations;
+
+use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\FunctionDeclarations::isPHPDoubleUnderscoreMethodName() method.
+ *
+ * @group functiondeclarations
+ *
+ * @since 1.0.0
+ */
+class IsPHPDoubleUnderscoreMethodNameTest extends TestCase
+{
+
+    /**
+     * Test valid PHP native double underscore method names.
+     *
+     * @dataProvider dataIsPHPDoubleUnderscoreMethodName
+     * @covers       \PHPCSUtils\Utils\FunctionDeclarations::isPHPDoubleUnderscoreMethodName
+     *
+     * @param string $name The function name to test.
+     *
+     * @return void
+     */
+    public function testIsPHPDoubleUnderscoreMethodName($name)
+    {
+        $this->assertTrue(FunctionDeclarations::isPHPDoubleUnderscoreMethodName($name));
+    }
+
+    /**
+     * Test valid PHP native double underscore method names.
+     *
+     * @dataProvider dataIsPHPDoubleUnderscoreMethodName
+     * @covers       \PHPCSUtils\Utils\FunctionDeclarations::isSpecialMethodName
+     *
+     * @param string $name The function name to test.
+     *
+     * @return void
+     */
+    public function testIsSpecialMethodName($name)
+    {
+        $this->assertTrue(FunctionDeclarations::isSpecialMethodName($name));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsPHPDoubleUnderscoreMethodName() For the array format.
+     * @see testIsSpecialMethodName()             For the array format.
+     *
+     * @return array
+     */
+    public function dataIsPHPDoubleUnderscoreMethodName()
+    {
+        return [
+            // Normal case.
+            'doRequest-defined-case'              => ['__doRequest'],
+            'getCookies-defined-case'             => ['__getCookies'],
+            'getFunctions-defined-case'           => ['__getFunctions'],
+            'getLastRequest-defined-case'         => ['__getLastRequest'],
+            'getLastRequestHeaders-defined-case'  => ['__getLastRequestHeaders'],
+            'getLastResponse-defined-case'        => ['__getLastResponse'],
+            'getLastResponseHeaders-defined-case' => ['__getLastResponseHeaders'],
+            'getTypes-defined-case'               => ['__getTypes'],
+            'setCookie-defined-case'              => ['__setCookie'],
+            'setLocation-defined-case'            => ['__setLocation'],
+            'setSoapHeaders-defined-case'         => ['__setSoapHeaders'],
+            'soapCall-defined-case'               => ['__soapCall'],
+
+            // Uppercase et al.
+            'doRequest-changed-case'              => ['__DOREQUEST'],
+            'getCookies-changed-case'             => ['__getcookies'],
+            'getFunctions-changed-case'           => ['__Getfunctions'],
+            'getLastRequest-changed-case'         => ['__GETLASTREQUEST'],
+            'getLastRequestHeaders-changed-case'  => ['__getlastrequestheaders'],
+            'getLastResponse-changed-case'        => ['__GetlastResponse'],
+            'getLastResponseHeaders-changed-case' => ['__GETLASTRESPONSEHEADERS'],
+            'getTypes-changed-case'               => ['__GetTypes'],
+            'setCookie-changed-case'              => ['__SETCookie'],
+            'setLocation-changed-case'            => ['__sETlOCATION'],
+            'setSoapHeaders-changed-case'         => ['__SetSOAPHeaders'],
+            'soapCall-changed-case'               => ['__SOAPCall'],
+        ];
+    }
+
+    /**
+     * Test function names which are not valid PHP native double underscore methods.
+     *
+     * @dataProvider dataIsNotPHPDoubleUnderscoreMethodName
+     * @covers       \PHPCSUtils\Utils\FunctionDeclarations::isPHPDoubleUnderscoreMethodName
+     *
+     * @param string $name The function name to test.
+     *
+     * @return void
+     */
+    public function testIsNotPHPDoubleUnderscoreMethodName($name)
+    {
+        $this->assertFalse(FunctionDeclarations::isPHPDoubleUnderscoreMethodName($name));
+    }
+
+    /**
+     * Test function names which are not valid PHP native double underscore methods.
+     *
+     * @dataProvider dataIsNotPHPDoubleUnderscoreMethodName
+     * @covers       \PHPCSUtils\Utils\FunctionDeclarations::isSpecialMethodName
+     *
+     * @param string $name The function name to test.
+     *
+     * @return void
+     */
+    public function testIsNotSpecialMethodName($name)
+    {
+        $this->assertFalse(FunctionDeclarations::isSpecialMethodName($name));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsNotPHPDoubleUnderscoreMethodName() For the array format.
+     * @see testIsNotSpecialMethodName()             For the array format.
+     *
+     * @return array
+     */
+    public function dataIsNotPHPDoubleUnderscoreMethodName()
+    {
+        return [
+            'no_underscore'           => ['getLastResponseHeaders'],
+            'single_underscore'       => ['_setLocation'],
+            'triple_underscore'       => ['___getCookies'],
+            'not_magic_function_name' => ['__getFirstRequestHeader'],
+        ];
+    }
+}

--- a/Tests/Utils/FunctionDeclarations/SpecialFunctionsTest.inc
+++ b/Tests/Utils/FunctionDeclarations/SpecialFunctionsTest.inc
@@ -1,0 +1,96 @@
+<?php
+
+/* testNotAFunction */
+echo 'foo';
+
+class MagicClass {
+    /* testMagicMethodInClass */
+    function __construct() {}
+
+    /* testMagicMethodInClassUppercase */
+    function __CALL($name, $args) {}
+
+    /* testMagicMethodInClassMixedCase */
+    function __Set($name, $value) {}
+
+    /* testMagicFunctionInClassNotGlobal */
+    function __autoload() {}
+
+    /* testMethodInClassNotMagicName */
+    function __myFunction() {}
+}
+
+/* testMagicMethodNotInClass */
+function __callStatic() {}
+
+/* testMagicFunction */
+function __autoload($class) {}
+
+if ( $someCondition ) {
+    /* testMagicFunctionInConditionMixedCase */
+    function __autoload($class) {}
+}
+
+/* testFunctionNotMagicName */
+function __myFunction() {}
+
+/* Magic methods in anonymous classes. */
+$a = new class {
+    /* testMagicMethodInAnonClass */
+    function __destruct() {}
+
+    /* testMagicMethodInAnonClassUppercase */
+    function __GET($name) {}
+
+    /* testMagicFunctionInAnonClassNotGlobal */
+    function __autoload() {}
+
+    /* testMethodInAnonClassNotMagicName */
+    function __myFunction() {}
+};
+
+class MySoapImplementation extends \SoapClient {
+    /* testDoubleUnderscoreMethodInClass */
+    public function __getCookies() {}
+
+    /* testDoubleUnderscoreMethodInClassMixedcase */
+    public function __getLASTRequestHeaders() {}
+}
+
+class NotSoapImplementation {
+    /* testDoubleUnderscoreMethodInClassNotExtended */
+    public function __getCookies() {}
+}
+
+/* testDoubleUnderscoreMethodNotInClass */
+function __getCookies() {}
+
+trait MagicTrait
+{
+    /* testMagicMethodInTrait */
+    function __toString() {}
+
+    /* testDoubleUnderscoreMethodInTrait */
+    public function __getLastRequest() {}
+
+    /* testMagicFunctionInTraitNotGlobal */
+    function __autoload() {}
+
+    /* testMethodInTraitNotMagicName */
+    function __myFunction() {}
+}
+
+interface MagicInterface
+{
+    /* testMagicMethodInInterface */
+    function __set_state($name, $args);
+
+    /* testDoubleUnderscoreMethodInInterface */
+    public function __setLocation() {}
+
+    /* testMagicFunctionInInterfaceNotGlobal */
+    function __autoload();
+
+    /* testMethodInInterfaceNotMagicName */
+    function __myFunction();
+}

--- a/Tests/Utils/FunctionDeclarations/SpecialFunctionsTest.php
+++ b/Tests/Utils/FunctionDeclarations/SpecialFunctionsTest.php
@@ -1,0 +1,396 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\FunctionDeclarations;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\FunctionDeclarations;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\FunctionDeclarations::isMagicFunction(),
+ * \PHPCSUtils\Utils\FunctionDeclarations::isMagicMethod(),
+ * \PHPCSUtils\Utils\FunctionDeclarations::isPHPDoubleUnderscoreMethod() and the
+ * \PHPCSUtils\Utils\FunctionDeclarations::isSpecialMethod() methods.
+ *
+ * @group functiondeclarations
+ *
+ * @since 1.0.0
+ */
+class SpecialFunctionsTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test that the special function methods return false when passed a non-existent token.
+     *
+     * @covers \PHPCSUtils\Utils\FunctionDeclarations::isMagicFunction
+     * @covers \PHPCSUtils\Utils\FunctionDeclarations::isMagicMethod
+     * @covers \PHPCSUtils\Utils\FunctionDeclarations::isPHPDoubleUnderscoreMethod
+     * @covers \PHPCSUtils\Utils\FunctionDeclarations::isSpecialMethod
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $result = FunctionDeclarations::isMagicFunction(self::$phpcsFile, 10000);
+        $this->assertFalse($result, 'isMagicFunction() did not return false');
+
+        $result = FunctionDeclarations::isMagicMethod(self::$phpcsFile, 10000);
+        $this->assertFalse($result, 'isMagicMethod() did not return false');
+
+        $result = FunctionDeclarations::isPHPDoubleUnderscoreMethod(self::$phpcsFile, 10000);
+        $this->assertFalse($result, 'isPHPDoubleUnderscoreMethod() did not return false');
+
+        $result = FunctionDeclarations::isSpecialMethod(self::$phpcsFile, 10000);
+        $this->assertFalse($result, 'isSpecialMethod() did not return false');
+    }
+
+    /**
+     * Test that the special function methods return false when passed a non-function token.
+     *
+     * @covers \PHPCSUtils\Utils\FunctionDeclarations::isMagicFunction
+     * @covers \PHPCSUtils\Utils\FunctionDeclarations::isMagicMethod
+     * @covers \PHPCSUtils\Utils\FunctionDeclarations::isPHPDoubleUnderscoreMethod
+     * @covers \PHPCSUtils\Utils\FunctionDeclarations::isSpecialMethod
+     *
+     * @return void
+     */
+    public function testNotAFunctionToken()
+    {
+        $stackPtr = $this->getTargetToken('/* testNotAFunction */', \T_ECHO);
+
+        $result = FunctionDeclarations::isMagicFunction(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result, 'isMagicFunction() did not return false');
+
+        $result = FunctionDeclarations::isMagicMethod(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result, 'isMagicMethod() did not return false');
+
+        $result = FunctionDeclarations::isPHPDoubleUnderscoreMethod(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result, 'isPHPDoubleUnderscoreMethod() did not return false');
+
+        $result = FunctionDeclarations::isSpecialMethod(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result, 'isSpecialMethod() did not return false');
+    }
+
+    /**
+     * Test correctly detecting magic functions.
+     *
+     * @dataProvider dataItsAKindOfMagic
+     * @covers       \PHPCSUtils\Utils\FunctionDeclarations::isMagicFunction
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   The expected return values for the various functions.
+     *
+     * @return void
+     */
+    public function testIsMagicFunction($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, \T_FUNCTION);
+        $result   = FunctionDeclarations::isMagicFunction(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected['function'], $result);
+    }
+
+    /**
+     * Test correctly detecting magic methods.
+     *
+     * @dataProvider dataItsAKindOfMagic
+     * @covers       \PHPCSUtils\Utils\FunctionDeclarations::isMagicMethod
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   The expected return values for the various functions.
+     *
+     * @return void
+     */
+    public function testIsMagicMethod($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, \T_FUNCTION);
+        $result   = FunctionDeclarations::isMagicMethod(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected['method'], $result);
+    }
+
+    /**
+     * Test correctly detecting PHP native double underscore methods.
+     *
+     * @dataProvider dataItsAKindOfMagic
+     * @covers       \PHPCSUtils\Utils\FunctionDeclarations::isPHPDoubleUnderscoreMethod
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   The expected return values for the various functions.
+     *
+     * @return void
+     */
+    public function testIsPHPDoubleUnderscoreMethod($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, \T_FUNCTION);
+        $result   = FunctionDeclarations::isPHPDoubleUnderscoreMethod(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected['double'], $result);
+    }
+
+    /**
+     * Test correctly detecting magic methods and double underscore methods.
+     *
+     * @dataProvider dataItsAKindOfMagic
+     * @covers       \PHPCSUtils\Utils\FunctionDeclarations::isSpecialMethod
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   The expected return values for the various functions.
+     *
+     * @return void
+     */
+    public function testIsSpecialMethod($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, \T_FUNCTION);
+        $result   = FunctionDeclarations::isSpecialMethod(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected['special'], $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsMagicFunction()             For the array format.
+     * @see testIsMagicMethod()               For the array format.
+     * @see testIsPHPDoubleUnderscoreMethod() For the array format.
+     * @see testIsSpecialMethod()             For the array format.
+     *
+     * @return array
+     */
+    public function dataItsAKindOfMagic()
+    {
+        return [
+            'MagicMethodInClass' => [
+                '/* testMagicMethodInClass */',
+                [
+                    'function' => false,
+                    'method'   => true,
+                    'double'   => false,
+                    'special'  => true,
+                ],
+            ],
+            'MagicMethodInClassUppercase' => [
+                '/* testMagicMethodInClassUppercase */',
+                [
+                    'function' => false,
+                    'method'   => true,
+                    'double'   => false,
+                    'special'  => true,
+                ],
+            ],
+            'MagicMethodInClassMixedCase' => [
+                '/* testMagicMethodInClassMixedCase */',
+                [
+                    'function' => false,
+                    'method'   => true,
+                    'double'   => false,
+                    'special'  => true,
+                ],
+            ],
+            'MagicFunctionInClassNotGlobal' => [
+                '/* testMagicFunctionInClassNotGlobal */',
+                [
+                    'function' => false,
+                    'method'   => false,
+                    'double'   => false,
+                    'special'  => false,
+                ],
+            ],
+            'MethodInClassNotMagicName' => [
+                '/* testMethodInClassNotMagicName */',
+                [
+                    'function' => false,
+                    'method'   => false,
+                    'double'   => false,
+                    'special'  => false,
+                ],
+            ],
+            'MagicMethodNotInClass' => [
+                '/* testMagicMethodNotInClass */',
+                [
+                    'function' => false,
+                    'method'   => false,
+                    'double'   => false,
+                    'special'  => false,
+                ],
+            ],
+            'MagicFunction' => [
+                '/* testMagicFunction */',
+                [
+                    'function' => true,
+                    'method'   => false,
+                    'double'   => false,
+                    'special'  => false,
+                ],
+            ],
+            'MagicFunctionInConditionMixedCase' => [
+                '/* testMagicFunctionInConditionMixedCase */',
+                [
+                    'function' => true,
+                    'method'   => false,
+                    'double'   => false,
+                    'special'  => false,
+                ],
+            ],
+            'FunctionNotMagicName' => [
+                '/* testFunctionNotMagicName */',
+                [
+                    'function' => false,
+                    'method'   => false,
+                    'double'   => false,
+                    'special'  => false,
+                ],
+            ],
+            'MagicMethodInAnonClass' => [
+                '/* testMagicMethodInAnonClass */',
+                [
+                    'function' => false,
+                    'method'   => true,
+                    'double'   => false,
+                    'special'  => true,
+                ],
+            ],
+            'MagicMethodInAnonClassUppercase' => [
+                '/* testMagicMethodInAnonClassUppercase */',
+                [
+                    'function' => false,
+                    'method'   => true,
+                    'double'   => false,
+                    'special'  => true,
+                ],
+            ],
+            'MagicFunctionInAnonClassNotGlobal' => [
+                '/* testMagicFunctionInAnonClassNotGlobal */',
+                [
+                    'function' => false,
+                    'method'   => false,
+                    'double'   => false,
+                    'special'  => false,
+                ],
+            ],
+            'MethodInAnonClassNotMagicName' => [
+                '/* testMethodInAnonClassNotMagicName */',
+                [
+                    'function' => false,
+                    'method'   => false,
+                    'double'   => false,
+                    'special'  => false,
+                ],
+            ],
+            'DoubleUnderscoreMethodInClass' => [
+                '/* testDoubleUnderscoreMethodInClass */',
+                [
+                    'function' => false,
+                    'method'   => false,
+                    'double'   => true,
+                    'special'  => true,
+                ],
+            ],
+            'DoubleUnderscoreMethodInClassMixedcase' => [
+                '/* testDoubleUnderscoreMethodInClassMixedcase */',
+                [
+                    'function' => false,
+                    'method'   => false,
+                    'double'   => true,
+                    'special'  => true,
+                ],
+            ],
+
+            'DoubleUnderscoreMethodInClassNotExtended' => [
+                '/* testDoubleUnderscoreMethodInClassNotExtended */',
+                [
+                    'function' => false,
+                    'method'   => false,
+                    'double'   => false,
+                    'special'  => false,
+                ],
+            ],
+            'DoubleUnderscoreMethodNotInClass' => [
+                '/* testDoubleUnderscoreMethodNotInClass */',
+                [
+                    'function' => false,
+                    'method'   => false,
+                    'double'   => false,
+                    'special'  => false,
+                ],
+            ],
+            'MagicMethodInTrait' => [
+                '/* testMagicMethodInTrait */',
+                [
+                    'function' => false,
+                    'method'   => true,
+                    'double'   => false,
+                    'special'  => true,
+                ],
+            ],
+
+            'DoubleUnderscoreMethodInTrait' => [
+                '/* testDoubleUnderscoreMethodInTrait */',
+                [
+                    'function' => false,
+                    'method'   => false,
+                    'double'   => true,
+                    'special'  => true,
+                ],
+            ],
+            'MagicFunctionInTraitNotGloba' => [
+                '/* testMagicFunctionInTraitNotGlobal */',
+                [
+                    'function' => false,
+                    'method'   => false,
+                    'double'   => false,
+                    'special'  => false,
+                ],
+            ],
+            'MethodInTraitNotMagicName' => [
+                '/* testMethodInTraitNotMagicName */',
+                [
+                    'function' => false,
+                    'method'   => false,
+                    'double'   => false,
+                    'special'  => false,
+                ],
+            ],
+            'MagicMethodInInterface' => [
+                '/* testMagicMethodInInterface */',
+                [
+                    'function' => false,
+                    'method'   => true,
+                    'double'   => false,
+                    'special'  => true,
+                ],
+            ],
+
+            'DoubleUnderscoreMethodInInterface' => [
+                '/* testDoubleUnderscoreMethodInInterface */',
+                [
+                    'function' => false,
+                    'method'   => false,
+                    'double'   => true,
+                    'special'  => true,
+                ],
+            ],
+            'MagicFunctionInInterfaceNotGlobal' => [
+                '/* testMagicFunctionInInterfaceNotGlobal */',
+                [
+                    'function' => false,
+                    'method'   => false,
+                    'double'   => false,
+                    'special'  => false,
+                ],
+            ],
+            'MethodInInterfaceNotMagicName' => [
+                '/* testMethodInInterfaceNotMagicName */',
+                [
+                    'function' => false,
+                    'method'   => false,
+                    'double'   => false,
+                    'special'  => false,
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Add three new properties related to PHP reserved function names:
* `$magicFunctions`
* `$magicMethods`
* `$methodsDoubleUnderscore`

Also adds eight new utility methods using these properties, for convenience:
* `isMagicFunction()` - to check if the function declared on a `T_FUNCTION` token is a PHP magic function. Returns true/false.
* `isMagicFunctionName()` - to check if a given function name is the name of a PHP magic function. Returns true/false.
* `isMagicMethod()` - to check if the function declared on a `T_FUNCTION` token is a PHP magic method. Returns true/false.
* `isMagicMethodName()` - to check if a given function name is the name of a PHP magic method. Returns true/false.
* `isPHPDoubleUnderscoreMethod()` - to check if the function declared on a `T_FUNCTION` token is a PHP native double underscore method. Returns true/false.
* `isPHPDoubleUnderscoreMethodName()` - to check if a given function name is the name of a PHP native double underscore method. Returns true/false.
* `isSpecialMethod()` - to check if the function declared on a `T_FUNCTION` token is a PHP magic method or a PHP native double underscore method. Returns true/false.
* `isSpecialMethodName()` - to check if a given function name is the name of a PHP magic method or PHP native double underscore method. Returns true/false.

The `Name` methods only check a given name, the non-`Name` method also check if the function is a method or global function.

Includes dedicated unit tests for the new methods.