### PR TITLE
New Utils\Operators class

### DIFF
--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Utils;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\BackCompat\BCTokens;
+
+/**
+ * Utility functions for use when working with operators.
+ *
+ * @since 1.0.0 The `isReference()` method is based on and inspired by
+ *              the method of the same name in the PHPCS native `File` class.
+ *              Also see {@see \PHPCSUtils\BackCompat\BCFile}.
+ */
+class Operators
+{
+
+    /**
+     * Determine if the passed token is a reference operator.
+     *
+     * @see \PHP_CodeSniffer\Files\File::isReference()   Original source.
+     * @see \PHPCSUtils\BackCompat\BCFile::isReference() Cross-version compatible version of the original.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the T_BITWISE_AND token.
+     *
+     * @return bool TRUE if the specified token position represents a reference.
+     *              FALSE if the token represents a bitwise operator.
+     */
+    public static function isReference(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['code'] !== \T_BITWISE_AND) {
+            return false;
+        }
+
+        $tokenBefore = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+
+        if ($tokens[$tokenBefore]['code'] === \T_FUNCTION) {
+            // Function returns a reference.
+            return true;
+        }
+
+        if ($tokens[$tokenBefore]['code'] === \T_DOUBLE_ARROW) {
+            // Inside a foreach loop or array assignment, this is a reference.
+            return true;
+        }
+
+        if ($tokens[$tokenBefore]['code'] === \T_AS) {
+            // Inside a foreach loop, this is a reference.
+            return true;
+        }
+
+        if (isset(BCTokens::assignmentTokens()[$tokens[$tokenBefore]['code']]) === true) {
+            // This is directly after an assignment. It's a reference. Even if
+            // it is part of an operation, the other tests will handle it.
+            return true;
+        }
+
+        $tokenAfter = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+
+        if ($tokens[$tokenAfter]['code'] === \T_NEW) {
+            return true;
+        }
+
+        if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
+            $brackets    = $tokens[$stackPtr]['nested_parenthesis'];
+            $lastBracket = \array_pop($brackets);
+            if (isset($tokens[$lastBracket]['parenthesis_owner']) === true) {
+                $owner = $tokens[$tokens[$lastBracket]['parenthesis_owner']];
+                if ($owner['code'] === \T_FUNCTION
+                    || $owner['code'] === \T_CLOSURE
+                ) {
+                    $params = BCFile::getMethodParameters($phpcsFile, $tokens[$lastBracket]['parenthesis_owner']);
+                    foreach ($params as $param) {
+                        $varToken = $tokenAfter;
+                        if ($param['variable_length'] === true) {
+                            $varToken = $phpcsFile->findNext(
+                                (Tokens::$emptyTokens + [\T_ELLIPSIS]),
+                                ($stackPtr + 1),
+                                null,
+                                true
+                            );
+                        }
+
+                        if ($param['token'] === $varToken
+                            && $param['pass_by_reference'] === true
+                        ) {
+                            // Function parameter declared to be passed by reference.
+                            return true;
+                        }
+                    }
+                }
+            } else {
+                $prev = false;
+                for ($t = ($tokens[$lastBracket]['parenthesis_opener'] - 1); $t >= 0; $t--) {
+                    if ($tokens[$t]['code'] !== \T_WHITESPACE) {
+                        $prev = $t;
+                        break;
+                    }
+                }
+
+                if ($prev !== false && $tokens[$prev]['code'] === \T_USE) {
+                    // Closure use by reference.
+                    return true;
+                }
+            }
+        }
+
+        // Pass by reference in function calls and assign by reference in arrays.
+        if ($tokens[$tokenBefore]['code'] === \T_OPEN_PARENTHESIS
+            || $tokens[$tokenBefore]['code'] === \T_COMMA
+            || $tokens[$tokenBefore]['code'] === \T_OPEN_SHORT_ARRAY
+        ) {
+            if ($tokens[$tokenAfter]['code'] === \T_VARIABLE) {
+                return true;
+            } else {
+                $skip   = Tokens::$emptyTokens;
+                $skip[] = \T_NS_SEPARATOR;
+                $skip[] = \T_SELF;
+                $skip[] = \T_PARENT;
+                $skip[] = \T_STATIC;
+                $skip[] = \T_STRING;
+                $skip[] = \T_NAMESPACE;
+                $skip[] = \T_DOUBLE_COLON;
+
+                $nextSignificantAfter = $phpcsFile->findNext(
+                    $skip,
+                    ($stackPtr + 1),
+                    null,
+                    true
+                );
+                if ($tokens[$nextSignificantAfter]['code'] === \T_VARIABLE) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/Tests/BackCompat/BCFile/IsReferenceTest.php
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.php
@@ -22,7 +22,6 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
-use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
 /**
@@ -30,10 +29,22 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @covers \PHPCSUtils\BackCompat\BCFile::isReference
  *
+ * @group operators
+ *
  * @since 1.0.0
  */
 class IsReferenceTest extends UtilityMethodTestCase
 {
+
+    /**
+     * The fully qualified name of the class being tested.
+     *
+     * This allows for the same unit tests to be run for both the BCFile functions
+     * as well as for the related PHPCSUtils functions.
+     *
+     * @var string
+     */
+    const TEST_CLASS = '\PHPCSUtils\BackCompat\BCFile';
 
     /**
      * Test that false is returned when a non-"bitwise and" token is passed.
@@ -42,8 +53,10 @@ class IsReferenceTest extends UtilityMethodTestCase
      */
     public function testNotBitwiseAndToken()
     {
+        $testClass = static::TEST_CLASS;
+
         $target = $this->getTargetToken('/* testBitwiseAndA */', T_STRING);
-        $this->assertFalse(BCFile::isReference(self::$phpcsFile, $target));
+        $this->assertFalse($testClass::isReference(self::$phpcsFile, $target));
     }
 
     /**
@@ -58,8 +71,10 @@ class IsReferenceTest extends UtilityMethodTestCase
      */
     public function testIsReference($identifier, $expected)
     {
+        $testClass = static::TEST_CLASS;
+
         $bitwiseAnd = $this->getTargetToken($identifier, T_BITWISE_AND);
-        $result     = BCFile::isReference(self::$phpcsFile, $bitwiseAnd);
+        $result     = $testClass::isReference(self::$phpcsFile, $bitwiseAnd);
         $this->assertSame($expected, $result);
     }
 

--- a/Tests/Utils/Operators/IsReferenceTest.php
+++ b/Tests/Utils/Operators/IsReferenceTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Operators;
+
+use PHPCSUtils\Tests\BackCompat\BCFile\IsReferenceTest as BCFile_IsReferenceTest;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Operators::isReference() method.
+ *
+ * @covers \PHPCSUtils\Utils\Operators::isReference
+ *
+ * @group operators
+ *
+ * @since 1.0.0
+ */
+class IsReferenceTest extends BCFile_IsReferenceTest
+{
+
+    /**
+     * The fully qualified name of the class being tested.
+     *
+     * This allows for the same unit tests to be run for both the BCFile functions
+     * as well as for the related PHPCSUtils functions.
+     *
+     * @var string
+     */
+    const TEST_CLASS = '\PHPCSUtils\Utils\Operators';
+
+    /**
+     * Full path to the test case file associated with this test class.
+     *
+     * @var string
+     */
+    protected static $caseFile = '';
+
+    /**
+     * Initialize PHPCS & tokenize the test case file.
+     *
+     * Overloaded to re-use the `$caseFile` from the BCFile test.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        self::$caseFile = \dirname(\dirname(__DIR__)) . '/BackCompat/BCFile/IsReferenceTest.inc';
+        parent::setUpTestFile();
+    }
+}


### PR DESCRIPTION
New `PHPCSUtils\Utils\Operators` class which will initially hold an improved version of the `File::isReference()` method as well as, at a later stage, additional methods related to examining operator tokens.

For the initial function in this class, the unit tests for the `PHPCSUtils\BackCompat\BCFile::isReference()` function are re-used to ensure that the improved function in this class stays compatible with the original function.