### PR TITLE
Operators::isReference(): various improvements

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -925,6 +925,7 @@ class BCFile
      *                  `namespace\ClassName::`, `classname::` were not recognized as references.
      *
      * @see \PHP_CodeSniffer\Files\File::isReference() Original source.
+     * @see \PHPCSUtils\Utils\Operators::isReference() PHPCSUtils native improved version.
      *
      * @since 1.0.0
      *

--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -31,6 +31,7 @@ class Operators
      *
      * Main differences with the PHPCS version:
      * - Defensive coding against incorrect calls to this method.
+     * - Improved handling of select tokenizer errors involving short lists/short arrays.
      *
      * @see \PHP_CodeSniffer\Files\File::isReference()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::isReference() Cross-version compatible version of the original.
@@ -111,6 +112,7 @@ class Operators
         if ($tokens[$tokenBefore]['code'] === \T_OPEN_PARENTHESIS
             || $tokens[$tokenBefore]['code'] === \T_COMMA
             || $tokens[$tokenBefore]['code'] === \T_OPEN_SHORT_ARRAY
+            || $tokens[$tokenBefore]['code'] === \T_OPEN_SQUARE_BRACKET // PHPCS 2.8.0 < 3.3.0.
         ) {
             if ($tokens[$tokenAfter]['code'] === \T_VARIABLE) {
                 return true;

--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -29,6 +29,9 @@ class Operators
     /**
      * Determine if the passed token is a reference operator.
      *
+     * Main differences with the PHPCS version:
+     * - Defensive coding against incorrect calls to this method.
+     *
      * @see \PHP_CodeSniffer\Files\File::isReference()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::isReference() Cross-version compatible version of the original.
      *
@@ -44,7 +47,7 @@ class Operators
     {
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[$stackPtr]['code'] !== \T_BITWISE_AND) {
+        if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== \T_BITWISE_AND) {
             return false;
         }
 

--- a/Tests/Utils/Operators/IsReferenceDiffTest.inc
+++ b/Tests/Utils/Operators/IsReferenceDiffTest.inc
@@ -1,0 +1,3 @@
+<?php
+
+// No PHPCSUtils native test cases yet.

--- a/Tests/Utils/Operators/IsReferenceDiffTest.inc
+++ b/Tests/Utils/Operators/IsReferenceDiffTest.inc
@@ -1,3 +1,13 @@
 <?php
 
-// No PHPCSUtils native test cases yet.
+/* testTokenizerIssue1971PHPCSlt330gt271A */
+// This has to be the first test in the file!
+[&$a, [$b, /* testTokenizerIssue1971PHPCSlt330gt271B */ &$c]] = $array;
+
+/* testTokenizerIssue1284PHPCSlt280A */
+if ($foo) {}
+[&$a, /* testTokenizerIssue1284PHPCSlt280B */ &$b] = $c;
+
+/* testTokenizerIssue1284PHPCSlt280C */
+if ($foo) {}
+[&$a, $b];

--- a/Tests/Utils/Operators/IsReferenceDiffTest.php
+++ b/Tests/Utils/Operators/IsReferenceDiffTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Operators;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Operators;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Operators::isReference() method.
+ *
+ * The tests in this class cover the differences between the PHPCS native method and the PHPCSUtils
+ * version. These tests would fail when using the BCFile `isReference()` method.
+ *
+ * @covers \PHPCSUtils\Utils\Operators::isReference
+ *
+ * @group operators
+ *
+ * @since 1.0.0
+ */
+class IsReferenceDiffDiffTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->assertFalse(Operators::isReference(self::$phpcsFile, 10000));
+    }
+}

--- a/Tests/Utils/Operators/IsReferenceDiffTest.php
+++ b/Tests/Utils/Operators/IsReferenceDiffTest.php
@@ -37,4 +37,54 @@ class IsReferenceDiffDiffTest extends UtilityMethodTestCase
     {
         $this->assertFalse(Operators::isReference(self::$phpcsFile, 10000));
     }
+
+    /**
+     * Test correctly identifying that whether a "bitwise and" token is a reference or not.
+     *
+     * @dataProvider dataIsReference
+     *
+     * @param string $identifier Comment which precedes the test case.
+     * @param bool   $expected   Expected function output.
+     *
+     * @return void
+     */
+    public function testIsReference($identifier, $expected)
+    {
+        $bitwiseAnd = $this->getTargetToken($identifier, \T_BITWISE_AND);
+        $result     = Operators::isReference(self::$phpcsFile, $bitwiseAnd);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsReference()
+     *
+     * @return array
+     */
+    public function dataIsReference()
+    {
+        return [
+            'issue-1971-list-first-in-file' => [
+                '/* testTokenizerIssue1971PHPCSlt330gt271A */',
+                true,
+            ],
+            'issue-1971-list-first-in-file-nested' => [
+                '/* testTokenizerIssue1971PHPCSlt330gt271B */',
+                true,
+            ],
+            'issue-1284-short-list-directly-after-close-curly-control-structure' => [
+                '/* testTokenizerIssue1284PHPCSlt280A */',
+                true,
+            ],
+            'issue-1284-short-list-directly-after-close-curly-control-structure-second-item' => [
+                '/* testTokenizerIssue1284PHPCSlt280B */',
+                true,
+            ],
+            'issue-1284-short-array-directly-after-close-curly-control-structure' => [
+                '/* testTokenizerIssue1284PHPCSlt280C */',
+                true,
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
## Operators::isReference(): implement use of the Parentheses and FunctionDeclarations classes

...and remove redundant code from the "is this a function parameter passed by reference" check.

## Operators::isReference(): improve defensive coding

Includes unit test.

## Operators::isReference(): add tests for select tokenizer issues

Refs:
* squizlabs/PHP_CodeSniffer#1971
* squizlabs/PHP_CodeSniffer#1284

## Operators::isReference(): fix compatibility with PHPCS 2.8.0 - 3.2.3

PHPCS 2.8.0 - 3.2.3 contained a bug where a square open bracket `[` as the first code content after the PHP open tag in a file would be tokenized as `T_OPEN_SQUARE_BRACKET` not `T_OPEN_SHORT_ARRAY`.

This is an edge-case bug as it can only occur when following the very first PHP open tag in a file and only if there is nothing before that open tag.

Either way, this commit adds work-arounds to the utility method to handle the situation correctly.

