### PR TITLE
Variables::getMemberProperties(): various improvements

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -747,14 +747,7 @@ class BCFile
             }
         }
 
-        $valid = [
-            T_PUBLIC    => T_PUBLIC,
-            T_PRIVATE   => T_PRIVATE,
-            T_PROTECTED => T_PROTECTED,
-            T_STATIC    => T_STATIC,
-            T_VAR       => T_VAR,
-        ];
-
+        $valid  = Collections::$propertyModifierKeywords;
         $valid += Tokens::$emptyTokens;
 
         $scope          = 'public';
@@ -801,15 +794,6 @@ class BCFile
 
         if ($i < $stackPtr) {
             // We've found a type.
-            $valid = [
-                T_STRING       => T_STRING,
-                T_CALLABLE     => T_CALLABLE,
-                T_SELF         => T_SELF,
-                T_PARENT       => T_PARENT,
-                T_NS_SEPARATOR => T_NS_SEPARATOR,
-                T_ARRAY_HINT   => T_ARRAY_HINT, // Array property type declarations in PHPCS < 3.3.0.
-            ];
-
             for ($i; $i < $stackPtr; $i++) {
                 if ($tokens[$i]['code'] === T_VARIABLE) {
                     // Hit another variable in a group definition.
@@ -823,7 +807,7 @@ class BCFile
                     $nullableType = true;
                 }
 
-                if (isset($valid[$tokens[$i]['code']]) === true) {
+                if (isset(Collections::$propertyTypeTokens[$tokens[$i]['code']]) === true) {
                     $typeEndToken = $i;
                     if ($typeToken === false) {
                         $typeToken = $i;

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -687,6 +687,7 @@ class BCFile
      *                `\PHP_CodeSniffer\Exceptions\RuntimeException`.
      *
      * @see \PHP_CodeSniffer\Files\File::getMemberProperties() Original source.
+     * @see \PHPCSUtils\Utils\Variables::getMemberProperties() PHPCSUtils native improved version.
      *
      * @since 1.0.0
      *

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -130,6 +130,37 @@ class Collections
     ];
 
     /**
+     * Modifier keywords which can be used for a property declaration.
+     *
+     * @since 1.0.0
+     *
+     * @var array <int|string> => <int|string>
+     */
+    public static $propertyModifierKeywords = [
+        \T_PUBLIC    => \T_PUBLIC,
+        \T_PRIVATE   => \T_PRIVATE,
+        \T_PROTECTED => \T_PROTECTED,
+        \T_STATIC    => \T_STATIC,
+        \T_VAR       => \T_VAR,
+    ];
+
+    /**
+     * Token types which can be encountered in a property type declaration.
+     *
+     * @since 1.0.0
+     *
+     * @var array <int|string> => <int|string>
+     */
+    public static $propertyTypeTokens = [
+        \T_ARRAY_HINT   => \T_ARRAY_HINT, // PHPCS < 3.3.0.
+        \T_CALLABLE     => \T_CALLABLE,
+        \T_SELF         => \T_SELF,
+        \T_PARENT       => \T_PARENT,
+        \T_STRING       => \T_STRING,
+        \T_NS_SEPARATOR => \T_NS_SEPARATOR,
+    ];
+
+    /**
      * Token types which can be encountered in a return type declaration.
      *
      * @since 1.0.0

--- a/PHPCSUtils/Utils/Variables.php
+++ b/PHPCSUtils/Utils/Variables.php
@@ -48,6 +48,7 @@ class Variables
      * - Removed the parse error warning for properties in interfaces.
      *   This will now throw the same "$stackPtr is not a class member var" runtime exception as
      *   other non-property variables passed to the method.
+     * - Defensive coding against incorrect calls to this method.
      *
      * @see \PHP_CodeSniffer\Files\File::getMemberProperties()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getMemberProperties() Cross-version compatible version of the original.
@@ -68,7 +69,7 @@ class Variables
     {
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[$stackPtr]['code'] !== \T_VARIABLE) {
+        if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== \T_VARIABLE) {
             throw new RuntimeException('$stackPtr must be of type T_VARIABLE');
         }
 

--- a/PHPCSUtils/Utils/Variables.php
+++ b/PHPCSUtils/Utils/Variables.php
@@ -13,6 +13,7 @@ namespace PHPCSUtils\Utils;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Scopes;
 
 /**
@@ -77,15 +78,7 @@ class Variables
             throw new RuntimeException('$stackPtr is not a class member var');
         }
 
-        $valid = [
-            \T_PUBLIC    => \T_PUBLIC,
-            \T_PRIVATE   => \T_PRIVATE,
-            \T_PROTECTED => \T_PROTECTED,
-            \T_STATIC    => \T_STATIC,
-            \T_VAR       => \T_VAR,
-        ];
-
-        $valid += Tokens::$emptyTokens;
+        $valid = Collections::$propertyModifierKeywords + Tokens::$emptyTokens;
 
         $scope          = 'public';
         $scopeSpecified = false;
@@ -131,15 +124,6 @@ class Variables
 
         if ($i < $stackPtr) {
             // We've found a type.
-            $valid = [
-                \T_STRING       => \T_STRING,
-                \T_CALLABLE     => \T_CALLABLE,
-                \T_SELF         => \T_SELF,
-                \T_PARENT       => \T_PARENT,
-                \T_NS_SEPARATOR => \T_NS_SEPARATOR,
-                \T_ARRAY_HINT   => \T_ARRAY_HINT, // Array property type declarations in PHPCS < 3.3.0.
-            ];
-
             for ($i; $i < $stackPtr; $i++) {
                 if ($tokens[$i]['code'] === \T_VARIABLE) {
                     // Hit another variable in a group definition.
@@ -153,7 +137,7 @@ class Variables
                     $nullableType = true;
                 }
 
-                if (isset($valid[$tokens[$i]['code']]) === true) {
+                if (isset(Collections::$propertyTypeTokens[$tokens[$i]['code']]) === true) {
                     $typeEndToken = $i;
                     if ($typeToken === false) {
                         $typeToken = $i;

--- a/Tests/Utils/Variables/GetMemberPropertiesDiffTest.inc
+++ b/Tests/Utils/Variables/GetMemberPropertiesDiffTest.inc
@@ -1,0 +1,7 @@
+<?php
+
+interface Base
+{
+    /* testInterfaceProperty */
+    protected $anonymous;
+}

--- a/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
@@ -29,6 +29,18 @@ class GetMemberPropertiesDiffTest extends UtilityMethodTestCase
 {
 
     /**
+     * Test passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->expectPhpcsException('$stackPtr must be of type T_VARIABLE');
+
+        Variables::getMemberProperties(self::$phpcsFile, 10000);
+    }
+
+    /**
      * Test receiving an expected exception when an (invalid) interface property is passed.
      *
      * @return void

--- a/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Variables;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Variables;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Variables::getMemberProperties method.
+ *
+ * The tests in this class cover the differences between the PHPCS native method and the PHPCSUtils
+ * version. These tests would fail when using the BCFile `getMemberProperties()` method.
+ *
+ * @covers \PHPCSUtils\Utils\Variables::getMemberProperties
+ *
+ * @group variables
+ *
+ * @since 1.0.0
+ */
+class GetMemberPropertiesDiffTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test receiving an expected exception when an (invalid) interface property is passed.
+     *
+     * @return void
+     */
+    public function testNotClassPropertyException()
+    {
+        $this->expectPhpcsException('$stackPtr is not a class member var');
+
+        $variable = $this->getTargetToken('/* testInterfaceProperty */', \T_VARIABLE);
+        Variables::getMemberProperties(self::$phpcsFile, $variable);
+    }
+}

--- a/Tests/Utils/Variables/GetMemberPropertiesTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesTest.php
@@ -55,4 +55,29 @@ class GetMemberPropertiesTest extends BCFile_GetMemberPropertiesTest
         self::$caseFile = \dirname(\dirname(__DIR__)) . '/BackCompat/BCFile/GetMemberPropertiesTest.inc';
         parent::setUpTestFile();
     }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetMemberProperties()
+     *
+     * @return array
+     */
+    public function dataGetMemberProperties()
+    {
+        $data = parent::dataGetMemberProperties();
+
+        /*
+         * Remove the data set related to the invalid interface property.
+         * This will now throw an exception instead.
+         */
+        foreach ($data as $key => $value) {
+            if ($value[0] === '/* testInterfaceProperty */') {
+                unset($data[$key]);
+                break;
+            }
+        }
+
+        return $data;
+    }
 }


### PR DESCRIPTION
## Variables::getMemberProperties(): implement use of Scopes class and remove parse error warning

The parse error warning is the purpose of this method, so doesn't belong here.

As an "interface property" is not a valid property, just throw the `$stackPtr is not a class member var` exception instead.

Includes a separate set of unit tests for the changes.

These additional tests would fail when using the BCFile version of the method.

## Variables::getMemberProperties(): improve defensive coding

Includes unit test.

## Variables::getMemberProperties(): minor code reorganization

* Move the modifier keywords token array to a class property in the `PHPCSUtils\Tokens\Collections` class.
* Move the property type tokens array to a class property in the `PHPCSUtils\Tokens\Collections` class.