### PR TITLE
Utils\Operators: add new isUnaryPlusMinus() utility method

### DIFF
--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -215,6 +215,14 @@ class Operators
             return true;
         }
 
+        /*
+         * BC for PHPCS < 3.1.0 in which the PHP 5.5 T_YIELD token was not yet backfilled.
+         * Note: not accounting for T_YIELD_FROM as that would be a parse error anyway.
+         */
+        if ($tokens[$prev]['code'] === \T_STRING && $tokens[$prev]['content'] === 'yield') {
+            return true;
+        }
+
         return false;
     }
 }

--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -22,9 +22,35 @@ use PHPCSUtils\Utils\Parentheses;
  * @since 1.0.0 The `isReference()` method is based on and inspired by
  *              the method of the same name in the PHPCS native `File` class.
  *              Also see {@see \PHPCSUtils\BackCompat\BCFile}.
+ *              The `isUnaryPlusMinus()` method is, in part, inspired by the
+ *              `Squiz.WhiteSpace.OperatorSpacing` sniff.
  */
 class Operators
 {
+
+    /**
+     * Tokens which indicate that a plus/minus is unary when they preceed it.
+     *
+     * @since 1.0.0
+     *
+     * @var array <int|string> => <irrelevant>
+     */
+    private static $extraUnaryIndicators = [
+        \T_STRING_CONCAT       => true,
+        \T_RETURN              => true,
+        \T_ECHO                => true,
+        \T_PRINT               => true,
+        \T_YIELD               => true,
+        \T_COMMA               => true,
+        \T_OPEN_PARENTHESIS    => true,
+        \T_OPEN_SQUARE_BRACKET => true,
+        \T_OPEN_SHORT_ARRAY    => true,
+        \T_OPEN_CURLY_BRACKET  => true,
+        \T_COLON               => true,
+        \T_INLINE_THEN         => true,
+        \T_INLINE_ELSE         => true,
+        \T_CASE                => true,
+    ];
 
     /**
      * Determine if the passed token is a reference operator.
@@ -136,6 +162,57 @@ class Operators
                     return true;
                 }
             }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine whether a T_MINUS/T_PLUS token is a unary operator.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the plus/minus token.
+     *
+     * @return bool True if the token passed is a unary operator.
+     *              False otherwise or if the token is not a T_PLUS/T_MINUS token.
+     */
+    public static function isUnaryPlusMinus(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]) === false
+            || ($tokens[$stackPtr]['code'] !== \T_PLUS
+            && $tokens[$stackPtr]['code'] !== \T_MINUS)
+        ) {
+            return false;
+        }
+
+        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($next === false) {
+            // Live coding or parse error.
+            return false;
+        }
+
+        if (isset(BCTokens::operators()[$tokens[$next]['code']]) === true) {
+            // Next token is an operator, so this is not a unary.
+            return false;
+        }
+
+        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+
+        /*
+         * Check the preceeding token for an indication that this is not an arithmetic operation.
+         */
+        if (isset(BCTokens::operators()[$tokens[$prev]['code']]) === true
+            || isset(BCTokens::comparisonTokens()[$tokens[$prev]['code']]) === true
+            || isset(Tokens::$booleanOperators[$tokens[$prev]['code']]) === true
+            || isset(BCTokens::assignmentTokens()[$tokens[$prev]['code']]) === true
+            || isset(Tokens::$castTokens[$tokens[$prev]['code']]) === true
+            || isset(self::$extraUnaryIndicators[$tokens[$prev]['code']]) === true
+        ) {
+            return true;
         }
 
         return false;

--- a/Tests/Utils/Operators/IsUnaryPlusMinusJSTest.js
+++ b/Tests/Utils/Operators/IsUnaryPlusMinusJSTest.js
@@ -1,0 +1,23 @@
+/* testNonUnaryPlus */
+result = 1 + 2;
+
+/* testNonUnaryMinus */
+result = 1-2;
+
+/* testUnaryMinusColon */
+$.localScroll({offset: {top: -32}});
+
+switch (result) {
+	/* testUnaryMinusCase */
+	case -1:
+		break;
+}
+
+/* testUnaryMinusTernaryThen */
+result = x?-y:z;
+
+/* testUnaryPlusTernaryElse */
+result = x ? y : +z;
+
+/* testUnaryMinusIfCondition */
+if (true || -1 == b) {}

--- a/Tests/Utils/Operators/IsUnaryPlusMinusJSTest.php
+++ b/Tests/Utils/Operators/IsUnaryPlusMinusJSTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Operators;
+
+use PHPCSUtils\Tests\Utils\Operators\IsUnaryPlusMinusTest;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Operators::isUnaryPlusMinus() method.
+ *
+ * @covers \PHPCSUtils\Utils\Operators::isUnaryPlusMinus
+ *
+ * @group operators
+ *
+ * @since 1.0.0
+ */
+class IsUnaryPlusMinusJSTest extends IsUnaryPlusMinusTest
+{
+
+    /**
+     * The file extension of the test case file (without leading dot).
+     *
+     * @var string
+     */
+    protected static $fileExtension = 'js';
+
+    /**
+     * Data provider.
+     *
+     * @see IsUnaryPlusMinusTest::testIsUnaryPlusMinus() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsUnaryPlusMinus()
+    {
+        return [
+            'non-unary-plus' => [
+                '/* testNonUnaryPlus */',
+                false,
+            ],
+            'non-unary-minus' => [
+                '/* testNonUnaryMinus */',
+                false,
+            ],
+            'unary-minus-colon' => [
+                '/* testUnaryMinusColon */',
+                true,
+            ],
+            'unary-minus-switch-case' => [
+                '/* testUnaryMinusCase */',
+                true,
+            ],
+            'unary-minus-ternary-then' => [
+                '/* testUnaryMinusTernaryThen */',
+                true,
+            ],
+            'unary-minus-ternary-else' => [
+                '/* testUnaryPlusTernaryElse */',
+                true,
+            ],
+            'unary-minus-if-condition' => [
+                '/* testUnaryMinusIfCondition */',
+                true,
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/Operators/IsUnaryPlusMinusTest.inc
+++ b/Tests/Utils/Operators/IsUnaryPlusMinusTest.inc
@@ -1,0 +1,151 @@
+<?php
+
+/* testNonUnaryPlus */
+$a = 1 + 2;
+
+/* testNonUnaryMinus */
+$a = 1-2;
+
+/* testNonUnaryPlusArrays */
+$a = [1] + [2];
+
+/* testUnaryMinusArithmetic */
+$a = 1 / -2;
+
+/* testUnaryPlusArithmetic */
+$a = 1 ** +2;
+
+/* testUnaryMinusConcatenation */
+$a = 'ID' . -$var;
+
+/* testUnaryPlusIntAssignment */
+$a = +1;
+
+/* testUnaryMinusVariableAssignment */
+$a += -$b;
+
+/* testUnaryPlusFloatAssignment */
+$a **= + 1.1;
+
+/* testUnaryMinusBoolAssignment */
+$a /= -true;
+
+/* testUnaryPlusStringAssignmentWithComment */
+$a &= + /* comment */ '1';
+
+/* testUnaryMinusStringAssignment */
+$a .= - <<<'EOD'
+123
+EOD;
+
+/* testUnaryPlusNullAssignment */
+$a = +null;
+
+/* testUnaryMinusVariableVariableAssignment */
+$a .= -${$var};
+
+/* testUnaryPlusIntComparison */
+$a = ($b === + 1);
+
+/* testUnaryPlusIntComparisonYoda */
+$a = (+1 <=> $b);
+
+/* testUnaryMinusFloatComparison */
+$a = ($b !== - 1.1);
+
+/* testUnaryMinusStringComparisonYoda */
+$a = (-'1' != $b);
+
+/* testUnaryPlusVariableBoolean */
+$a = ($a && - $b);
+
+/* testUnaryMinusVariableBoolean */
+$a = ($a || -$b);
+
+/* testUnaryPlusLogicalXor */
+$a = ($a xor -$b);
+
+/* testUnaryMinusTernaryThen */
+$a = $a ? -1 :
+    /* testUnaryPlusTernaryElse */
+    + 10;
+
+/* testUnaryMinusCoalesce */
+$a = $a ?? -1 :
+
+/* testUnaryPlusIntReturn */
+return +1;
+
+/* testUnaryMinusFloatReturn */
+return -1.1;
+
+/* testUnaryPlusPrint */
+print +$b;
+
+/* testUnaryMinusEcho */
+echo -$a;
+
+/* testUnaryPlusYield */
+yield +$a;
+
+/* testUnaryPlusArrayAccess */
+$a = $array[ + 2 ];
+
+/* testUnaryMinusStringArrayAccess */
+if ($line{-1} === ':') {}
+
+$array = array(
+    /* testUnaryPlusLongArrayAssignment */
+    +1,
+    /* testUnaryMinusLongArrayAssignmentKey */
+    -1 =>
+        /* testUnaryPlusLongArrayAssignmentValue */
+        +20,
+);
+
+$array = [
+    /* testUnaryPlusShortArrayAssignment */
+    +1 =>
+        /* testNonUnaryMinusShortArrayAssignment */
+        5-20,
+];
+
+/* testUnaryMinusCast */
+$a = (bool) -2;
+
+functionCall(
+    /* testUnaryPlusFunctionCallParam */
+    +2,
+    /* testUnaryMinusFunctionCallParam */
+    - 123.456,
+);
+
+/* testUnaryPlusDeclare */
+declare( ticks = +10 );
+
+switch ($a) {
+    /* testUnaryPlusCase */
+    case +20:
+        // Something.
+        break;
+
+    /* testUnaryMinusCase */
+    case -1.23:
+        // Something.
+        break;
+}
+
+// Testing `$a = -+-+10`;
+$a =
+    /* testSequenceNonUnary1 */
+    -
+    /* testSequenceNonUnary2 */
+    +
+    /* testSequenceNonUnary3 */
+    -
+    /* testSequenceUnaryEnd */
+    + /*comment*/ 10;
+
+// Intentional parse error. This has to be the last test in the file.
+/* testParseError */
+$a = -

--- a/Tests/Utils/Operators/IsUnaryPlusMinusTest.php
+++ b/Tests/Utils/Operators/IsUnaryPlusMinusTest.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Operators;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Operators;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Operators::isUnaryPlusMinus() method.
+ *
+ * @covers \PHPCSUtils\Utils\Operators::isUnaryPlusMinus
+ *
+ * @group operators
+ *
+ * @since 1.0.0
+ */
+class IsUnaryPlusMinusTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test that false is returned when a non-existent token is passed.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->assertFalse(Operators::isUnaryPlusMinus(self::$phpcsFile, 10000));
+    }
+
+    /**
+     * Test that false is returned when a non-plus/minus token is passed.
+     *
+     * @return void
+     */
+    public function testNotPlusMinusToken()
+    {
+        $target = $this->getTargetToken('/* testNonUnaryPlus */', \T_LNUMBER);
+        $this->assertFalse(Operators::isUnaryPlusMinus(self::$phpcsFile, $target));
+    }
+
+    /**
+     * Test whether a T_PLUS or T_MINUS token is a unary operator.
+     *
+     * @dataProvider dataIsUnaryPlusMinus
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param bool   $expected   The expected boolean return value.
+     *
+     * @return void
+     */
+    public function testIsUnaryPlusMinus($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, [\T_PLUS, \T_MINUS]);
+        $result   = Operators::isUnaryPlusMinus(self::$phpcsFile, $stackPtr);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsUnaryPlusMinus() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsUnaryPlusMinus()
+    {
+        return [
+            'non-unary-plus' => [
+                '/* testNonUnaryPlus */',
+                false,
+            ],
+            'non-unary-minus' => [
+                '/* testNonUnaryMinus */',
+                false,
+            ],
+            'non-unary-plus-arrays' => [
+                '/* testNonUnaryPlusArrays */',
+                false,
+            ],
+            'unary-minus-arithmetic' => [
+                '/* testUnaryMinusArithmetic */',
+                true,
+            ],
+            'unary-plus-arithmetic' => [
+                '/* testUnaryPlusArithmetic */',
+                true,
+            ],
+            'unary-minus-concatenation' => [
+                '/* testUnaryMinusConcatenation */',
+                true,
+            ],
+            'unary-plus-int-assignment' => [
+                '/* testUnaryPlusIntAssignment */',
+                true,
+            ],
+            'unary-minus-variable-assignment' => [
+                '/* testUnaryMinusVariableAssignment */',
+                true,
+            ],
+            'unary-plus-float-assignment' => [
+                '/* testUnaryPlusFloatAssignment */',
+                true,
+            ],
+            'unary-minus-bool-assignment' => [
+                '/* testUnaryMinusBoolAssignment */',
+                true,
+            ],
+            'unary-plus-string-assignment-with-comment' => [
+                '/* testUnaryPlusStringAssignmentWithComment */',
+                true,
+            ],
+            'unary-minus-string-assignment' => [
+                '/* testUnaryMinusStringAssignment */',
+                true,
+            ],
+            'unary-plus-plus-null-assignment' => [
+                '/* testUnaryPlusNullAssignment */',
+                true,
+            ],
+            'unary-minus-variable-variable-assignment' => [
+                '/* testUnaryMinusVariableVariableAssignment */',
+                true,
+            ],
+            'unary-plus-int-comparison' => [
+                '/* testUnaryPlusIntComparison */',
+                true,
+            ],
+            'unary-plus-int-comparison-yoda' => [
+                '/* testUnaryPlusIntComparisonYoda */',
+                true,
+            ],
+            'unary-minus-float-comparison' => [
+                '/* testUnaryMinusFloatComparison */',
+                true,
+            ],
+            'unary-minus-string-comparison-yoda' => [
+                '/* testUnaryMinusStringComparisonYoda */',
+                true,
+            ],
+            'unary-plus-variable-boolean' => [
+                '/* testUnaryPlusVariableBoolean */',
+                true,
+            ],
+            'unary-minus-variable-boolean' => [
+                '/* testUnaryMinusVariableBoolean */',
+                true,
+            ],
+            'unary-plus-logical-xor' => [
+                '/* testUnaryPlusLogicalXor */',
+                true,
+            ],
+            'unary-minus-ternary-then' => [
+                '/* testUnaryMinusTernaryThen */',
+                true,
+            ],
+            'unary-plus-ternary-else' => [
+                '/* testUnaryPlusTernaryElse */',
+                true,
+            ],
+            'unary-minus-coalesce' => [
+                '/* testUnaryMinusCoalesce */',
+                true,
+            ],
+            'unary-plus-int-return' => [
+                '/* testUnaryPlusIntReturn */',
+                true,
+            ],
+            'unary-minus-float-return' => [
+                '/* testUnaryMinusFloatReturn */',
+                true,
+            ],
+            'unary-plus-print' => [
+                '/* testUnaryPlusPrint */',
+                true,
+            ],
+            'unary-minus-echo' => [
+                '/* testUnaryMinusEcho */',
+                true,
+            ],
+            'unary-plus-yield' => [
+                '/* testUnaryPlusYield */',
+                true,
+            ],
+            'unary-plus-array-access' => [
+                '/* testUnaryPlusArrayAccess */',
+                true,
+            ],
+            'unary-minus-string-array-access' => [
+                '/* testUnaryMinusStringArrayAccess */',
+                true,
+            ],
+            'unary-plus-long-array-assignment' => [
+                '/* testUnaryPlusLongArrayAssignment */',
+                true,
+            ],
+            'unary-minus-long-array-assignment-key' => [
+                '/* testUnaryMinusLongArrayAssignmentKey */',
+                true,
+            ],
+            'unary-plus-long-array-assignment-value' => [
+                '/* testUnaryPlusLongArrayAssignmentValue */',
+                true,
+            ],
+            'unary-plus-short-array-assignment' => [
+                '/* testUnaryPlusShortArrayAssignment */',
+                true,
+            ],
+            'non-unary-minus-short-array-assignment' => [
+                '/* testNonUnaryMinusShortArrayAssignment */',
+                false,
+            ],
+            'unary-minus-casts' => [
+                '/* testUnaryMinusCast */',
+                true,
+            ],
+            'unary-plus-function-call-param' => [
+                '/* testUnaryPlusFunctionCallParam */',
+                true,
+            ],
+            'unary-minus-function-call-param' => [
+                '/* testUnaryMinusFunctionCallParam */',
+                true,
+            ],
+            'unary-plus-declare' => [
+                '/* testUnaryPlusDeclare */',
+                true,
+            ],
+            'unary-plus-switch-case' => [
+                '/* testUnaryPlusCase */',
+                true,
+            ],
+            'unary-minus-switch-case' => [
+                '/* testUnaryMinusCase */',
+                true,
+            ],
+            'operator-sequence-non-unary-1' => [
+                '/* testSequenceNonUnary1 */',
+                false,
+            ],
+            'operator-sequence-non-unary-2' => [
+                '/* testSequenceNonUnary2 */',
+                false,
+            ],
+            'operator-sequence-non-unary-3' => [
+                '/* testSequenceNonUnary3 */',
+                false,
+            ],
+            'operator-sequence-unary-end' => [
+                '/* testSequenceUnaryEnd */',
+                true,
+            ],
+            'parse-error' => [
+                '/* testParseError */',
+                false,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## Utils\Operators: add new isUnaryPlusMinus() utility method

This adds a new utility method:
* `isUnaryPlusMinus()` - to check whether a plus/minus sign is a unary or an arithmetic operator. Returns boolean.

Includes extensive dedicated unit tests.

## Operators::isUnaryPlusMinus(): fix compatibility with PHPCS < 3.1.0

The PHP 5.5 `T_YIELD` token was not backfilled in PHPCS until version 3.1.0.

This commit adds work-arounds to the utility method to handle the situation correctly.

Refs:
* squizlabs/PHP_CodeSniffer#1513
* squizlabs/PHP_CodeSniffer#1524