### PR TITLE
Utils\Variables: add new reserved name related utility methods

### DIFF
--- a/Tests/Utils/Variables/IsPHPReservedVarNameTest.php
+++ b/Tests/Utils/Variables/IsPHPReservedVarNameTest.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Variables;
+
+use PHPCSUtils\Utils\Variables;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Variables::isPHPReservedVarName() method.
+ *
+ * @covers \PHPCSUtils\Utils\Variables::isPHPReservedVarName
+ *
+ * @group variables
+ *
+ * @since 1.0.0
+ */
+class IsPHPReservedVarNameTest extends TestCase
+{
+
+    /**
+     * Test valid PHP reserved variable names.
+     *
+     * @dataProvider dataIsPHPReservedVarName
+     *
+     * @param string $name The variable name to test.
+     *
+     * @return void
+     */
+    public function testIsPHPReservedVarName($name)
+    {
+        $this->assertTrue(Variables::isPHPReservedVarName($name));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsPHPReservedVarName() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsPHPReservedVarName()
+    {
+        return [
+            // With dollar sign.
+            '$_SERVER'              => ['$_SERVER'],
+            '$_GET'                 => ['$_GET'],
+            '$_POST'                => ['$_POST'],
+            '$_REQUEST'             => ['$_REQUEST'],
+            '$_SESSION'             => ['$_SESSION'],
+            '$_ENV'                 => ['$_ENV'],
+            '$_COOKIE'              => ['$_COOKIE'],
+            '$_FILES'               => ['$_FILES'],
+            '$GLOBALS'              => ['$GLOBALS'],
+            '$http_response_header' => ['$http_response_header'],
+            '$argc'                 => ['$argc'],
+            '$argv'                 => ['$argv'],
+            '$php_errormsg'         => ['$php_errormsg'],
+            '$HTTP_SERVER_VARS'     => ['$HTTP_SERVER_VARS'],
+            '$HTTP_GET_VARS'        => ['$HTTP_GET_VARS'],
+            '$HTTP_POST_VARS'       => ['$HTTP_POST_VARS'],
+            '$HTTP_SESSION_VARS'    => ['$HTTP_SESSION_VARS'],
+            '$HTTP_ENV_VARS'        => ['$HTTP_ENV_VARS'],
+            '$HTTP_COOKIE_VARS'     => ['$HTTP_COOKIE_VARS'],
+            '$HTTP_POST_FILES'      => ['$HTTP_POST_FILES'],
+            '$HTTP_RAW_POST_DATA'   => ['$HTTP_RAW_POST_DATA'],
+
+            // Without dollar sign.
+            '_SERVER'               => ['_SERVER'],
+            '_GET'                  => ['_GET'],
+            '_POST'                 => ['_POST'],
+            '_REQUEST'              => ['_REQUEST'],
+            '_SESSION'              => ['_SESSION'],
+            '_ENV'                  => ['_ENV'],
+            '_COOKIE'               => ['_COOKIE'],
+            '_FILES'                => ['_FILES'],
+            'GLOBALS'               => ['GLOBALS'],
+            'http_response_header'  => ['http_response_header'],
+            'argc'                  => ['argc'],
+            'argv'                  => ['argv'],
+            'php_errormsg'          => ['php_errormsg'],
+            'HTTP_SERVER_VARS'      => ['HTTP_SERVER_VARS'],
+            'HTTP_GET_VARS'         => ['HTTP_GET_VARS'],
+            'HTTP_POST_VARS'        => ['HTTP_POST_VARS'],
+            'HTTP_SESSION_VARS'     => ['HTTP_SESSION_VARS'],
+            'HTTP_ENV_VARS'         => ['HTTP_ENV_VARS'],
+            'HTTP_COOKIE_VARS'      => ['HTTP_COOKIE_VARS'],
+            'HTTP_POST_FILES'       => ['HTTP_POST_FILES'],
+            'HTTP_RAW_POST_DATA'    => ['HTTP_RAW_POST_DATA'],
+        ];
+    }
+
+    /**
+     * Test non-reserved variable names.
+     *
+     * @dataProvider dataIsPHPReservedVarNameFalse
+     *
+     * @param string $name The variable name to test.
+     *
+     * @return void
+     */
+    public function testIsPHPReservedVarNameFalse($name)
+    {
+        $this->assertFalse(Variables::isPHPReservedVarName($name));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsPHPReservedVarNameFalse() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsPHPReservedVarNameFalse()
+    {
+        return [
+            // Different case.
+            'different-case-1'               => ['$_Server'],
+            'different-case-2'               => ['$_get'],
+            'different-case-3'               => ['$_pOST'],
+            'different-case-4'               => ['$HTTP_RESPONSE_HEADER'],
+            'different-case-5'               => ['_EnV'],
+            'different-case-6'               => ['PHP_errormsg'],
+
+            // Shouldn't be possible, but all the same: double dollar.
+            'double-dollar'                  => ['$$_REQUEST'],
+
+            // No underscore.
+            'missing-underscore-var'         => ['$SERVER'],
+            'missing-underscore-string'      => ['SERVER'],
+
+            // Double underscore.
+            'double-underscore-var'          => ['$__SERVER'],
+            'double-underscore-string'       => ['__SERVER'],
+
+            // Globals with underscore.
+            'globals-with-underscore-var'    => ['$_GLOBALS'],
+            'globals-with-underscore-string' => ['_GLOBALS'],
+
+            // Array key with quotes.
+            'array-key-with-quotes-1'        => ['"argc"'],
+            'array-key-with-quotes-2'        => ["'argv'"],
+
+            // Some completely different variable name.
+            'name-not-in-list'               => ['my_php_errormsg'],
+        ];
+    }
+}

--- a/Tests/Utils/Variables/IsSuperglobalTest.inc
+++ b/Tests/Utils/Variables/IsSuperglobalTest.inc
@@ -1,0 +1,41 @@
+<?php
+
+/* testNotAVariable */
+return $something;
+
+/* testNotAReservedVar */
+echo $something;
+
+/* testReservedVarNotSuperglobal */
+echo $php_errormsg;
+
+/* testReservedVarIsSuperglobal */
+echo $_GET['key'];
+
+/* testGLOBALSArrayKeyNotAReservedVar */
+echo $GLOBALS['key'];
+
+/* testGLOBALSArrayKeyVar */
+echo $GLOBALS[$something];
+
+/* testGLOBALSArrayKeyReservedVar */
+echo $GLOBALS[$php_errormsg];
+
+// Won't work, but not our concern.
+/* testGLOBALSArrayKeySuperglobal */
+echo $GLOBALS[$_COOKIE];
+
+/* testGLOBALSArrayKeyNotSingleString */
+echo $GLOBALS['key'.'more'];
+
+/* testGLOBALSArrayKeyInterpolatedVar */
+echo $GLOBALS["{$key}more"];
+
+/* testGLOBALSArrayKeySingleStringSuperglobal */
+echo $GLOBALS['_GET'];
+
+/* testGLOBALSArrayKeySuperglobalWithKey */
+echo $GLOBALS[$_GET['key']];
+
+/* testSuperglobalKeyNotGLOBALSArray */
+echo $not_globals['_GET'];

--- a/Tests/Utils/Variables/IsSuperglobalTest.php
+++ b/Tests/Utils/Variables/IsSuperglobalTest.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Variables;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Variables;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Variables::IsSuperglobal() and
+ * \PHPCSUtils\Utils\Variables::IsSuperglobalName() methods.
+ *
+ * @covers \PHPCSUtils\Utils\Variables::isSuperglobal
+ * @covers \PHPCSUtils\Utils\Variables::isSuperglobalName
+ *
+ * @group variables
+ *
+ * @since 1.0.0
+ */
+class IsSuperglobalTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $result = Variables::isSuperglobal(self::$phpcsFile, 10000);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test correctly detecting superglobal variables.
+     *
+     * @dataProvider dataIsSuperglobal
+     *
+     * @param string     $testMarker      The comment which prefaces the target token in the test file.
+     * @param bool       $expected        The expected function return value.
+     * @param int|string $testTargetType  Optional. The token type for the target token in the test file.
+     * @param string     $testTargetValue Optional. The token content for the target token in the test file.
+     *
+     * @return void
+     */
+    public function testIsSuperglobal($testMarker, $expected, $testTargetType = \T_VARIABLE, $testTargetValue = null)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, $testTargetType, $testTargetValue);
+        $result   = Variables::isSuperglobal(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsSuperglobal() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsSuperglobal()
+    {
+        return [
+            'not-a-variable' => [
+                '/* testNotAVariable */',
+                false,
+                \T_RETURN,
+            ],
+            'not-a-reserved-var' => [
+                '/* testNotAReservedVar */',
+                false,
+            ],
+            'reserved-var-not-superglobal' => [
+                '/* testReservedVarNotSuperglobal */',
+                false,
+            ],
+            'reserved-var-superglobal' => [
+                '/* testReservedVarIsSuperglobal */',
+                true,
+            ],
+            'array-key-not-a-reserved-var' => [
+                '/* testGLOBALSArrayKeyNotAReservedVar */',
+                false,
+                \T_CONSTANT_ENCAPSED_STRING,
+            ],
+            'array-key-variable' => [
+                '/* testGLOBALSArrayKeyVar */',
+                false,
+                \T_VARIABLE,
+                '$something',
+            ],
+            'array-key-reserved-var-not-superglobal' => [
+                '/* testGLOBALSArrayKeyReservedVar */',
+                false,
+                \T_VARIABLE,
+                '$php_errormsg',
+            ],
+            'array-key-var-superglobal' => [
+                '/* testGLOBALSArrayKeySuperglobal */',
+                true,
+                \T_VARIABLE,
+                '$_COOKIE',
+            ],
+            'array-key-not-single-string' => [
+                '/* testGLOBALSArrayKeyNotSingleString */',
+                false,
+                \T_CONSTANT_ENCAPSED_STRING,
+            ],
+            'array-key-interpolated-var' => [
+                '/* testGLOBALSArrayKeyInterpolatedVar */',
+                false,
+                \T_DOUBLE_QUOTED_STRING,
+            ],
+            'array-key-string-superglobal' => [
+                '/* testGLOBALSArrayKeySingleStringSuperglobal */',
+                true,
+                \T_CONSTANT_ENCAPSED_STRING,
+            ],
+            'array-key-var-superglobal-with-array-access' => [
+                '/* testGLOBALSArrayKeySuperglobalWithKey */',
+                true,
+                \T_VARIABLE,
+                '$_GET',
+            ],
+            'array-key-not-globals-array' => [
+                '/* testSuperglobalKeyNotGLOBALSArray */',
+                false,
+                \T_CONSTANT_ENCAPSED_STRING,
+            ],
+        ];
+    }
+
+    /**
+     * Test valid PHP superglobal names.
+     *
+     * @dataProvider dataIsSuperglobalName
+     *
+     * @param string $name The variable name to test.
+     *
+     * @return void
+     */
+    public function testIsSuperglobalName($name)
+    {
+        $this->assertTrue(Variables::isSuperglobalName($name));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsSuperglobalName() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsSuperglobalName()
+    {
+        return [
+            '$_SERVER'  => ['$_SERVER'],
+            '$_GET'     => ['$_GET'],
+            '$_POST'    => ['$_POST'],
+            '$_REQUEST' => ['$_REQUEST'],
+            '_SESSION'  => ['_SESSION'],
+            '_ENV'      => ['_ENV'],
+            '_COOKIE'   => ['_COOKIE'],
+            '_FILES'    => ['_FILES'],
+            'GLOBALS'   => ['GLOBALS'],
+        ];
+    }
+
+    /**
+     * Test non-superglobal variable names.
+     *
+     * @dataProvider dataIsSuperglobalNameFalse
+     *
+     * @param string $name The variable name to test.
+     *
+     * @return void
+     */
+    public function testIsSuperglobalNameFalse($name)
+    {
+        $this->assertFalse(Variables::isSuperglobalName($name));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsSuperglobalNameFalse() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsSuperglobalNameFalse()
+    {
+        return [
+            'non-reserved-var'                    => ['$not_a_superglobal'],
+            'php-reserved-var-not-superglobal-1'  => ['$http_response_header'],
+            'php-reserved-var-not-superglobal-2'  => ['$argc'],
+            'php-reserved-var-not-superglobal-3'  => ['$argv'],
+            'php-reserved-var-not-superglobal-4'  => ['$HTTP_RAW_POST_DATA'],
+            'php-reserved-var-not-superglobal-5'  => ['$php_errormsg'],
+            'php-reserved-var-not-superglobal-6'  => ['HTTP_SERVER_VARS'],
+            'php-reserved-var-not-superglobal-7'  => ['HTTP_GET_VARS'],
+            'php-reserved-var-not-superglobal-8'  => ['HTTP_POST_VARS'],
+            'php-reserved-var-not-superglobal-9'  => ['HTTP_SESSION_VARS'],
+            'php-reserved-var-not-superglobal-10' => ['HTTP_ENV_VARS'],
+            'php-reserved-var-not-superglobal-11' => ['HTTP_COOKIE_VARS'],
+            'php-reserved-var-not-superglobal-12' => ['HTTP_POST_FILES'],
+        ];
+    }
+}


### PR DESCRIPTION
Add a new property related to PHP reserved variables names:
* `$phpReservedVars`

Also adds three new utility methods using this property, for convenience:
* `isPHPReservedVarName()` - to check if a given variable name is the name of a PHP reserved variable. Returns true/false.
* `isSuperglobal()` - to check if a given variable or string array key token points to a PHP superglobal. Returns true/false.
* `isSuperglobalName()` - to check if a given variable name is the name of a PHP superglobal variable. Returns true/false.

When passing a `T_CONSTANT_ENCAPSED_STRING` array index token to the `Name` functions, the string quotes around the name should be stripped in advance.

**Note**: I have not currently added a `isPHPReservedVar()` method as a number of the reserved vars are created within a particular scope depending on the use of a function which creates them and that would need to be checked thoroughly if such a function would be implemented.

Includes dedicated unit tests for the new methods.