### PR TITLE
New Utils\Lists class

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -59,6 +59,21 @@ class Collections
     ];
 
     /**
+     * Tokens which are used to create lists.
+     *
+     * @since 1.0.0
+     *
+     * @see \PHPCSUtils\Tokens\Collections::$shortListTokens Related list containing only tokens used for short lists.
+     *
+     * @var array <int|string> => <int|string>
+     */
+    public static $listTokens = [
+        \T_LIST              => \T_LIST,
+        \T_OPEN_SHORT_ARRAY  => \T_OPEN_SHORT_ARRAY,
+        \T_CLOSE_SHORT_ARRAY => \T_CLOSE_SHORT_ARRAY,
+    ];
+
+    /**
      * List of tokens which can end a namespace declaration statement.
      *
      * @since 1.0.0
@@ -188,5 +203,19 @@ class Collections
         \T_NS_SEPARATOR => \T_NS_SEPARATOR,
         \T_RETURN_TYPE  => \T_RETURN_TYPE, // PHPCS 2.4.0 < 3.3.0.
         \T_ARRAY_HINT   => \T_ARRAY_HINT, // PHPCS < 2.8.0.
+    ];
+
+    /**
+     * Tokens which are used for short lists.
+     *
+     * @since 1.0.0
+     *
+     * @see \PHPCSUtils\Tokens\Collections::$listTokens Related list containing all tokens used for lists.
+     *
+     * @var array <int|string> => <int|string>
+     */
+    public static $shortListTokens = [
+        \T_OPEN_SHORT_ARRAY  => \T_OPEN_SHORT_ARRAY,
+        \T_CLOSE_SHORT_ARRAY => \T_CLOSE_SHORT_ARRAY,
     ];
 }

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -74,6 +74,26 @@ class Collections
     ];
 
     /**
+     * Tokens which are used to create lists.
+     *
+     * List which is backward-compatible with PHPCS < 3.3.0.
+     * Should only be used selectively.
+     *
+     * @since 1.0.0
+     *
+     * @see \PHPCSUtils\Tokens\Collections::$shortListTokensBC Related list containing only tokens used for short lists.
+     *
+     * @var array <int|string> => <int|string>
+     */
+    public static $listTokensBC = [
+        \T_LIST                 => \T_LIST,
+        \T_OPEN_SHORT_ARRAY     => \T_OPEN_SHORT_ARRAY,
+        \T_CLOSE_SHORT_ARRAY    => \T_CLOSE_SHORT_ARRAY,
+        \T_OPEN_SQUARE_BRACKET  => \T_OPEN_SQUARE_BRACKET,
+        \T_CLOSE_SQUARE_BRACKET => \T_CLOSE_SQUARE_BRACKET,
+    ];
+
+    /**
      * List of tokens which can end a namespace declaration statement.
      *
      * @since 1.0.0
@@ -217,5 +237,24 @@ class Collections
     public static $shortListTokens = [
         \T_OPEN_SHORT_ARRAY  => \T_OPEN_SHORT_ARRAY,
         \T_CLOSE_SHORT_ARRAY => \T_CLOSE_SHORT_ARRAY,
+    ];
+
+    /**
+     * Tokens which are used for short lists.
+     *
+     * List which is backward-compatible with PHPCS < 3.3.0.
+     * Should only be used selectively.
+     *
+     * @since 1.0.0
+     *
+     * @see \PHPCSUtils\Tokens\Collections::$listTokensBC Related list containing all tokens used for lists.
+     *
+     * @var array <int|string> => <int|string>
+     */
+    public static $shortListTokensBC = [
+        \T_OPEN_SHORT_ARRAY     => \T_OPEN_SHORT_ARRAY,
+        \T_CLOSE_SHORT_ARRAY    => \T_CLOSE_SHORT_ARRAY,
+        \T_OPEN_SQUARE_BRACKET  => \T_OPEN_SQUARE_BRACKET,
+        \T_CLOSE_SQUARE_BRACKET => \T_CLOSE_SQUARE_BRACKET,
     ];
 }

--- a/PHPCSUtils/Utils/Lists.php
+++ b/PHPCSUtils/Utils/Lists.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Utils;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
+
+/**
+ * Utility functions to retrieve information when working with lists.
+ *
+ * @since 1.0.0
+ */
+class Lists
+{
+
+    /**
+     * Determine whether a T_OPEN/CLOSE_SHORT_ARRAY token is a short list() construct.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the short array bracket token.
+     *
+     * @return bool True if the token passed is the open/close bracket of a short list.
+     *              False if the token is a short array bracket or not
+     *              a T_OPEN/CLOSE_SHORT_ARRAY token.
+     */
+    public static function isShortList(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Is this one of the tokens this function handles ?
+        if (isset($tokens[$stackPtr]) === false
+            || isset(Collections::$shortListTokens[$tokens[$stackPtr]['code']]) === false
+        ) {
+            return false;
+        }
+
+        switch ($tokens[$stackPtr]['code']) {
+            case \T_OPEN_SHORT_ARRAY:
+                $opener = $stackPtr;
+                $closer = $tokens[$stackPtr]['bracket_closer'];
+                break;
+
+            case \T_CLOSE_SHORT_ARRAY:
+                $opener = $tokens[$stackPtr]['bracket_opener'];
+                $closer = $stackPtr;
+                break;
+        }
+
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($closer + 1), null, true);
+        if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === \T_EQUAL) {
+            return true;
+        }
+
+        // Check for short list in foreach, i.e. `foreach($array as [$a, $b])`.
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true);
+        if ($prevNonEmpty !== false
+            && ($tokens[$prevNonEmpty]['code'] === \T_AS
+                || $tokens[$prevNonEmpty]['code'] === \T_DOUBLE_ARROW)
+            && Parentheses::lastOwnerIn($phpcsFile, $prevNonEmpty, \T_FOREACH) !== false
+        ) {
+            return true;
+        }
+
+        // Maybe this is a short list syntax nested inside another short list syntax ?
+        $parentOpen = $opener;
+        do {
+            $parentOpen = $phpcsFile->findPrevious(
+                \T_OPEN_SHORT_ARRAY,
+                ($parentOpen - 1),
+                null,
+                false,
+                null,
+                true
+            );
+
+            if ($parentOpen === false) {
+                return false;
+            }
+        } while ($tokens[$parentOpen]['bracket_closer'] < $opener);
+
+        return self::isShortList($phpcsFile, $parentOpen);
+    }
+}

--- a/Tests/Utils/Lists/IsShortListTest.inc
+++ b/Tests/Utils/Lists/IsShortListTest.inc
@@ -1,0 +1,87 @@
+<?php
+
+/* testLongList */
+list( $a ) = $b;
+
+/* testArrayAssignment */
+$b[] = $c;
+
+/* testNonNestedShortArray */
+$array = [$a];
+
+/* testNoAssignment */
+if( [$a, /* testNestedNoAssignment */ [$b]] === $array ) {};
+
+/* testShortArrayInForeach */
+foreach ([1, 2, 3] as $id) {}
+
+echo 'just here to prevent the below test running into a tokenizer issue tested separately';
+
+/* testShortList */
+[$b] = $c;
+
+/* testShortListDetectOnCloseBracket */
+[$a, $b] = $c;
+
+/* testShortListWithNesting */
+[$a, /* testNestedShortList */ [$b]] = array(new stdclass, array(new stdclass));
+
+/* testShortListInForeach */
+foreach ($data as [$id, $name, $info]) {}
+
+/* testShortListInForeachWithKey */
+foreach ($data as $key => [$id, $name, $info]) {}
+
+foreach ($array as [$a, /* testShortListInForeachNested */ [$b, $c]]) {}
+
+/* testMultiAssignShortlist */
+$foo = [$baz, $bat] = [$a, $b];
+
+/* testShortListWithKeys */
+["id" => $id1, "name" => $name1] = $data[0];
+
+/* testShortListInForeachWithKeysDetectOnCloseBracket */
+foreach ($data as ["id" => $id, "name" => $name]) {}
+
+echo 'just here to prevent the below test running into a tokenizer issue tested separately';
+
+// Invalid as empty lists are not allowed, but it is short list syntax.
+[$x, /* testNestedShortListEmpty */ [], $y] = $a;
+
+[$x, [ $y, /* testDeeplyNestedShortList */ [$z]], $q] = $a;
+
+/* testShortListWithNestingAndKeys */
+[
+    /* testNestedShortListWithKeys_1 */
+    ["x" => $x1, "y" => $y1],
+    /* testNestedShortListWithKeys_2 */
+    ["x" => $x2, "y" => $y2],
+    /* testNestedShortListWithKeys_3 */
+    ["x" => $x3, "y" => $y3],
+] = $points;
+
+/* testShortListWithoutVars */
+// Invalid list as it doesn't contain variables, but it is short list syntax.
+[42] = [1];
+
+/* testShortListNestedLongList */
+// Invalid list as mixing short list syntax with list() is not allowed, but it is short list syntax.
+[list($a, $b), list($c, $d)] = [[1, 2], [3, 4]];
+
+/* testNestedAnonClassWithTraitUseAs */
+// Parse error, but not short list syntax.
+array_map(function($a) {
+    return new class() {
+        use MyTrait {
+            MyTrait::functionName as [];
+        }
+    };
+}, $array);
+
+/* testParseError */
+// Parse error, but not short list syntax.
+use Something as [$a];
+
+/* testLiveCoding */
+// Intentional parse error. This has to be the last test in the file.
+[$a, [$b]

--- a/Tests/Utils/Lists/IsShortListTest.php
+++ b/Tests/Utils/Lists/IsShortListTest.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Lists;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Lists;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Lists::isShortList() method.
+ *
+ * @covers \PHPCSUtils\Utils\Lists::isShortList
+ *
+ * @group lists
+ *
+ * @since 1.0.0
+ */
+class IsShortListTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->assertFalse(Lists::isShortList(self::$phpcsFile, 100000));
+    }
+
+    /**
+     * Test that false is returned when a non-short array token is passed.
+     *
+     * @dataProvider dataNotShortArrayToken
+     *
+     * @param string           $testMarker  The comment which prefaces the target token in the test file.
+     * @param int|string|array $targetToken The token type(s) to look for.
+     *
+     * @return void
+     */
+    public function testNotShortArrayToken($testMarker, $targetToken)
+    {
+        $target = $this->getTargetToken($testMarker, $targetToken);
+        $this->assertFalse(Lists::isShortList(self::$phpcsFile, $target));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNotShortArrayToken() For the array format.
+     *
+     * @return array
+     */
+    public function dataNotShortArrayToken()
+    {
+        return [
+            'long-list' => [
+                '/* testLongList */',
+                \T_LIST,
+            ],
+            'array-assignment' => [
+                '/* testArrayAssignment */',
+                \T_CLOSE_SQUARE_BRACKET,
+            ],
+            'live-coding' => [
+                '/* testLiveCoding */',
+                \T_OPEN_SQUARE_BRACKET,
+            ],
+        ];
+    }
+
+    /**
+     * Test whether a T_OPEN_SHORT_ARRAY token is a short list.
+     *
+     * @dataProvider dataIsShortList
+     *
+     * @param string           $testMarker  The comment which prefaces the target token in the test file.
+     * @param bool             $expected    The expected boolean return value.
+     * @param int|string|array $targetToken The token type(s) to test. Defaults to T_OPEN_SHORT_ARRAY.
+     *
+     * @return void
+     */
+    public function testIsShortList($testMarker, $expected, $targetToken = \T_OPEN_SHORT_ARRAY)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, $targetToken);
+        $result   = Lists::isShortList(self::$phpcsFile, $stackPtr);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsShortList() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsShortList()
+    {
+        return [
+            'short-array-not-nested' => [
+                '/* testNonNestedShortArray */',
+                false,
+            ],
+            'comparison-no-assignment' => [
+                '/* testNoAssignment */',
+                false,
+            ],
+            'comparison-no-assignment-nested' => [
+                '/* testNestedNoAssignment */',
+                false,
+            ],
+            'short-array-in-foreach' => [
+                '/* testShortArrayInForeach */',
+                false,
+            ],
+            'short-list' => [
+                '/* testShortList */',
+                true,
+            ],
+            'short-list-detect-on-close-bracket' => [
+                '/* testShortListDetectOnCloseBracket */',
+                true,
+                \T_CLOSE_SHORT_ARRAY,
+            ],
+            'short-list-with-nesting' => [
+                '/* testShortListWithNesting */',
+                true,
+            ],
+            'short-list-nested' => [
+                '/* testNestedShortList */',
+                true,
+            ],
+            'short-list-in-foreach' => [
+                '/* testShortListInForeach */',
+                true,
+            ],
+            'short-list-in-foreach-with-key' => [
+                '/* testShortListInForeachWithKey */',
+                true,
+            ],
+            'short-list-in-foreach-nested' => [
+                '/* testShortListInForeachNested */',
+                true,
+            ],
+            'short-list-chained-assignment' => [
+                '/* testMultiAssignShortlist */',
+                true,
+            ],
+            'short-list-with-keys' => [
+                '/* testShortListWithKeys */',
+                true,
+            ],
+            'short-list-in-foreach-with-keys-detect-on-close-bracket' => [
+                '/* testShortListInForeachWithKeysDetectOnCloseBracket */',
+                true,
+                \T_CLOSE_SHORT_ARRAY,
+            ],
+            'short-list-nested-empty' => [
+                '/* testNestedShortListEmpty */',
+                true,
+            ],
+            'short-list-deeply-nested' => [
+                '/* testDeeplyNestedShortList */',
+                true,
+            ],
+            'short-list-with-nesting-and-keys' => [
+                '/* testShortListWithNestingAndKeys */',
+                true,
+            ],
+            'short-list-nested-with-keys-1' => [
+                '/* testNestedShortListWithKeys_1 */',
+                true,
+            ],
+            'short-list-nested-with-keys-2' => [
+                '/* testNestedShortListWithKeys_2 */',
+                true,
+            ],
+            'short-list-nested-with-keys-3' => [
+                '/* testNestedShortListWithKeys_3 */',
+                true,
+            ],
+            'short-list-without-vars' => [
+                '/* testShortListWithoutVars */',
+                true,
+            ],
+            'short-list-nested-long-list' => [
+                '/* testShortListNestedLongList */',
+                true,
+            ],
+            'parse-error-anon-class-trait-use-as' => [
+                '/* testNestedAnonClassWithTraitUseAs */',
+                false,
+            ],
+            'parse-error-use-as' => [
+                '/* testParseError */',
+                false,
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/Lists/IsShortListTokenizerBC1Test.inc
+++ b/Tests/Utils/Lists/IsShortListTokenizerBC1Test.inc
@@ -1,0 +1,5 @@
+<?php
+
+/* testTokenizerIssue1971PHPCSlt330gt271A */
+// This has to be the first test in the file!
+[$a, /* testTokenizerIssue1971PHPCSlt330gt271B */ [$b]] = $array;

--- a/Tests/Utils/Lists/IsShortListTokenizerBC1Test.inc
+++ b/Tests/Utils/Lists/IsShortListTokenizerBC1Test.inc
@@ -3,3 +3,15 @@
 /* testTokenizerIssue1971PHPCSlt330gt271A */
 // This has to be the first test in the file!
 [$a, /* testTokenizerIssue1971PHPCSlt330gt271B */ [$b]] = $array;
+
+/* testTokenizerIssue1381PHPCSlt290A1 */
+echo [ 1,2,3 ] /* testTokenizerIssue1381PHPCSlt290A2 */ [0];
+
+/* testTokenizerIssue1381PHPCSlt290B */
+echo 'PHP'[0];
+
+/* testTokenizerIssue1381PHPCSlt290C */
+echo $this->addedCustomFunctions['nonce'];
+
+/* testTokenizerIssue1381PHPCSlt290D1 */
+echo $this->deprecated_functions[ $function_name ]/* testTokenizerIssue1381PHPCSlt290D2 */['version'];

--- a/Tests/Utils/Lists/IsShortListTokenizerBC1Test.inc
+++ b/Tests/Utils/Lists/IsShortListTokenizerBC1Test.inc
@@ -15,3 +15,17 @@ echo $this->addedCustomFunctions['nonce'];
 
 /* testTokenizerIssue1381PHPCSlt290D1 */
 echo $this->deprecated_functions[ $function_name ]/* testTokenizerIssue1381PHPCSlt290D2 */['version'];
+
+/* testTokenizerIssue1284PHPCSlt280A */
+if ($foo) {}
+[$a, $b] = $c;
+
+/* testTokenizerIssue1284PHPCSlt280B */
+if ($foo) {}
+[$a, $b];
+
+/* testTokenizerIssue1284PHPCSlt290C */
+$foo = ${$bar}['key'];
+
+/* testTokenizerIssue1284PHPCSlt280D */
+$c->{$var}[ ] = 2;

--- a/Tests/Utils/Lists/IsShortListTokenizerBC1Test.php
+++ b/Tests/Utils/Lists/IsShortListTokenizerBC1Test.php
@@ -62,6 +62,30 @@ class IsShortListTokenizerBC1Test extends UtilityMethodTestCase
                 '/* testTokenizerIssue1971PHPCSlt330gt271B */',
                 true,
             ],
+            'issue-1381-array-dereferencing-1' => [
+                '/* testTokenizerIssue1381PHPCSlt290A1 */',
+                false,
+            ],
+            'issue-1381-array-dereferencing-1-deref' => [
+                '/* testTokenizerIssue1381PHPCSlt290A2 */',
+                false,
+            ],
+            'issue-1381-array-dereferencing-2' => [
+                '/* testTokenizerIssue1381PHPCSlt290B */',
+                false,
+            ],
+            'issue-1381-array-dereferencing-3' => [
+                '/* testTokenizerIssue1381PHPCSlt290C */',
+                false,
+            ],
+            'issue-1381-array-dereferencing-4' => [
+                '/* testTokenizerIssue1381PHPCSlt290D1 */',
+                false,
+            ],
+            'issue-1381-array-dereferencing-4-deref-deref' => [
+                '/* testTokenizerIssue1381PHPCSlt290D2 */',
+                false,
+            ],
         ];
     }
 }

--- a/Tests/Utils/Lists/IsShortListTokenizerBC1Test.php
+++ b/Tests/Utils/Lists/IsShortListTokenizerBC1Test.php
@@ -86,6 +86,22 @@ class IsShortListTokenizerBC1Test extends UtilityMethodTestCase
                 '/* testTokenizerIssue1381PHPCSlt290D2 */',
                 false,
             ],
+            'issue-1284-short-list-directly-after-close-curly-control-structure' => [
+                '/* testTokenizerIssue1284PHPCSlt280A */',
+                true,
+            ],
+            'issue-1284-short-array-directly-after-close-curly-control-structure' => [
+                '/* testTokenizerIssue1284PHPCSlt280B */',
+                false,
+            ],
+            'issue-1284-array-access-variable-variable' => [
+                '/* testTokenizerIssue1284PHPCSlt290C */',
+                false,
+            ],
+            'issue-1284-array-access-variable-property' => [
+                '/* testTokenizerIssue1284PHPCSlt280D */',
+                false,
+            ],
         ];
     }
 }

--- a/Tests/Utils/Lists/IsShortListTokenizerBC1Test.php
+++ b/Tests/Utils/Lists/IsShortListTokenizerBC1Test.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Lists;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Lists;
+
+/**
+ * Tests for specific PHPCS tokenizer issues which can affect the \PHPCSUtils\Utils\Lists::isShortList() method.
+ *
+ * @covers \PHPCSUtils\Utils\Lists::isShortList
+ *
+ * @group lists
+ *
+ * @since 1.0.0
+ */
+class IsShortListTokenizerBC1Test extends UtilityMethodTestCase
+{
+
+    /**
+     * Test correctly determining whether a short array open token is a short array or a short list,
+     * even when the token is incorrectly tokenized.
+     *
+     * @dataProvider dataIsShortList
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param bool   $expected   The expected boolean return value.
+     *
+     * @return void
+     */
+    public function testIsShortList($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, [\T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET]);
+        $result   = Lists::isShortList(self::$phpcsFile, $stackPtr);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsShortList() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsShortList()
+    {
+        return [
+            'issue-1971-list-first-in-file' => [
+                '/* testTokenizerIssue1971PHPCSlt330gt271A */',
+                true,
+            ],
+            'issue-1971-list-first-in-file-nested' => [
+                '/* testTokenizerIssue1971PHPCSlt330gt271B */',
+                true,
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/Lists/IsShortListTokenizerBC2Test.inc
+++ b/Tests/Utils/Lists/IsShortListTokenizerBC2Test.inc
@@ -1,0 +1,5 @@
+<?php
+
+/* testTokenizerIssue1971PHPCSlt330gt271C */
+// Valid PHP, though not useful. Declaring an array without assigning it to anything.
+[1, 2, /* testTokenizerIssue1971PHPCSlt330gt271D */ [3]];

--- a/Tests/Utils/Lists/IsShortListTokenizerBC2Test.php
+++ b/Tests/Utils/Lists/IsShortListTokenizerBC2Test.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Lists;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Lists;
+
+/**
+ * Tests for specific PHPCS tokenizer issues which can affect the \PHPCSUtils\Utils\Lists::isShortList() method.
+ *
+ * @covers \PHPCSUtils\Utils\Lists::isShortList
+ *
+ * @group lists
+ *
+ * @since 1.0.0
+ */
+class IsShortListTokenizerBC2Test extends UtilityMethodTestCase
+{
+
+    /**
+     * Test correctly determining whether a short array open token is a short array or a short list,
+     * even when the token is incorrectly tokenized.
+     *
+     * @dataProvider dataIsShortList
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param bool   $expected   The expected boolean return value.
+     *
+     * @return void
+     */
+    public function testIsShortList($testMarker, $expected)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, [\T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET]);
+        $result   = Lists::isShortList(self::$phpcsFile, $stackPtr);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsShortList() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsShortList()
+    {
+        return [
+            // Make sure the utility method does not throw false positives for a short array at the start of a file.
+            'issue-1971-short-array-first-in-file' => [
+                '/* testTokenizerIssue1971PHPCSlt330gt271C */',
+                false,
+            ],
+            'issue-1971-short-array-first-in-file-nested' => [
+                '/* testTokenizerIssue1971PHPCSlt330gt271D */',
+                false,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## New Utils\Lists class

This adds a new utility method:
* `isShortList()` - to check whether a short array is in actual fact a short list. Returns boolean.

This method has been battle-tested in the past year or so in the PHPCompatibility standard.

This commit also adds two convenience token arrays for working with lists to the `PHPCSUtils\Tokens\Collections` class.

Includes dedicated unit tests.

## Lists::isShortList(): fix compatibility with PHPCS 2.8.0 - 3.2.3 [1]

PHPCS 2.8.0 - 3.2.3 contained a bug where a square open bracket `[` as the first code content after the PHP open tag in a file would be tokenized as `T_OPEN_SQUARE_BRACKET` not `T_OPEN_SHORT_ARRAY`.

This is an edge-case bug as it can only occur when following the very first PHP open tag in a file and only if there is nothing before that open tag.

Either way, this commit adds work-arounds to the utility method to handle the situation correctly.

Includes unit tests.

Includes adding two convenience token arrays for working with lists in older PHPCS versions to the `PHPCSUtils\Tokens\Collections` class.

Ref: squizlabs/PHP_CodeSniffer#1971

## Lists::isShortList(): safeguard PHPCS cross-version compatibility [2]

Add unit tests safeguarding that the method handles upstream tokenizer bug 1381 correctly.

Ref: squizlabs/PHP_CodeSniffer#1381

## Lists::isShortList(): fix compatibility with PHPCS < 2.8.0 [3]

PHPCS < 2.8.0 contained a bug where a square open bracket `[` directly following a closing curly would always be tokenized as `T_OPEN_SQUARE_BRACKET`, presuming this was array dereferencing/assignment on a variable variable.

If the closing curly however belonged to a control structure, this was incorrect and the token should have been changed to `T_OPEN_SHORT_ARRAY`.

This commit adds work-arounds to the utility method to handle the situation correctly.

Includes unit tests.

Ref: squizlabs/PHP_CodeSniffer#1284