### PR TITLE
New Utils\TextStrings class

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -331,4 +331,18 @@ class Collections
         \T_OPEN_SQUARE_BRACKET  => \T_OPEN_SQUARE_BRACKET,
         \T_CLOSE_SQUARE_BRACKET => \T_CLOSE_SQUARE_BRACKET,
     ];
+
+    /**
+     * Tokens which can start a - potentially multi-line - text string.
+     *
+     * @since 1.0.0
+     *
+     * @var array <int|string> => <int|string>
+     */
+    public static $textStingStartTokens = [
+        \T_START_HEREDOC            => \T_START_HEREDOC,
+        \T_START_NOWDOC             => \T_START_NOWDOC,
+        \T_CONSTANT_ENCAPSED_STRING => \T_CONSTANT_ENCAPSED_STRING,
+        \T_DOUBLE_QUOTED_STRING     => \T_DOUBLE_QUOTED_STRING,
+    ];
 }

--- a/PHPCSUtils/Utils/TextStrings.php
+++ b/PHPCSUtils/Utils/TextStrings.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Utils;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Tokens\Collections;
+
+/**
+ * Utility functions for working with text string tokens.
+ *
+ * @since 1.0.0
+ */
+class TextStrings
+{
+
+    /**
+     * Get the complete contents of a - potentially multi-line - text string.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
+     * @param int                         $stackPtr    Pointer to the first text string token
+     *                                                 of a multi-line text string or to a
+     *                                                 Nowdoc/Heredoc opener.
+     * @param bool                        $stripQuotes Optional. Whether to strip text delimiter
+     *                                                 quotes off the resulting text string.
+     *                                                 Defaults to true.
+     *
+     * @return string
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
+     *                                                      valid text string token or if the
+     *                                                      token is not the first text string token.
+     */
+    public static function getCompleteTextString(File $phpcsFile, $stackPtr, $stripQuotes = true)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Must be the start of a text string token.
+        if (isset($tokens[$stackPtr], Collections::$textStingStartTokens[$tokens[$stackPtr]['code']]) === false) {
+            throw new RuntimeException(
+                '$stackPtr must be of type T_START_HEREDOC, T_START_NOWDOC, T_CONSTANT_ENCAPSED_STRING'
+                . ' or T_DOUBLE_QUOTED_STRING'
+            );
+        }
+
+        if ($tokens[$stackPtr]['code'] === \T_CONSTANT_ENCAPSED_STRING
+            || $tokens[$stackPtr]['code'] === \T_DOUBLE_QUOTED_STRING
+        ) {
+            $prev = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);
+            if ($tokens[$stackPtr]['code'] === $tokens[$prev]['code']) {
+                throw new RuntimeException('$stackPtr must be the start of the text string');
+            }
+        }
+
+        switch ($tokens[$stackPtr]['code']) {
+            case \T_START_HEREDOC:
+                $stripQuotes = false;
+                $targetType  = \T_HEREDOC;
+                $current     = ($stackPtr + 1);
+                break;
+
+            case \T_START_NOWDOC:
+                $stripQuotes = false;
+                $targetType  = \T_NOWDOC;
+                $current     = ($stackPtr + 1);
+                break;
+
+            default:
+                $targetType = $tokens[$stackPtr]['code'];
+                $current    = $stackPtr;
+                break;
+        }
+
+        $string = '';
+        do {
+            $string .= $tokens[$current]['content'];
+            ++$current;
+        } while (isset($tokens[$current]) && $tokens[$current]['code'] === $targetType);
+
+        if ($stripQuotes === true) {
+            return self::stripQuotes($string);
+        }
+
+        return $string;
+    }
+
+    /**
+     * Strip text delimiter quotes from an arbitrary string.
+     *
+     * Intended for use with the "contents" of a T_CONSTANT_ENCAPSED_STRING / T_DOUBLE_QUOTED_STRING.
+     *
+     * Prevents stripping mis-matched quotes.
+     * Prevents stripping quotes from the textual content of the string.
+     *
+     * @since 1.0.0
+     *
+     * @param string $string The raw string.
+     *
+     * @return string String without quotes around it.
+     */
+    public static function stripQuotes($string)
+    {
+        return \preg_replace('`^([\'"])(.*)\1$`Ds', '$2', $string);
+    }
+}

--- a/Tests/Utils/TextStrings/GetCompleteTextStringTest.inc
+++ b/Tests/Utils/TextStrings/GetCompleteTextStringTest.inc
@@ -1,0 +1,49 @@
+<?php
+
+/* testNotATextString */
+return $something;
+
+/* testNotFirstTextStringToken */
+echo 'first line
+second line
+third line
+fourth line';
+
+/* testSingleLineConstantEncapsedString */
+echo 'single line text string';
+
+/* testMultiLineConstantEncapsedString */
+echo "first line
+second line
+third line
+fourth line";
+
+/* testSingleLineDoubleQuotedString */
+echo "single $line text string";
+
+/* testMultiLineDoubleQuotedString */
+echo "first line
+second $line
+third line
+fourth line";
+
+/* testHeredocString */
+echo <<<EOD
+first line
+second $line
+third line
+fourth line
+EOD;
+
+/* testNowdocString */
+echo <<<'EOD'
+first line
+second line
+third line
+fourth line
+EOD;
+
+/* testTextStringAtEndOfFile */
+// This has to be the last test in the file without a new line after it.
+echo 'first line
+last line'

--- a/Tests/Utils/TextStrings/GetCompleteTextStringTest.php
+++ b/Tests/Utils/TextStrings/GetCompleteTextStringTest.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\TextStrings;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\TextStrings;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\TextStrings::getCompleteTextString() method.
+ *
+ * @covers \PHPCSUtils\Utils\TextStrings::getCompleteTextString
+ *
+ * @group textstrings
+ *
+ * @since 1.0.0
+ */
+class GetCompleteTextStringTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Token types to target for these tests.
+     *
+     * @var array
+     */
+    private $targets = [
+        \T_START_HEREDOC,
+        \T_START_NOWDOC,
+        \T_CONSTANT_ENCAPSED_STRING,
+        \T_DOUBLE_QUOTED_STRING,
+    ];
+
+    /**
+     * Test passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->expectPhpcsException(
+            '$stackPtr must be of type T_START_HEREDOC, T_START_NOWDOC, T_CONSTANT_ENCAPSED_STRING'
+            . ' or T_DOUBLE_QUOTED_STRING'
+        );
+
+        TextStrings::getCompleteTextString(self::$phpcsFile, 100000);
+    }
+
+    /**
+     * Test receiving an expected exception when a non text string is passed.
+     *
+     * @return void
+     */
+    public function testNotATextStringException()
+    {
+        $this->expectPhpcsException(
+            '$stackPtr must be of type T_START_HEREDOC, T_START_NOWDOC, T_CONSTANT_ENCAPSED_STRING'
+            . ' or T_DOUBLE_QUOTED_STRING'
+        );
+
+        $next = $this->getTargetToken('/* testNotATextString */', \T_RETURN);
+        TextStrings::getCompleteTextString(self::$phpcsFile, $next);
+    }
+
+    /**
+     * Test receiving an expected exception when a text string token is not the first token
+     * of a multi-line text string.
+     *
+     * @return void
+     */
+    public function testNotFirstTextStringException()
+    {
+        $this->expectPhpcsException('$stackPtr must be the start of the text string');
+
+        $next = $this->getTargetToken(
+            '/* testNotFirstTextStringToken */',
+            \T_CONSTANT_ENCAPSED_STRING,
+            'second line
+'
+        );
+        TextStrings::getCompleteTextString(self::$phpcsFile, $next);
+    }
+
+    /**
+     * Test correctly retrieving the contents of a (potentially) multi-line text string.
+     *
+     * @dataProvider dataGetCompleteTextString
+     *
+     * @param string $testMarker         The comment which prefaces the target token in the test file.
+     * @param string $expected           The expected function return value.
+     * @param string $expectedWithQuotes The expected function return value when $stripQuotes is set to "false".
+     *
+     * @return void
+     */
+    public function testGetCompleteTextString($testMarker, $expected, $expectedWithQuotes)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, $this->targets);
+
+        $result = TextStrings::getCompleteTextString(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result, 'Test failed getting the correct string with quotes stripped');
+
+        $result = TextStrings::getCompleteTextString(self::$phpcsFile, $stackPtr, false);
+        $this->assertSame($expectedWithQuotes, $result, 'Test failed getting the correct string (unchanged)');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetCompleteTextString() For the array format.
+     *
+     * @return array
+     */
+    public function dataGetCompleteTextString()
+    {
+        return [
+            'single-line-constant-encapsed-string' => [
+                '/* testSingleLineConstantEncapsedString */',
+                'single line text string',
+                "'single line text string'",
+            ],
+            'multi-line-constant-encapsed-string' => [
+                '/* testMultiLineConstantEncapsedString */',
+                'first line
+second line
+third line
+fourth line',
+                '"first line
+second line
+third line
+fourth line"',
+            ],
+            'single-line-double-quoted-string' => [
+                '/* testSingleLineDoubleQuotedString */',
+                'single $line text string',
+                '"single $line text string"',
+            ],
+            'multi-line-double-quoted-string' => [
+                '/* testMultiLineDoubleQuotedString */',
+                'first line
+second $line
+third line
+fourth line',
+                '"first line
+second $line
+third line
+fourth line"',
+            ],
+            'heredoc' => [
+                '/* testHeredocString */',
+                'first line
+second $line
+third line
+fourth line
+',
+                'first line
+second $line
+third line
+fourth line
+',
+            ],
+            'nowdoc' => [
+                '/* testNowdocString */',
+                'first line
+second line
+third line
+fourth line
+',
+                'first line
+second line
+third line
+fourth line
+',
+            ],
+            'text-string-at-end-of-file' => [
+                '/* testTextStringAtEndOfFile */',
+                'first line
+last line',
+                "'first line
+last line'",
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/TextStrings/StripQuotesTest.php
+++ b/Tests/Utils/TextStrings/StripQuotesTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\TextStrings;
+
+use PHPCSUtils\Utils\TextStrings;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\TextStrings::stripQuotes() method.
+ *
+ * @covers \PHPCSUtils\Utils\TextStrings::stripQuotes
+ *
+ * @group textstrings
+ *
+ * @since 1.0.0
+ */
+class StripQuotesTest extends TestCase
+{
+
+    /**
+     * Test correctly stripping quotes surrounding text strings.
+     *
+     * @dataProvider dataStripQuotes
+     *
+     * @param string $input    The input string.
+     * @param string $expected The expected function output.
+     *
+     * @return void
+     */
+    public function testStripQuotes($input, $expected)
+    {
+        $this->assertSame($expected, TextStrings::stripQuotes($input));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testStripQuotes() For the array format.
+     *
+     * @return array
+     */
+    public function dataStripQuotes()
+    {
+        return [
+            'simple-string-double-quotes' => [
+                '"dir_name"',
+                'dir_name',
+            ],
+            'simple-string-single-quotes' => [
+                "'soap.wsdl_cache'",
+                'soap.wsdl_cache',
+            ],
+            'string-with-escaped-quotes-within-1' => [
+                '"arbitrary-\'string\" with\' quotes within"',
+                'arbitrary-\'string\" with\' quotes within',
+            ],
+            'string-with-escaped-quotes-within-2' => [
+                '"\'quoted_name\'"',
+                '\'quoted_name\'',
+            ],
+            'string-with-different-quotes-at-start-of-string' => [
+                "'\"quoted\" start of string'",
+                '"quoted" start of string',
+            ],
+            'incomplete-quote-set-only-start-quote' => [
+                "'no stripping when there is only a start quote",
+                "'no stripping when there is only a start quote",
+            ],
+            'incomplete-quote-set-only-end-quote' => [
+                'no stripping when there is only an end quote"',
+                'no stripping when there is only an end quote"',
+            ],
+            'start-end-quote-mismatch' => [
+                "'no stripping when quotes at start/end are mismatched\"",
+                "'no stripping when quotes at start/end are mismatched\"",
+            ],
+            'multi-line-string-single-quotes' => [
+                "'some
+    text
+        and
+more'",
+                'some
+    text
+        and
+more',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This introduces two new methods:
* `getCompleteTextString()` - to retrieve the complete text string content of a - potentially multi-line - text string. Returns the text string.
* `stripQuotes()` - to strip the text delimiter quotes off an arbitrary text string. Returns the resulting text string.

These methods have been battle-tested in various forms in the past year or two in the PHPCompatibility and the WordPressCS standards.

This commit includes a new convenience token array for working with text strings to the `PHPCSUtils\Tokens\Collections` class.

Includes dedicated unit tests for each method.