### PR TITLE
New Utils\Orthography class

### DIFF
--- a/PHPCSUtils/Utils/Orthography.php
+++ b/PHPCSUtils/Utils/Orthography.php
@@ -10,6 +10,8 @@
 
 namespace PHPCSUtils\Utils;
 
+use PHPCSUtils\BackCompat\Helper;
+
 /**
  * Utility functions for checking the orthography of arbitrary text strings.
  *
@@ -97,15 +99,21 @@ class Orthography
      */
     public static function isLastCharPunctuation($string, $allowedChars = self::TERMINAL_POINTS)
     {
+        static $encoding;
+
+        if (isset($encoding) === false) {
+            $encoding = Helper::getConfigData('encoding');
+        }
+
         $string = \rtrim($string);
         if (\function_exists('iconv_substr') === true) {
-            $lastChar = \iconv_substr($string, -1);
+            $lastChar = \iconv_substr($string, -1, 1, $encoding);
         } else {
             $lastChar = \substr($string, -1);
         }
 
         if (\function_exists('iconv_strpos') === true) {
-            return (\iconv_strpos($allowedChars, $lastChar) !== false);
+            return (\iconv_strpos($allowedChars, $lastChar, 0, $encoding) !== false);
         } else {
             return (\strpos($allowedChars, $lastChar) !== false);
         }

--- a/PHPCSUtils/Utils/Orthography.php
+++ b/PHPCSUtils/Utils/Orthography.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Utils;
+
+/**
+ * Utility functions for checking the orthography of arbitrary text strings.
+ *
+ * > An orthography is a set of conventions for writing a language. It includes norms of spelling,
+ * > hyphenation, capitalization, word breaks, emphasis, and punctuation.
+ * > Source: https://en.wikipedia.org/wiki/Orthography
+ *
+ * @since 1.0.0
+ */
+class Orthography
+{
+
+    /**
+     * Characters which are considered terminal points for a sentence.
+     *
+     * @link https://www.thepunctuationguide.com/terminal-points.html
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const TERMINAL_POINTS = '.?!';
+
+    /**
+     * Check if the first character of an arbitrary text string is a capital letter.
+     *
+     * Letter characters which do not have a concept of lower/uppercase will
+     * be accepted as correctly capitalized.
+     *
+     * @since 1.0.0
+     *
+     * @param string $string The text string to examine.
+     *                       This can be the contents of a text string token,
+     *                       but also, for instance, a comment text.
+     *                       Potential text delimiter quotes should be stripped
+     *                       off a text string before passing it to this method.
+     *
+     * @return bool True when the first character is a capital letter or a letter
+     *              which doesn't have a concept of capitalization.
+     *              False otherwise, including for non-letter characters.
+     */
+    public static function isFirstCharCapitalized($string)
+    {
+        $string = \ltrim($string);
+        return (\preg_match('`^[\p{Lu}\p{Lt}\p{Lo}]`u', $string) > 0);
+    }
+
+    /**
+     * Check if the first character of an arbitrary text string is a lowercase letter.
+     *
+     * @since 1.0.0
+     *
+     * @param string $string The text string to examine.
+     *                       This can be the contents of a text string token,
+     *                       but also, for instance, a comment text.
+     *                       Potential text delimiter quotes should be stripped
+     *                       off a text string before passing it to this method.
+     *
+     * @return bool True when the first character is a lowercase letter.
+     *              False otherwise, including for letters which don't have a concept of
+     *              capitalization and for non-letter characters.
+     */
+    public static function isFirstCharLowercase($string)
+    {
+        $string = \ltrim($string);
+        return (\preg_match('`^\p{Ll}`u', $string) > 0);
+    }
+
+    /**
+     * Check if the last character of an arbitrary text string is a valid punctuation character.
+     *
+     * @since 1.0.0
+     *
+     * @param string $string       The text string to examine.
+     *                             This can be the contents of a text string token,
+     *                             but also, for instance, a comment text.
+     *                             Potential text delimiter quotes should be stripped
+     *                             off a text string before passing it to this method.
+     * @param string $allowedChars Characters which are considered valid punctuation
+     *                             to end the text string.
+     *                             Defaults to '.?!', i.e. a full stop, question mark
+     *                             or exclamation mark.
+     *
+     * @return bool
+     */
+    public static function isLastCharPunctuation($string, $allowedChars = self::TERMINAL_POINTS)
+    {
+        $string = \rtrim($string);
+        if (\function_exists('iconv_substr') === true) {
+            $lastChar = \iconv_substr($string, -1);
+        } else {
+            $lastChar = \substr($string, -1);
+        }
+
+        if (\function_exists('iconv_strpos') === true) {
+            return (\iconv_strpos($allowedChars, $lastChar) !== false);
+        } else {
+            return (\strpos($allowedChars, $lastChar) !== false);
+        }
+    }
+}

--- a/Tests/Utils/Orthography/FirstCharTest.php
+++ b/Tests/Utils/Orthography/FirstCharTest.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Orthography;
+
+use PHPCSUtils\Utils\Orthography;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Orthography::isFirstCharCapitalized()
+ * and the \PHPCSUtils\Utils\Orthography::isFirstCharLowercase() methods.
+ *
+ * @covers \PHPCSUtils\Utils\Orthography::isFirstCharCapitalized
+ * @covers \PHPCSUtils\Utils\Orthography::isFirstCharLowercase
+ *
+ * @group orthography
+ *
+ * @since 1.0.0
+ */
+class FirstCharTest extends TestCase
+{
+
+    /**
+     * Test correctly detecting whether the first character of a phrase is capitalized.
+     *
+     * @dataProvider dataFirstChar
+     *
+     * @param string $input    The input string.
+     * @param array  $expected The expected function output for the respective functions.
+     *
+     * @return void
+     */
+    public function testIsFirstCharCapitalized($input, $expected)
+    {
+        $this->assertSame($expected['capitalized'], Orthography::isFirstCharCapitalized($input));
+    }
+
+    /**
+     * Test correctly detecting whether the first character of a phrase is lowercase.
+     *
+     * @dataProvider dataFirstChar
+     *
+     * @param string $input    The input string.
+     * @param array  $expected The expected function output for the respective functions.
+     *
+     * @return void
+     */
+    public function testIsFirstCharLowercase($input, $expected)
+    {
+        $this->assertSame($expected['lowercase'], Orthography::isFirstCharLowercase($input));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsFirstCharCapitalized() For the array format.
+     * @see testIsFirstCharLowercase()   For the array format.
+     *
+     * @return array
+     */
+    public function dataFirstChar()
+    {
+        $data = [
+            // Quotes should be stripped before passing the string.
+            'double-quoted' => [
+                '"This is a test"',
+                [
+                    'capitalized' => false,
+                    'lowercase'   => false,
+                ],
+            ],
+            'single-quoted' => [
+                "'This is a test'",
+                [
+                    'capitalized' => false,
+                    'lowercase'   => false,
+                ],
+            ],
+
+            // Not starting with a letter.
+            'start-numeric' => [
+                '12 Foostreet',
+                [
+                    'capitalized' => false,
+                    'lowercase'   => false,
+                ],
+            ],
+            'start-bracket' => [
+                '[Optional]',
+                [
+                    'capitalized' => false,
+                    'lowercase'   => false,
+                ],
+            ],
+
+            // Leading whitespace.
+            'english-lowercase-leading-whitespace' => [
+                '
+                this is a test',
+                [
+                    'capitalized' => false,
+                    'lowercase'   => true,
+                ],
+            ],
+            'english-propercase-leading-whitespace' => [
+                '
+                This is a test',
+                [
+                    'capitalized' => true,
+                    'lowercase'   => false,
+                ],
+            ],
+
+            // First character lowercase.
+            'english-lowercase' => [
+                'this is a test',
+                [
+                    'capitalized' => false,
+                    'lowercase'   => true,
+                ],
+            ],
+            'russian-lowercase' => [
+                'предназначена для‎',
+                [
+                    'capitalized' => false,
+                    'lowercase'   => true,
+                ],
+            ],
+            'latvian-lowercase' => [
+                'ir domāta',
+                [
+                    'capitalized' => false,
+                    'lowercase'   => true,
+                ],
+            ],
+            'armenian-lowercase' => [
+                'սա թեստ է',
+                [
+                    'capitalized' => false,
+                    'lowercase'   => true,
+                ],
+            ],
+            'mandinka-lowercase' => [
+                'ŋanniya',
+                [
+                    'capitalized' => false,
+                    'lowercase'   => true,
+                ],
+            ],
+            'greek-lowercase' => [
+                'δημιουργήθηκε από',
+                [
+                    'capitalized' => false,
+                    'lowercase'   => true,
+                ],
+            ],
+
+            // First character capitalized.
+            'english-propercase' => [
+                'This is a test',
+                [
+                    'capitalized' => true,
+                    'lowercase'   => false,
+                ],
+            ],
+            'russian-propercase' => [
+                'Дата написания этой книги',
+                [
+                    'capitalized' => true,
+                    'lowercase'   => false,
+                ],
+            ],
+            'latvian-propercase' => [
+                'Šodienas datums',
+                [
+                    'capitalized' => true,
+                    'lowercase'   => false,
+                ],
+            ],
+            'armenian-propercase' => [
+                'Սա թեստ է',
+                [
+                    'capitalized' => true,
+                    'lowercase'   => false,
+                ],
+            ],
+            'igbo-propercase' => [
+                'Ụbọchị tata bụ',
+                [
+                    'capitalized' => true,
+                    'lowercase'   => false,
+                ],
+            ],
+            'greek-propercase' => [
+                'Η σημερινή ημερομηνία',
+                [
+                    'capitalized' => true,
+                    'lowercase'   => false,
+                ],
+            ],
+
+            // No concept of "case", but starting with a letter.
+            'arabic' => [
+                'هذا اختبار',
+                [
+                    'capitalized' => true,
+                    'lowercase'   => false,
+                ],
+            ],
+            'pashto' => [
+                'دا یوه آزموینه ده',
+                [
+                    'capitalized' => true,
+                    'lowercase'   => false,
+                ],
+            ],
+            'hebrew' => [
+                'זה מבחן',
+                [
+                    'capitalized' => true,
+                    'lowercase'   => false,
+                ],
+            ],
+            'chinese-traditional' => [
+                '這是一個測試',
+                [
+                    'capitalized' => true,
+                    'lowercase'   => false,
+                ],
+            ],
+            'urdu' => [
+                'کا منشاء برائے',
+                [
+                    'capitalized' => true,
+                    'lowercase'   => false,
+                ],
+            ],
+        ];
+
+        /*
+         * PCRE2 - included in PHP 7.3+ - recognizes Georgian as a language with
+         * upper and lowercase letters as defined in Unicode v 11.0 / June 2018.
+         * While, as far as I can tell, this is linguistically incorrect - the upper
+         * and lowercase letters are from different alphabets used to write Georgian -,
+         * the unit test should allow for the reality as implemented in ICU/PCRE2/PHP.
+         *
+         * @link https://en.wikipedia.org/wiki/Georgian_scripts#Unicode
+         * @link https://unicode.org/charts/PDF/U10A0.pdf
+         */
+
+        if (\PCRE_VERSION >= 10) {
+            $data['georgian'] = [
+                'ეს ტესტია',
+                [
+                    'capitalized' => false,
+                    'lowercase'   => true,
+                ],
+            ];
+        } else {
+            $data['georgian'] = [
+                'ეს ტესტია',
+                [
+                    'capitalized' => true,
+                    'lowercase'   => false,
+                ],
+            ];
+        }
+
+        return $data;
+    }
+}

--- a/Tests/Utils/Orthography/IsLastCharPunctuationTest.php
+++ b/Tests/Utils/Orthography/IsLastCharPunctuationTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Orthography;
+
+use PHPCSUtils\Utils\Orthography;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Orthography::isLastCharPunctuation() method.
+ *
+ * @covers \PHPCSUtils\Utils\Orthography::isLastCharPunctuation
+ *
+ * @group orthography
+ *
+ * @since 1.0.0
+ */
+class IsLastCharPunctuationTest extends TestCase
+{
+
+    /**
+     * Test correctly detecting sentence end punctuation.
+     *
+     * @dataProvider dataIsLastCharPunctuation
+     *
+     * @param string $input        The input string.
+     * @param bool   $expected     The expected function output.
+     * @param string $allowedChars Optional. Custom punctuation character set.
+     *
+     * @return void
+     */
+    public function testIsLastCharPunctuation($input, $expected, $allowedChars = null)
+    {
+        if (isset($allowedChars) === true) {
+            $result = Orthography::isLastCharPunctuation($input, $allowedChars);
+        } else {
+            $result = Orthography::isLastCharPunctuation($input);
+        }
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsLastCharPunctuation() For the array format.
+     *
+     * @return array
+     */
+    public function dataIsLastCharPunctuation()
+    {
+        return [
+            // Quotes should be stripped before passing the string.
+            'double-quoted' => [
+                '"This is a test."',
+                false,
+            ],
+            'single-quoted' => [
+                "'This is a test?'",
+                false,
+            ],
+
+            // Invalid end char.
+            'no-punctuation' => [
+                'This is a test',
+                false,
+            ],
+            'invalid-punctuation' => [
+                'This is a test;',
+                false,
+            ],
+            'invalid-punctuationtrailing-whitespace' => [
+                'This is a test;       ',
+                false,
+            ],
+
+            // Valid end char, default charset.
+            'valid' => [
+                'This is a test.',
+                true,
+            ],
+            'valid-trailing-whitespace' => [
+                'This is a test.
+',
+                true,
+            ],
+
+            // Invalid end char, custom charset.
+            'invalid-custom' => [
+                'This is a test.',
+                false,
+                '!?,;#',
+            ],
+
+            // Valid end char, custom charset.
+            'valid-custom-1' => [
+                'This is a test;',
+                true,
+                '!?,;#',
+            ],
+            'valid-custom-2' => [
+                'This is a test!',
+                true,
+                '!?,;#',
+            ],
+            'valid-custom-3' => [
+                'Is this is a test?',
+                true,
+                '!?,;#',
+            ],
+            'valid-custom-4' => [
+                'This is a test,',
+                true,
+                '!?,;#',
+            ],
+            'valid-custom-5' => [
+                'This is a test#',
+                true,
+                '!?,;#',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## New Utils\Orthography class

This class adds three new utility methods for dealing with the contents of arbitrary text strings:
* `isFirstCharCapitalized()` - to check whether the first character of an arbitrary text string is a capital letter. Returns boolean.
* `isFirstCharLowercase()` - to check whether the first character of an arbitrary text string is a lowercase letter. Returns boolean.
* `isLastCharPunctuation()` - to check whether the last character of an arbitrary text string is a punctuation character. By default, the full stop, question mark and exclamation mark are accepted as valid punctuation, but this can easily be changed by passing the `$allowedChars` parameter. Returns boolean.
    Ref: https://www.thepunctuationguide.com/terminal-points.html

It also adds a `TERMINAL_POINTS` class constant containing the default allowed punctuation characters.
That way, sniffs have access to that information to display it in error messages, if so desired.

Important note: The return of `isFirstCharCapitalized()` is _not_ the direct opposite of the output of `isFirstCharLowercase()`.
- `isFirstCharCapitalized()` will return `true` for capital letters and letters which don't have a concept of capitalization. It will return `false` for lowercase letters and non-letters.
- `isFirstCharLowercase()` will return `true` for lowercase letters only. It will return `false` for all other characters, including non-letters.

Includes dedicated unit tests.

## Orthography::isLastCharPunctuation(): PHP/PHPCS cross-version compatibility fix

The default charset for the PHP iconv extension changed in PHP 5.6 from ISO-8859-1 to UTF-8.
The default charset used by PHPCS changed with PHPCS 3.0.0 from ISO-8859-1 to UTF-8.

For consistent results, retrieve the charset as used by PHPCS and pass it to the iconv functions.