### PR TITLE
Utils\PassedParameters: fix PHPC cross-version compatibility for short arrays

### DIFF
--- a/Tests/Utils/PassedParameters/HasParametersTest.inc
+++ b/Tests/Utils/PassedParameters/HasParametersTest.inc
@@ -10,6 +10,9 @@ class Foo {
     }
 }
 
+/* testShortListNotShortArray */
+[ $a, $b ] = $array;
+
 // Function calls: no parameters.
 
 /* testNoParamsFunctionCall1 */

--- a/Tests/Utils/PassedParameters/HasParametersTest.php
+++ b/Tests/Utils/PassedParameters/HasParametersTest.php
@@ -71,6 +71,24 @@ class HasParametersTest extends UtilityMethodTestCase
     }
 
     /**
+     * Test receiving an expected exception when T_OPEN_SHORT_ARRAY is passed but represents a short list.
+     *
+     * @return void
+     */
+    public function testNotAShortArray()
+    {
+        $this->expectPhpcsException(
+            'The hasParameters() method expects a function call, array, isset or unset token to be passed.'
+        );
+
+        $self = $this->getTargetToken(
+            '/* testShortListNotShortArray */',
+            [\T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET]
+        );
+        PassedParameters::hasParameters(self::$phpcsFile, $self);
+    }
+
+    /**
      * Test correctly identifying whether parameters were passed to a function call or construct.
      *
      * @dataProvider dataHasParameters


### PR DESCRIPTION
... by implementing support for passing a `T_OPEN_SQUARE_BRACKET` token, as well as making sure that any `T_OPEN_SHORT_ARRAY` token is actually a short array and not a short list.