### PR TITLE
New Utils\PassedParameters class

### DIFF
--- a/PHPCSUtils/Utils/PassedParameters.php
+++ b/PHPCSUtils/Utils/PassedParameters.php
@@ -1,0 +1,310 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Utils;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\GetTokensAsString;
+
+/**
+ * Utility functions to retrieve information about parameters passed to function calls,
+ * array declarations, isset and unset constructs.
+ *
+ * @since 1.0.0
+ */
+class PassedParameters
+{
+
+    /**
+     * The token types these methods can handle.
+     *
+     * @since 1.0.0
+     *
+     * @var array <int|string> => <irrelevant>
+     */
+    private static $allowedConstructs = [
+        \T_STRING           => true,
+        \T_VARIABLE         => true,
+        \T_SELF             => true,
+        \T_STATIC           => true,
+        \T_ARRAY            => true,
+        \T_OPEN_SHORT_ARRAY => true,
+        \T_ISSET            => true,
+        \T_UNSET            => true,
+    ];
+
+    /**
+     * Tokens which are considered stop point, either because they are the end
+     * of the parameter (comma) or because we need to skip over them.
+     *
+     * @since 1.0.0
+     *
+     * @var array <int|string> => <int|string>
+     */
+    private static $callParsingStopPoints = [
+        \T_COMMA                => \T_COMMA,
+        \T_OPEN_SHORT_ARRAY     => \T_OPEN_SHORT_ARRAY,
+        \T_OPEN_SQUARE_BRACKET  => \T_OPEN_SQUARE_BRACKET,
+        \T_OPEN_PARENTHESIS     => \T_OPEN_PARENTHESIS,
+        \T_DOC_COMMENT_OPEN_TAG => \T_DOC_COMMENT_OPEN_TAG,
+    ];
+
+    /**
+     * Checks if any parameters have been passed.
+     *
+     * - If passed a T_STRING or T_VARIABLE stack pointer, it will treat it as a function call.
+     *   If a T_STRING or T_VARIABLE which is *not* a function call is passed, the behaviour is
+     *   unreliable.
+     * - If passed a T_SELF or T_STATIC stack pointer, it will accept it as a
+     *   function call when used like `new self()`.
+     * - If passed a T_ARRAY or T_OPEN_SHORT_ARRAY stack pointer, it will detect
+     *   whether the array has values or is empty.
+     * - If passed a T_ISSET or T_UNSET stack pointer, it will detect whether those
+     *   language constructs have "parameters".
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The position of the T_STRING, T_VARIABLE, T_ARRAY,
+     *                                               T_OPEN_SHORT_ARRAY, T_ISSET, or T_UNSET token.
+     *
+     * @return bool
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the token passed is not one of the
+     *                                                      accepted types or doesn't exist.
+     */
+    public static function hasParameters(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr], self::$allowedConstructs[$tokens[$stackPtr]['code']]) === false) {
+            throw new RuntimeException(
+                'The hasParameters() method expects a function call, array, isset or unset token to be passed.'
+            );
+        }
+
+        if ($tokens[$stackPtr]['code'] === \T_SELF || $tokens[$stackPtr]['code'] === \T_STATIC) {
+            $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            if ($tokens[$prev]['code'] !== \T_NEW) {
+                throw new RuntimeException(
+                    'The hasParameters() method expects a function call, array, isset or unset token to be passed.'
+                );
+            }
+        }
+
+        $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($next === false) {
+            return false;
+        }
+
+        // Deal with short array syntax.
+        if ($tokens[$stackPtr]['code'] === \T_OPEN_SHORT_ARRAY) {
+            if ($next === $tokens[$stackPtr]['bracket_closer']) {
+                // No parameters.
+                return false;
+            }
+
+            return true;
+        }
+
+        // Deal with function calls, long arrays, isset and unset.
+        // Next non-empty token should be the open parenthesis.
+        if ($tokens[$next]['code'] !== \T_OPEN_PARENTHESIS) {
+            return false;
+        }
+
+        if (isset($tokens[$next]['parenthesis_closer']) === false) {
+            return false;
+        }
+
+        $closeParenthesis = $tokens[$next]['parenthesis_closer'];
+        $nextNextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($next + 1), ($closeParenthesis + 1), true);
+
+        if ($nextNextNonEmpty === $closeParenthesis) {
+            // No parameters.
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get information on all parameters passed.
+     *
+     * See {@see PHPCSUtils\Utils\PassedParameters::hasParameters()} for information on the supported
+     * constructs.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The position of the T_STRING, T_VARIABLE, T_ARRAY,
+     *                                               T_OPEN_SHORT_ARRAY, T_ISSET, or T_UNSET token.
+     *
+     * @return array Returns a multi-dimentional array with the "start" token pointer, "end" token
+     *               pointer, "raw" parameter value and "clean" (only code, no comments) parameter
+     *               value for all parameters. The array starts at index 1.
+     *               If no parameters are found, will return an empty array.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the token passed is not one of the
+     *                                                      accepted types or doesn't exist.
+     */
+    public static function getParameters(File $phpcsFile, $stackPtr)
+    {
+        if (self::hasParameters($phpcsFile, $stackPtr) === false) {
+            return [];
+        }
+
+        // Ok, we know we have a valid token with parameters and valid open & close brackets/parenthesis.
+        $tokens = $phpcsFile->getTokens();
+
+        // Mark the beginning and end tokens.
+        if ($tokens[$stackPtr]['code'] === \T_OPEN_SHORT_ARRAY) {
+            $opener = $stackPtr;
+            $closer = $tokens[$stackPtr]['bracket_closer'];
+        } else {
+            $opener = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            $closer = $tokens[$opener]['parenthesis_closer'];
+        }
+
+        $parameters   = [];
+        $nextComma    = $opener;
+        $paramStart   = ($opener + 1);
+        $cnt          = 1;
+        $stopPoints   = self::$callParsingStopPoints + Tokens::$scopeOpeners;
+        $stopPoints[] = $tokens[$closer]['code'];
+
+        while (($nextComma = $phpcsFile->findNext($stopPoints, ($nextComma + 1), ($closer + 1))) !== false) {
+            // Ignore anything within square brackets.
+            if (isset($tokens[$nextComma]['bracket_opener'], $tokens[$nextComma]['bracket_closer'])
+                && $nextComma === $tokens[$nextComma]['bracket_opener']
+            ) {
+                $nextComma = $tokens[$nextComma]['bracket_closer'];
+                continue;
+            }
+
+            // Skip past nested arrays, function calls and arbitrary groupings.
+            if ($tokens[$nextComma]['code'] === \T_OPEN_PARENTHESIS
+                && isset($tokens[$nextComma]['parenthesis_closer'])
+            ) {
+                $nextComma = $tokens[$nextComma]['parenthesis_closer'];
+                continue;
+            }
+
+            // Skip past closures, anonymous classes and anything else scope related.
+            if (isset($tokens[$nextComma]['scope_condition'], $tokens[$nextComma]['scope_closer'])
+                && $tokens[$nextComma]['scope_condition'] === $nextComma
+            ) {
+                $nextComma = $tokens[$nextComma]['scope_closer'];
+                continue;
+            }
+
+            // Skip over potentially large docblocks.
+            if ($tokens[$nextComma]['code'] === \T_DOC_COMMENT_OPEN_TAG
+                && isset($tokens[$nextComma]['comment_closer'])
+            ) {
+                $nextComma = $tokens[$nextComma]['comment_closer'];
+                continue;
+            }
+
+            if ($tokens[$nextComma]['code'] !== \T_COMMA
+                && $tokens[$nextComma]['code'] !== $tokens[$closer]['code']
+            ) {
+                // Just in case.
+                continue;
+            }
+
+            // Ok, we've reached the end of the parameter.
+            $paramEnd                  = ($nextComma - 1);
+            $parameters[$cnt]['start'] = $paramStart;
+            $parameters[$cnt]['end']   = $paramEnd;
+            $parameters[$cnt]['raw']   = \trim(GetTokensAsString::normal($phpcsFile, $paramStart, $paramEnd));
+            $parameters[$cnt]['clean'] = \trim(GetTokensAsString::noComments($phpcsFile, $paramStart, $paramEnd));
+
+            // Check if there are more tokens before the closing parenthesis.
+            // Prevents function calls with trailing comma's from setting an extra parameter:
+            // `functionCall( $param1, $param2, );`.
+            $hasNextParam = $phpcsFile->findNext(
+                Tokens::$emptyTokens,
+                ($nextComma + 1),
+                $closer,
+                true
+            );
+            if ($hasNextParam === false) {
+                break;
+            }
+
+            // Prepare for the next parameter.
+            $paramStart = ($nextComma + 1);
+            $cnt++;
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * Get information on a specific parameter passed.
+     *
+     * See {@see PHPCSUtils\Utils\PassedParameters::hasParameters()} for information on the supported
+     * constructs.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
+     * @param int                         $stackPtr    The position of the T_STRING, T_VARIABLE, T_ARRAY,
+     *                                                 T_OPEN_SHORT_ARRAY, T_ISSET or T_UNSET token.
+     * @param int                         $paramOffset The 1-based index position of the parameter to retrieve.
+     *
+     * @return array|false Returns an array with the "start" token pointer, "end" token pointer,
+     *                     "raw" parameter value and "clean" (only code, no comments) parameter
+     *                     value for the parameter at the specified offset.
+     *                     Or FALSE if the specified parameter is not found.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the token passed is not one of the
+     *                                                      accepted types or doesn't exist.
+     */
+    public static function getParameter(File $phpcsFile, $stackPtr, $paramOffset)
+    {
+        $parameters = self::getParameters($phpcsFile, $stackPtr);
+
+        if (isset($parameters[$paramOffset]) === false) {
+            return false;
+        }
+
+        return $parameters[$paramOffset];
+    }
+
+    /**
+     * Count the number of parameters which have been passed.
+     *
+     * See {@see PHPCSUtils\Utils\PassedParameters::hasParameters()} for information on the supported
+     * constructs.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The position of the T_STRING, T_VARIABLE, T_ARRAY,
+     *                                               T_OPEN_SHORT_ARRAY, T_ISSET or T_UNSET token.
+     *
+     * @return int
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the token passed is not one of the
+     *                                                      accepted types or doesn't exist.
+     */
+    public static function getParameterCount(File $phpcsFile, $stackPtr)
+    {
+        if (self::hasParameters($phpcsFile, $stackPtr) === false) {
+            return 0;
+        }
+
+        return \count(self::getParameters($phpcsFile, $stackPtr));
+    }
+}

--- a/Tests/Utils/PassedParameters/GetParameterCountTest.inc
+++ b/Tests/Utils/PassedParameters/GetParameterCountTest.inc
@@ -1,0 +1,199 @@
+<?php
+
+/* testFunctionCall0 */
+myfunction();
+
+/* testFunctionCall1 */
+myfunction(1);
+
+/* testFunctionCall2 */
+myfunction( 1, 2 );
+
+/* testFunctionCall3 */
+myfunction(1, 2, 3);
+
+/* testFunctionCall4 */
+myfunction(1, 2, 3, 4);
+
+/* testFunctionCall5 */
+myfunction(1, 2, 3, 4, 5);
+
+/* testFunctionCall6 */
+myfunction(1, 2, 3, 4, 5, 6);
+
+/* testFunctionCall7 */
+myfunction( 1, 2, 3, 4, 5, 6, true );
+
+/* testFunctionCall8 */
+dirname( dirname( __FILE__ ) ); // 1
+
+/* testFunctionCall9 */
+(dirname( dirname( __FILE__ ) )); // 1
+
+/* testFunctionCall10 */
+dirname( plugin_basename( __FILE__ ) ); // 1
+
+/* testFunctionCall11 */
+dirname( plugin_basename( __FILE__ ), 2 ); // 2
+
+/* testFunctionCall12 */
+unserialize(trim($value, "'")); // 1
+
+/* testFunctionCall13 */
+dirname(str_replace("../","/", $value)); // 1
+
+/* testFunctionCall14 */
+dirname(str_replace("../", "/", trim($value))); // 1
+
+/* testFunctionCall15 */
+dirname( plugin_basename( __FILE__ ), trim( 2 ) ); // 2
+
+/* testFunctionCall16 */
+mktime($stHour, 0, 0, $arrStDt[0], $arrStDt[1], $arrStDt[2]); // 6
+
+/* testFunctionCall17 */
+mktime(0, 0, 0, date('m'), date('d'), date('Y')); // 6
+
+/* testFunctionCall18 */
+mktime(0, 0, 0, date('m'), date('d') - 1, date('Y') + 1); // 6
+
+/* testFunctionCall19 */
+mktime(0, 0, 0, date('m') + 1, date('d'), date('Y')); // 6
+
+/* testFunctionCall20 */
+mktime(date('H'), 0, 0, date('m'), date('d'), date('Y')); // 6
+
+/* testFunctionCall21 */
+mktime(0, 0, date('s'), date('m'), date('d'), date('Y')); // 6
+
+/* testFunctionCall22 */
+mktime(some_call(5, 1), another(1), why(5, 1, 2), 4, 5, 6); // 6
+
+/* testFunctionCall23 */
+filter_input_array(
+    INPUT_POST,
+    $args,
+    false
+); // 3
+
+/* testFunctionCall24 */
+gettimeofday (
+               true
+             ); // 1
+
+/* testFunctionCall25 */
+json_encode( array(), );
+
+/* testFunctionCall26 */
+json_encode(['a' => 'b',]);
+
+/* testFunctionCall27 */
+json_encode(['a' => $a,]);
+
+/* testFunctionCall28 */
+json_encode(['a' => $a,] + (isset($b) ? ['b' => $b,] : []));
+
+/* testFunctionCall29 */
+json_encode(['a' => $a,] + (isset($b) ? ['b' => $b, 'c' => $c,] : []));
+
+/* testFunctionCall30 */
+json_encode(['a' => $a, 'b' => $b] + (isset($c) ? ['c' => $c, 'd' => $d] : []));
+
+/* testFunctionCall31 */
+json_encode(['a' => $a, 'b' => $b] + (isset($c) ? ['c' => $c, 'd' => $d,] : []));
+
+/* testFunctionCall32 */
+json_encode(['a' => $a, 'b' => $b] + (isset($c) ? ['c' => $c, 'd' => $d, $c => 'c'] : []));
+
+/* testFunctionCall33 */
+json_encode(['a' => $a,] + (isset($b) ? ['b' => $b,] : []) + ['c' => $c, 'd' => $d,]);
+
+/* testFunctionCall34 */
+json_encode(['a' => 'b', 'c' => 'd',]);
+
+/* testFunctionCall35 */
+json_encode(['a' => ['b',],]);
+
+/* testFunctionCall36 */
+json_encode(['a' => ['b' => 'c',],]);
+
+/* testFunctionCall37 */
+json_encode(['a' => ['b' => 'c',], 'd' => ['e' => 'f',],]);
+
+/* testFunctionCall38 */
+json_encode(['a' => $a, 'b' => $b,]);
+
+/* testFunctionCall39 */
+json_encode(['a' => $a,] + ['b' => $b,]);
+
+/* testFunctionCall40 */
+json_encode(['a' => $a] + ['b' => $b, 'c' => $c,]);
+
+/* testFunctionCall41 */
+json_encode(['a' => $a, 'b' => $b] + ['c' => $c, 'd' => $d]);
+
+/* testFunctionCall42 */
+json_encode(['a' => $a, 'b' => $b] + ['c' => $c, 'd' => $d,]);
+
+/* testFunctionCall43 */
+json_encode(['a' => $a, 'b' => $b] + ['c' => $c, 'd' => $d, $c => 'c']);
+
+/* testFunctionCall44 */
+json_encode(['a' => $a, 'b' => $b,] + ['c' => $c]);
+
+/* testFunctionCall45 */
+json_encode(['a' => $a, 'b' => $b,] + ['c' => $c,]);
+
+/* testFunctionCall46 */
+json_encode(['a' => $a, 'b' => $b, 'c' => $c]);
+
+/* testFunctionCall47 */
+json_encode(['a' => $a, 'b' => $b, 'c' => $c,] + ['c' => $c, 'd' => $d,]);
+
+/* testLongArray1 */
+$foo = array( 1, 2, 3, 4, 5, 6, true );
+
+/* testLongArray2 */
+$foo = array(str_replace("../", "/", trim($value))); // 1
+
+/* testLongArray3 */
+$foo = array($stHour, 0, 0, $arrStDt[0], $arrStDt[1], $arrStDt[2]); // 6
+
+/* testLongArray4 */
+$foo = array(0, 0, date('s'), date('m'), date('d'), date('Y')); // 6
+
+/* testLongArray5 */
+$foo = array(some_call(5, 1), another(1), why(5, 1, 2), 4, 5, 6); // 6
+
+/* testLongArray6 */
+$foo = array('a' => $a, 'b' => $b, 'c' => $c);
+
+/* testLongArray7 */
+$foo = array('a' => $a, 'b' => $b, 'c' => (isset($c) ? $c : null));
+
+/* testLongArray8 */
+$foo = array(0 => $a, 2 => $b, 6 => (isset($c) ? $c : null));
+
+/* testShortArray1 */
+$bar = [ 1, 2, 3, 4, 5, 6, true ];
+
+/* testShortArray2 */
+$bar = [str_replace("../", "/", trim($value))]; // 1
+
+/* testShortArray3 */
+$bar = [$stHour, 0, 0, $arrStDt[0], $arrStDt[1], $arrStDt[2]]; // 6
+
+/* testShortArray4 */
+$bar = [0, 0, date('s'), date('m'), date('d'), date('Y')]; // 6
+
+/* testShortArray5 */
+$bar = [some_call(5, 1), another(1), why(5, 1, 2), 4, 5, 6]; // 6
+
+/* testShortArray6 */
+$bar = ['a' => $a, 'b' => $b, 'c' => $c];
+
+/* testShortArray7 */
+$bar = ['a' => $a, 'b' => $b, 'c' => (isset($c) ? $c : null)];
+
+/* testShortArray8 */
+$bar = [0 => $a, 2 => $b, 6 => (isset($c) ? $c : null)];

--- a/Tests/Utils/PassedParameters/GetParameterCountTest.php
+++ b/Tests/Utils/PassedParameters/GetParameterCountTest.php
@@ -1,0 +1,322 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\PassedParameters;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\PassedParameters;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\PassedParameters::getParameterCount() method.
+ *
+ * @covers \PHPCSUtils\Utils\PassedParameters::getParameterCount
+ * @covers \PHPCSUtils\Utils\PassedParameters::getParameters
+ * @covers \PHPCSUtils\Utils\PassedParameters::hasParameters
+ *
+ * @group passedparameters
+ *
+ * @since 1.0.0
+ */
+class GetParameterCountTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test correctly counting the number of passed parameters.
+     *
+     * @dataProvider dataGetParameterCount
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param int    $expected   The expected parameter count.
+     *
+     * @return void
+     */
+    public function testGetParameterCount($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken(
+            $testMarker,
+            [\T_STRING, \T_ARRAY, \T_OPEN_SHORT_ARRAY, \T_ISSET, \T_UNSET]
+        );
+        $result   = PassedParameters::getParameterCount(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetParameterCount() For the array format.
+     *
+     * @return array
+     */
+    public function dataGetParameterCount()
+    {
+        return [
+            'function-call-0' => [
+                '/* testFunctionCall0 */',
+                0,
+            ],
+            'function-call-1' => [
+                '/* testFunctionCall1 */',
+                1,
+            ],
+            'function-call-2' => [
+                '/* testFunctionCall2 */',
+                2,
+            ],
+            'function-call-3' => [
+                '/* testFunctionCall3 */',
+                3,
+            ],
+            'function-call-4' => [
+                '/* testFunctionCall4 */',
+                4,
+            ],
+            'function-call-5' => [
+                '/* testFunctionCall5 */',
+                5,
+            ],
+            'function-call-6' => [
+                '/* testFunctionCall6 */',
+                6,
+            ],
+            'function-call-7' => [
+                '/* testFunctionCall7 */',
+                7,
+            ],
+            'function-call-8' => [
+                '/* testFunctionCall8 */',
+                1,
+            ],
+            'function-call-9' => [
+                '/* testFunctionCall9 */',
+                1,
+            ],
+            'function-call-10' => [
+                '/* testFunctionCall10 */',
+                1,
+            ],
+            'function-call-11' => [
+                '/* testFunctionCall11 */',
+                2,
+            ],
+            'function-call-12' => [
+                '/* testFunctionCall12 */',
+                1,
+            ],
+            'function-call-13' => [
+                '/* testFunctionCall13 */',
+                1,
+            ],
+            'function-call-14' => [
+                '/* testFunctionCall14 */',
+                1,
+            ],
+            'function-call-15' => [
+                '/* testFunctionCall15 */',
+                2,
+            ],
+            'function-call-16' => [
+                '/* testFunctionCall16 */',
+                6,
+            ],
+            'function-call-17' => [
+                '/* testFunctionCall17 */',
+                6,
+            ],
+            'function-call-18' => [
+                '/* testFunctionCall18 */',
+                6,
+            ],
+            'function-call-19' => [
+                '/* testFunctionCall19 */',
+                6,
+            ],
+            'function-call-20' => [
+                '/* testFunctionCall20 */',
+                6,
+            ],
+            'function-call-21' => [
+                '/* testFunctionCall21 */',
+                6,
+            ],
+            'function-call-22' => [
+                '/* testFunctionCall22 */',
+                6,
+            ],
+            'function-call-23' => [
+                '/* testFunctionCall23 */',
+                3,
+            ],
+            'function-call-24' => [
+                '/* testFunctionCall24 */',
+                1,
+            ],
+            'function-call-25' => [
+                '/* testFunctionCall25 */',
+                1,
+            ],
+            'function-call-26' => [
+                '/* testFunctionCall26 */',
+                1,
+            ],
+            'function-call-27' => [
+                '/* testFunctionCall27 */',
+                1,
+            ],
+            'function-call-28' => [
+                '/* testFunctionCall28 */',
+                1,
+            ],
+            'function-call-29' => [
+                '/* testFunctionCall29 */',
+                1,
+            ],
+            'function-call-30' => [
+                '/* testFunctionCall30 */',
+                1,
+            ],
+            'function-call-31' => [
+                '/* testFunctionCall31 */',
+                1,
+            ],
+            'function-call-32' => [
+                '/* testFunctionCall32 */',
+                1,
+            ],
+            'function-call-33' => [
+                '/* testFunctionCall33 */',
+                1,
+            ],
+            'function-call-34' => [
+                '/* testFunctionCall34 */',
+                1,
+            ],
+            'function-call-35' => [
+                '/* testFunctionCall35 */',
+                1,
+            ],
+            'function-call-36' => [
+                '/* testFunctionCall36 */',
+                1,
+            ],
+            'function-call-37' => [
+                '/* testFunctionCall37 */',
+                1,
+            ],
+            'function-call-38' => [
+                '/* testFunctionCall38 */',
+                1,
+            ],
+            'function-call-39' => [
+                '/* testFunctionCall39 */',
+                1,
+            ],
+            'function-call-40' => [
+                '/* testFunctionCall40 */',
+                1,
+            ],
+            'function-call-41' => [
+                '/* testFunctionCall41 */',
+                1,
+            ],
+            'function-call-42' => [
+                '/* testFunctionCall42 */',
+                1,
+            ],
+            'function-call-43' => [
+                '/* testFunctionCall43 */',
+                1,
+            ],
+            'function-call-44' => [
+                '/* testFunctionCall44 */',
+                1,
+            ],
+            'function-call-45' => [
+                '/* testFunctionCall45 */',
+                1,
+            ],
+            'function-call-46' => [
+                '/* testFunctionCall46 */',
+                1,
+            ],
+            'function-call-47' => [
+                '/* testFunctionCall47 */',
+                1,
+            ],
+
+            // Long arrays.
+            'long-array-1' => [
+                '/* testLongArray1 */',
+                7,
+            ],
+            'long-array-2' => [
+                '/* testLongArray2 */',
+                1,
+            ],
+            'long-array-3' => [
+                '/* testLongArray3 */',
+                6,
+            ],
+            'long-array-4' => [
+                '/* testLongArray4 */',
+                6,
+            ],
+            'long-array-5' => [
+                '/* testLongArray5 */',
+                6,
+            ],
+            'long-array-6' => [
+                '/* testLongArray6 */',
+                3,
+            ],
+            'long-array-7' => [
+                '/* testLongArray7 */',
+                3,
+            ],
+            'long-array-8' => [
+                '/* testLongArray8 */',
+                3,
+            ],
+
+            // Short arrays.
+            'short-array-1' => [
+                '/* testShortArray1 */',
+                7,
+            ],
+            'short-array-2' => [
+                '/* testShortArray2 */',
+                1,
+            ],
+            'short-array-3' => [
+                '/* testShortArray3 */',
+                6,
+            ],
+            'short-array-4' => [
+                '/* testShortArray4 */',
+                6,
+            ],
+            'short-array-5' => [
+                '/* testShortArray5 */',
+                6,
+            ],
+            'short-array-6' => [
+                '/* testShortArray6 */',
+                3,
+            ],
+            'short-array-7' => [
+                '/* testShortArray7 */',
+                3,
+            ],
+            'short-array-8' => [
+                '/* testShortArray8 */',
+                3,
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/PassedParameters/GetParametersTest.inc
+++ b/Tests/Utils/PassedParameters/GetParametersTest.inc
@@ -1,0 +1,114 @@
+<?php
+
+/* testNoParams */
+myfunction();
+
+/* testFunctionCall */
+myfunction( 1, 2, 3, 4, 5, 6, true );
+
+/* testFunctionCallNestedFunctionCall */
+dirname( dirname( __FILE__ ) ); // 1
+
+/* testAnotherFunctionCall */
+mktime($stHour, 0, 0, $arrStDt[0], $arrStDt[1], $arrStDt[2]); // 6
+
+/* testFunctionCallTrailingComma */
+json_encode( array(), );
+
+/* testFunctionCallNestedShortArray */
+json_encode(['a' => $a,] + (isset($b) ? ['b' => $b,] : []));
+
+/* testLongArrayNestedFunctionCalls */
+$foo = array(some_call(5, 1), another(1), why(5, 1, 2), 4, 5, 6); // 6
+
+/* testSimpleLongArray */
+$foo = array( 1, 2, 3, 4, 5, 6, true );
+
+/* testLongArrayWithKeys */
+$foo = array('a' => $a, 'b' => $b, 'c' => $c);
+
+/* testShortArrayNestedFunctionCalls */
+$bar = [0, 0, date('s', $timestamp), date('m'), date('d'), date('Y')]; // 6
+
+/* testShortArrayMoreNestedFunctionCalls */
+$bar = [str_replace("../", "/", trim($value))]; // 1
+
+/* testShortArrayWithKeysAndTernary */
+$bar = [0 => $a, 2 => $b, 6 => (isset($c) ? $c : null)];
+
+/* testShortArrayWithKeysTernaryAndNullCoalesce */
+$bar = [
+    'foo' => 'foo',
+    'bar' => $baz ?
+        ['abc'] :
+        ['def'],
+    'hey' => $baz ??
+        ['one'] ??
+        ['two'],
+];
+
+/* testNestedArraysToplevel */
+$array = array(
+    '1' => array(
+        0 => 'more nesting',
+        /* testNestedArraysLevel2 */
+        1 => array(1,2,3),
+    ),
+    /* testNestedArraysLevel1 */
+    '2' => [
+        0 => 'more nesting',
+        1 => [1,2,3],
+    ],
+);
+
+/* testFunctionCallNestedArrayNestedClosureWithCommas */
+preg_replace_callback_array(
+    /* testShortArrayNestedClosureWithCommas */
+    [
+        '~'.$dyn.'~J' => function ($match) {
+            echo strlen($match[0]), ' matches for "a" found', PHP_EOL;
+        },
+        '~'.function_call().'~i' => function ($match) {
+            echo strlen($match[0]), ' matches for "b" found', PHP_EOL;
+        },
+    ],
+    $subject
+);
+
+/* testShortArrayNestedAnonClass */
+$array = [
+    /**
+     * Docblock to skip over.
+     */
+    'class' => new class() {
+        public $prop = [1,2,3];
+        public function test( $foo, $bar ) {
+            echo $foo, $bar;
+        }
+    },
+    /**
+     * Docblock to skip over.
+     */
+    'anotherclass' => new class() {
+        public function test( $foo, $bar ) {
+            echo $foo, $bar;
+        }
+    },
+];
+
+/* testVariableFunctionCall */
+$closure($a, (1 + 20), $a & $b );
+
+/* testStaticVariableFunctionCall */
+self::$closureInStaticProperty($a->property, $b->call() );
+
+/* testIsset */
+if ( isset(
+    $variable,
+    $object->property,
+    static::$property,
+    $array[$name][$sub],
+)) {}
+
+/* testUnset */
+unset( $variable, $object->property, static::$property, $array[$name], );

--- a/Tests/Utils/PassedParameters/GetParametersTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersTest.php
@@ -1,0 +1,671 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\PassedParameters;
+
+use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\PassedParameters;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\PassedParameters::getParameters() and
+ * \PHPCSUtils\Utils\PassedParameters::getParameter() methods.
+ *
+ * @covers \PHPCSUtils\Utils\PassedParameters::getParameters
+ * @covers \PHPCSUtils\Utils\PassedParameters::getParameter
+ * @covers \PHPCSUtils\Utils\PassedParameters::hasParameters
+ *
+ * @group passedparameters
+ *
+ * @since 1.0.0
+ */
+class GetParametersTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test retrieving the parameter details from a function call without parameters.
+     *
+     * @return void
+     */
+    public function testGetParametersNoParams()
+    {
+        $stackPtr = $this->getTargetToken('/* testNoParams */', \T_STRING);
+
+        $result = PassedParameters::getParameters(self::$phpcsFile, $stackPtr);
+        $this->assertSame([], $result);
+
+        $result = PassedParameters::getParameter(self::$phpcsFile, $stackPtr, 2);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test retrieving the parameter details from a function call or construct.
+     *
+     * @dataProvider dataGetParameters
+     *
+     * @param string     $testMarker The comment which prefaces the target token in the test file.
+     * @param int|string $targetType The type of token to look for.
+     * @param array      $expected   The expected parameter array.
+     *
+     * @return void
+     */
+    public function testGetParameters($testMarker, $targetType, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, [$targetType]);
+
+        // Start/end token position values in the expected array are set as offsets
+        // in relation to the target token.
+        // Change these to exact positions based on the retrieved stackPtr.
+        foreach ($expected as $key => $value) {
+            $expected[$key]['start'] = ($stackPtr + $value['start']);
+            $expected[$key]['end']   = ($stackPtr + $value['end']);
+        }
+
+        $result = PassedParameters::getParameters(self::$phpcsFile, $stackPtr);
+
+        foreach ($result as $key => $value) {
+            $this->assertArrayHasKey('clean', $value);
+
+            // The GetTokensAsString functions have their own tests, no need to duplicate it here.
+            unset($result[$key]['clean']);
+        }
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetParameters() For the array format.
+     *
+     * @return array
+     */
+    public function dataGetParameters()
+    {
+        return [
+            'function-call' => [
+                '/* testFunctionCall */',
+                \T_STRING,
+                [
+                    1 => [
+                        'start' => 2,
+                        'end'   => 3,
+                        'raw'   => '1',
+                    ],
+                    2 => [
+                        'start' => 5,
+                        'end'   => 6,
+                        'raw'   => '2',
+                    ],
+                    3 => [
+                        'start' => 8,
+                        'end'   => 9,
+                        'raw'   => '3',
+                    ],
+                    4 => [
+                        'start' => 11,
+                        'end'   => 12,
+                        'raw'   => '4',
+                    ],
+                    5 => [
+                        'start' => 14,
+                        'end'   => 15,
+                        'raw'   => '5',
+                    ],
+                    6 => [
+                        'start' => 17,
+                        'end'   => 18,
+                        'raw'   => '6',
+                    ],
+                    7 => [
+                        'start' => 20,
+                        'end'   => 22,
+                        'raw'   => 'true',
+                    ],
+                ],
+            ],
+            'function-call-nested' => [
+                '/* testFunctionCallNestedFunctionCall */',
+                \T_STRING,
+                [
+                    1 => [
+                        'start' => 2,
+                        'end'   => 9,
+                        'raw'   => 'dirname( __FILE__ )',
+                    ],
+                ],
+            ],
+            'another-function-call' => [
+                '/* testAnotherFunctionCall */',
+                \T_STRING,
+                [
+                    1 => [
+                        'start' => 2,
+                        'end'   => 2,
+                        'raw'   => '$stHour',
+                    ],
+                    2 => [
+                        'start' => 4,
+                        'end'   => 5,
+                        'raw'   => '0',
+                    ],
+                    3 => [
+                        'start' => 7,
+                        'end'   => 8,
+                        'raw'   => '0',
+                    ],
+                    4 => [
+                        'start' => 10,
+                        'end'   => 14,
+                        'raw'   => '$arrStDt[0]',
+                    ],
+                    5 => [
+                        'start' => 16,
+                        'end'   => 20,
+                        'raw'   => '$arrStDt[1]',
+                    ],
+                    6 => [
+                        'start' => 22,
+                        'end'   => 26,
+                        'raw'   => '$arrStDt[2]',
+                    ],
+                ],
+
+            ],
+            'function-call-trailing-comma' => [
+                '/* testFunctionCallTrailingComma */',
+                \T_STRING,
+                [
+                    1 => [
+                        'start' => 2,
+                        'end'   => 5,
+                        'raw'   => 'array()',
+                    ],
+                ],
+            ],
+            'function-call-nested-short-array' => [
+                '/* testFunctionCallNestedShortArray */',
+                \T_STRING,
+                [
+                    1 => [
+                        'start' => 2,
+                        'end'   => 34,
+                        'raw'   => '[\'a\' => $a,] + (isset($b) ? [\'b\' => $b,] : [])',
+                    ],
+                ],
+            ],
+            'function-call-nested-array-nested-closure-with-commas' => [
+                '/* testFunctionCallNestedArrayNestedClosureWithCommas */',
+                \T_STRING,
+                [
+                    1 => [
+                        'start' => 2,
+                        'end'   => 90,
+                        'raw'   => '/* testShortArrayNestedClosureWithCommas */
+    [
+        \'~\'.$dyn.\'~J\' => function ($match) {
+            echo strlen($match[0]), \' matches for "a" found\', PHP_EOL;
+        },
+        \'~\'.function_call().\'~i\' => function ($match) {
+            echo strlen($match[0]), \' matches for "b" found\', PHP_EOL;
+        },
+    ]',
+                    ],
+                    2 => [
+                        'start' => 92,
+                        'end'   => 95,
+                        'raw'   => '$subject',
+                    ],
+                ],
+            ],
+
+            // Long array.
+            'long-array' => [
+                '/* testLongArrayNestedFunctionCalls */',
+                \T_ARRAY,
+                [
+                    1 => [
+                        'start' => 2,
+                        'end'   => 8,
+                        'raw'   => 'some_call(5, 1)',
+                    ],
+                    2 => [
+                        'start' => 10,
+                        'end'   => 14,
+                        'raw'   => 'another(1)',
+                    ],
+                    3 => [
+                        'start' => 16,
+                        'end'   => 26,
+                        'raw'   => 'why(5, 1, 2)',
+                    ],
+                    4 => [
+                        'start' => 28,
+                        'end'   => 29,
+                        'raw'   => '4',
+                    ],
+                    5 => [
+                        'start' => 31,
+                        'end'   => 32,
+                        'raw'   => '5',
+                    ],
+                    6 => [
+                        'start' => 34,
+                        'end'   => 35,
+                        'raw'   => '6',
+                    ],
+                ],
+            ],
+
+            // Short array.
+            'short-array' => [
+                '/* testShortArrayNestedFunctionCalls */',
+                \T_OPEN_SHORT_ARRAY,
+                [
+                    1 => [
+                        'start' => 1,
+                        'end'   => 1,
+                        'raw'   => '0',
+                    ],
+                    2 => [
+                        'start' => 3,
+                        'end'   => 4,
+                        'raw'   => '0',
+                    ],
+                    3 => [
+                        'start' => 6,
+                        'end'   => 13,
+                        'raw'   => 'date(\'s\', $timestamp)',
+                    ],
+                    4 => [
+                        'start' => 15,
+                        'end'   => 19,
+                        'raw'   => 'date(\'m\')',
+                    ],
+                    5 => [
+                        'start' => 21,
+                        'end'   => 25,
+                        'raw'   => 'date(\'d\')',
+                    ],
+                    6 => [
+                        'start' => 27,
+                        'end'   => 31,
+                        'raw'   => 'date(\'Y\')',
+                    ],
+                ],
+            ],
+            'short-array-with-keys-ternary-and-null-coalesce' => [
+                '/* testShortArrayWithKeysTernaryAndNullCoalesce */',
+                \T_OPEN_SHORT_ARRAY,
+                [
+                    1 => [
+                        'start' => 1,
+                        'end'   => 7,
+                        'raw'   => "'foo' => 'foo'",
+                    ],
+                    2 => [
+                        'start' => 9,
+                        'end'   => 29,
+                        'raw'   => '\'bar\' => $baz ?
+        [\'abc\'] :
+        [\'def\']',
+                    ],
+                    3 => [
+                        'start' => 31,
+                        // Account for null coalesce tokenization difference.
+                        'end'   => (Helper::getVersion() === '2.6.0' && \PHP_VERSION_ID < 59999)
+                            ? 53
+                            : 51,
+                        'raw'   => '\'hey\' => $baz ??
+        [\'one\'] ??
+        [\'two\']',
+                    ],
+                ],
+            ],
+
+            // Nested arrays.
+            'nested-arrays-top-level' => [
+                '/* testNestedArraysToplevel */',
+                \T_ARRAY,
+                [
+                    1 => [
+                        'start' => 2,
+                        'end'   => 38,
+                        'raw'   => '\'1\' => array(
+        0 => \'more nesting\',
+        /* testNestedArraysLevel2 */
+        1 => array(1,2,3),
+    )',
+                    ],
+                    2 => [
+                        'start' => 40,
+                        'end'   => 74,
+                        'raw'   => '/* testNestedArraysLevel1 */
+    \'2\' => [
+        0 => \'more nesting\',
+        1 => [1,2,3],
+    ]',
+                    ],
+                ],
+            ],
+
+            // Array containing closure.
+            'short-array-nested-closure-with-commas' => [
+                '/* testShortArrayNestedClosureWithCommas */',
+                \T_OPEN_SHORT_ARRAY,
+                [
+                    1 => [
+                        'start' => 1,
+                        'end'   => 38,
+                        'raw'   => '\'~\'.$dyn.\'~J\' => function ($match) {
+            echo strlen($match[0]), \' matches for "a" found\', PHP_EOL;
+        }',
+                    ],
+                    2 => [
+                        'start' => 40,
+                        'end'   => 79,
+                        'raw'   => '\'~\'.function_call().\'~i\' => function ($match) {
+            echo strlen($match[0]), \' matches for "b" found\', PHP_EOL;
+        }',
+                    ],
+                ],
+            ],
+
+            // Array containing anonymous class.
+            'short-array-nested-anon-class' => [
+                '/* testShortArrayNestedAnonClass */',
+                \T_OPEN_SHORT_ARRAY,
+                [
+                    1 => [
+                        'start' => 1,
+                        'end'   => 72,
+                        'raw'   => '/**
+     * Docblock to skip over.
+     */
+    \'class\' => new class() {
+        public $prop = [1,2,3];
+        public function test( $foo, $bar ) {
+            echo $foo, $bar;
+        }
+    }',
+                    ],
+                    2 => [
+                        'start' => 74,
+                        'end'   => 129,
+                        'raw'   => '/**
+     * Docblock to skip over.
+     */
+    \'anotherclass\' => new class() {
+        public function test( $foo, $bar ) {
+            echo $foo, $bar;
+        }
+    }',
+                    ],
+                ],
+            ],
+
+            // Function calling closure in variable.
+            'variable-function-call' => [
+                '/* testVariableFunctionCall */',
+                \T_VARIABLE,
+                [
+                    1 => [
+                        'start' => 2,
+                        'end'   => 2,
+                        'raw'   => '$a',
+                    ],
+                    2 => [
+                        'start' => 4,
+                        'end'   => 11,
+                        'raw'   => '(1 + 20)',
+                    ],
+                    3 => [
+                        'start' => 13,
+                        'end'   => 19,
+                        'raw'   => '$a & $b',
+                    ],
+                ],
+            ],
+            'static-variable-function-call' => [
+                '/* testStaticVariableFunctionCall */',
+                \T_VARIABLE,
+                [
+                    1 => [
+                        'start' => 2,
+                        'end'   => 4,
+                        'raw'   => '$a->property',
+                    ],
+                    2 => [
+                        'start' => 6,
+                        'end'   => 12,
+                        'raw'   => '$b->call()',
+                    ],
+                ],
+            ],
+            'isset' => [
+                '/* testIsset */',
+                \T_ISSET,
+                [
+                    1 => [
+                        'start' => 2,
+                        'end'   => 4,
+                        'raw'   => '$variable',
+                    ],
+                    2 => [
+                        'start' => 6,
+                        'end'   => 10,
+                        'raw'   => '$object->property',
+                    ],
+                    3 => [
+                        'start' => 12,
+                        'end'   => 16,
+                        'raw'   => 'static::$property',
+                    ],
+                    4 => [
+                        'start' => 18,
+                        'end'   => 26,
+                        'raw'   => '$array[$name][$sub]',
+                    ],
+                ],
+            ],
+            'unset' => [
+                '/* testUnset */',
+                \T_UNSET,
+                [
+                    1 => [
+                        'start' => 2,
+                        'end'   => 3,
+                        'raw'   => '$variable',
+                    ],
+                    2 => [
+                        'start' => 5,
+                        'end'   => 8,
+                        'raw'   => '$object->property',
+                    ],
+                    3 => [
+                        'start' => 10,
+                        'end'   => 13,
+                        'raw'   => 'static::$property',
+                    ],
+                    4 => [
+                        'start' => 15,
+                        'end'   => 19,
+                        'raw'   => '$array[$name]',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test retrieving the details for a specific parameter from a function call or construct.
+     *
+     * @dataProvider dataGetParameter
+     *
+     * @param string     $testMarker    The comment which prefaces the target token in the test file.
+     * @param int|string $targetType    The type of token to look for.
+     * @param int        $paramPosition The position of the parameter we want to retrieve the details for.
+     * @param array      $expected      The expected array for the specific parameter.
+     *
+     * @return void
+     */
+    public function testGetParameter($testMarker, $targetType, $paramPosition, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, [$targetType]);
+
+        // Start/end token position values in the expected array are set as offsets
+        // in relation to the target token.
+        // Change these to exact positions based on the retrieved stackPtr.
+        $expected['start'] += $stackPtr;
+        $expected['end']   += $stackPtr;
+
+        $result = PassedParameters::getParameter(self::$phpcsFile, $stackPtr, $paramPosition);
+
+        $this->assertArrayHasKey('clean', $result);
+
+        // The GetTokensAsString functions have their own tests, no need to duplicate it here.
+        unset($result['clean']);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetParameter() For the array format.
+     *
+     * @return array
+     */
+    public function dataGetParameter()
+    {
+        return [
+            'function-call-param-4' => [
+                '/* testFunctionCall */',
+                \T_STRING,
+                4,
+                [
+                    'start' => 11,
+                    'end'   => 12,
+                    'raw'   => '4',
+                ],
+            ],
+            'function-call-nested-param-1' => [
+                '/* testFunctionCallNestedFunctionCall */',
+                \T_STRING,
+                1,
+                [
+                    'start' => 2,
+                    'end'   => 9,
+                    'raw'   => 'dirname( __FILE__ )',
+                ],
+            ],
+            'another-function-call-param-1' => [
+                '/* testAnotherFunctionCall */',
+                \T_STRING,
+                1,
+                [
+                    'start' => 2,
+                    'end'   => 2,
+                    'raw'   => '$stHour',
+                ],
+            ],
+            'another-function-call-param-6' => [
+                '/* testAnotherFunctionCall */',
+                \T_STRING,
+                6,
+                [
+                    'start' => 22,
+                    'end'   => 26,
+                    'raw'   => '$arrStDt[2]',
+                ],
+            ],
+            'long-array-nested-function-calls-param-3' => [
+                '/* testLongArrayNestedFunctionCalls */',
+                \T_ARRAY,
+                3,
+                [
+                    'start' => 16,
+                    'end'   => 26,
+                    'raw'   => 'why(5, 1, 2)',
+                ],
+            ],
+            'simple-long-array-param-1' => [
+                '/* testSimpleLongArray */',
+                \T_ARRAY,
+                1,
+                [
+                    'start' => 2,
+                    'end'   => 3,
+                    'raw'   => '1',
+                ],
+            ],
+            'simple-long-array-param-7' => [
+                '/* testSimpleLongArray */',
+                \T_ARRAY,
+                7,
+                [
+                    'start' => 20,
+                    'end'   => 22,
+                    'raw'   => 'true',
+                ],
+            ],
+            'long-array-with-keys-param-' => [
+                '/* testLongArrayWithKeys */',
+                \T_ARRAY,
+                2,
+                [
+                    'start' => 8,
+                    'end'   => 13,
+                    'raw'   => '\'b\' => $b',
+                ],
+            ],
+            'short-array-more-nested-function-calls-param-1' => [
+                '/* testShortArrayMoreNestedFunctionCalls */',
+                \T_OPEN_SHORT_ARRAY,
+                1,
+                [
+                    'start' => 1,
+                    'end'   => 13,
+                    'raw'   => 'str_replace("../", "/", trim($value))',
+                ],
+            ],
+            'short-array-with-keys-and-ternary-param-3' => [
+                '/* testShortArrayWithKeysAndTernary */',
+                \T_OPEN_SHORT_ARRAY,
+                3,
+                [
+                    'start' => 14,
+                    'end'   => 32,
+                    'raw'   => '6 => (isset($c) ? $c : null)',
+                ],
+            ],
+            'nested-arrays-level-2-param-1' => [
+                '/* testNestedArraysLevel2 */',
+                \T_ARRAY,
+                1,
+                [
+                    'start' => 2,
+                    'end'   => 2,
+                    'raw'   => '1',
+                ],
+            ],
+            'nested-arrays-level-1-param-2' => [
+                '/* testNestedArraysLevel1 */',
+                \T_OPEN_SHORT_ARRAY,
+                2,
+                [
+                    'start' => 9,
+                    'end'   => 21,
+                    'raw'   => '1 => [1,2,3]',
+                ],
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/PassedParameters/HasParametersTest.inc
+++ b/Tests/Utils/PassedParameters/HasParametersTest.inc
@@ -1,0 +1,117 @@
+<?php
+
+/* testNotAnAcceptedToken */
+interface NotAFunctionCallOrArray {}
+
+class Foo {
+    public function Bar() {
+        /* testNotACallToConstructor */
+        $a = self::some_method();
+    }
+}
+
+// Function calls: no parameters.
+
+/* testNoParamsFunctionCall1 */
+some_function();
+
+/* testNoParamsFunctionCall2 */
+some_function(     );
+
+/* testNoParamsFunctionCall3 */
+some_function( /*nothing here*/ );
+
+/* testNoParamsFunctionCall4 */
+$closure(/*nothing here*/);
+
+// Function calls: has parameters.
+
+/* testHasParamsFunctionCall1 */
+some_function( 1 );
+
+/* testHasParamsFunctionCall2 */
+$closure(1,2,3);
+
+class Bar {
+    public static function getInstance() {
+        /* testHasParamsFunctionCall3 */
+        return new self(true);
+    }
+}
+
+// Arrays: no parameters.
+
+/* testNoParamsLongArray1 */
+$foo = array();
+
+/* testNoParamsLongArray2 */
+$foo = array(     );
+
+/* testNoParamsLongArray3 */
+$foo = array( /*nothing here*/ );
+
+/* testNoParamsLongArray4 */
+$foo = array(/*nothing here*/);
+
+/* testNoParamsShortArray1 */
+$bar = [];
+
+/* testNoParamsShortArray2 */
+$bar = [     ];
+
+/* testNoParamsShortArray3 */
+$bar = [ /*nothing here*/ ];
+
+/* testNoParamsShortArray4 */
+$bar = [/*nothing here*/];
+
+// Arrays: has parameters.
+
+/* testHasParamsLongArray1 */
+$foo = array( 1 );
+
+/* testHasParamsLongArray2 */
+$foo = array(1,2,3);
+
+/* testHasParamsLongArray3 */
+$foo = array(true);
+
+/* testHasParamsShortArray1 */
+$bar = [ 1 ];
+
+/* testHasParamsShortArray2 */
+$bar = [1,2,3];
+
+/* testHasParamsShortArray3 */
+$bar = [true];
+
+/* testNoParamsIsset */
+$a = isset( /* comment */ ); // Intentional parse error.
+
+/* testHasParamsIsset */
+$a = isset( $array[$key] );
+
+/* testNoParamsUnset */
+unset(
+
+
+); // Intentional parse error.
+
+/* testHasParamsUnset */
+unset(
+
+      $hello,
+
+);
+
+// Intentional parse error.
+/* testNoCloseParenthesis */
+$array = array(1, 2, 3
+
+// Intentional parse error.
+/* testNoOpenParenthesis */
+$array = function_call[];
+
+// Intentional parse error. This has to be the last test in the file without a new line after it.
+/* testLiveCoding */
+$array = array

--- a/Tests/Utils/PassedParameters/HasParametersTest.php
+++ b/Tests/Utils/PassedParameters/HasParametersTest.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Operators;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\PassedParameters;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\PassedParameters::hasParameters() method.
+ *
+ * @covers \PHPCSUtils\Utils\PassedParameters::hasParameters
+ *
+ * @group passedparameters
+ *
+ * @since 1.0.0
+ */
+class HasParametersTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test receiving an expected exception when an invalid token pointer is passed.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->expectPhpcsException(
+            'The hasParameters() method expects a function call, array, isset or unset token to be passed'
+        );
+
+        PassedParameters::hasParameters(self::$phpcsFile, 100000);
+    }
+
+    /**
+     * Test receiving an expected exception when a token which is not supported by
+     * these methods is passed.
+     *
+     * @return void
+     */
+    public function testNotAnAcceptedTokenException()
+    {
+        $this->expectPhpcsException(
+            'The hasParameters() method expects a function call, array, isset or unset token to be passed.'
+        );
+
+        $interface = $this->getTargetToken('/* testNotAnAcceptedToken */', \T_INTERFACE);
+        PassedParameters::hasParameters(self::$phpcsFile, $interface);
+    }
+
+    /**
+     * Test receiving an expected exception when T_SELF is passed not preceeded by `new`.
+     *
+     * @return void
+     */
+    public function testNotACallToConstructor()
+    {
+        $this->expectPhpcsException(
+            'The hasParameters() method expects a function call, array, isset or unset token to be passed.'
+        );
+
+        $self = $this->getTargetToken('/* testNotACallToConstructor */', \T_SELF);
+        PassedParameters::hasParameters(self::$phpcsFile, $self);
+    }
+
+    /**
+     * Test correctly identifying whether parameters were passed to a function call or construct.
+     *
+     * @dataProvider dataHasParameters
+     *
+     * @param string     $testMarker The comment which prefaces the target token in the test file.
+     * @param int|string $targetType The type of token to look for.
+     * @param bool       $expected   Whether or not the function/array has parameters/values.
+     *
+     * @return void
+     */
+    public function testHasParameters($testMarker, $targetType, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, $targetType);
+        $result   = PassedParameters::hasParameters(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testHasParameters() For the array format.
+     *
+     * @return array
+     */
+    public function dataHasParameters()
+    {
+        return [
+            // Function calls.
+            'no-params-function-call-1' => [
+                '/* testNoParamsFunctionCall1 */',
+                \T_STRING,
+                false,
+            ],
+            'no-params-function-call-2' => [
+                '/* testNoParamsFunctionCall2 */',
+                \T_STRING,
+                false,
+            ],
+            'no-params-function-call-3' => [
+                '/* testNoParamsFunctionCall3 */',
+                \T_STRING,
+                false,
+            ],
+            'no-params-function-call-4' => [
+                '/* testNoParamsFunctionCall4 */',
+                \T_VARIABLE,
+                false,
+            ],
+            'has-params-function-call-1' => [
+                '/* testHasParamsFunctionCall1 */',
+                \T_STRING,
+                true,
+            ],
+            'has-params-function-call-2' => [
+                '/* testHasParamsFunctionCall2 */',
+                \T_VARIABLE,
+                true,
+            ],
+            'has-params-function-call-3' => [
+                '/* testHasParamsFunctionCall3 */',
+                // In PHPCS < 2.8.0, self in "new self" is tokenized as T_STRING.
+                [\T_SELF, \T_STRING],
+                true,
+            ],
+
+            // Arrays.
+            'no-params-long-array-1' => [
+                '/* testNoParamsLongArray1 */',
+                \T_ARRAY,
+                false,
+            ],
+            'no-params-long-array-2' => [
+                '/* testNoParamsLongArray2 */',
+                \T_ARRAY,
+                false,
+            ],
+            'no-params-long-array-3' => [
+                '/* testNoParamsLongArray3 */',
+                \T_ARRAY,
+                false,
+            ],
+            'no-params-long-array-4' => [
+                '/* testNoParamsLongArray4 */',
+                \T_ARRAY,
+                false,
+            ],
+            'no-params-short-array-1' => [
+                '/* testNoParamsShortArray1 */',
+                \T_OPEN_SHORT_ARRAY,
+                false,
+            ],
+            'no-params-short-array-2' => [
+                '/* testNoParamsShortArray2 */',
+                \T_OPEN_SHORT_ARRAY,
+                false,
+            ],
+            'no-params-short-array-3' => [
+                '/* testNoParamsShortArray3 */',
+                \T_OPEN_SHORT_ARRAY,
+                false,
+            ],
+            'no-params-short-array-4' => [
+                '/* testNoParamsShortArray4 */',
+                \T_OPEN_SHORT_ARRAY,
+                false,
+            ],
+            'has-params-long-array-1' => [
+                '/* testHasParamsLongArray1 */',
+                \T_ARRAY,
+                true,
+            ],
+            'has-params-long-array-2' => [
+                '/* testHasParamsLongArray2 */',
+                \T_ARRAY,
+                true,
+            ],
+            'has-params-long-array-3' => [
+                '/* testHasParamsLongArray3 */',
+                \T_ARRAY,
+                true,
+            ],
+            'has-params-short-array-1' => [
+                '/* testHasParamsShortArray1 */',
+                \T_OPEN_SHORT_ARRAY,
+                true,
+            ],
+            'has-params-short-array-2' => [
+                '/* testHasParamsShortArray2 */',
+                \T_OPEN_SHORT_ARRAY,
+                true,
+            ],
+            'has-params-short-array-3' => [
+                '/* testHasParamsShortArray3 */',
+                \T_OPEN_SHORT_ARRAY,
+                true,
+            ],
+
+            // Isset.
+            'no-params-isset' => [
+                '/* testNoParamsIsset */',
+                \T_ISSET,
+                false,
+            ],
+            'has-params-isset' => [
+                '/* testHasParamsIsset */',
+                \T_ISSET,
+                true,
+            ],
+
+            // Unset.
+            'no-params-unset' => [
+                '/* testNoParamsUnset */',
+                \T_UNSET,
+                false,
+            ],
+            'has-params-unset' => [
+                '/* testHasParamsUnset */',
+                \T_UNSET,
+                true,
+            ],
+
+            // Defensive coding against parse errors and live coding.
+            'defense-in-depth-no-close-parens' => [
+                '/* testNoCloseParenthesis */',
+                \T_ARRAY,
+                false,
+            ],
+            'defense-in-depth-no-open-parens' => [
+                '/* testNoOpenParenthesis */',
+                \T_STRING,
+                false,
+            ],
+            'defense-in-depth-live-coding' => [
+                '/* testLiveCoding */',
+                \T_ARRAY,
+                false,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This introduces four new methods to PHPCSUtils.

These methods are intended for use with:
* `T_STRING` and `T_VARIABLE` tokens for function calls;
* `T_SELF` and `T_STATIC` token for function calls in the form of `new self()`;
* `T_ARRAY` and `T_OPEN_SHORT_ARRAY` tokens for array declarations;
* `T_ISSET` and `T_UNSET` tokens for calls to these language constructs.

Methods:
* `hasParameters()` - to check if parameters have been passed. Returns true/false.
* `getParameters()` - to retrieve details of the passed parameters. Returns an array with `start` (token position), `end` (token position), `raw` (string content) and `clean` (string content without comments) information for each parameter.
* `getParameter()` - to retrieve the details of a specific parameter. Index for the parameters is 1-based. Returns an array with the details for the specified parameter or `false` if the parameter does not exist.
* `getParameterCount()` - to get the a count of the number of parameters. Returns integer.

These methods have been battle-tested in the past year or two in the PHPCompatibility and the WordPressCS standards.

Includes dedicated unit tests.

N.B.: In the class as pulled to PHPCS originally, these methods also handled (short/long) list constructs, however, as lists can have empty entries - `list(,,)` - prior to PHP 7 and can skip items - `list($a,, $b)` - in cross-version PHP, parsing lists with the functions in this class will break on those type of list definitions.
So, I've decided that this is better served with a dedicated utility function focussing just on list constructs.