### PR TITLE
Utils\Operators: add new isShortTernary() utility method

### DIFF
--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -225,4 +225,40 @@ class Operators
 
         return false;
     }
+
+    /**
+     * Determine whether a ternary is a short ternary/elvis operator, i.e. without "middle".
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the ternary then/else
+     *                                         operator in the stack.
+     *
+     * @return bool True if short ternary, or false otherwise.
+     */
+    public static function isShortTernary(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        if (isset($tokens[$stackPtr]) === false) {
+            return false;
+        }
+
+        if ($tokens[$stackPtr]['code'] === \T_INLINE_THEN) {
+            $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === \T_INLINE_ELSE) {
+                return true;
+            }
+        }
+
+        if ($tokens[$stackPtr]['code'] === \T_INLINE_ELSE) {
+            $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            if ($prevNonEmpty !== false && $tokens[$prevNonEmpty]['code'] === \T_INLINE_THEN) {
+                return true;
+            }
+        }
+
+        // Not a ternary operator token.
+        return false;
+    }
 }

--- a/Tests/Utils/Operators/IsShortTernaryTest.inc
+++ b/Tests/Utils/Operators/IsShortTernaryTest.inc
@@ -1,0 +1,42 @@
+<?php
+
+/* testNotATernaryToken */
+echo 123;
+
+/* testLongTernary */
+$foo = ($a === true) ? $b : $c;
+
+/* testShortTernaryNoSpace */
+$foo = $foo ?: 'bar';
+
+/* testShortTernaryLongSpace */
+$foo = $foo ?
+
+    : 'bar';
+
+/* testShortTernaryWithCommentAndAnnotations */
+$foo = $foo ? /* deliberately left empty */
+    // phpcs:ignore Stnd.Cat.Sniff -- For reasons.
+    : 'bar';
+
+/* testDontConfuseWithNullCoalesce */
+$foo = $foo ?? 0;
+
+/* testDontConfuseWithNullCoalesceEquals */
+$foo ??= 0;
+
+class Foo {
+    /* testDontConfuseWithNullable1 */
+    protected ?int $property = 1;
+
+    public function bar(
+        /* testDontConfuseWithNullable2 */
+        ?bool $param
+        /* testDontConfuseWithNullable3 */
+    ) : ?\My\ClassName {
+    }
+}
+
+/* testParseError */
+// Intentional parse error. This has to be the last test in the file.
+$foo = $foo ?

--- a/Tests/Utils/Operators/IsShortTernaryTest.php
+++ b/Tests/Utils/Operators/IsShortTernaryTest.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Operators;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Operators;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Operators::isShortTernary() method.
+ *
+ * @covers \PHPCSUtils\Utils\Operators::isShortTernary
+ *
+ * @group operators
+ *
+ * @since 1.0.0
+ */
+class IsShortTernaryTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test that false is returned when a non-existent token is passed.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->assertFalse(Operators::isShortTernary(self::$phpcsFile, 10000));
+    }
+
+    /**
+     * Test that false is returned when a non-ternary then/else token is passed.
+     *
+     * @return void
+     */
+    public function testNotTernaryToken()
+    {
+        $target = $this->getTargetToken('/* testNotATernaryToken */', \T_ECHO);
+        $this->assertFalse(Operators::isShortTernary(self::$phpcsFile, $target));
+    }
+
+    /**
+     * Test whether a T_INLINE_THEN or T_INLINE_ELSE token is correctly identified for being a short ternary.
+     *
+     * @dataProvider dataIsShortTernary
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param bool   $expected   The expected boolean return value.
+     *
+     * @return void
+     */
+    public function testIsShortTernary($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, \T_INLINE_THEN);
+        $result   = Operators::isShortTernary(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result, 'Test failed with inline then');
+
+        $stackPtr = $this->getTargetToken($testMarker, \T_INLINE_ELSE);
+        $result   = Operators::isShortTernary(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result, 'Test failed with inline else');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsShortTernary() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsShortTernary()
+    {
+        return [
+            'long-ternary' => [
+                '/* testLongTernary */',
+                false,
+            ],
+            'short-ternary-no-space' => [
+                '/* testShortTernaryNoSpace */',
+                true,
+            ],
+            'short-ternary-long-space' => [
+                '/* testShortTernaryLongSpace */',
+                true,
+            ],
+            'short-ternary-comments-annotations' => [
+                '/* testShortTernaryWithCommentAndAnnotations */',
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * Safeguard that incorrectly tokenized T_INLINE_THEN or T_INLINE_ELSE tokens are correctly
+     * rejected as not short ternary.
+     *
+     * {@internal None of these are really problematic, but better to be safe than sorry.}
+     *
+     * @dataProvider dataIsShortTernaryTokenizerIssues
+     *
+     * @param string     $testMarker The comment which prefaces the target token in the test file.
+     * @param int|string $tokenType  The token code to look for.
+     *
+     * @return void
+     */
+    public function testIsShortTernaryTokenizerIssues($testMarker, $tokenType = \T_INLINE_THEN)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, $tokenType);
+        $result   = Operators::isShortTernary(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsShortTernaryTokenizerIssues() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsShortTernaryTokenizerIssues()
+    {
+        $targetCoalesce = [\T_INLINE_THEN];
+        if (\defined('T_COALESCE')) {
+            $targetCoalesce[] = \T_COALESCE;
+        }
+
+        $targetCoalesceAndEquals = $targetCoalesce;
+        if (\defined('T_COALESCE_EQUAL')) {
+            $targetCoalesceAndEquals[] = \T_COALESCE_EQUAL;
+        }
+
+        $targetNullable = [\T_INLINE_THEN];
+        if (\defined('T_NULLABLE')) {
+            $targetNullable[] = \T_NULLABLE;
+        }
+
+        return [
+            'null-coalesce' => [
+                '/* testDontConfuseWithNullCoalesce */',
+                $targetCoalesce,
+            ],
+            'null-coalesce-equals' => [
+                '/* testDontConfuseWithNullCoalesceEquals */',
+                $targetCoalesceAndEquals,
+            ],
+            'nullable-property' => [
+                '/* testDontConfuseWithNullable1 */',
+                $targetNullable,
+            ],
+            'nullable-param-type' => [
+                '/* testDontConfuseWithNullable2 */',
+                $targetNullable,
+            ],
+            'nullable-return-type' => [
+                '/* testDontConfuseWithNullable3 */',
+                $targetNullable,
+            ],
+            'parse-error' => [
+                '/* testParseError */',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This adds a new utility method:
* `isShortTernary()` - to check whether a ternary then/else operator is part of a short ternary. Returns boolean.

Includes dedicated unit tests.