### PR TITLE
New Utils\Numbers class

### DIFF
--- a/PHPCSUtils/Utils/Numbers.php
+++ b/PHPCSUtils/Utils/Numbers.php
@@ -1,0 +1,480 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Utils;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\BackCompat\Helper;
+
+/**
+ * Utility functions for working with integer/float tokens.
+ *
+ * PHP 7.4 introduced numeric literal separators which break number tokenization in older PHP versions.
+ * PHPCS backfills this since PHPCS 3.5.3/4.
+ *
+ * However, if an external standard intends to support PHPCS < 3.5.4 and PHP < 7.4, working with
+ * number tokens has suddenly become a challenge.
+ *
+ * The functions in this class have been put in place to ease that pain and it is
+ * *strongly* recommended to always use these functions when sniffing for and examining the
+ * contents of `T_LNUMBER` or `T_DNUMBER` tokens.
+ *
+ * @since 1.0.0
+ */
+class Numbers
+{
+
+    /**
+     * Regex to determine whether the contents of an arbitrary string represents a decimal integer.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const REGEX_DECIMAL_INT = '`^(?:0|[1-9][0-9]*)$`D';
+
+    /**
+     * Regex to determine whether the contents of an arbitrary string represents an octal integer.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const REGEX_OCTAL_INT = '`^0[0-7]+$`D';
+
+    /**
+     * Regex to determine whether the contents of an arbitrary string represents a binary integer.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const REGEX_BINARY_INT = '`^0b[0-1]+$`iD';
+
+    /**
+     * Regex to determine whether the contents of an arbitrary string represents a hexidecimal integer.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const REGEX_HEX_INT = '`^0x[0-9A-F]+$`iD';
+
+    /**
+     * Regex to determine whether the contents of an arbitrary string represents a float.
+     *
+     * @link https://www.php.net/manual/en/language.types.float.php
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const REGEX_FLOAT = '`
+        ^(?:
+            (?:
+                (?:
+                    (?P<LNUM>[0-9]+)
+                |
+                    (?P<DNUM>([0-9]*\.(?P>LNUM)|(?P>LNUM)\.[0-9]*))
+                )
+                [e][+-]?(?P>LNUM)
+            )
+            |
+            (?P>DNUM)
+            |
+            (?:0|[1-9][0-9]*)
+        )$
+        `ixD';
+
+    /**
+     * Regex to determine is a T_STRING following a T_[DL]NUMBER is part of a numeric literal sequence.
+     *
+     * PHP cross-version compat for PHP 7.4 numeric literals with underscore separators.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const REGEX_NUMLIT_STRING = '`^((?<![\.e])_[0-9][0-9e\.]*)+$`iD';
+
+    /**
+     * Regex to determine is a T_STRING following a T_[DL]NUMBER is part of a hexidecimal numeric literal sequence.
+     *
+     * PHP cross-version compat for PHP 7.4 numeric literals with underscore separators.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const REGEX_HEX_NUMLIT_STRING = '`^((?<!\.)_[0-9A-F]*)+$`iD';
+
+    /**
+     * PHPCS versions in which the backfill for PHP 7.4 numeric literal separators is broken.
+     *
+     * @since 1.0.0
+     *
+     * @var array
+     */
+    public static $unsupportedPHPCSVersions = [
+        '3.5.3' => true,
+    ];
+
+    /**
+     * Valid tokens which could be part of a numeric literal sequence in PHP < 7.4.
+     *
+     * @since 1.0.0
+     *
+     * @var array
+     */
+    private static $numericLiteralAcceptedTokens = [
+        \T_LNUMBER => true,
+        \T_DNUMBER => true,
+        \T_STRING  => true,
+    ];
+
+    /**
+     * Helper function to deal with numeric literals, potentially with underscore separators.
+     *
+     * PHP < 7.4 does not tokenize numeric literals containing underscores correctly.
+     * As of PHPCS 3.5.3, PHPCS contains a back-fill, but this backfill was buggy in the initial
+     * implementation. A fix for this broken backfill is included in PHPCS 3.5.4.
+     *
+     * Either way, this function provides a backfill for all PHPCS/PHP combinations where
+     * PHP 7.4 numbers with underscore separators are tokenized incorrectly - with the
+     * exception of PHPCS 3.5.3 as the buggyness of the original backfill implementation makes
+     * it impossible to provide reliable results.
+     *
+     * @link https://github.com/squizlabs/PHP_CodeSniffer/issues/2546
+     * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/2771
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of a T_LNUMBER or T_DNUMBER token.
+     *
+     * @return array An array with the following information about the number:
+     *               - 'orig_content' string The (potentially concatenated) original content of the tokens;
+     *               - 'content'      string The (potentially concatenated) content, underscore(s) removed;
+     *               - 'code'         int    The token code of the number, either T_LNUMBER or T_DNUMBER.
+     *               - 'type'         string The token type, either 'T_LNUMBER' or 'T_DNUMBER'.
+     *               - 'decimal'      string The decimal value of the number;
+     *               - 'last_token'   int    The stackPtr to the last token which was part of the number;
+     *                                       This will be the same as the original stackPtr if it is not
+     *                                       a PHP 7.4 number with underscores.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified token is not of type
+     *                                                      T_LNUMBER or T_DNUMBER.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If this function is called in combination
+     *                                                      with an unsupported PHPCS version.
+     */
+    public static function getCompleteNumber(File $phpcsFile, $stackPtr)
+    {
+
+        static $php74, $phpcsVersion, $phpcsWithBackfill;
+
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]) === false
+            || ($tokens[$stackPtr]['code'] !== \T_LNUMBER && $tokens[$stackPtr]['code'] !== \T_DNUMBER)
+        ) {
+            throw new RuntimeException(
+                'Token type "' . $tokens[$stackPtr]['type'] . '" is not T_LNUMBER or T_DNUMBER'
+            );
+        }
+
+        if (isset($php74, $phpcsVersion, $phpcsWithBackfill) === false) {
+            $php74             = \version_compare(\PHP_VERSION_ID, '70399', '>');
+            $phpcsVersion      = Helper::getVersion();
+            $maxUnsupported    = \max(\array_keys(self::$unsupportedPHPCSVersions));
+            $phpcsWithBackfill = \version_compare($phpcsVersion, $maxUnsupported, '>');
+        }
+
+        /*
+         * Bow out for PHPCS version(s) with broken tokenization of PHP 7.4 numeric literals with
+         * separators, including for PHP 7.4, as the backfill kicks in for PHP 7.4 while it shouldn't.
+         *
+         * @link https://github.com/squizlabs/PHP_CodeSniffer/issues/2546
+         */
+        if (isset(self::$unsupportedPHPCSVersions[$phpcsVersion]) === true) {
+            throw new RuntimeException('The ' . __METHOD__ . '() method does not support PHPCS ' . $phpcsVersion);
+        }
+
+        $content = $tokens[$stackPtr]['content'];
+        $result  = [
+            'orig_content' => $content,
+            'content'      => \str_replace('_', '', $content),
+            'code'         => $tokens[$stackPtr]['code'],
+            'type'         => $tokens[$stackPtr]['type'],
+            'decimal'      => self::getDecimalValue($content),
+            'last_token'   => $stackPtr,
+        ];
+
+        // When things are already correctly tokenized, there's not much to do.
+        if ($php74 === true
+            || $phpcsWithBackfill === true
+            || isset($tokens[($stackPtr + 1)]) === false
+            || $tokens[($stackPtr + 1)]['code'] !== \T_STRING
+            || $tokens[($stackPtr + 1)]['content'][0] !== '_'
+        ) {
+            return $result;
+        }
+
+        $hex = false;
+        if (\strpos($content, '0x') === 0) {
+            $hex = true;
+        }
+
+        $lastChar = \substr($content, -1);
+        if (\preg_match('`[0-9]`', $lastChar) !== 1) {
+            if ($hex === false || \preg_match('`[A-F]`i', $lastChar) !== 1) {
+                // Last character not valid for numeric literal sequence with underscores.
+                // No need to look any further.
+                return $result;
+            }
+        }
+
+        /*
+         * OK, so this could potentially be a PHP 7.4 number with an underscore separator with PHPCS
+         * being run on PHP < 7.4.
+         */
+
+        $regex = self::REGEX_NUMLIT_STRING;
+        if ($hex === true) {
+            $regex = self::REGEX_HEX_NUMLIT_STRING;
+        }
+
+        $next      = $stackPtr;
+        $lastToken = $stackPtr;
+
+        while (isset($tokens[++$next], self::$numericLiteralAcceptedTokens[$tokens[$next]['code']]) === true) {
+            if ($tokens[$next]['code'] === \T_STRING
+                && \preg_match($regex, $tokens[$next]['content'], $matches) !== 1
+            ) {
+                break;
+            }
+
+            $content  .= $tokens[$next]['content'];
+            $lastToken = $next;
+            $lastChar  = \substr(\strtolower($content), -1);
+
+            // Support floats.
+            if ($lastChar === 'e'
+                && isset($tokens[($next + 1)], $tokens[($next + 2)]) === true
+                && ($tokens[($next + 1)]['code'] === \T_MINUS
+                || $tokens[($next + 1)]['code'] === \T_PLUS)
+                && $tokens[($next + 2)]['code'] === \T_LNUMBER
+            ) {
+                $content  .= $tokens[($next + 1)]['content'];
+                $content  .= $tokens[($next + 2)]['content'];
+                $next     += 2;
+                $lastToken = $next;
+            }
+
+            // Don't look any further if the last char is not valid before a separator.
+            if (\preg_match('`[0-9]`', $lastChar) !== 1) {
+                if ($hex === false || \preg_match('`[a-f]`i', $lastChar) !== 1) {
+                    break;
+                }
+            }
+        }
+
+        // OK, so we now have `content` including potential underscores. Let's strip them out.
+        $result['orig_content'] = $content;
+        $result['content']      = \str_replace('_', '', $content);
+        $result['decimal']      = self::getDecimalValue($result['content']);
+        $result['last_token']   = $lastToken;
+
+        // Determine actual token type.
+        $type = $result['type'];
+        if ($type === 'T_LNUMBER') {
+            if ($hex === false
+                && (\strpos($result['content'], '.') !== false
+                || \stripos($result['content'], 'e') !== false)
+            ) {
+                $type = 'T_DNUMBER';
+            } elseif (($result['decimal'] + 0) > \PHP_INT_MAX) {
+                $type = 'T_DNUMBER';
+            }
+        }
+
+        $result['code'] = \constant($type);
+        $result['type'] = $type;
+
+        return $result;
+    }
+
+    /**
+     * Get the decimal number value of a numeric string.
+     *
+     * Takes PHP 7.4 numeric literal separators in numbers into account.
+     *
+     * @since 1.0.0
+     *
+     * @param string $string Arbitrary token content string.
+     *
+     * @return string|false Decimal number as a string or false if the passed parameter
+     *                      was not a numeric string.
+     *                      Note: floating point numbers with exponent will not be expanded,
+     *                      but returned as-is.
+     */
+    public static function getDecimalValue($string)
+    {
+        if (\is_string($string) === false || $string === '') {
+            return false;
+        }
+
+        /*
+         * Remove potential PHP 7.4 numeric literal separators.
+         *
+         * {@internal While the is..() functions also do this, this is still needed
+         * here to allow the hexdec(), bindec() functions to work correctly and for
+         * the decimal/float to return a cross-version compatible decimal value.}
+         */
+        $string = \str_replace('_', '', $string);
+
+        if (self::isDecimalInt($string) === true) {
+            return $string;
+        }
+
+        if (self::isHexidecimalInt($string) === true) {
+            return (string) \hexdec($string);
+        }
+
+        if (self::isBinaryInt($string) === true) {
+            return (string) \bindec($string);
+        }
+
+        if (self::isOctalInt($string) === true) {
+            return (string) \octdec($string);
+        }
+
+        if (self::isFloat($string) === true) {
+            return $string;
+        }
+
+        return false;
+    }
+
+    /**
+     * Verify whether the contents of an arbitrary string represents a decimal integer.
+     *
+     * Takes PHP 7.4 numeric literal separators in numbers into account.
+     *
+     * @since 1.0.0
+     *
+     * @param string $string Arbitrary string.
+     *
+     * @return bool
+     */
+    public static function isDecimalInt($string)
+    {
+        if (\is_string($string) === false || $string === '') {
+            return false;
+        }
+
+        // Remove potential PHP 7.4 numeric literal separators.
+        $string = \str_replace('_', '', $string);
+
+        return (\preg_match(self::REGEX_DECIMAL_INT, $string) === 1);
+    }
+
+    /**
+     * Verify whether the contents of an arbitrary string represents a hexidecimal integer.
+     *
+     * Takes PHP 7.4 numeric literal separators in numbers into account.
+     *
+     * @since 1.0.0
+     *
+     * @param string $string Arbitrary string.
+     *
+     * @return bool
+     */
+    public static function isHexidecimalInt($string)
+    {
+        if (\is_string($string) === false || $string === '') {
+            return false;
+        }
+
+        // Remove potential PHP 7.4 numeric literal separators.
+        $string = \str_replace('_', '', $string);
+
+        return (\preg_match(self::REGEX_HEX_INT, $string) === 1);
+    }
+
+    /**
+     * Verify whether the contents of an arbitrary string represents a binary integer.
+     *
+     * Takes PHP 7.4 numeric literal separators in numbers into account.
+     *
+     * @since 1.0.0
+     *
+     * @param string $string Arbitrary string.
+     *
+     * @return bool
+     */
+    public static function isBinaryInt($string)
+    {
+        if (\is_string($string) === false || $string === '') {
+            return false;
+        }
+
+        // Remove potential PHP 7.4 numeric literal separators.
+        $string = \str_replace('_', '', $string);
+
+        return (\preg_match(self::REGEX_BINARY_INT, $string) === 1);
+    }
+
+    /**
+     * Verify whether the contents of an arbitrary string represents an octal integer.
+     *
+     * Takes PHP 7.4 numeric literal separators in numbers into account.
+     *
+     * @since 1.0.0
+     *
+     * @param string $string Arbitrary string.
+     *
+     * @return bool
+     */
+    public static function isOctalInt($string)
+    {
+        if (\is_string($string) === false || $string === '') {
+            return false;
+        }
+
+        // Remove potential PHP 7.4 numeric literal separators.
+        $string = \str_replace('_', '', $string);
+
+        return (\preg_match(self::REGEX_OCTAL_INT, $string) === 1);
+    }
+
+    /**
+     * Verify whether the contents of an arbitrary string represents a floating point number.
+     *
+     * Takes PHP 7.4 numeric literal separators in numbers into account.
+     *
+     * @since 1.0.0
+     *
+     * @param string $string Arbitrary string.
+     *
+     * @return bool
+     */
+    public static function isFloat($string)
+    {
+        if (\is_string($string) === false || $string === '') {
+            return false;
+        }
+
+        // Remove potential PHP 7.4 numeric literal separators.
+        $string = \str_replace('_', '', $string);
+
+        return (\preg_match(self::REGEX_FLOAT, $string) === 1);
+    }
+}

--- a/Tests/Utils/Numbers/GetCompleteNumberTest.inc
+++ b/Tests/Utils/Numbers/GetCompleteNumberTest.inc
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * Make sure that number literals are correctly identified.
+ */
+
+/* testNotAnLNumber */
+const _100 = null;
+
+
+/*
+ * OK: ordinary numeric sequences.
+ */
+/* testIntDecimal */
+$a = 1000000000;
+
+/* testFloat */
+$b = 107925284.88;
+
+/* testFloatNegative */
+$discount = -58987.789;
+
+/* testIntBinary */
+$binary = 0b1;
+
+/* testIntHex */
+$hex = 0xA;
+
+/* testIntOctal */
+$octal = 052;
+
+/* testParseError */
+$a = 100 'test'; // Intentional parse error, not our concern.
+
+
+/*
+ * PHP 7.4 numeric sequences with a numeric literal separator.
+ */
+/* testPHP74IntDecimalMultiUnderscore */
+$threshold = 1_000_000_000;
+
+/* testPHP74Float */
+$testValue = 107_925_284.88;
+
+/* testPHP74IntDecimalSingleUnderscore */
+$discount  = 135_00;
+
+/* testPHP74FloatExponentNegative */
+$a = 6.674_083e-11; // float
+
+/* testPHP74FloatExponentPositive */
+$a = 6.674_083e+11; // float
+
+/* testPHP74IntDecimalMultiUnderscore2 */
+$a = 299_792_458;   // decimal
+
+/* testPHP74IntHex */
+$a = 0xCAFE_F00D;   // hexadecimal
+
+/* testPHP74IntBinary */
+$a = 0b0101_1111;   // binary
+
+/* testPHP74IntOctal */
+$a = 0137_041;      // octal
+
+/* testPHP74FloatExponentMultiUnderscore */
+$a = 1_2.3_4e1_23;
+
+
+/*
+ * Make sure the backfill doesn't do more than it should.
+ */
+/* testPHP74IntCalc1 */
+$a = 667_083 - 11; // Calculation.
+
+/* testPHP74IntCalc2 */
+$a = 74_083 + 11; // Calculation.
+
+/* testPHP74FloatCalc1 */
+$a = 6.674_08e3 - 11; // Calculation.
+
+/* testPHP74FloatCalc2 */
+$a = 6.674_08e3 + 11; // Calculation.
+
+/* testPHP74IntWhitespace */
+$testValue = 107_925_284 .88;
+
+/* testPHP74FloatComments */
+$testValue = 107_925_284/*comment*/.88;
+
+
+/*
+ * Invalid use of underscores in numeric sequences.
+ * Each underscore in a numeric literal must be directly between two digits.
+ * The below all produce "Parse error: syntax error" in PHP 7.4.
+ */
+/* testPHP74Invalid1 */
+$a = 100_;   // trailing underscore
+
+/* testPHP74Invalid2 */
+$a = 1__1;   // next to underscore
+
+/* testPHP74Invalid3 */
+$a = 1_.0;   // next to decimal point
+
+/* testPHP74Invalid4 */
+$a = 1._0;   // next to decimal point
+
+/* testPHP74Invalid5 */
+$a = 0x_123; // next to x
+
+/* testPHP74Invalid6 */
+$a = 0b_101; // next to b
+
+/* testPHP74Invalid7 */
+$a = 1_e2;   // next to e
+
+/* testPHP74Invalid8 */
+$a = 1e_2;   // next to e
+
+
+/* testLiveCoding */
+// Intentional parse error. This has to be the last test in the file (and on the last line) !
+$a = 100

--- a/Tests/Utils/Numbers/GetCompleteNumberTest.php
+++ b/Tests/Utils/Numbers/GetCompleteNumberTest.php
@@ -1,0 +1,519 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Numbers;
+
+use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Numbers;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Numbers::getCompleteNumber() method.
+ *
+ * @covers \PHPCSUtils\Utils\Numbers::getCompleteNumber
+ *
+ * @group numbers
+ *
+ * @since 1.0.0
+ */
+class GetCompleteNumberTest extends UtilityMethodTestCase
+{
+
+    /**
+     * The PHPCS version being used to run the tests.
+     *
+     * @var string
+     */
+    public static $phpcsVersion = null;
+
+    /**
+     * Whether or not the tests are being run on PHP 7.4 or higher.
+     *
+     * @var bool
+     */
+    public static $php74OrHigher = false;
+
+    /**
+     * The PHPCS version being used to run the tests.
+     *
+     * @var string
+     */
+    public static $usableBackfill = false;
+
+    /**
+     * Initialize the static properties, if not done before.
+     *
+     * @return void
+     */
+    public static function setUpStaticProperties()
+    {
+        if (isset(self::$phpcsVersion)) {
+            return;
+        }
+
+        self::$phpcsVersion   = Helper::getVersion();
+        self::$php74OrHigher  = \version_compare(\PHP_VERSION_ID, '70399', '>');
+        $maxUnsupported       = \max(\array_keys(Numbers::$unsupportedPHPCSVersions));
+        self::$usableBackfill = \version_compare(self::$phpcsVersion, $maxUnsupported, '>');
+    }
+
+    /**
+     * Test receiving an exception when a non-numeric token is passed to the method.
+     *
+     * @return void
+     */
+    public function testNotANumberException()
+    {
+        $this->expectPhpcsException('Token type "T_STRING" is not T_LNUMBER or T_DNUMBER');
+
+        $stackPtr = $this->getTargetToken('/* testNotAnLNumber */', \T_STRING);
+        Numbers::getCompleteNumber(self::$phpcsFile, $stackPtr);
+    }
+
+    /**
+     * Test receiving an exception when PHPCS is run on PHP < 7.4 in combination with PHPCS 3.5.3.
+     *
+     * @return void
+     */
+    public function testUnsupportedPhpcsException()
+    {
+        self::setUpStaticProperties();
+        if (isset(Numbers::$unsupportedPHPCSVersions[self::$phpcsVersion]) === false) {
+            $this->markTestSkipped('Test specific to a limited set of PHPCS versions');
+        }
+
+        $this->expectPhpcsException(
+            'The PHPCSUtils\Utils\Numbers::getCompleteNumber() method does not support PHPCS '
+        );
+
+        $stackPtr = $this->getTargetToken('/* testPHP74IntDecimalMultiUnderscore */', \T_LNUMBER);
+        Numbers::getCompleteNumber(self::$phpcsFile, $stackPtr);
+    }
+
+    /**
+     * Test correctly identifying all tokens belonging to a numeric literal.
+     *
+     * @dataProvider dataGetCompleteNumber
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   Expected function return value.
+     *
+     * @return void
+     */
+    public function testGetCompleteNumber($testMarker, $expected)
+    {
+        // Skip the test(s) on unsupported PHPCS versions.
+        self::setUpStaticProperties();
+        if (isset(Numbers::$unsupportedPHPCSVersions[self::$phpcsVersion]) === true) {
+            $this->markTestSkipped(
+                'PHPCS ' . self::$phpcsVersion . ' is not supported due to buggy numeric string literal backfill.'
+            );
+        }
+
+        $stackPtr                = $this->getTargetToken($testMarker, [\T_LNUMBER, \T_DNUMBER]);
+        $expected['last_token'] += $stackPtr;
+
+        // Allow for 32 vs 64-bit systems with different maximum integer size.
+        if ($expected['code'] === \T_LNUMBER && ($expected['decimal'] + 0) > \PHP_INT_MAX) {
+            $expected['code'] = \T_DNUMBER;
+            $expected['type'] = 'T_DNUMBER';
+        }
+
+        $result = Numbers::getCompleteNumber(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data Provider.
+     *
+     * @see testGetCompleteNumber() For the array format.
+     *
+     * @return array
+     */
+    public function dataGetCompleteNumber()
+    {
+        self::setUpStaticProperties();
+        $multiToken = true;
+        if (self::$php74OrHigher === true || self::$usableBackfill === true) {
+            $multiToken = false;
+        }
+
+        /*
+         * Disabling the hexnumeric string detection for the rest of the file.
+         * These are only strings within the context of PHPCS and need to be tested as such.
+         *
+         * @phpcs:disable PHPCompatibility.Miscellaneous.ValidIntegers.HexNumericStringFound
+         */
+
+        return [
+            // Ordinary numbers.
+            'normal-integer-decimal' => [
+                '/* testIntDecimal */',
+                [
+                    'orig_content' => '1000000000',
+                    'content'      => '1000000000',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '1000000000',
+                    'last_token'   => 0, // Offset from $stackPtr.
+                ],
+            ],
+            'normal-float' => [
+                '/* testFloat */',
+                [
+                    'orig_content' => '107925284.88',
+                    'content'      => '107925284.88',
+                    'code'         => \T_DNUMBER,
+                    'type'         => 'T_DNUMBER',
+                    'decimal'      => '107925284.88',
+                    'last_token'   => 0, // Offset from $stackPtr.
+                ],
+            ],
+            'normal-float-negative' => [
+                '/* testFloatNegative */',
+                [
+                    'orig_content' => '58987.789',
+                    'content'      => '58987.789',
+                    'code'         => \T_DNUMBER,
+                    'type'         => 'T_DNUMBER',
+                    'decimal'      => '58987.789',
+                    'last_token'   => 0, // Offset from $stackPtr.
+                ],
+            ],
+            'normal-integer-binary' => [
+                '/* testIntBinary */',
+                [
+                    'orig_content' => '0b1',
+                    'content'      => '0b1',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '1',
+                    'last_token'   => 0, // Offset from $stackPtr.
+                ],
+            ],
+            'normal-integer-hex' => [
+                '/* testIntHex */',
+                [
+                    'orig_content' => '0xA',
+                    'content'      => '0xA',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '10',
+                    'last_token'   => 0, // Offset from $stackPtr.
+                ],
+            ],
+            'normal-integer-octal' => [
+                '/* testIntOctal */',
+                [
+                    'orig_content' => '052',
+                    'content'      => '052',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '42',
+                    'last_token'   => 0, // Offset from $stackPtr.
+                ],
+            ],
+
+            // Parse error.
+            'parse-error' => [
+                '/* testParseError */',
+                [
+                    'orig_content' => '100',
+                    'content'      => '100',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '100',
+                    'last_token'   => 0, // Offset from $stackPtr.
+                ],
+            ],
+
+            // Numeric literal with underscore.
+            'php-7.4-integer-decimal-multi-underscore' => [
+                '/* testPHP74IntDecimalMultiUnderscore */',
+                [
+                    'orig_content' => '1_000_000_000',
+                    'content'      => '1000000000',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '1000000000',
+                    'last_token'   => $multiToken ? 1 : 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-float' => [
+                '/* testPHP74Float */',
+                [
+                    'orig_content' => '107_925_284.88',
+                    'content'      => '107925284.88',
+                    'code'         => \T_DNUMBER,
+                    'type'         => 'T_DNUMBER',
+                    'decimal'      => '107925284.88',
+                    'last_token'   => $multiToken ? 2 : 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-integer-decimal-single-underscore' => [
+                '/* testPHP74IntDecimalSingleUnderscore */',
+                [
+                    'orig_content' => '135_00',
+                    'content'      => '13500',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '13500',
+                    'last_token'   => $multiToken ? 1 : 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-float-exponent-negative' => [
+                '/* testPHP74FloatExponentNegative */',
+                [
+                    'orig_content' => '6.674_083e-11',
+                    'content'      => '6.674083e-11',
+                    'code'         => \T_DNUMBER,
+                    'type'         => 'T_DNUMBER',
+                    'decimal'      => '6.674083e-11',
+                    'last_token'   => $multiToken ? 3 : 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-float-exponent-positive' => [
+                '/* testPHP74FloatExponentPositive */',
+                [
+                    'orig_content' => '6.674_083e+11',
+                    'content'      => '6.674083e+11',
+                    'code'         => \T_DNUMBER,
+                    'type'         => 'T_DNUMBER',
+                    'decimal'      => '6.674083e+11',
+                    'last_token'   => $multiToken ? 3 : 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-integer-decimal-multi-underscore-2' => [
+                '/* testPHP74IntDecimalMultiUnderscore2 */',
+                [
+                    'orig_content' => '299_792_458',
+                    'content'      => '299792458',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '299792458',
+                    'last_token'   => $multiToken ? 1 : 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-integer-hex' => [
+                '/* testPHP74IntHex */',
+                [
+                    'orig_content' => '0xCAFE_F00D',
+                    'content'      => '0xCAFEF00D',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '3405705229',
+                    'last_token'   => $multiToken ? 1 : 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-integer-binary' => [
+                '/* testPHP74IntBinary */',
+                [
+                    'orig_content' => '0b0101_1111',
+                    'content'      => '0b01011111',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '95',
+                    'last_token'   => $multiToken ? 1 : 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-integer-octal' => [
+                '/* testPHP74IntOctal */',
+                [
+                    'orig_content' => '0137_041',
+                    'content'      => '0137041',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '48673',
+                    'last_token'   => $multiToken ? 1 : 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-float-exponent-multi-underscore' => [
+                '/* testPHP74FloatExponentMultiUnderscore */',
+                [
+                    'orig_content' => '1_2.3_4e1_23',
+                    'content'      => '12.34e123',
+                    'code'         => \T_DNUMBER,
+                    'type'         => 'T_DNUMBER',
+                    'decimal'      => '12.34e123',
+                    'last_token'   => $multiToken ? 3 : 0, // Offset from $stackPtr.
+                ],
+            ],
+
+            // Make sure the backfill doesn't do more than it should.
+            'php-7.4-integer-calculation-1' => [
+                '/* testPHP74IntCalc1 */',
+                [
+                    'orig_content' => '667_083',
+                    'content'      => '667083',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '667083',
+                    'last_token'   => $multiToken ? 1 : 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-integer-calculation-2' => [
+                '/* testPHP74IntCalc2 */',
+                [
+                    'orig_content' => '74_083',
+                    'content'      => '74083',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '74083',
+                    'last_token'   => $multiToken ? 1 : 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-float-calculation-1' => [
+                '/* testPHP74FloatCalc1 */',
+                [
+                    'orig_content' => '6.674_08e3',
+                    'content'      => '6.67408e3',
+                    'code'         => \T_DNUMBER,
+                    'type'         => 'T_DNUMBER',
+                    'decimal'      => '6.67408e3',
+                    'last_token'   => $multiToken ? 1 : 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-float-calculation-2' => [
+                '/* testPHP74FloatCalc2 */',
+                [
+                    'orig_content' => '6.674_08e3',
+                    'content'      => '6.67408e3',
+                    'code'         => \T_DNUMBER,
+                    'type'         => 'T_DNUMBER',
+                    'decimal'      => '6.67408e3',
+                    'last_token'   => $multiToken ? 1 : 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-integer-whitespace' => [
+                '/* testPHP74IntWhitespace */',
+                [
+                    'orig_content' => '107_925_284',
+                    'content'      => '107925284',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '107925284',
+                    'last_token'   => $multiToken ? 1 : 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-float-comments' => [
+                '/* testPHP74FloatComments */',
+                [
+                    'orig_content' => '107_925_284',
+                    'content'      => '107925284',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '107925284',
+                    'last_token'   => $multiToken ? 1 : 0, // Offset from $stackPtr.
+                ],
+            ],
+
+            // Invalid numeric literal with underscore.
+            'php-7.4-invalid-1' => [
+                '/* testPHP74Invalid1 */',
+                [
+                    'orig_content' => '100',
+                    'content'      => '100',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '100',
+                    'last_token'   => 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-invalid-2' => [
+                '/* testPHP74Invalid2 */',
+                [
+                    'orig_content' => '1',
+                    'content'      => '1',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '1',
+                    'last_token'   => 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-invalid-3' => [
+                '/* testPHP74Invalid3 */',
+                [
+                    'orig_content' => '1',
+                    'content'      => '1',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '1',
+                    'last_token'   => 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-invalid-4' => [
+                '/* testPHP74Invalid4 */',
+                [
+                    'orig_content' => '1.',
+                    'content'      => '1.',
+                    'code'         => \T_DNUMBER,
+                    'type'         => 'T_DNUMBER',
+                    'decimal'      => '1.',
+                    'last_token'   => 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-invalid-5' => [
+                '/* testPHP74Invalid5 */',
+                [
+                    'orig_content' => '0',
+                    'content'      => '0',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '0',
+                    'last_token'   => 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-invalid-6' => [
+                '/* testPHP74Invalid6 */',
+                [
+                    'orig_content' => '0',
+                    'content'      => '0',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '0',
+                    'last_token'   => 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-invalid-7' => [
+                '/* testPHP74Invalid7 */',
+                [
+                    'orig_content' => '1',
+                    'content'      => '1',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '1',
+                    'last_token'   => 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-invalid-8' => [
+                '/* testPHP74Invalid8 */',
+                [
+                    'orig_content' => '1',
+                    'content'      => '1',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '1',
+                    'last_token'   => 0, // Offset from $stackPtr.
+                ],
+            ],
+            'live-coding' => [
+                '/* testLiveCoding */',
+                [
+                    'orig_content' => '100',
+                    'content'      => '100',
+                    'code'         => \T_LNUMBER,
+                    'type'         => 'T_LNUMBER',
+                    'decimal'      => '100',
+                    'last_token'   => 0, // Offset from $stackPtr.
+                ],
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/Numbers/GetDecimalValueTest.php
+++ b/Tests/Utils/Numbers/GetDecimalValueTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Numbers;
+
+use PHPCSUtils\Utils\Numbers;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Numbers::getDecimalValue() method.
+ *
+ * @covers \PHPCSUtils\Utils\Numbers::getDecimalValue
+ *
+ * @group numbers
+ *
+ * @since 1.0.0
+ */
+class GetDecimalValueTest extends TestCase
+{
+
+    /**
+     * Test determining the decimal value of an arbitrary numeric string.
+     *
+     * @dataProvider dataGetDecimalValue
+     *
+     * @param string $input    The input string.
+     * @param string $expected The expected function output.
+     *
+     * @return void
+     */
+    public function testGetDecimalValue($input, $expected)
+    {
+        $this->assertSame($expected, Numbers::getDecimalValue($input));
+    }
+
+    /**
+     * Data Provider.
+     *
+     * @see testGetDecimalValue() For the array format.
+     *
+     * @return array
+     */
+    public function dataGetDecimalValue()
+    {
+        return [
+            // Decimal integers.
+            'single-digit-zero'                             => ['0', '0'],
+            'single-digit-nine'                             => ['9', '9'],
+            'multi-digit-decimal-int'                       => ['123', '123'],
+            'multi-digit-decimal-php-7.4'                   => ['12_34_56', '123456'],
+
+            // Floats.
+            'multi-digit-decimal-float'                     => ['0.123', '0.123'],
+            'multi-digit-float-scientific-uppercase-e'      => ['01E3', '01E3'],
+            'multi-digit-float-scientific-lowercase-e'      => ['01e3', '01e3'],
+            'multi-digit-decimal-float-php-7.4'             => ['0.123_456', '0.123456'],
+            'multi-digit-scientific-float-with-underscores' => ['6.674_083e+11', '6.674083e+11'],
+
+            // Hex.
+            // phpcs:disable PHPCompatibility.Miscellaneous.ValidIntegers.HexNumericStringFound
+            'hex-int-no-numbers'                            => ['0xA', '10'],
+            'hex-int-all-numbers'                           => ['0x400', '1024'],
+            'hex-int-mixed-uppercase-x'                     => ['0XAB953C', '11244860'],
+            'hex-int-mixed-php-7.4'                         => ['0xAB_95_3C', '11244860'],
+            // phpcs:enable
+
+            // Binary.
+            'binary-int-10'                                 => ['0b1010', '10'],
+            'binary-int-1024-uppercase-b'                   => ['0B10000000000', '1024'],
+            'binary-int-1024-php-7.4'                       => ['0b100_000_000_00', '1024'],
+
+            // Octal.
+            'octal-int-10'                                  => ['012', '10'],
+            'octal-int-1024'                                => ['02000', '1024'],
+            'octal-int-1024-php-7.4'                        => ['020_00', '1024'],
+        ];
+    }
+
+    /**
+     * Test that the method returns false when a non-string, a non-numeric string or an
+     * invalid numeric format is received.
+     *
+     * @dataProvider dataGetDecimalValueInvalid
+     *
+     * @param string $input The input string.
+     *
+     * @return void
+     */
+    public function testGetDecimalValueInvalid($input)
+    {
+        $this->assertFalse(Numbers::getDecimalValue($input));
+    }
+
+    /**
+     * Data Provider.
+     *
+     * @see testGetDecimalValueInvalid() For the array format.
+     *
+     * @return array
+     */
+    public function dataGetDecimalValueInvalid()
+    {
+        return [
+            'not-a-string-bool'                             => [true],
+            'not-a-string-int'                              => [10],
+            'not-a-string-float'                            => [1.23],
+            'empty-string'                                  => [''],
+            'string-not-a-number'                           => ['foobar'],
+            'string-not-a-number-with-full-stop'            => ['foo? bar.'],
+
+            // Invalid formats.
+            'invalid-hex'                                   => ['0xZBHI28'],
+            'invalid-binary'                                => ['0b121457182'],
+            'invalid-octal'                                 => ['0289'],
+        ];
+    }
+}

--- a/Tests/Utils/Numbers/NumberTypesTest.php
+++ b/Tests/Utils/Numbers/NumberTypesTest.php
@@ -1,0 +1,857 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Numbers;
+
+use PHPCSUtils\Utils\Numbers;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Numbers::isDecimalInt(),
+ * \PHPCSUtils\Utils\Numbers::isHexidecimalInt(),
+ * \PHPCSUtils\Utils\Numbers::isBinaryInt(),
+ * \PHPCSUtils\Utils\Numbers::isOctalInt() and the
+ * \PHPCSUtils\Utils\Numbers::isFloat() method.
+ *
+ * @group numbers
+ *
+ * @since 1.0.0
+ */
+class NumberTypesTest extends TestCase
+{
+
+    /**
+     * Test correctly recognizing an arbitrary string representing a decimal integer.
+     *
+     * @dataProvider dataNumbers
+     * @covers       \PHPCSUtils\Utils\Numbers::isDecimalInt
+     *
+     * @param string $input    The input string.
+     * @param string $expected The expected output for the various functions.
+     *
+     * @return void
+     */
+    public function testIsDecimalInt($input, $expected)
+    {
+        $this->assertSame($expected['decimal'], Numbers::isDecimalInt($input));
+    }
+
+    /**
+     * Test correctly recognizing an arbitrary string representing a hexidecimal integer.
+     *
+     * @dataProvider dataNumbers
+     * @covers       \PHPCSUtils\Utils\Numbers::isHexidecimalInt
+     *
+     * @param string $input    The input string.
+     * @param string $expected The expected output for the various functions.
+     *
+     * @return void
+     */
+    public function testIsHexidecimalInt($input, $expected)
+    {
+        $this->assertSame($expected['hex'], Numbers::isHexidecimalInt($input));
+    }
+
+    /**
+     * Test correctly recognizing an arbitrary string representing a binary integer.
+     *
+     * @dataProvider dataNumbers
+     * @covers       \PHPCSUtils\Utils\Numbers::isBinaryInt
+     *
+     * @param string $input    The input string.
+     * @param string $expected The expected output for the various functions.
+     *
+     * @return void
+     */
+    public function testIsBinaryInt($input, $expected)
+    {
+        $this->assertSame($expected['binary'], Numbers::isBinaryInt($input));
+    }
+
+    /**
+     * Test correctly recognizing an arbitrary string representing an octal integer.
+     *
+     * @dataProvider dataNumbers
+     * @covers       \PHPCSUtils\Utils\Numbers::isOctalInt
+     *
+     * @param string $input    The input string.
+     * @param string $expected The expected output for the various functions.
+     *
+     * @return void
+     */
+    public function testIsOctalInt($input, $expected)
+    {
+        $this->assertSame($expected['octal'], Numbers::isOctalInt($input));
+    }
+
+    /**
+     * Test correctly recognizing an arbitrary string representing a decimal float.
+     *
+     * @dataProvider dataNumbers
+     * @covers       \PHPCSUtils\Utils\Numbers::isFloat
+     *
+     * @param string $input    The input string.
+     * @param string $expected The expected output for the various functions.
+     *
+     * @return void
+     */
+    public function testIsFloat($input, $expected)
+    {
+        $this->assertSame($expected['float'], Numbers::isFloat($input));
+    }
+
+    /**
+     * Data Provider.
+     *
+     * @see testIsDecimalInt()     For the array format.
+     * @see testIsHexidecimalInt() For the array format.
+     * @see testIsBinaryInt()      For the array format.
+     * @see testIsOctalInt()       For the array format.
+     * @see testIsDecimalFloat()   For the array format.
+     *
+     * @return array
+     */
+    public static function dataNumbers()
+    {
+        return [
+            // Not strings.
+            'not-a-string-bool' => [
+                true,
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'not-a-string-int' => [
+                10,
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+
+            // Not numeric strings.
+            'empty-string' => [
+                '',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'string-not-a-number' => [
+                'foobar',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'string-not-a-number-with-full-stop' => [
+                'foo. bar',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-hex' => [
+                '0xZBHI28',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-binary' => [
+                '0b121457182',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-octal' => [
+                // Note: in PHP 5.x this would still be accepted, though not interpreted correctly.
+                '0289',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-float-two-decimal-points' => [
+                '1.287.2763',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-float-plus-no-exponent' => [
+                '1.287+2763',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-float-minus-no-exponent' => [
+                '1287-2763',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-float-exponent-no-multiplier' => [
+                '2872e',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-float-exponent-plus-no-multiplier' => [
+                '1.2872e+',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-float-exponent-minus-no-multiplier' => [
+                '1.2872e-',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-float-exponent-multiplier-float' => [
+                '376e2.3',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-float-exponent-plus-multiplier-float' => [
+                '3.76e+2.3',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-float-exponent-minus-multiplier-float' => [
+                '37.6e-2.3',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-float-exponent-plus-minus-multiplier' => [
+                '37.6e+-2',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-float-double-exponent' => [
+                '37.6e2e6',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+
+            // Decimal numeric strings.
+            'decimal-single-digit-zero' => [
+                '0',
+                [
+                    'decimal' => true,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'decimal-single-digit' => [
+                '9',
+                [
+                    'decimal' => true,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'decimal-multi-digit' => [
+                '123456',
+                [
+                    'decimal' => true,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'decimal-multi-digit-php-7.4' => [
+                '12_34_56',
+                [
+                    'decimal' => true,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+
+            // Hexidecimal numeric strings.
+            // phpcs:disable PHPCompatibility.Miscellaneous.ValidIntegers.HexNumericStringFound
+            'hexidecimal-single-digit-zero' => [
+                '0x0',
+                [
+                    'decimal' => false,
+                    'hex'     => true,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'hexidecimal-single-digit' => [
+                '0xA',
+                [
+                    'decimal' => false,
+                    'hex'     => true,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'hexidecimal-multi-digit-all-numbers' => [
+                '0x123456',
+                [
+                    'decimal' => false,
+                    'hex'     => true,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'hexidecimal-multi-digit-no-numbers' => [
+                '0xABCDEF',
+                [
+                    'decimal' => false,
+                    'hex'     => true,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'hexidecimal-multi-digit-mixed' => [
+                '0xAB02F6',
+                [
+                    'decimal' => false,
+                    'hex'     => true,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'hexidecimal-multi-digit-mixed-uppercase-x' => [
+                '0XAB953C',
+                [
+                    'decimal' => false,
+                    'hex'     => true,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'hexidecimal-multi-digit-php-7.4' => [
+                '0x23_6A_3C',
+                [
+                    'decimal' => false,
+                    'hex'     => true,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            // phpcs:enable
+
+            // Binary numeric strings.
+            'binary-single-digit-zero' => [
+                '0b0',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => true,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'binary-single-digit-one' => [
+                '0b1',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => true,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'binary-multi-digit' => [
+                '0b1010',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => true,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'binary-multi-digit-uppercase-b' => [
+                '0B1000100100000',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => true,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'binary-multi-digit-php-7.4' => [
+                '0b100_000_000_00',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => true,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+
+            // Octal numeric strings.
+            'octal-single-digit-zero' => [
+                '00',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => true,
+                    'float'   => false,
+                ],
+            ],
+            'octal-single-digit' => [
+                '07',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => true,
+                    'float'   => false,
+                ],
+            ],
+            'octal-multi-digit' => [
+                '076543210',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => true,
+                    'float'   => false,
+                ],
+            ],
+            'octal-multi-digit-php-7.4' => [
+                '020_631_542',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => true,
+                    'float'   => false,
+                ],
+            ],
+
+            // Floating point numeric strings. Also see: decimal numeric strings.
+            'float-single-digit-dot-zero' => [
+                '0.',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-single-digit-dot' => [
+                '1.',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-multi-digit-dot' => [
+                '56458.',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-multi-digit-dot-leading-zero' => [
+                '0023.',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-multi-digit-dot-php-7.4' => [
+                '521_879.',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+
+            'float-dot-single-digit-zero' => [
+                '.0',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-dot-single-digit' => [
+                '.2',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-dot-multi-digit' => [
+                '.232746',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-dot-multi-digit-trailing-zero' => [
+                '.345300',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-dot-multi-digit-php-7.4' => [
+                '.421_789_8',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+
+            'float-digit-dot-digit-single-zero' => [
+                '0.0',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-digit-dot-digit-single' => [
+                '9.1',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-digit-dot-digit-multi' => [
+                '7483.2182',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-digit-dot-digit-multi-leading-zero' => [
+                '002781.21928173',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-digit-dot-digit-multi-trailing-zero' => [
+                '213.2987000',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-digit-dot-digit-multi-leading-zero-trailing-zero' => [
+                '07262.2760',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-digit-dot-digit-multi--php-7.4' => [
+                '07_262.276_720',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+
+            'float-exponent-digit-dot-digit-zero-exp-single-digit' => [
+                '0.0e1',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-exponent-single-digit-dot-exp-double-digit' => [
+                '1.e28',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-exponent-multi-digit-dot-exp-plus-digit' => [
+                '56458.e+2',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-exponent-multi-digit-dot-leading-zero-exp-minus-digit' => [
+                '0023.e-44',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+
+            'float-exponent-dot-single-digit-zero-exp-minus-digit' => [
+                '.0e-1',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-exponent-dot-single-digit-exp-plus-digit-zero' => [
+                '.2e+0',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-exponent-dot-multi-digit-exp-multi-digit' => [
+                '.232746e41',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-exponent-dot-multi-digit-trailing-zero-exp-multi-digit' => [
+                '.345300e87',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+
+            'float-exponent-digit-dot-digit-single-zero-exp-uppercase' => [
+                '0.0E2',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-exponent-digit-dot-digit-single-exp-uppercase' => [
+                '9.1E47',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-exponent-digit-dot-digit-multi-exp-minus-digit' => [
+                '7483.2182e-3',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-exponent-digit-dot-digit-multi-leading-zero-exp-uppercase' => [
+                '002781.21928173E+56',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-exponent-digit-dot-digit-multi-trailing-zero-exp-plus-digit' => [
+                '213.2987000e+2',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-exponent-digit-dot-digit-multi-leading-zero-trailing-zero-exp-digit' => [
+                '07262.2760e4',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+            'float-exponent-digit-dot-digit-exp-digit-php-7.4' => [
+                '6.674_083e+1_1',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => true,
+                ],
+            ],
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
         "jakub-onderka/php-console-highlighter": "^0.4",
         "phpunit/phpunit" : "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
     },
+    "conflict": {
+        "squizlabs/php_codesniffer": "3.5.3"
+    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {


### PR DESCRIPTION
PHP 7.4 introduced numeric literal separators which break number tokenization in older PHP versions.
PHPCS backfills this since PHPCS 3.5.3, but that backfill implementation is broken in such a bad way that PHPCS 3.5.3 can not be supported.

A fix for the backfill has been merged and will be included in PHPCS 3.5.4.

Having said that, if an external standard intends to support PHPCS < 3.5.3 and/or PHP < 7.4, working with number tokens has become a challenge, as without the backfill any number token is potentially broken

The functions in this class have been put in place to ease that pain and it is *strongly* recommended to always use these functions when sniffing for and/or examining the contents of `T_LNUMBER` or `T_DNUMBER` tokens.

Note: sniffing for `T_STRING` tokens is also affected by this PHP 7.4 change, but that is not addressed here.

The `Numbers` class introduces two new methods:
* `getCompleteNumber()` - Helper function to deal with numeric literals, potentially with underscore separators. Returns an array with information about the number.
* `getDecimalValue()` - Get the decimal number value of a numeric string. Returns the value as a string or false if the passed parameter was not a (numeric) string.
* `isDecimalInt()` - Check if an arbitrary string represents a decimal integer. Returns boolean.
* `isHexidecimalInt()` - Check if an arbitrary string represents a hexidecimal integer. Returns boolean.
* `isBinaryInt()` - Check if an arbitrary string represents a binary integer. Returns boolean.
* `isOctalInt()` - Check if an arbitrary string represents a octal integer. Returns boolean.
* `isFloat()` - Check if an arbitrary string represents a floating point number. Returns boolean.

Includes dedicated unit tests for these methods.