### PR TITLE
New Utils\UseStatements class

### DIFF
--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Utils;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\Utils\Conditions;
+use PHPCSUtils\Utils\Parentheses;
+
+/**
+ * Utility functions for examining use statements.
+ *
+ * @since 1.0.0
+ */
+class UseStatements
+{
+
+    /**
+     * Determine what a T_USE token is used for.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the T_USE token.
+     *
+     * @return string Either 'closure', 'import' or 'trait'.
+     *                An empty string will be returned if the token is used in an
+     *                invalid context or if it couldn't be reliably determined
+     *                what the T_USE token is used for.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
+     *                                                      T_USE token.
+     */
+    public static function getType(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]) === false
+            || $tokens[$stackPtr]['code'] !== \T_USE
+        ) {
+            throw new RuntimeException('$stackPtr must be of type T_USE');
+        }
+
+        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($next === false) {
+            // Live coding or parse error.
+            return '';
+        }
+
+        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($prev !== false && $tokens[$prev]['code'] === \T_CLOSE_PARENTHESIS
+            && Parentheses::isOwnerIn($phpcsFile, $prev, \T_CLOSURE) === true
+        ) {
+            return 'closure';
+        }
+
+        $lastCondition = Conditions::getLastCondition($phpcsFile, $stackPtr);
+        if ($lastCondition === false || $tokens[$lastCondition]['code'] === \T_NAMESPACE) {
+            // Global or scoped namespace and not a closure use statement.
+            return 'import';
+        }
+
+        $traitScopes = BCTokens::ooScopeTokens();
+        // Only classes and traits can import traits.
+        unset($traitScopes[\T_INTERFACE]);
+
+        if (isset($traitScopes[$tokens[$lastCondition]['code']]) === true) {
+            return 'trait';
+        }
+
+        return '';
+    }
+
+    /**
+     * Determine whether a T_USE token represents a closure use statement.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the T_USE token.
+     *
+     * @return bool True if the token passed is a closure use statement.
+     *              False if it's not.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
+     *                                                      T_USE token.
+     */
+    public static function isClosureUse(File $phpcsFile, $stackPtr)
+    {
+        return (self::getType($phpcsFile, $stackPtr) === 'closure');
+    }
+
+    /**
+     * Determine whether a T_USE token represents a class/function/constant import use statement.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the T_USE token.
+     *
+     * @return bool True if the token passed is an import use statement.
+     *              False if it's not.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
+     *                                                      T_USE token.
+     */
+    public static function isImportUse(File $phpcsFile, $stackPtr)
+    {
+        return (self::getType($phpcsFile, $stackPtr) === 'import');
+    }
+
+    /**
+     * Determine whether a T_USE token represents a trait use statement.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the T_USE token.
+     *
+     * @return bool True if the token passed is a trait use statement.
+     *              False if it's not.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
+     *                                                      T_USE token.
+     */
+    public static function isTraitUse(File $phpcsFile, $stackPtr)
+    {
+        return (self::getType($phpcsFile, $stackPtr) === 'trait');
+    }
+
+    /**
+     * Split an import use statement into individual imports.
+     *
+     * Handles single import, multi-import and group-import statements.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The position in the stack of the T_USE token.
+     *
+     * @return array A multi-level array containing information about the use statement.
+     *               The first level is 'name', 'function' and 'const'. These keys will always exist.
+     *               If any statements are found for any of these categories, the second level
+     *               will contain the alias/name as the key and the full original use name as the
+     *               value for each of the found imports or an empty array if no imports were found
+     *               in this use statement for this category.
+     *
+     *               For example, for this function group use statement:
+     *               `use function Vendor\Package\{LevelA\Name as Alias, LevelB\Another_Name}`
+     *               the return value would look like this:
+     *               `[
+     *                 'name'     => [],
+     *                 'function' => [
+     *                   'Alias'        => 'Vendor\Package\LevelA\Name',
+     *                   'Another_Name' => 'Vendor\Package\LevelB\Another_Name',
+     *                 ],
+     *                 'const'    => [],
+     *               ]`
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
+     *                                                      T_USE token or not an import use statement.
+     */
+    public static function splitImportUseStatement(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== \T_USE) {
+            throw new RuntimeException('$stackPtr must be of type T_USE');
+        }
+
+        if (self::isImportUse($phpcsFile, $stackPtr) === false) {
+            throw new RuntimeException('$stackPtr must be an import use statement');
+        }
+
+        $statements = [
+            'name'     => [],
+            'function' => [],
+            'const'    => [],
+        ];
+
+        $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
+        if ($endOfStatement === false) {
+            // Live coding or parse error.
+            return $statements;
+        }
+
+        $endOfStatement++;
+
+        $start     = true;
+        $useGroup  = false;
+        $hasAlias  = false;
+        $baseName  = '';
+        $name      = '';
+        $type      = '';
+        $fixedType = false;
+        $alias     = '';
+
+        for ($i = ($stackPtr + 1); $i < $endOfStatement; $i++) {
+            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+                continue;
+            }
+
+            switch ($tokens[$i]['code']) {
+                case \T_STRING:
+                    // Only when either at the start of the statement or at the start of a new sub within a group.
+                    if ($start === true && $fixedType === false) {
+                        $content = \strtolower($tokens[$i]['content']);
+                        if ($content === 'function'
+                            || $content === 'const'
+                        ) {
+                            $type  = $content;
+                            $start = false;
+                            if ($useGroup === false) {
+                                $fixedType = true;
+                            }
+
+                            break;
+                        } else {
+                            $type = 'name';
+                        }
+                    }
+
+                    $start = false;
+
+                    if ($hasAlias === false) {
+                        $name .= $tokens[$i]['content'];
+                    }
+
+                    $alias = $tokens[$i]['content'];
+                    break;
+
+                case \T_AS:
+                    $hasAlias = true;
+                    break;
+
+                case \T_OPEN_USE_GROUP:
+                    $start    = true;
+                    $useGroup = true;
+                    $baseName = $name;
+                    $name     = '';
+                    break;
+
+                case \T_SEMICOLON:
+                case \T_CLOSE_TAG:
+                case \T_CLOSE_USE_GROUP:
+                case \T_COMMA:
+                    if ($name !== '') {
+                        if ($useGroup === true) {
+                            $statements[$type][$alias] = $baseName . $name;
+                        } else {
+                            $statements[$type][$alias] = $name;
+                        }
+                    }
+
+                    if ($tokens[$i]['code'] !== \T_COMMA) {
+                        break 2;
+                    }
+
+                    // Reset.
+                    $start    = true;
+                    $name     = '';
+                    $hasAlias = false;
+                    if ($fixedType === false) {
+                        $type = '';
+                    }
+                    break;
+
+                case \T_NS_SEPARATOR:
+                    $name .= $tokens[$i]['content'];
+                    break;
+
+                // Fall back in case reserved keyword is (illegally) used in name.
+                // Parse error, but not our concern.
+                default:
+                    if ($hasAlias === false) {
+                        $name .= $tokens[$i]['content'];
+                    }
+
+                    $alias = $tokens[$i]['content'];
+                    break;
+            }
+        }
+
+        return $statements;
+    }
+}

--- a/Tests/Utils/UseStatements/SplitImportUseStatementTest.inc
+++ b/Tests/Utils/UseStatements/SplitImportUseStatementTest.inc
@@ -1,0 +1,97 @@
+<?php
+
+/* testClosureUse */
+$closure = function() use($bar) {};
+
+class Foo {
+    /* testTraitUse */
+    use MyNamespace\Bar;
+}
+
+/* testUsePlain */
+use MyNamespace\MyClass;
+
+/* testUsePlainAliased */
+use MyNamespace \ YourClass as ClassAlias;
+
+/* testUseMultipleWithComments */
+use Vendor\Foo\ClassA as ClassABC,
+   Vendor \ /*comment*/ Bar \ /*another comment */ InterfaceB,
+   // phpcs:ignore Standard.Category.Sniff -- for reasons.
+   Vendor\Baz\ClassC;
+
+/* testUseFunctionPlainEndsOnCloseTag */
+use function MyNamespace\myFunction ?>
+
+<?php
+
+/* testUseFunctionPlainAliased */
+use function Vendor\YourNamespace\yourFunction as FunctionAlias;
+
+/* testUseFunctionMultiple */
+use /* comment */ function foo\math\sin, foo\math\cos as FooCos, foo\math\cosh;
+
+/* testUseConstPlainUppercaseConstKeyword */
+use CONST MyNamespace\MY_CONST;
+
+/* testUseConstPlainAliased */
+use const MyNamespace\YOUR_CONST as CONST_ALIAS;
+
+/* testUseConstMultiple */
+use const foo\math\PI, foo\math\GOLDEN_RATIO as MATH_GOLDEN;
+
+/* testGroupUse */
+use some\namespacing\{
+    SomeClassA,
+    deeper\level\SomeClassB,
+    another\level\SomeClassC as C
+};
+
+/* testGroupUseFunctionTrailingComma */
+use function bar\math\{
+    Msin,
+    level\Mcos as BarCos,
+    Mcosh,
+};
+
+/* testGroupUseConst */
+use // phpcs:ignore Standard.Category
+    const
+        bar\math\{ BGAMMA as BAR_GAMMA, BGOLDEN_RATIO };
+
+// Mixed group use statement. Yes, this is allowed.
+/* testGroupUseMixed */
+use Some\NS\ {
+   ClassName,
+   function SubLevel\functionName,
+   const Constants\CONSTANT_NAME as SOME_CONSTANT,
+   function SubLevel\AnotherName,
+   AnotherLevel,
+};
+
+/* testUseFunctionPlainReservedKeyword */
+// Intentional parse error - use of reserved keyword in namespace.
+use function Vendor\YourNamespace\switch\yourFunction;
+
+/* testUseConstPlainReservedKeyword */
+// Intentional parse error - use of reserved keyword in namespace.
+use const Vendor\YourNamespace\function\yourConst;
+
+/* testUsePlainAliasReservedKeyword */
+// Intentional parse error - use of reserved keyword as alias.
+use Vendor\YourNamespace\ClassName as class;
+
+/* testUsePlainAliasReservedKeywordFunction */
+// Intentional parse error - use of reserved keyword as alias.
+use Vendor\{
+	YourNamespace\ClassName as function
+};
+
+/* testUsePlainAliasReservedKeywordConst */
+// Intentional parse error - use of reserved keyword as alias.
+use Vendor\YourNamespace\ClassName as const;
+
+// Intentional parse error. This has to be the last test in the file.
+/* testParseError */
+use MyNS\Level\{
+    Something,

--- a/Tests/Utils/UseStatements/SplitImportUseStatementTest.php
+++ b/Tests/Utils/UseStatements/SplitImportUseStatementTest.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\UseStatements;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\UseStatements;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\UseStatements::splitImportUseStatement() method.
+ *
+ * @covers \PHPCSUtils\Utils\UseStatements::splitImportUseStatement
+ *
+ * @group usestatements
+ *
+ * @since 1.0.0
+ */
+class SplitImportUseStatementTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->expectPhpcsException('$stackPtr must be of type T_USE');
+
+        UseStatements::splitImportUseStatement(self::$phpcsFile, 10000);
+    }
+
+    /**
+     * Test receiving an expected exception when a non-supported token is passed.
+     *
+     * @return void
+     */
+    public function testInvalidTokenPassed()
+    {
+        $this->expectPhpcsException('$stackPtr must be of type T_USE');
+
+        // 0 = PHP open tag.
+        UseStatements::splitImportUseStatement(self::$phpcsFile, 0);
+    }
+
+    /**
+     * Test receiving an expected exception when a non-import use statement token is passed.
+     *
+     * @dataProvider dataNonImportUseTokenPassed
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     *
+     * @return void
+     */
+    public function testNonImportUseTokenPassed($testMarker)
+    {
+        $this->expectPhpcsException('$stackPtr must be an import use statement');
+
+        $stackPtr = $this->getTargetToken($testMarker, \T_USE);
+        UseStatements::splitImportUseStatement(self::$phpcsFile, $stackPtr);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testSplitImportUseStatement() For the array format.
+     *
+     * @return array
+     */
+    public function dataNonImportUseTokenPassed()
+    {
+        return [
+            'closure-use' => ['/* testClosureUse */'],
+            'trait-use'   => ['/* testTraitUse */'],
+        ];
+    }
+
+    /**
+     * Test correctly splitting a T_USE statement into individual statements.
+     *
+     * @dataProvider dataSplitImportUseStatement
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   The expected return value of the function.
+     *
+     * @return void
+     */
+    public function testSplitImportUseStatement($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, \T_USE);
+        $result   = UseStatements::splitImportUseStatement(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testSplitImportUseStatement() For the array format.
+     *
+     * @return array
+     */
+    public function dataSplitImportUseStatement()
+    {
+        return [
+            'plain' => [
+                '/* testUsePlain */',
+                [
+                    'name'     => ['MyClass' => 'MyNamespace\MyClass'],
+                    'function' => [],
+                    'const'    => [],
+                ],
+            ],
+            'plain-aliased' => [
+                '/* testUsePlainAliased */',
+                [
+                    'name'     => ['ClassAlias' => 'MyNamespace\YourClass'],
+                    'function' => [],
+                    'const'    => [],
+                ],
+            ],
+            'multiple-with-comments' => [
+                '/* testUseMultipleWithComments */',
+                [
+                    'name'     => [
+                        'ClassABC'   => 'Vendor\Foo\ClassA',
+                        'InterfaceB' => 'Vendor\Bar\InterfaceB',
+                        'ClassC'     => 'Vendor\Baz\ClassC',
+                    ],
+                    'function' => [],
+                    'const'    => [],
+                ],
+            ],
+            'function-plain-ends-on-close-tag' => [
+                '/* testUseFunctionPlainEndsOnCloseTag */',
+                [
+                    'name'     => [],
+                    'function' => ['myFunction' => 'MyNamespace\myFunction'],
+                    'const'    => [],
+                ],
+            ],
+            'function-plain-aliased' => [
+                '/* testUseFunctionPlainAliased */',
+                [
+                    'name'     => [],
+                    'function' => ['FunctionAlias' => 'Vendor\YourNamespace\yourFunction'],
+                    'const'    => [],
+                ],
+            ],
+            'function-multiple' => [
+                '/* testUseFunctionMultiple */',
+                [
+                    'name'     => [],
+                    'function' => [
+                        'sin'    => 'foo\math\sin',
+                        'FooCos' => 'foo\math\cos',
+                        'cosh'   => 'foo\math\cosh',
+                    ],
+                    'const'    => [],
+                ],
+            ],
+            'const-plain-uppercase-const-keyword' => [
+                '/* testUseConstPlainUppercaseConstKeyword */',
+                [
+                    'name'     => [],
+                    'function' => [],
+                    'const'    => ['MY_CONST' => 'MyNamespace\MY_CONST'],
+                ],
+            ],
+            'const-plain-aliased' => [
+                '/* testUseConstPlainAliased */',
+                [
+                    'name'     => [],
+                    'function' => [],
+                    'const'    => ['CONST_ALIAS' => 'MyNamespace\YOUR_CONST'],
+                ],
+            ],
+            'const-multiple' => [
+                '/* testUseConstMultiple */',
+                [
+                    'name'     => [],
+                    'function' => [],
+                    'const'    => [
+                        'PI'          => 'foo\math\PI',
+                        'MATH_GOLDEN' => 'foo\math\GOLDEN_RATIO',
+                    ],
+                ],
+            ],
+            'group' => [
+                '/* testGroupUse */',
+                [
+                    'name'     => [
+                        'SomeClassA' => 'some\namespacing\SomeClassA',
+                        'SomeClassB' => 'some\namespacing\deeper\level\SomeClassB',
+                        'C'          => 'some\namespacing\another\level\SomeClassC',
+                    ],
+                    'function' => [],
+                    'const'    => [],
+                ],
+            ],
+            'group-function-trailing-comma' => [
+                '/* testGroupUseFunctionTrailingComma */',
+                [
+                    'name'     => [],
+                    'function' => [
+                        'Msin'   => 'bar\math\Msin',
+                        'BarCos' => 'bar\math\level\Mcos',
+                        'Mcosh'  => 'bar\math\Mcosh',
+                    ],
+                    'const'    => [],
+                ],
+            ],
+            'group-const' => [
+                '/* testGroupUseConst */',
+                [
+                    'name'     => [],
+                    'function' => [],
+                    'const'    => [
+                        'BAR_GAMMA'     => 'bar\math\BGAMMA',
+                        'BGOLDEN_RATIO' => 'bar\math\BGOLDEN_RATIO',
+                    ],
+                ],
+            ],
+            'group-mixed' => [
+                '/* testGroupUseMixed */',
+                [
+                    'name'     => [
+                        'ClassName'    => 'Some\NS\ClassName',
+                        'AnotherLevel' => 'Some\NS\AnotherLevel',
+                    ],
+                    'function' => [
+                        'functionName' => 'Some\NS\SubLevel\functionName',
+                        'AnotherName'  => 'Some\NS\SubLevel\AnotherName',
+                    ],
+                    'const'    => ['SOME_CONSTANT' => 'Some\NS\Constants\CONSTANT_NAME'],
+                ],
+            ],
+            'parse-error-function-plain-reserved-keyword' => [
+                '/* testUseFunctionPlainReservedKeyword */',
+                [
+                    'name'     => [],
+                    'function' => ['yourFunction' => 'Vendor\YourNamespace\switch\yourFunction'],
+                    'const'    => [],
+                ],
+            ],
+            'parse-error-const-plain-reserved-keyword' => [
+                '/* testUseConstPlainReservedKeyword */',
+                [
+                    'name'     => [],
+                    'function' => [],
+                    'const'    => ['yourConst' => 'Vendor\YourNamespace\function\yourConst'],
+                ],
+            ],
+            'parse-error-plain-alias-reserved-keyword' => [
+                '/* testUsePlainAliasReservedKeyword */',
+                [
+                    'name'     => ['class' => 'Vendor\YourNamespace\ClassName'],
+                    'function' => [],
+                    'const'    => [],
+                ],
+            ],
+            'parse-error-plain-alias-reserved-keyword-function' => [
+                '/* testUsePlainAliasReservedKeywordFunction */',
+                [
+                    'name'     => ['function' => 'Vendor\YourNamespace\ClassName'],
+                    'function' => [],
+                    'const'    => [],
+                ],
+            ],
+            'parse-error-plain-alias-reserved-keyword-const' => [
+                '/* testUsePlainAliasReservedKeywordConst */',
+                [
+                    'name'     => [],
+                    'function' => [],
+                    'const'    => [],
+                ],
+            ],
+            'parse-error' => [
+                '/* testParseError */',
+                [
+                    'name'     => [],
+                    'function' => [],
+                    'const'    => [],
+                ],
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/UseStatements/UseTypeTest.inc
+++ b/Tests/Utils/UseStatements/UseTypeTest.inc
@@ -1,0 +1,53 @@
+<?php
+
+/* testUseImport1 */
+use Imported\ClassName;
+
+/* testUseImport2 */
+use function Imported\functionName;
+
+/* testUseImport3 */
+use const Imported\CONSTANT_NAME;
+
+namespace Some\NS {
+    /* testUseImport4 */
+    use Imported\AnotherClass;
+}
+
+/* testClosureUse */
+$closure = function($param) use ($var) {};
+
+class ClassUsingTrait {
+    /* testUseTrait */
+    use SomeTrait;
+
+    public function functionName() {
+        /* testClosureUseNestedInClass */
+        $closure = function($param) use ($var) {};
+
+        $anon_class = new class($param) {
+            /* testUseTraitInNestedAnonClass */
+            use SomeOtherTrait;
+        };
+    }
+}
+
+trait TraitUsingTrait {
+    /* testUseTraitInTrait */
+    use SomeTrait;
+
+    public function functionName() {
+        /* testClosureUseNestedInTrait */
+        $closure = function($param) use ($var) {};
+    }
+}
+
+// Intentional parse error. Interfaces can not use traits.
+interface InterfaceUsingTrait {
+    /* testUseTraitInInterface */
+    use SomeTrait;
+}
+
+// Intentional parse error. Live coding. This has to be the last test in the file.
+/* testLiveCoding */
+use

--- a/Tests/Utils/UseStatements/UseTypeTest.php
+++ b/Tests/Utils/UseStatements/UseTypeTest.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\UseStatements;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\UseStatements;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\UseStatements::isImportUse(),
+ * \PHPCSUtils\Utils\UseStatements::isTraitUse(),
+ * \PHPCSUtils\Utils\UseStatements::isClosureUse()
+ * and \PHPCSUtils\Utils\UseStatements::getType() methods.
+ *
+ * @covers \PHPCSUtils\Utils\UseStatements::isTraitUse
+ * @covers \PHPCSUtils\Utils\UseStatements::isImportUse
+ * @covers \PHPCSUtils\Utils\UseStatements::isClosureUse
+ * @covers \PHPCSUtils\Utils\UseStatements::getType
+ *
+ * @group usestatements
+ *
+ * @since 1.0.0
+ */
+class UseTypeTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test receiving an expected exception when passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->expectPhpcsException('$stackPtr must be of type T_USE');
+
+        UseStatements::getType(self::$phpcsFile, 100000);
+    }
+
+    /**
+     * Test receiving an expected exception when passing a non T_USE token.
+     *
+     * @return void
+     */
+    public function testNonUseToken()
+    {
+        $this->expectPhpcsException('$stackPtr must be of type T_USE');
+
+        $result = UseStatements::getType(self::$phpcsFile, 0);
+    }
+
+    /**
+     * Test correctly identifying whether a T_USE token is used as a closure use statement.
+     *
+     * @dataProvider dataUseType
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   The expected return values for the various functions.
+     *
+     * @return void
+     */
+    public function testIsClosureUse($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, \T_USE);
+
+        $result = UseStatements::isClosureUse(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected['closure'], $result);
+    }
+
+    /**
+     * Test correctly identifying whether a T_USE token is used as an import use statement.
+     *
+     * @dataProvider dataUseType
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   The expected return values for the various functions.
+     *
+     * @return void
+     */
+    public function testIsImportUse($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, \T_USE);
+
+        $result = UseStatements::isImportUse(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected['import'], $result);
+    }
+
+    /**
+     * Test correctly identifying whether a T_USE token is used as a trait import use statement.
+     *
+     * @dataProvider dataUseType
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   The expected return values for the various functions.
+     *
+     * @return void
+     */
+    public function testIsTraitUse($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, \T_USE);
+
+        $result = UseStatements::isTraitUse(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected['trait'], $result, 'isTraitUseStatement() test failed');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsClosureUse() For the array format.
+     * @see testIsImportUse()  For the array format.
+     * @see testIsTraitUse()   For the array format.
+     *
+     * @return array
+     */
+    public function dataUseType()
+    {
+        return [
+            'import-1' => [
+                '/* testUseImport1 */',
+                [
+                    'closure' => false,
+                    'import'  => true,
+                    'trait'   => false,
+                ],
+            ],
+            'import-2' => [
+                '/* testUseImport2 */',
+                [
+                    'closure' => false,
+                    'import'  => true,
+                    'trait'   => false,
+                ],
+            ],
+            'import-3' => [
+                '/* testUseImport3 */',
+                [
+                    'closure' => false,
+                    'import'  => true,
+                    'trait'   => false,
+                ],
+            ],
+            'import-4' => [
+                '/* testUseImport4 */',
+                [
+                    'closure' => false,
+                    'import'  => true,
+                    'trait'   => false,
+                ],
+            ],
+            'closure' => [
+                '/* testClosureUse */',
+                [
+                    'closure' => true,
+                    'import'  => false,
+                    'trait'   => false,
+                ],
+            ],
+            'trait' => [
+                '/* testUseTrait */',
+                [
+                    'closure' => false,
+                    'import'  => false,
+                    'trait'   => true,
+                ],
+            ],
+            'closure-in-nested-class' => [
+                '/* testClosureUseNestedInClass */',
+                [
+                    'closure' => true,
+                    'import'  => false,
+                    'trait'   => false,
+                ],
+            ],
+            'trait-in-nested-anon-class' => [
+                '/* testUseTraitInNestedAnonClass */',
+                [
+                    'closure' => false,
+                    'import'  => false,
+                    'trait'   => true,
+                ],
+            ],
+            'trait-in-trait' => [
+                '/* testUseTraitInTrait */',
+                [
+                    'closure' => false,
+                    'import'  => false,
+                    'trait'   => true,
+                ],
+            ],
+            'closure-nested-in-trait' => [
+                '/* testClosureUseNestedInTrait */',
+                [
+                    'closure' => true,
+                    'import'  => false,
+                    'trait'   => false,
+                ],
+            ],
+            'trait-in-interface' => [
+                '/* testUseTraitInInterface */',
+                [
+                    'closure' => false,
+                    'import'  => false,
+                    'trait'   => false,
+                ],
+            ],
+            'live-coding' => [
+                '/* testLiveCoding */',
+                [
+                    'closure' => false,
+                    'import'  => false,
+                    'trait'   => false,
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## New Utils\UseStatements class

This introduces five new utility methods to PHPCSUtils.

Methods:
* `getType()` - to determine the type of statement a T_USE token is used for. Returns a string. Either `closure`, `import` or `trait` or an empty string when the type of statement for which it's used could not be determined.
* `isClosureUse()` - Wrapper method to check whether a T_USE token is a closure use statement. Returns boolean.
* `isImportUse()` - Wrapper method to check whether a T_USE token is a class/function/constant import use statement. Returns boolean.
* `isTraitUse()` - Wrapper method to check whether a T_USE token is a trait importing use statement. Returns boolean.
* `splitImportUseStatement()` - to split a multi-import or group-import use statement into information about the individual imports. Returns an array with information about all imports found in the use statement.
    Please refer to the function documentation for more detailed information.

Includes dedicated unit tests.

## UseStatements::splitImportUseStatement(): fix PHPCS cross-version compatibility

For this class to be compatible with PHPCS 2.6.0 - `master`, two work-arounds need to be added:
1. Prior to PHPCS 3.4.1 `function`/`const` in `use function`/`use const` tokenized as T_FUNCTION/T_CONST instead of T_STRING when there is a comment between the keywords.
2. When a `function` or `const` would be used as the alias - which is in fact a parse error as both are reserved keywords -, the semi-colon/use group close curly is tokenized as T_STRING instead of as the appropriate token.
    With certain code patterns, this is currently still the case.

The second case should be considered a total edge case and no guarantee is given that this is 100% sorted now.