### PR TITLE
New Utils\Namespaces class

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -59,6 +59,19 @@ class Collections
     ];
 
     /**
+     * List of tokens which can end a namespace declaration statement.
+     *
+     * @since 1.0.0
+     *
+     * @var array <int|string> => <int|string>
+     */
+    public static $namespaceDeclarationClosers = [
+        \T_SEMICOLON          => \T_SEMICOLON,
+        \T_OPEN_CURLY_BRACKET => \T_OPEN_CURLY_BRACKET,
+        \T_CLOSE_TAG          => \T_CLOSE_TAG,
+    ];
+
+    /**
      * OO structures which can use the `extends` keyword.
      *
      * @since 1.0.0

--- a/PHPCSUtils/Utils/Namespaces.php
+++ b/PHPCSUtils/Utils/Namespaces.php
@@ -263,6 +263,12 @@ class Namespaces
                 // Stop if we encounter a scoped namespace declaration as we already know we're not in one.
                 if (isset($tokens[$prev]['scope_condition']) === true
                     && $tokens[$tokens[$prev]['scope_condition']]['code'] === \T_NAMESPACE
+                    /*
+                     * BC: Work around a bug where curlies for variable variables received an incorrect
+                     * and irrelevant scope condition in PHPCS < 3.3.0.
+                     * {@link https://github.com/squizlabs/PHP_CodeSniffer/issues/1882}
+                     */
+                    && self::isDeclaration($phpcsFile, $tokens[$prev]['scope_condition']) === true
                 ) {
                     break;
                 }

--- a/PHPCSUtils/Utils/Namespaces.php
+++ b/PHPCSUtils/Utils/Namespaces.php
@@ -1,0 +1,346 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Utils;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Conditions;
+use PHPCSUtils\Utils\GetTokensAsString;
+use PHPCSUtils\Utils\Parentheses;
+
+/**
+ * Utility functions for use when examining T_NAMESPACE tokens and to determine the
+ * namespace of arbitrary tokens.
+ *
+ * @since 1.0.0
+ */
+class Namespaces
+{
+
+    /**
+     * Determine what a T_NAMESPACE token is used for.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the T_NAMESPACE token.
+     *
+     * @return string Either 'declaration', 'operator'.
+     *                An empty string will be returned if it couldn't be
+     *                reliably determined what the T_NAMESPACE token is used for,
+     *                which will normally mean the code contains a parse/fatal error.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is
+     *                                                      not a T_NAMESPACE token.
+     */
+    public static function getType(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== \T_NAMESPACE) {
+            throw new RuntimeException('$stackPtr must be of type T_NAMESPACE');
+        }
+
+        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($next === false) {
+            // Live coding or parse error.
+            return '';
+        }
+
+        if (empty($tokens[$stackPtr]['conditions']) === false
+            || empty($tokens[$stackPtr]['nested_parenthesis']) === false
+        ) {
+            /*
+             * Namespace declarations are only allowed at top level, so this can definitely not
+             * be a namespace declaration.
+             */
+            if ($tokens[$next]['code'] === \T_NS_SEPARATOR) {
+                return 'operator';
+            }
+
+            return '';
+        }
+
+        $start = BCFile::findStartOfStatement($phpcsFile, $stackPtr);
+        if ($start === $stackPtr
+            && ($tokens[$next]['code'] === \T_STRING
+               || $tokens[$next]['code'] === \T_OPEN_CURLY_BRACKET)
+        ) {
+            return 'declaration';
+        }
+
+        if ($start !== $stackPtr
+            && $tokens[$next]['code'] === \T_NS_SEPARATOR
+        ) {
+            return 'operator';
+        }
+
+        return '';
+    }
+
+    /**
+     * Determine whether a T_NAMESPACE token is the keyword for a namespace declaration.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of a T_NAMESPACE token.
+     *
+     * @return bool True if the token passed is the keyword for a namespace declaration.
+     *              False if not.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is
+     *                                                      not a T_NAMESPACE token.
+     */
+    public static function isDeclaration(File $phpcsFile, $stackPtr)
+    {
+        return (self::getType($phpcsFile, $stackPtr) === 'declaration');
+    }
+
+    /**
+     * Determine whether a T_NAMESPACE token is used as an operator.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of a T_NAMESPACE token.
+     *
+     * @return bool True if the token passed is used as an operator. False if not.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is
+     *                                                      not a T_NAMESPACE token.
+     */
+    public static function isOperator(File $phpcsFile, $stackPtr)
+    {
+        return (self::getType($phpcsFile, $stackPtr) === 'operator');
+    }
+
+    /**
+     * Get the complete namespace name as declared.
+     *
+     * For hierarchical namespaces, the name will be composed of several tokens,
+     * i.e. MyProject\Sub\Level which will be returned together as one string.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of a T_NAMESPACE token.
+     * @param bool                        $clean     Optional. Whether to get the name stripped
+     *                                               of potentially interlaced whitespace and/or
+     *                                               comments. Defaults to true.
+     *
+     * @return string|false The namespace name, or false if the specified position is not a
+     *                      T_NAMESPACE token, the token points to a namespace operator
+     *                      or when parse errors are encountered/during live coding.
+     *                      Note: The name can be an empty string for a valid global
+     *                      namespace declaration.
+     */
+    public static function getDeclaredName(File $phpcsFile, $stackPtr, $clean = true)
+    {
+        try {
+            if (self::isDeclaration($phpcsFile, $stackPtr) === false) {
+                // Not a namespace declaration.
+                return false;
+            }
+        } catch (RuntimeException $e) {
+            // Non-existent token or not a namespace keyword token.
+            return false;
+        }
+
+        $endOfStatement = $phpcsFile->findNext(Collections::$namespaceDeclarationClosers, ($stackPtr + 1));
+        if ($endOfStatement === false) {
+            // Live coding or parse error.
+            return false;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $next   = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), ($endOfStatement + 1), true);
+        if ($next === $endOfStatement) {
+            // Declaration of global namespace. I.e.: namespace {}.
+            // If not a scoped {} namespace declaration, no name/global declarations are invalid
+            // and result in parse errors, but that's not our concern.
+            return '';
+        }
+
+        if ($clean === false) {
+            return \trim(GetTokensAsString::origContent($phpcsFile, $next, ($endOfStatement - 1)));
+        }
+
+        return \trim(GetTokensAsString::noEmpties($phpcsFile, $next, ($endOfStatement - 1)));
+    }
+
+    /**
+     * Determine the namespace an arbitrary token lives in.
+     *
+     * Note: when a namespace declaration token or a token which is part of the namespace
+     * name is passed to this method, the result will be false as technically, they are not
+     * **within** a namespace.
+     *
+     * Note: this method has no opinion on whether the token passed is actually _subject_
+     * to namespacing.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The token for which to determine
+     *                                               the namespace.
+     *
+     * @return int|false Token pointer to the applicable namespace keyword or
+     *                   false if it couldn't be determined or no namespace applies.
+     */
+    public static function findNamespacePtr(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Check for the existence of the token.
+        if (isset($tokens[$stackPtr]) === false) {
+            return false;
+        }
+
+        // The namespace keyword in a namespace declaration is itself not namespaced.
+        if ($tokens[$stackPtr]['code'] === \T_NAMESPACE
+            && self::isDeclaration($phpcsFile, $stackPtr) === true
+        ) {
+            return false;
+        }
+
+        // Check for scoped namespace {}.
+        $namespacePtr = Conditions::getCondition($phpcsFile, $stackPtr, \T_NAMESPACE);
+        if ($namespacePtr !== false) {
+            return $namespacePtr;
+        }
+
+        /*
+         * Not in a scoped namespace, so let's see if we can find a non-scoped namespace instead.
+         * Keeping in mind that:
+         * - there can be multiple non-scoped namespaces in a file (bad practice, but is allowed);
+         * - the namespace keyword can also be used as an operator;
+         * - a non-named namespace resolves to the global namespace;
+         * - and that namespace declarations can't be nested in anything, so we can skip over any
+         *   nesting structures.
+         */
+
+        // Start by breaking out of any scoped structures this token is in.
+        $prev           = $stackPtr;
+        $firstCondition = Conditions::getFirstCondition($phpcsFile, $stackPtr);
+        if ($firstCondition !== false) {
+            $prev = $firstCondition;
+        }
+
+        // And break out of any surrounding parentheses as well.
+        $firstParensOpener = Parentheses::getFirstOpener($phpcsFile, $prev);
+        if ($firstParensOpener !== false) {
+            $prev = $firstParensOpener;
+        }
+
+        $find = [
+            \T_NAMESPACE,
+            \T_CLOSE_CURLY_BRACKET,
+            \T_CLOSE_PARENTHESIS,
+            \T_CLOSE_SHORT_ARRAY,
+            \T_CLOSE_SQUARE_BRACKET,
+            \T_DOC_COMMENT_CLOSE_TAG,
+        ];
+
+        do {
+            $prev = $phpcsFile->findPrevious($find, ($prev - 1));
+            if ($prev === false) {
+                break;
+            }
+
+            if ($tokens[$prev]['code'] === \T_CLOSE_CURLY_BRACKET) {
+                // Stop if we encounter a scoped namespace declaration as we already know we're not in one.
+                if (isset($tokens[$prev]['scope_condition']) === true
+                    && $tokens[$tokens[$prev]['scope_condition']]['code'] === \T_NAMESPACE
+                ) {
+                    break;
+                }
+
+                // Skip over other scoped structures for efficiency.
+                if (isset($tokens[$prev]['scope_condition']) === true) {
+                    $prev = $tokens[$prev]['scope_condition'];
+                } elseif (isset($tokens[$prev]['scope_opener']) === true) {
+                    $prev = $tokens[$prev]['scope_opener'];
+                }
+
+                continue;
+            }
+
+            // Skip over other nesting structures for efficiency.
+            if (isset($tokens[$prev]['bracket_opener']) === true) {
+                $prev = $tokens[$prev]['bracket_opener'];
+                continue;
+            }
+
+            if (isset($tokens[$prev]['parenthesis_owner']) === true) {
+                $prev = $tokens[$prev]['parenthesis_owner'];
+                continue;
+            } elseif (isset($tokens[$prev]['parenthesis_opener']) === true) {
+                $prev = $tokens[$prev]['parenthesis_opener'];
+                continue;
+            }
+
+            // Skip over potentially large docblocks.
+            if (isset($tokens[$prev]['comment_opener'])) {
+                $prev = $tokens[$prev]['comment_opener'];
+                continue;
+            }
+
+            // So this is a namespace keyword, check if it's a declaration.
+            if ($tokens[$prev]['code'] === \T_NAMESPACE
+                && self::isDeclaration($phpcsFile, $prev) === true
+            ) {
+                // Now make sure the token was not part of the declaration.
+                $endOfStatement = $phpcsFile->findNext(Collections::$namespaceDeclarationClosers, ($prev + 1));
+                if ($endOfStatement > $stackPtr) {
+                    return false;
+                }
+
+                return $prev;
+            }
+        } while (true);
+
+        return false;
+    }
+
+    /**
+     * Determine the namespace name an arbitrary token lives in.
+     *
+     * Note: this method has no opinion on whether the token passed is actually _subject_
+     * to namespacing.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The token for which to determine
+     *                                               the namespace.
+     *
+     * @return string Namespace name or empty string if it couldn't be determined
+     *                or no namespace applies.
+     */
+    public static function determineNamespace(File $phpcsFile, $stackPtr)
+    {
+        $namespacePtr = self::findNamespacePtr($phpcsFile, $stackPtr);
+        if ($namespacePtr === false) {
+            return '';
+        }
+
+        $namespace = self::getDeclaredName($phpcsFile, $namespacePtr);
+        if ($namespace !== false) {
+            return $namespace;
+        }
+
+        return '';
+    }
+}

--- a/Tests/Utils/Namespaces/DetermineNamespaceTest.inc
+++ b/Tests/Utils/Namespaces/DetermineNamespaceTest.inc
@@ -1,0 +1,126 @@
+<?php
+
+/* Global namespace */
+echo namespace\func();
+
+echo ( 'arbitrary parentheses' . ' to skip over' );
+
+/* testNoNamespace */
+echo 0;
+
+class Foo {
+    function test() {
+        /* testNoNamespaceNested */
+        echo 0;
+    }
+}
+
+
+/* Non-scoped named namespace 1 */
+namespace Vendor\Package\Baz;
+
+echo namespace\func();
+
+$var = array_map(
+    function () {
+        /* testNonScopedNamedNamespace1 */
+        echo 0;
+    },
+    $array
+);
+
+$array = [ /*long array */ ];
+
+if (true) {
+    // Control structure to skip over.
+}
+
+class Foo {
+    function test() {
+        /* testNonScopedNamedNamespace1Nested */
+        echo 0;
+    }
+}
+
+
+/* Scoped global namespace */
+namespace {
+    echo namespace\func();
+
+    /* testGlobalNamespaceScoped */
+    echo 0;
+
+    class Bar {
+        function test() {
+            /* testGlobalNamespaceScopedNested */
+            echo 0;
+        }
+    }
+}
+
+echo namespace\fn();
+
+/* testNoNamespaceAfterUnnamedScoped */
+echo 0;
+
+$array = array( /*long array to skip over */ );
+
+class Baz {
+    function test() {
+        /* testNoNamespaceNestedAfterUnnamedScoped */
+        echo 0;
+    }
+}
+
+
+/* Scoped named namespace */
+namespace Vendor\Package\Foo {
+    echo namespace\func();
+
+    /* testNamedNamespaceScoped */
+    echo 0;
+
+    class ABC {
+        function test() {
+            /* testNamedNamespaceScopedNested */
+            echo 0;
+        }
+    }
+}
+
+echo namespace\fn();
+
+/* testNoNamespaceAfterNamedScoped */
+echo 0;
+
+class Baz {
+    function test() {
+        /* testNoNamespaceNestedAfterNamedScoped */
+        echo 0;
+    }
+}
+
+
+/* Non-scoped named namespace 2 */
+namespace Vendor\Package\Foz;
+
+echo namespace\func();
+
+echo ${$string};
+
+/* testNonScopedNamedNamespace2 */
+echo 0;
+
+/**
+ * Docblock to skip over.
+ */
+class Foo {
+    function test() {
+        /* testNonScopedNamedNamespace2Nested */
+        echo 0;
+    }
+}
+
+// Intentional parse error. This has to be the last test in the file.
+/* testParseError */
+namespace MyNS\ /* comment */

--- a/Tests/Utils/Namespaces/DetermineNamespaceTest.php
+++ b/Tests/Utils/Namespaces/DetermineNamespaceTest.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Namespaces;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Namespaces;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Namespaces::findNamespacePtr() and
+ * \PHPCSUtils\Utils\Namespaces::determineNamespace() methods.
+ *
+ * @covers \PHPCSUtils\Utils\Namespaces::findNamespacePtr
+ * @covers \PHPCSUtils\Utils\Namespaces::determineNamespace
+ *
+ * @group namespaces
+ *
+ * @since 1.0.0
+ */
+class DetermineNamespaceTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test that false is returned when an invalid token is passed.
+     *
+     * @return void
+     */
+    public function testInvalidTokenPassed()
+    {
+        $this->assertFalse(Namespaces::findNamespacePtr(self::$phpcsFile, 100000));
+    }
+
+    /**
+     * Test finding the correct namespace token for an arbitrary token in a file.
+     *
+     * @dataProvider dataDetermineNamespace
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   The expected output for the functions.
+     *
+     * @return void
+     */
+    public function testFindNamespacePtr($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, \T_ECHO);
+
+        if ($expected['ptr'] !== false) {
+            $expected['ptr'] = $this->getTargetToken($expected['ptr'], \T_NAMESPACE);
+        }
+
+        $result = Namespaces::findNamespacePtr(self::$phpcsFile, $stackPtr);
+
+        $this->assertSame($expected['ptr'], $result);
+    }
+
+    /**
+     * Test retrieving the applicable namespace name for an arbitrary token in a file.
+     *
+     * @dataProvider dataDetermineNamespace
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   The expected output for the functions.
+     *
+     * @return void
+     */
+    public function testDetermineNamespace($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, \T_ECHO);
+        $result   = Namespaces::determineNamespace(self::$phpcsFile, $stackPtr);
+
+        $this->assertSame($expected['name'], $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testDetermineNamespace() For the array format.
+     *
+     * @return array
+     */
+    public function dataDetermineNamespace()
+    {
+        return [
+            'no-namespace' => [
+                '/* testNoNamespace */',
+                [
+                    'ptr'  => false,
+                    'name' => '',
+                ],
+            ],
+            'no-namespace-nested' => [
+                '/* testNoNamespaceNested */',
+                [
+                    'ptr'  => false,
+                    'name' => '',
+                ],
+            ],
+            'non-scoped-namespace-1' => [
+                '/* testNonScopedNamedNamespace1 */',
+                [
+                    'ptr'  => '/* Non-scoped named namespace 1 */',
+                    'name' => 'Vendor\Package\Baz',
+                ],
+            ],
+            'non-scoped-namespace-1-nested' => [
+                '/* testNonScopedNamedNamespace1Nested */',
+                [
+                    'ptr'  => '/* Non-scoped named namespace 1 */',
+                    'name' => 'Vendor\Package\Baz',
+                ],
+            ],
+            'global-namespace-scoped' => [
+                '/* testGlobalNamespaceScoped */',
+                [
+                    'ptr'  => '/* Scoped global namespace */',
+                    'name' => '',
+                ],
+            ],
+            'global-namespace-scoped-nested' => [
+                '/* testGlobalNamespaceScopedNested */',
+                [
+                    'ptr'  => '/* Scoped global namespace */',
+                    'name' => '',
+                ],
+            ],
+            'no-namespace-after-unnamed-scoped' => [
+                '/* testNoNamespaceAfterUnnamedScoped */',
+                [
+                    'ptr'  => false,
+                    'name' => '',
+                ],
+            ],
+            'no-namespace-nested-after-unnamed-scoped' => [
+                '/* testNoNamespaceNestedAfterUnnamedScoped */',
+                [
+                    'ptr'  => false,
+                    'name' => '',
+                ],
+            ],
+            'named-namespace-scoped' => [
+                '/* testNamedNamespaceScoped */',
+                [
+                    'ptr'  => '/* Scoped named namespace */',
+                    'name' => 'Vendor\Package\Foo',
+                ],
+            ],
+            'named-namespace-scoped-nested' => [
+                '/* testNamedNamespaceScopedNested */',
+                [
+                    'ptr'  => '/* Scoped named namespace */',
+                    'name' => 'Vendor\Package\Foo',
+                ],
+            ],
+            'no-namespace-after-named-scoped' => [
+                '/* testNoNamespaceAfterNamedScoped */',
+                [
+                    'ptr'  => false,
+                    'name' => '',
+                ],
+            ],
+            'no-namespace-nested-after-named-scoped' => [
+                '/* testNoNamespaceNestedAfterNamedScoped */',
+                [
+                    'ptr'  => false,
+                    'name' => '',
+                ],
+            ],
+            'non-scoped-namespace-2' => [
+                '/* testNonScopedNamedNamespace2 */',
+                [
+                    'ptr'  => '/* Non-scoped named namespace 2 */',
+                    'name' => 'Vendor\Package\Foz',
+                ],
+            ],
+            'non-scoped-namespace-2-nested' => [
+                '/* testNonScopedNamedNamespace2Nested */',
+                [
+                    'ptr'  => '/* Non-scoped named namespace 2 */',
+                    'name' => 'Vendor\Package\Foz',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test that the namespace declaration itself is not regarded as being namespaced.
+     *
+     * @return void
+     */
+    public function testNamespaceDeclarationIsNotNamespaced()
+    {
+        $stackPtr = $this->getTargetToken('/* Non-scoped named namespace 2 */', \T_NAMESPACE);
+        $result   = Namespaces::findNamespacePtr(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result, 'Failed checking that namespace declaration token is not regarded as namespaced');
+
+        $stackPtr = $this->getTargetToken('/* Non-scoped named namespace 2 */', \T_STRING, 'Package');
+        $result   = Namespaces::findNamespacePtr(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result, 'Failed checking that a token in the namespace name is not regarded as namespaced');
+    }
+
+    /**
+     * Test returning an empty string if the namespace could not be determined (parse error).
+     *
+     * @return void
+     */
+    public function testFallbackToEmptyString()
+    {
+        $stackPtr = $this->getTargetToken('/* testParseError */', \T_COMMENT, '/* comment */');
+
+        $expected = $this->getTargetToken('/* testParseError */', \T_NAMESPACE);
+        $result   = Namespaces::findNamespacePtr(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result, 'Failed test with findNamespacePtr');
+
+        $result = Namespaces::determineNamespace(self::$phpcsFile, $stackPtr, false);
+        $this->assertSame('', $result, 'Failed test with determineNamespace');
+    }
+}

--- a/Tests/Utils/Namespaces/GetDeclaredNameTest.inc
+++ b/Tests/Utils/Namespaces/GetDeclaredNameTest.inc
@@ -1,0 +1,49 @@
+<?php
+
+/* testGlobalNamespaceCurlies */
+namespace {}
+
+/* testNamespaceSemiColon */
+namespace Vendor;
+
+/* testNamespaceCurlies */
+namespace Vendor\Package\Sublevel\End {}
+
+/* testNamespaceCurliesNoSpaceAtEnd */
+namespace Vendor\Package\Sublevel\Deeperlevel\End{}
+
+/* testNamespaceCloseTag */
+namespace My\Name ?>
+<?php
+
+/* testNamespaceCloseTagNoSpaceAtEnd */
+namespace My\Other\Name?>
+<?php
+
+/* testNamespaceLotsOfWhitespace */
+namespace          Vendor \
+    Package\
+        Sub		\
+            Deeperlevel\
+                End             ;
+
+/* testNamespaceWithCommentsWhitespaceAndAnnotations */
+namespace /*comment*/ Vendor\/*comment*/
+    Package\Sublevel  \ //phpcs:ignore Standard.Category.Sniff -- for reasons.
+            Deeper\ // Another comment
+                End             ;
+
+/* testNamespaceOperator */
+$a = namespace\functionName();
+
+/* testParseErrorReservedKeywords */
+// Intentional parse error. Reserved word used in namespace, but not our concern.
+namespace Vendor\while\Package\protected\name\try\this ;
+
+/* testParseErrorSemiColon */
+// Intentional parse error.
+namespace;
+
+// Intentional parse error. This has to be the last test in the file.
+/* testLiveCoding */
+namespace Vendor\

--- a/Tests/Utils/Namespaces/GetDeclaredNameTest.php
+++ b/Tests/Utils/Namespaces/GetDeclaredNameTest.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Namespaces;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Namespaces;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Namespaces::getDeclaredName() method.
+ *
+ * @covers \PHPCSUtils\Utils\Namespaces::getDeclaredName
+ *
+ * @group namespaces
+ *
+ * @since 1.0.0
+ */
+class GetDeclaredNameTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test that false is returned when an invalid token is passed.
+     *
+     * @return void
+     */
+    public function testInvalidTokenPassed()
+    {
+        // Non-existent token.
+        $this->assertFalse(Namespaces::getDeclaredName(self::$phpcsFile, 100000), 'Failed with non-existent token');
+
+        // Non namespace token.
+        $this->assertFalse(Namespaces::getDeclaredName(self::$phpcsFile, 0), 'Failed with non-namespace token');
+    }
+
+    /**
+     * Test retrieving the cleaned up namespace name based on a T_NAMESPACE token.
+     *
+     * @dataProvider dataGetDeclaredName
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   The expected output for the function.
+     *
+     * @return void
+     */
+    public function testGetDeclaredNameClean($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, \T_NAMESPACE);
+        $result   = Namespaces::getDeclaredName(self::$phpcsFile, $stackPtr, true);
+
+        $this->assertSame($expected['clean'], $result);
+    }
+
+    /**
+     * Test retrieving the "dirty" namespace name based on a T_NAMESPACE token.
+     *
+     * @dataProvider dataGetDeclaredName
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   The expected output for the function.
+     *
+     * @return void
+     */
+    public function testGetDeclaredNameDirty($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, \T_NAMESPACE);
+        $result   = Namespaces::getDeclaredName(self::$phpcsFile, $stackPtr, false);
+
+        $this->assertSame($expected['dirty'], $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetDeclaredName() For the array format.
+     *
+     * @return array
+     */
+    public function dataGetDeclaredName()
+    {
+        return [
+            'global-namespace-curlies' => [
+                '/* testGlobalNamespaceCurlies */',
+                [
+                    'clean' => '',
+                    'dirty' => '',
+                ],
+            ],
+            'namespace-semicolon' => [
+                '/* testNamespaceSemiColon */',
+                [
+                    'clean' => 'Vendor',
+                    'dirty' => 'Vendor',
+                ],
+            ],
+            'namespace-curlies' => [
+                '/* testNamespaceCurlies */',
+                [
+                    'clean' => 'Vendor\Package\Sublevel\End',
+                    'dirty' => 'Vendor\Package\Sublevel\End',
+                ],
+            ],
+            'namespace-curlies-no-space-at-end' => [
+                '/* testNamespaceCurliesNoSpaceAtEnd */',
+                [
+                    'clean' => 'Vendor\Package\Sublevel\Deeperlevel\End',
+                    'dirty' => 'Vendor\Package\Sublevel\Deeperlevel\End',
+                ],
+            ],
+            'namespace-close-tag' => [
+                '/* testNamespaceCloseTag */',
+                [
+                    'clean' => 'My\Name',
+                    'dirty' => 'My\Name',
+                ],
+            ],
+            'namespace-close-tag-no-space-at-end' => [
+                '/* testNamespaceCloseTagNoSpaceAtEnd */',
+                [
+                    'clean' => 'My\Other\Name',
+                    'dirty' => 'My\Other\Name',
+                ],
+            ],
+            'namespace-whitespace-tolerance' => [
+                '/* testNamespaceLotsOfWhitespace */',
+                [
+                    'clean' => 'Vendor\Package\Sub\Deeperlevel\End',
+                    'dirty' => 'Vendor \
+    Package\
+        Sub		\
+            Deeperlevel\
+                End',
+                ],
+            ],
+            'namespace-with-comments-and-annotations' => [
+                '/* testNamespaceWithCommentsWhitespaceAndAnnotations */',
+                [
+                    'clean' => 'Vendor\Package\Sublevel\Deeper\End',
+                    'dirty' => 'Vendor\/*comment*/
+    Package\Sublevel  \ //phpcs:ignore Standard.Category.Sniff -- for reasons.
+            Deeper\ // Another comment
+                End',
+                ],
+            ],
+            'namespace-operator' => [
+                '/* testNamespaceOperator */',
+                [
+                    'clean' => false,
+                    'dirty' => false,
+                ],
+            ],
+            'parse-error-reserved-keywords' => [
+                '/* testParseErrorReservedKeywords */',
+                [
+                    'clean' => 'Vendor\while\Package\protected\name\try\this',
+                    'dirty' => 'Vendor\while\Package\protected\name\try\this',
+                ],
+            ],
+            'parse-error-semicolon' => [
+                '/* testParseErrorSemiColon */',
+                [
+                    'clean' => false,
+                    'dirty' => false,
+                ],
+            ],
+            'live-coding' => [
+                '/* testLiveCoding */',
+                [
+                    'clean' => false,
+                    'dirty' => false,
+                ],
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/Namespaces/NamespaceTypeTest.inc
+++ b/Tests/Utils/Namespaces/NamespaceTypeTest.inc
@@ -1,0 +1,57 @@
+<?php
+
+/* testNamespaceDeclaration */
+namespace MyNamespace;
+
+/* testNamespaceDeclarationWithComment */
+namespace /*comment*/ My\Other\Namespace;
+
+/* testNamespaceDeclarationScoped */
+namespace {
+}
+
+/* testNamespaceOperator */
+$a = namespace\functionCall();
+
+/* testNamespaceOperatorWithAnnotation */
+$a = namespace
+     // phpcs:ignore Standard.Category.SniffName -- for reasons.
+     \functionCall();
+
+/* testNamespaceOperatorInConditional */
+if ( $a === $b ) {
+    echo namespace\CONSTANT_NAME;
+}
+
+/* testNamespaceOperatorInClosedScope */
+function closedScope() {
+    echo namespace\ClassName::method();
+
+    while( true ) {
+		/* testNamespaceOperatorInParentheses */
+	    function_call( namespace\ClassName::$property );
+	}
+}
+
+/* testParseErrorScopedNamespaceDeclaration */
+function testScope() {
+    namespace My\Namespace;
+}
+
+/* testParseErrorConditionalNamespace */
+if ( $a === $b ) {
+    namespace MyName\space;
+}
+
+/* testFatalErrorDeclarationLeadingSlash */
+namespace \MyNamespace;
+
+/* testParseErrorDoubleColon */
+$a = namespace::Something();
+
+/* testParseErrorSemiColon */
+namespace;
+
+// Intentional parse error. This has to be the last test in the file.
+/* testLiveCoding */
+namespace

--- a/Tests/Utils/Namespaces/NamespaceTypeTest.php
+++ b/Tests/Utils/Namespaces/NamespaceTypeTest.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Namespaces;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Namespaces;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Namespaces::isDeclaration(),
+ * \PHPCSUtils\Utils\Namespaces::isOperator() and the.
+ * \PHPCSUtils\Utils\Namespaces::getType() methods.
+ *
+ * @covers \PHPCSUtils\Utils\Namespaces::isDeclaration
+ * @covers \PHPCSUtils\Utils\Namespaces::isOperator
+ * @covers \PHPCSUtils\Utils\Namespaces::getType
+ *
+ * @group namespaces
+ *
+ * @since 1.0.0
+ */
+class NamespaceTypeTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test receiving an expected exception when passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->expectPhpcsException('$stackPtr must be of type T_NAMESPACE');
+
+        Namespaces::getType(self::$phpcsFile, 100000);
+    }
+
+    /**
+     * Test receiving an expected exception when passing a non T_NAMESPACE token.
+     *
+     * @return void
+     */
+    public function testNonNamespaceToken()
+    {
+        $this->expectPhpcsException('$stackPtr must be of type T_NAMESPACE');
+
+        Namespaces::getType(self::$phpcsFile, 0);
+    }
+
+    /**
+     * Test whether a T_NAMESPACE token is used as the keyword for a namespace declaration.
+     *
+     * @dataProvider dataNamespaceType
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   The expected output for the functions.
+     *
+     * @return void
+     */
+    public function testIsDeclaration($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, \T_NAMESPACE);
+        $result   = Namespaces::isDeclaration(self::$phpcsFile, $stackPtr);
+
+        $this->assertSame($expected['declaration'], $result);
+    }
+
+    /**
+     * Test whether a T_NAMESPACE token is used as an operator.
+     *
+     * @dataProvider dataNamespaceType
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   The expected output for the functions.
+     *
+     * @return void
+     */
+    public function testIsOperator($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, \T_NAMESPACE);
+        $result   = Namespaces::isOperator(self::$phpcsFile, $stackPtr);
+
+        $this->assertSame($expected['operator'], $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsDeclaration() For the array format.
+     * @see testIsOperator()    For the array format.
+     *
+     * @return array
+     */
+    public function dataNamespaceType()
+    {
+        return [
+            'namespace-declaration' => [
+                '/* testNamespaceDeclaration */',
+                [
+                    'declaration' => true,
+                    'operator'    => false,
+                ],
+            ],
+            'namespace-declaration-with-comment' => [
+                '/* testNamespaceDeclarationWithComment */',
+                [
+                    'declaration' => true,
+                    'operator'    => false,
+                ],
+            ],
+            'namespace-declaration-scoped' => [
+                '/* testNamespaceDeclarationScoped */',
+                [
+                    'declaration' => true,
+                    'operator'    => false,
+                ],
+            ],
+            'namespace-operator' => [
+                '/* testNamespaceOperator */',
+                [
+                    'declaration' => false,
+                    'operator'    => true,
+                ],
+            ],
+            'namespace-operator-with-annotation' => [
+                '/* testNamespaceOperatorWithAnnotation */',
+                [
+                    'declaration' => false,
+                    'operator'    => true,
+                ],
+            ],
+            'namespace-operator-in-conditional' => [
+                '/* testNamespaceOperatorInConditional */',
+                [
+                    'declaration' => false,
+                    'operator'    => true,
+                ],
+            ],
+            'namespace-operator-in-closed-scope' => [
+                '/* testNamespaceOperatorInClosedScope */',
+                [
+                    'declaration' => false,
+                    'operator'    => true,
+                ],
+            ],
+            'namespace-operator-in-parentheses' => [
+                '/* testNamespaceOperatorInParentheses */',
+                [
+                    'declaration' => false,
+                    'operator'    => true,
+                ],
+            ],
+            'parse-error-scoped-namespace-declaration' => [
+                '/* testParseErrorScopedNamespaceDeclaration */',
+                [
+                    'declaration' => false,
+                    'operator'    => false,
+                ],
+            ],
+            'parse-error-conditional-namespace' => [
+                '/* testParseErrorConditionalNamespace */',
+                [
+                    'declaration' => false,
+                    'operator'    => false,
+                ],
+            ],
+
+            'fatal-error-declaration-leading-slash' => [
+                '/* testFatalErrorDeclarationLeadingSlash */',
+                [
+                    'declaration' => false,
+                    'operator'    => false,
+                ],
+            ],
+            'parse-error-double-colon' => [
+                '/* testParseErrorDoubleColon */',
+                [
+                    'declaration' => false,
+                    'operator'    => false,
+                ],
+            ],
+            'parse-error-semicolon' => [
+                '/* testParseErrorSemiColon */',
+                [
+                    'declaration' => false,
+                    'operator'    => false,
+                ],
+            ],
+            'live-coding' => [
+                '/* testLiveCoding */',
+                [
+                    'declaration' => false,
+                    'operator'    => false,
+                ],
+            ],
+        ];
+    }
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -95,4 +95,19 @@
         <exclude-pattern>/Tests/BackCompat/BCFile/*Test\.php$</exclude-pattern>
     </rule>
 
+    <!--
+    #############################################################################
+    TEMPORARY ADJUSTMENTS
+    Adjustments which should be removed once the associated issue has been resolved.
+    #############################################################################
+    -->
+
+    <!-- Bug in PHPCS 3.5.0 - 3.5.3. Fixed in PHPCS 3.5.4. This exclusion can be removed once
+         3.5.4 comes out.
+         Ref: https://github.com/squizlabs/PHP_CodeSniffer/pull/2730
+    -->
+    <rule ref="PSR12.ControlStructures.ControlStructureSpacing.LineIndent">
+        <exclude-pattern>/PHPCSUtils/Utils/Namespaces\.php$</exclude-pattern>
+    </rule>
+
 </ruleset>


### PR DESCRIPTION
## New Utils\Namespaces class

This introduces six new methods to PHPCSUtils.

Methods:
* `getType()` - to determine what a T_NAMESPACE token is used for. Returns a string. Either `declaration` or `operator` or an empty string when the type of statement for which it's used could not be determined.
* `isDeclaration()` - to check whether a `T_NAMESPACE` token is used to declare a namespace. Returns boolean.
* `isOperator()` - to check whether a `T_NAMESPACE` token is used as an operator. Returns boolean.
* `getDeclaredName()` - to retrieve the (cleaned up) name of a namespace based on the T_NAMESPACE token for the namespace declaration. Returns string|false - the namespace name or an empty string if the code is declared to be in the global namespace. Will return false if the passed token is not for a namespace declaration or in the case of parse errors.
* `findNamespacePtr()` - to find the stackPtr to the `T_NAMESPACE` token for the namespace an arbitrary token lives in. Returns the integer stackPtr to the keyword token or false if it couldn't be determined or if no namespace applies.
* `determineNamespace()` - to retrieve the (clean) name of the namespace an arbitrary token lives in. Returns string - the namespace name or an empty string if the code is not namespaced or it could not be determined.

Some of these methods have been battle-tested in the past year or two in the PHPCompatibility standard.

Includes dedicated unit tests.

Includes introduction of a new `$namespaceDeclarationClosers` property into the `PHPCSUtils\Tokens\Collections` class.

## Namespaces::findNamespacePtr(): fix compatibility with PHPCS < 3.3.0

This method runs into a bug in PHPCS where curlies for variable variables received an incorrect and irrelevant scope condition in PHPCS < 3.3.0.

Fixed by just ignoring it if a namespace condition is assigned which is not a namespace declaration.

Note: the fact that the `$prev` pointer is still set to the incorrect "condition" is not an issue as it just means that no other relevant namespace token was found between the two, so skipping ahead is fine.

Ref:
* squizlabs/PHP_CodeSniffer#1882