### PR TITLE
New Utils\Arrays class

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -25,6 +25,22 @@ class Collections
 {
 
     /**
+     * Tokens which are used to create arrays.
+     *
+     * @since 1.0.0
+     *
+     * @see \PHPCSUtils\Tokens\Collections::$shortArrayTokens Related property containing only tokens used
+     *                                                        for short arrays.
+     *
+     * @var array <int|string> => <int|string>
+     */
+    public static $arrayTokens = [
+        \T_ARRAY             => \T_ARRAY,
+        \T_OPEN_SHORT_ARRAY  => \T_OPEN_SHORT_ARRAY,
+        \T_CLOSE_SHORT_ARRAY => \T_CLOSE_SHORT_ARRAY,
+    ];
+
+    /**
      * Modifier keywords which can be used for a class declaration.
      *
      * @since 1.0.0
@@ -225,6 +241,20 @@ class Collections
         \T_NS_SEPARATOR => \T_NS_SEPARATOR,
         \T_RETURN_TYPE  => \T_RETURN_TYPE, // PHPCS 2.4.0 < 3.3.0.
         \T_ARRAY_HINT   => \T_ARRAY_HINT, // PHPCS < 2.8.0.
+    ];
+
+    /**
+     * Tokens which are used for short arrays.
+     *
+     * @since 1.0.0
+     *
+     * @see \PHPCSUtils\Tokens\Collections::$arrayTokens Related property containing all tokens used for arrays.
+     *
+     * @var array <int|string> => <int|string>
+     */
+    public static $shortArrayTokens = [
+        \T_OPEN_SHORT_ARRAY  => \T_OPEN_SHORT_ARRAY,
+        \T_CLOSE_SHORT_ARRAY => \T_CLOSE_SHORT_ARRAY,
     ];
 
     /**

--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Utils;
+
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Lists;
+
+/**
+ * Utility functions for use when examining arrays.
+ *
+ * @since 1.0.0
+ */
+class Arrays
+{
+
+    /**
+     * Determine whether a `T_OPEN/CLOSE_SHORT_ARRAY` token is a short array() construct
+     * and not a short list.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the short array bracket token.
+     *
+     * @return bool True if the token passed is the open/close bracket of a short array.
+     *              False if the token is a short list bracket or not one of the accepted tokens.
+     */
+    public static function isShortArray(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Is this one of the tokens this function handles ?
+        if (isset($tokens[$stackPtr]) === false
+            || isset(Collections::$shortArrayTokens[$tokens[$stackPtr]['code']]) === false
+        ) {
+            return false;
+        }
+
+        return (Lists::isShortList($phpcsFile, $stackPtr) === false);
+    }
+}

--- a/Tests/Utils/Arrays/IsShortArrayTest.inc
+++ b/Tests/Utils/Arrays/IsShortArrayTest.inc
@@ -1,0 +1,68 @@
+<?php
+
+/* testLongArray */
+$b = array( $a );
+
+/* testArrayAssignmentEmpty */
+$b[] = $c;
+
+/* testArrayAssignmentStringKey */
+$b['key'] = $c;
+
+/* testArrayAssignmentIntKey */
+$b[10] = $c;
+
+/* testArrayAssignmentVarKey */
+$b[$a] = $c;
+
+/* testArrayAccessStringKey */
+function_call($array['key']);
+
+/* testArrayAccessIntKey1 */
+function_call($array[1]/* testArrayAccessIntKey2 */[1]);
+
+/* testArrayAccessFunctionCall */
+return function_call()[1];
+
+/* testArrayAccessConstant */
+return MY_CONSTANT[1];
+
+/* testNonNestedShortArray */
+$array = [$a];
+
+/* testInComparison */
+if( [$a, /* testNestedInComparison */ [$b]] === $array ) {};
+
+/* testShortArrayInForeach */
+foreach ([1, 2, 3] as /* testShortListInForeach */ [$id]) {}
+
+/* testMultiAssignShortlist */
+$foo = [$baz, $bat] = /* testMultiAssignShortArray */ [$a, $b];
+
+/* testShortArrayWithNestingAndKeys */
+$array = [
+    /* testNestedShortArrayWithKeys_1 */
+    ["x" => $x1, "y" => $y1],
+    /* testNestedShortArrayWithKeys_2 */
+    1 => ["x" => $x2, "y" => $y2],
+    /* testNestedShortArrayWithKeys_3 */
+    'key' => ["x" => $x3, "y" => $y3],
+];
+
+/* testNestedAnonClassWithTraitUseAs */
+// Parse error, but not our concern, it is short array syntax.
+array_map(function($a) {
+    return new class() {
+        use MyTrait {
+            MyTrait::functionName as [];
+        }
+    };
+}, $array);
+
+/* testParseError */
+// Parse error, but not our concern, it is short array syntax.
+use Something as [$a];
+
+/* testLiveCoding */
+// This has to be the last test in the file.
+[$a, /* testLiveCodingNested */ [$b]

--- a/Tests/Utils/Arrays/IsShortArrayTest.php
+++ b/Tests/Utils/Arrays/IsShortArrayTest.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Arrays;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Arrays;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Arrays::isShortArray() method.
+ *
+ * @covers \PHPCSUtils\Utils\Arrays::isShortArray
+ *
+ * @group arrays
+ *
+ * @since 1.0.0
+ */
+class IsShortArrayTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->assertFalse(Arrays::isShortArray(self::$phpcsFile, 100000));
+    }
+
+    /**
+     * Test that false is returned when a non-short array token is passed.
+     *
+     * @dataProvider dataNotShortArrayToken
+     *
+     * @param string           $testMarker  The comment which prefaces the target token in the test file.
+     * @param int|string|array $targetToken The token type(s) to look for.
+     *
+     * @return void
+     */
+    public function testNotShortArrayToken($testMarker, $targetToken)
+    {
+        $target = $this->getTargetToken($testMarker, $targetToken);
+        $this->assertFalse(Arrays::isShortArray(self::$phpcsFile, $target));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNotShortArrayToken() For the array format.
+     *
+     * @return array
+     */
+    public function dataNotShortArrayToken()
+    {
+        return [
+            'long-array' => [
+                '/* testLongArray */',
+                \T_ARRAY,
+            ],
+            'array-assignment-no-key' => [
+                '/* testArrayAssignmentEmpty */',
+                \T_OPEN_SQUARE_BRACKET,
+            ],
+            'array-assignment-string-key' => [
+                '/* testArrayAssignmentStringKey */',
+                \T_OPEN_SQUARE_BRACKET,
+            ],
+            'array-assignment-int-key' => [
+                '/* testArrayAssignmentIntKey */',
+                \T_OPEN_SQUARE_BRACKET,
+            ],
+            'array-assignment-var-key' => [
+                '/* testArrayAssignmentVarKey */',
+                \T_OPEN_SQUARE_BRACKET,
+            ],
+            'array-access-string-key' => [
+                '/* testArrayAccessStringKey */',
+                \T_CLOSE_SQUARE_BRACKET,
+            ],
+            'array-access-int-key-1' => [
+                '/* testArrayAccessIntKey1 */',
+                \T_OPEN_SQUARE_BRACKET,
+            ],
+            'array-access-int-key-2' => [
+                '/* testArrayAccessIntKey2 */',
+                \T_OPEN_SQUARE_BRACKET,
+            ],
+            'array-access-function-call' => [
+                '/* testArrayAccessFunctionCall */',
+                \T_OPEN_SQUARE_BRACKET,
+            ],
+            'array-access-constant' => [
+                '/* testArrayAccessConstant */',
+                \T_OPEN_SQUARE_BRACKET,
+            ],
+            'live-coding' => [
+                '/* testLiveCoding */',
+                \T_OPEN_SQUARE_BRACKET,
+            ],
+        ];
+    }
+
+    /**
+     * Test whether a T_OPEN_SHORT_ARRAY token is a short array.
+     *
+     * @dataProvider dataIsShortArray
+     *
+     * @param string           $testMarker  The comment which prefaces the target token in the test file.
+     * @param bool             $expected    The expected boolean return value.
+     * @param int|string|array $targetToken The token type(s) to test. Defaults to T_OPEN_SHORT_ARRAY.
+     *
+     * @return void
+     */
+    public function testIsShortArray($testMarker, $expected, $targetToken = \T_OPEN_SHORT_ARRAY)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, $targetToken);
+        $result   = Arrays::isShortArray(self::$phpcsFile, $stackPtr);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsShortArray() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsShortArray()
+    {
+        return [
+            'short-array-not-nested' => [
+                '/* testNonNestedShortArray */',
+                true,
+            ],
+            'comparison-no-assignment' => [
+                '/* testInComparison */',
+                true,
+            ],
+            'comparison-no-assignment-nested' => [
+                '/* testNestedInComparison */',
+                true,
+            ],
+            'short-array-in-foreach' => [
+                '/* testShortArrayInForeach */',
+                true,
+            ],
+            'short-list-in-foreach' => [
+                '/* testShortListInForeach */',
+                false,
+            ],
+            'chained-assignment-short-list' => [
+                '/* testMultiAssignShortlist */',
+                false,
+            ],
+            'chained-assignment-short-array' => [
+                '/* testMultiAssignShortArray */',
+                true,
+                \T_CLOSE_SHORT_ARRAY,
+            ],
+            'short-array-with-nesting-and-keys' => [
+                '/* testShortArrayWithNestingAndKeys */',
+                true,
+            ],
+            'short-array-nested-with-keys-1' => [
+                '/* testNestedShortArrayWithKeys_1 */',
+                true,
+            ],
+            'short-array-nested-with-keys-2' => [
+                '/* testNestedShortArrayWithKeys_2 */',
+                true,
+            ],
+            'short-array-nested-with-keys-3' => [
+                '/* testNestedShortArrayWithKeys_3 */',
+                true,
+            ],
+            'parse-error-anon-class-trait-use-as' => [
+                '/* testNestedAnonClassWithTraitUseAs */',
+                true,
+            ],
+            'parse-error-use-as' => [
+                '/* testParseError */',
+                true,
+            ],
+            'parse-error-live-coding' => [
+                '/* testLiveCodingNested */',
+                true,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This adds a new utility method:
* `isShortArray()` - to check whether a short array is in actual fact a short array and not a short list. Returns boolean.

This commit also adds two convenience token arrays for working with arrays to the `PHPCSUtils\Tokens\Collections` class.

Includes dedicated unit tests.