### PR TITLE
New `Abstracts\AbstractArrayDeclarationSniff`

### DIFF
--- a/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
+++ b/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
@@ -1,0 +1,352 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\AbstractSniffs;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHPCSUtils\Utils\Arrays;
+use PHPCSUtils\Utils\PassedParameters;
+
+/**
+ * Abstract sniff to easily examine all parts of an array declaration.
+ *
+ * @since 1.0.0
+ */
+abstract class AbstractArrayDeclarationSniff implements Sniff
+{
+
+    /**
+     * The stack pointer to the array keyword or the short array open token.
+     *
+     * @since 1.0.0
+     *
+     * @var int
+     */
+    protected $stackPtr;
+
+    /**
+     * The token stack for the current file being examined.
+     *
+     * @since 1.0.0
+     *
+     * @var array
+     */
+    protected $tokens;
+
+    /**
+     * The stack pointer to the array opener.
+     *
+     * @since 1.0.0
+     *
+     * @var int
+     */
+    protected $arrayOpener;
+
+    /**
+     * The stack pointer to the array closer.
+     *
+     * @since 1.0.0
+     *
+     * @var int
+     */
+    protected $arrayCloser;
+
+    /**
+     * A multi-dimentional array with information on each array item.
+     *
+     * The array index is 1-based and contains the following information on each array item:
+     * - 'start' : The stack pointer to the first token in the array item.
+     * - 'end'   : The stack pointer to the first token in the array item.
+     * - 'raw'   : A string with the contents of all tokens between `start` and `end`.
+     * - 'clean' : Same as `raw`, but all comment tokens have been stripped out.
+     *
+     * @since 1.0.0
+     *
+     * @var array
+     */
+    protected $arrayItems;
+
+    /**
+     * How many items are in the array.
+     *
+     * @since 1.0.0
+     *
+     * @var int
+     */
+    protected $itemCount = 0;
+
+    /**
+     * Whether or not the array is single line.
+     *
+     * @since 1.0.0
+     *
+     * @var bool
+     */
+    protected $singleLine;
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @codeCoverageIgnore
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return [
+            \T_ARRAY,
+            \T_OPEN_SHORT_ARRAY,
+            \T_OPEN_SQUARE_BRACKET,
+        ];
+    }
+
+    /**
+     * Processes this test when one of its tokens is encountered.
+     *
+     * This method fills the properties with relevant information for examining the array
+     * and then passes off to the `processArray()` method.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     * @param int                         $stackPtr  The position in the PHP_CodeSniffer
+     *                                               file's token stack where the token
+     *                                               was found.
+     *
+     * @return void
+     */
+    final public function process(File $phpcsFile, $stackPtr)
+    {
+        try {
+            $this->arrayItems = PassedParameters::getParameters($phpcsFile, $stackPtr);
+        } catch (RuntimeException $e) {
+            // Parse error, short list, real square open bracket or incorrectly tokenized short array token.
+            return;
+        }
+
+        $this->stackPtr    = $stackPtr;
+        $this->tokens      = $phpcsFile->getTokens();
+        $openClose         = Arrays::getOpenClose($phpcsFile, $stackPtr, true);
+        $this->arrayOpener = $openClose['opener'];
+        $this->arrayCloser = $openClose['closer'];
+        $this->itemCount   = \count($this->arrayItems);
+
+        $this->singleLine = true;
+        if ($this->tokens[$openClose['opener']]['line'] !== $this->tokens[$openClose['closer']]['line']) {
+            $this->singleLine = false;
+        }
+
+        $this->processArray($phpcsFile);
+
+        // Reset select properties between calls to this sniff to lower memory usage.
+        unset($this->tokens, $this->arrayItems);
+    }
+
+    /**
+     * Process every part of the array declaration.
+     *
+     * This contains the default logic for the sniff, but can be overloaded in a concrete child class
+     * if needed.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     *
+     * @return void
+     */
+    public function processArray(File $phpcsFile)
+    {
+        if ($this->processOpenClose($phpcsFile, $this->arrayOpener, $this->arrayCloser) === true) {
+            return;
+        }
+
+        if ($this->itemCount === 0) {
+            return;
+        }
+
+        foreach ($this->arrayItems as $itemNr => $arrayItem) {
+            $arrowPtr = Arrays::getDoubleArrowPtr($phpcsFile, $arrayItem['start'], $arrayItem['end']);
+
+            if ($arrowPtr !== false) {
+                if ($this->processKey($phpcsFile, $arrayItem['start'], ($arrowPtr - 1), $itemNr) === true) {
+                    return;
+                }
+
+                if ($this->processArrow($phpcsFile, $arrowPtr, $itemNr) === true) {
+                    return;
+                }
+
+                if ($this->processValue($phpcsFile, ($arrowPtr + 1), $arrayItem['end'], $itemNr) === true) {
+                    return;
+                }
+            } else {
+                if ($this->processNoKey($phpcsFile, $arrayItem['start'], $itemNr) === true) {
+                    return;
+                }
+
+                if ($this->processValue($phpcsFile, $arrayItem['start'], $arrayItem['end'], $itemNr) === true) {
+                    return;
+                }
+            }
+
+            $commaPtr = ($arrayItem['end'] + 1);
+            if ($itemNr < $this->itemCount || $this->tokens[$commaPtr]['code'] === \T_COMMA) {
+                if ($this->processComma($phpcsFile, $commaPtr, $itemNr) === true) {
+                    return;
+                }
+            }
+        }
+    }
+
+    /**
+     * Process the array opener and closer.
+     *
+     * Optional method to be implemented in concrete child classes.
+     *
+     * @since 1.0.0
+     *
+     * @codeCoverageIgnore
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     * @param int                         $openPtr   The position of the array opener token in the token stack.
+     * @param int                         $closePtr  The position of the array closer token in the token stack.
+     *
+     * @return true|void Returning `true` will short-circuit the sniff and stop processing.
+     */
+    public function processOpenClose(File $phpcsFile, $openPtr, $closePtr)
+    {
+    }
+
+    /**
+     * Process the tokens in an array key.
+     *
+     * Optional method to be implemented in concrete child classes.
+     *
+     * The $startPtr and $endPtr do not discount whitespace or comments, but are all inclusive to
+     * allow examining all tokens in an array key.
+     *
+     * @since 1.0.0
+     *
+     * @codeCoverageIgnore
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     * @param int                         $startPtr  The stack pointer to the first token in the "key" part of
+     *                                               an array item.
+     * @param int                         $endPtr    The stack pointer to the last token in the "key" part of
+     *                                               an array item.
+     * @param int                         $itemNr    Which item in the array is being handled.
+     *                                               1-based, i.e. the first item is item 1, the second 2 etc.
+     *
+     * @return true|void Returning `true` will short-circuit the array item loop and stop processing.
+     */
+    public function processKey(File $phpcsFile, $startPtr, $endPtr, $itemNr)
+    {
+    }
+
+    /**
+     * Process an array item without an array key.
+     *
+     * Optional method to be implemented in concrete child classes.
+     *
+     * @since 1.0.0
+     *
+     * @codeCoverageIgnore
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     * @param int                         $startPtr  The stack pointer to the first token in the array item,
+     *                                               which in this case will be the first token of the array
+     *                                               value part of the array item.
+     * @param int                         $itemNr    Which item in the array is being handled.
+     *                                               1-based, i.e. the first item is item 1, the second 2 etc.
+     *
+     * @return true|void Returning `true` will short-circuit the array item loop and stop processing.
+     */
+    public function processNoKey(File $phpcsFile, $startPtr, $itemNr)
+    {
+    }
+
+    /**
+     * Process the double arrow.
+     *
+     * Optional method to be implemented in concrete child classes.
+     *
+     * @since 1.0.0
+     *
+     * @codeCoverageIgnore
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     * @param int                         $arrowPtr  The stack pointer to the double arrow for the array item.
+     * @param int                         $itemNr    Which item in the array is being handled.
+     *                                               1-based, i.e. the first item is item 1, the second 2 etc.
+     *
+     * @return true|void Returning `true` will short-circuit the array item loop and stop processing.
+     */
+    public function processArrow(File $phpcsFile, $arrowPtr, $itemNr)
+    {
+    }
+
+    /**
+     * Process the tokens in an array value.
+     *
+     * Optional method to be implemented in concrete child classes.
+     *
+     * The $startPtr and $endPtr do not discount whitespace or comments, but are all inclusive to
+     * allow examining all tokens in an array value.
+     *
+     * @since 1.0.0
+     *
+     * @codeCoverageIgnore
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     * @param int                         $startPtr  The stack pointer to the first token in the "value" part of
+     *                                               an array item.
+     * @param int                         $endPtr    The stack pointer to the last token in the "value" part of
+     *                                               an array item.
+     * @param int                         $itemNr    Which item in the array is being handled.
+     *                                               1-based, i.e. the first item is item 1, the second 2 etc.
+     *
+     * @return true|void Returning `true` will short-circuit the array item loop and stop processing.
+     */
+    public function processValue(File $phpcsFile, $startPtr, $endPtr, $itemNr)
+    {
+    }
+
+    /**
+     * Process the comma after an array item.
+     *
+     * Optional method to be implemented in concrete child classes.
+     *
+     * @since 1.0.0
+     *
+     * @codeCoverageIgnore
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     * @param int                         $commaPtr  The stack pointer to the comma.
+     * @param int                         $itemNr    Which item in the array is being handled.
+     *                                               1-based, i.e. the first item is item 1, the second 2 etc.
+     *
+     * @return true|void Returning `true` will short-circuit the array item loop and stop processing.
+     */
+    public function processComma(File $phpcsFile, $commaPtr, $itemNr)
+    {
+    }
+}

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.inc
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.inc
@@ -1,0 +1,28 @@
+<?php
+
+/* testEmptyArray */
+$array = array(  );
+
+/* testSingleLineShortArrayNoKeysNoTrailingComma */
+$array = [1, 2];
+
+/* testMultiLineLongArrayKeysTrailingComma */
+$array = array(
+    1 => 'a',
+    2 => 'b',
+    3 => 'c',
+    4 => 'd',
+);
+
+/* testMultiLineShortArrayMixedKeysNoKeys */
+$array = [
+    12 => 'numeric key',
+    'value',
+    'string' => 'string key',
+];
+
+/* testShortCircuit */
+$array = [1, 'a' => 2, ];
+
+/* testShortList */
+[$a, $b] = $array;

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
@@ -1,0 +1,612 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\AbstractSniffs\AbstractArrayDeclaration;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+
+/**
+ * Tests for the \PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff class.
+ *
+ * @covers \PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff
+ *
+ * @group abstracts
+ *
+ * @since 1.0.0
+ */
+class AbstractArrayDeclarationSniffTest extends UtilityMethodTestCase
+{
+
+    /**
+     * List of methods in the abstract which should be mocked.
+     *
+     * Needed for PHPUnit cross-version support as PHPUnit 4.x does not have a
+     * `setMethodsExcept()` method yet.
+     *
+     * @var array
+     */
+    public $methodsToMock = [
+        'processOpenClose',
+        'processKey',
+        'processNoKey',
+        'processArrow',
+        'processValue',
+        'processComma',
+    ];
+
+    /**
+     * Test that the abstract sniff correctly bows out when presented with a token which is not an array.
+     *
+     * @return void
+     */
+    public function testShortList()
+    {
+        $target = $this->getTargetToken(
+            '/* testShortList */',
+            [\T_ARRAY, \T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET]
+        );
+
+        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
+            ->setMethods($this->methodsToMock)
+            ->getMockForAbstractClass();
+
+        $mockObj->expects($this->never())
+            ->method('processOpenClose');
+
+        $mockObj->expects($this->never())
+            ->method('processKey');
+
+        $mockObj->expects($this->never())
+            ->method('processNoKey');
+
+        $mockObj->expects($this->never())
+            ->method('processArrow');
+
+        $mockObj->expects($this->never())
+            ->method('processValue');
+
+        $mockObj->expects($this->never())
+            ->method('processComma');
+
+        $mockObj->process(self::$phpcsFile, $target);
+    }
+
+    /**
+     * Test that the abstract sniff correctly bows out after the processOpenClose() method
+     * when presented with an empty array.
+     *
+     * @return void
+     */
+    public function testEmptyArray()
+    {
+        $target = $this->getTargetToken(
+            '/* testEmptyArray */',
+            [\T_ARRAY, \T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET]
+        );
+
+        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
+            ->setMethods($this->methodsToMock)
+            ->getMockForAbstractClass();
+
+        $mockObj->expects($this->once())
+            ->method('processOpenClose');
+
+        $mockObj->expects($this->never())
+            ->method('processKey');
+
+        $mockObj->expects($this->never())
+            ->method('processNoKey');
+
+        $mockObj->expects($this->never())
+            ->method('processArrow');
+
+        $mockObj->expects($this->never())
+            ->method('processValue');
+
+        $mockObj->expects($this->never())
+            ->method('processComma');
+
+        $mockObj->process(self::$phpcsFile, $target);
+    }
+
+    /**
+     * Test all features of the abstract sniff when presented with a single line short array
+     * without array keys and without trailing comma after the last array item.
+     *
+     * @return void
+     */
+    public function testSingleLineShortArrayNoKeysNoTrailingComma()
+    {
+        $target = $this->getTargetToken(
+            '/* testSingleLineShortArrayNoKeysNoTrailingComma */',
+            [\T_ARRAY, \T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET]
+        );
+
+        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
+            ->setMethods($this->methodsToMock)
+            ->getMockForAbstractClass();
+
+        $mockObj->expects($this->once())
+            ->method('processOpenClose')
+            ->with(
+                $this->identicalTo(self::$phpcsFile),
+                $this->equalTo($target),
+                $this->equalTo($target + 5)
+            );
+
+        $mockObj->expects($this->exactly(2))
+            ->method('processNoKey')
+            ->withConsecutive(
+                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 1), $this->equalTo(1)],
+                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 3), $this->equalTo(2)]
+            );
+
+        $mockObj->expects($this->exactly(2))
+            ->method('processValue')
+            ->withConsecutive(
+                [
+                    $this->identicalTo(self::$phpcsFile),
+                    $this->equalTo($target + 1),
+                    $this->equalTo($target + 1),
+                    $this->equalTo(1),
+                ],
+                [
+                    $this->identicalTo(self::$phpcsFile),
+                    $this->equalTo($target + 3),
+                    $this->equalTo($target + 4),
+                    $this->equalTo(2),
+                ]
+            );
+
+        $mockObj->expects($this->once())
+            ->method('processComma')
+            ->with(
+                $this->identicalTo(self::$phpcsFile),
+                $this->equalTo($target + 2),
+                $this->equalTo(1)
+            );
+
+        $mockObj->process(self::$phpcsFile, $target);
+
+        // Note: these methods are deprecated in PHPUnit 8.x and removed in PHPUnit 9.x
+
+        // Verify that the properties have been correctly set.
+        $this->assertAttributeSame($target, 'stackPtr', $mockObj);
+        $this->assertAttributeSame($target, 'arrayOpener', $mockObj);
+        $this->assertAttributeSame(($target + 5), 'arrayCloser', $mockObj);
+        $this->assertAttributeSame(2, 'itemCount', $mockObj);
+        $this->assertAttributeSame(true, 'singleLine', $mockObj);
+    }
+
+    /**
+     * Test all features of the abstract sniff when presented with a mutli line long array
+     * with array keys, double arrows and with a trailing comma after the last array item.
+     *
+     * @return void
+     */
+    public function testMultiLineLongArrayKeysTrailingComma()
+    {
+        $target = $this->getTargetToken(
+            '/* testMultiLineLongArrayKeysTrailingComma */',
+            [\T_ARRAY, \T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET]
+        );
+
+        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
+            ->setMethods($this->methodsToMock)
+            ->getMockForAbstractClass();
+
+        $mockObj->expects($this->once())
+            ->method('processOpenClose')
+            ->with(
+                $this->identicalTo(self::$phpcsFile),
+                $this->equalTo($target + 1),
+                $this->equalTo($target + 35)
+            );
+
+        $mockObj->expects($this->exactly(3))
+            ->method('processKey')
+            ->withConsecutive(
+                [
+                    $this->identicalTo(self::$phpcsFile),
+                    $this->equalTo($target + 2),
+                    $this->equalTo($target + 5),
+                    $this->equalTo(1),
+                ],
+                [
+                    $this->identicalTo(self::$phpcsFile),
+                    $this->equalTo($target + 10),
+                    $this->equalTo($target + 13),
+                    $this->equalTo(2),
+                ],
+                [
+                    $this->identicalTo(self::$phpcsFile),
+                    $this->equalTo($target + 18),
+                    $this->equalTo($target + 21),
+                    $this->equalTo(3),
+                ]
+            );
+
+        $mockObj->expects($this->exactly(3))
+            ->method('processArrow')
+            ->withConsecutive(
+                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 6), $this->equalTo(1)],
+                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 14), $this->equalTo(2)],
+                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 22), $this->equalTo(3)]
+            );
+
+        $mockObj->expects($this->exactly(3))
+            ->method('processValue')
+            ->withConsecutive(
+                [
+                    $this->identicalTo(self::$phpcsFile),
+                    $this->equalTo($target + 7),
+                    $this->equalTo($target + 8),
+                    $this->equalTo(1),
+                ],
+                [
+                    $this->identicalTo(self::$phpcsFile),
+                    $this->equalTo($target + 15),
+                    $this->equalTo($target + 16),
+                    $this->equalTo(2),
+                ],
+                [
+                    $this->identicalTo(self::$phpcsFile),
+                    $this->equalTo($target + 23),
+                    $this->equalTo($target + 24),
+                    $this->equalTo(3),
+                ]
+            )
+            ->will($this->onConsecutiveCalls(null, null, true)); // Testing short-circuiting the loop.
+
+        $mockObj->expects($this->exactly(2))
+            ->method('processComma')
+            ->withConsecutive(
+                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 9), $this->equalTo(1)],
+                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 17), $this->equalTo(2)]
+            );
+
+        $mockObj->process(self::$phpcsFile, $target);
+
+        // Note: these methods are deprecated in PHPUnit 8.x and removed in PHPUnit 9.x
+
+        // Verify that the properties have been correctly set.
+        $this->assertAttributeSame($target, 'stackPtr', $mockObj);
+        $this->assertAttributeSame(($target + 1), 'arrayOpener', $mockObj);
+        $this->assertAttributeSame(($target + 35), 'arrayCloser', $mockObj);
+        $this->assertAttributeSame(4, 'itemCount', $mockObj);
+        $this->assertAttributeSame(false, 'singleLine', $mockObj);
+    }
+
+    /**
+     * Test all features of the abstract sniff when presented with a multi line short array with
+     * a mix of items with and without array keys and with a trailing comma after the last array item.
+     *
+     * @return void
+     */
+    public function testMultiLineShortArrayMixedKeysNoKeys()
+    {
+        $target = $this->getTargetToken(
+            '/* testMultiLineShortArrayMixedKeysNoKeys */',
+            [\T_ARRAY, \T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET]
+        );
+
+        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
+            ->setMethods($this->methodsToMock)
+            ->getMockForAbstractClass();
+
+        $mockObj->expects($this->once())
+            ->method('processOpenClose')
+            ->with(
+                $this->identicalTo(self::$phpcsFile),
+                $this->equalTo($target),
+                $this->equalTo($target + 22)
+            );
+
+        $mockObj->expects($this->exactly(2))
+            ->method('processKey')
+            ->withConsecutive(
+                [
+                    $this->identicalTo(self::$phpcsFile),
+                    $this->equalTo($target + 1),
+                    $this->equalTo($target + 4),
+                    $this->equalTo(1),
+                ],
+                [
+                    $this->identicalTo(self::$phpcsFile),
+                    $this->equalTo($target + 13),
+                    $this->equalTo($target + 16),
+                    $this->equalTo(3),
+                ]
+            );
+
+        $mockObj->expects($this->once())
+            ->method('processNoKey')
+            ->withConsecutive(
+                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 9), $this->equalTo(2)]
+            );
+
+        $mockObj->expects($this->exactly(2))
+            ->method('processArrow')
+            ->withConsecutive(
+                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 5), $this->equalTo(1)],
+                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 17), $this->equalTo(3)]
+            );
+
+        $mockObj->expects($this->exactly(3))
+            ->method('processValue')
+            ->withConsecutive(
+                [
+                    $this->identicalTo(self::$phpcsFile),
+                    $this->equalTo($target + 6),
+                    $this->equalTo($target + 7),
+                    $this->equalTo(1),
+                ],
+                [
+                    $this->identicalTo(self::$phpcsFile),
+                    $this->equalTo($target + 9),
+                    $this->equalTo($target + 11),
+                    $this->equalTo(2),
+                ],
+                [
+                    $this->identicalTo(self::$phpcsFile),
+                    $this->equalTo($target + 18),
+                    $this->equalTo($target + 19),
+                    $this->equalTo(3),
+                ]
+            );
+
+        $mockObj->expects($this->exactly(3))
+            ->method('processComma')
+            ->withConsecutive(
+                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 8), $this->equalTo(1)],
+                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 12), $this->equalTo(2)],
+                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 20), $this->equalTo(3)]
+            );
+
+        $mockObj->process(self::$phpcsFile, $target);
+
+        // Note: these methods are deprecated in PHPUnit 8.x and removed in PHPUnit 9.x
+
+        // Verify that the properties have been correctly set.
+        $this->assertAttributeSame($target, 'stackPtr', $mockObj);
+        $this->assertAttributeSame($target, 'arrayOpener', $mockObj);
+        $this->assertAttributeSame(($target + 22), 'arrayCloser', $mockObj);
+        $this->assertAttributeSame(3, 'itemCount', $mockObj);
+        $this->assertAttributeSame(false, 'singleLine', $mockObj);
+    }
+
+    /**
+     * Test short-circuiting the sniff on the call to processOpenClose().
+     *
+     * @return void
+     */
+    public function testShortCircuitOnProcessOpenClose()
+    {
+        $target = $this->getTargetToken(
+            '/* testShortCircuit */',
+            [\T_ARRAY, \T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET]
+        );
+
+        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
+            ->setMethods($this->methodsToMock)
+            ->getMockForAbstractClass();
+
+        $mockObj->expects($this->once())
+            ->method('processOpenClose')
+            ->willReturn(true);
+
+        $mockObj->expects($this->never())
+            ->method('processKey');
+
+        $mockObj->expects($this->never())
+            ->method('processNoKey');
+
+        $mockObj->expects($this->never())
+            ->method('processArrow');
+
+        $mockObj->expects($this->never())
+            ->method('processValue');
+
+        $mockObj->expects($this->never())
+            ->method('processComma');
+
+        $mockObj->process(self::$phpcsFile, $target);
+    }
+
+    /**
+     * Test short-circuiting the sniff on the call to processKey().
+     *
+     * @return void
+     */
+    public function testShortCircuitOnProcessKey()
+    {
+        $target = $this->getTargetToken(
+            '/* testShortCircuit */',
+            [\T_ARRAY, \T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET]
+        );
+
+        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
+            ->setMethods($this->methodsToMock)
+            ->getMockForAbstractClass();
+
+        $mockObj->expects($this->once())
+            ->method('processOpenClose');
+
+        $mockObj->expects($this->once())
+            ->method('processKey')
+            ->willReturn(true);
+
+        $mockObj->expects($this->once())
+            ->method('processNoKey');
+
+        $mockObj->expects($this->never())
+            ->method('processArrow');
+
+        $mockObj->expects($this->once())
+            ->method('processValue');
+
+        $mockObj->expects($this->once())
+            ->method('processComma');
+
+        $mockObj->process(self::$phpcsFile, $target);
+    }
+
+    /**
+     * Test short-circuiting the sniff on the call to processNoKey().
+     *
+     * @return void
+     */
+    public function testShortCircuitOnProcessNoKey()
+    {
+        $target = $this->getTargetToken(
+            '/* testShortCircuit */',
+            [\T_ARRAY, \T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET]
+        );
+
+        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
+            ->setMethods($this->methodsToMock)
+            ->getMockForAbstractClass();
+
+        $mockObj->expects($this->once())
+            ->method('processOpenClose');
+
+        $mockObj->expects($this->never())
+            ->method('processKey');
+
+        $mockObj->expects($this->once())
+            ->method('processNoKey')
+            ->willReturn(true);
+
+        $mockObj->expects($this->never())
+            ->method('processArrow');
+
+        $mockObj->expects($this->never())
+            ->method('processValue');
+
+        $mockObj->expects($this->never())
+            ->method('processComma');
+
+        $mockObj->process(self::$phpcsFile, $target);
+    }
+
+    /**
+     * Test short-circuiting the sniff on the call to processArrow().
+     *
+     * @return void
+     */
+    public function testShortCircuitOnProcessArrow()
+    {
+        $target = $this->getTargetToken(
+            '/* testShortCircuit */',
+            [\T_ARRAY, \T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET]
+        );
+
+        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
+            ->setMethods($this->methodsToMock)
+            ->getMockForAbstractClass();
+
+        $mockObj->expects($this->once())
+            ->method('processOpenClose');
+
+        $mockObj->expects($this->once())
+            ->method('processKey');
+
+        $mockObj->expects($this->once())
+            ->method('processNoKey');
+
+        $mockObj->expects($this->once())
+            ->method('processArrow')
+            ->willReturn(true);
+
+        $mockObj->expects($this->once())
+            ->method('processValue');
+
+        $mockObj->expects($this->once())
+            ->method('processComma');
+
+        $mockObj->process(self::$phpcsFile, $target);
+    }
+
+    /**
+     * Test short-circuiting the sniff on the call to processValue().
+     *
+     * @return void
+     */
+    public function testShortCircuitOnProcessValue()
+    {
+        $target = $this->getTargetToken(
+            '/* testShortCircuit */',
+            [\T_ARRAY, \T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET]
+        );
+
+        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
+            ->setMethods($this->methodsToMock)
+            ->getMockForAbstractClass();
+
+        $mockObj->expects($this->once())
+            ->method('processOpenClose');
+
+        $mockObj->expects($this->never())
+            ->method('processKey');
+
+        $mockObj->expects($this->once())
+            ->method('processNoKey');
+
+        $mockObj->expects($this->never())
+            ->method('processArrow');
+
+        $mockObj->expects($this->once())
+            ->method('processValue')
+            ->willReturn(true);
+
+        $mockObj->expects($this->never())
+            ->method('processComma');
+
+        $mockObj->process(self::$phpcsFile, $target);
+    }
+
+    /**
+     * Test short-circuiting the sniff on the call to processComma().
+     *
+     * @return void
+     */
+    public function testShortCircuitOnProcessComma()
+    {
+        $target = $this->getTargetToken(
+            '/* testShortCircuit */',
+            [\T_ARRAY, \T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET]
+        );
+
+        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
+            ->setMethods($this->methodsToMock)
+            ->getMockForAbstractClass();
+
+        $mockObj->expects($this->once())
+            ->method('processOpenClose');
+
+        $mockObj->expects($this->never())
+            ->method('processKey');
+
+        $mockObj->expects($this->once())
+            ->method('processNoKey');
+
+        $mockObj->expects($this->never())
+            ->method('processArrow');
+
+        $mockObj->expects($this->once())
+            ->method('processValue');
+
+        $mockObj->expects($this->once())
+            ->method('processComma')
+            ->willReturn(true);
+
+        $mockObj->process(self::$phpcsFile, $target);
+    }
+}

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/ArrayDeclarationSniffTestDouble.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/ArrayDeclarationSniffTestDouble.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\AbstractSniffs\AbstractArrayDeclaration;
+
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff;
+
+/**
+ * Test double for the AbstractArrayDeclarationSniff to allow for testing the getActualArrayKey() method.
+ *
+ * @since 1.0.0
+ */
+class ArrayDeclarationSniffTestDouble extends AbstractArrayDeclarationSniff
+{
+
+    /**
+     * The token stack for the current file being examined.
+     *
+     * @var array
+     */
+    public $tokens;
+
+    /**
+     * Process every part of the array declaration.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     *
+     * @return void
+     */
+    public function processArray(File $phpcsFile)
+    {
+    }
+}

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.inc
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.inc
@@ -1,0 +1,114 @@
+<?php
+
+/* testAllVoid */
+$excluded = [
+    $var                        => 'excluded',
+    MY_CONSTANT                 => 'excluded',
+    PHP_INT_MAX                 => 'excluded',
+    str_replace('.', '', '1.1') => 'excluded',
+    self::CONSTANT              => 'excluded',
+    $obj->get_key()             => 'excluded',
+    $obj->prop                  => 'excluded',
+    "my $var text"              => 'excluded',
+    <<<EOD
+my $var text
+EOD
+                                => 'excluded',
+    $var['key']{1}              => 'excluded',
+];
+
+/* testAllEmptyString */
+$emptyStringKey = array(
+    ''             => 'empty',
+    null           => 'null',
+    (string) false => 'false',
+);
+
+/* testAllZero */
+$everythingZero = [
+    '0',
+    0                => 'a',
+    0.0              => 'b',
+    '0'              => 'c',
+    0b0              => 'd',
+    0x0              => 'e',
+    00               => 'f',
+    false            => 'g',
+    0.4              => 'h',
+    -0.8             => 'i',
+    0e0              => 'j',
+    0_0              => 'k',
+    -1 + 1           => 'l',
+    3 * 0            => 'm',
+    00.00            => 'n',
+    (int) 'nothing'  => 'o',
+    15 > 200         => 'p',
+    "0"              => 'q',
+    0.               => 'r',
+    .0               => 's',
+    (true) ? 0 : 1   => 't',
+    ! true           => 'u',
+];
+
+/* testAllOne */
+$everythingOne = [
+    '0',
+    '1',
+    1                => 'a',
+    1.1              => 'b',
+    '1'              => 'c',
+    0b1              => 'd',
+    0x1              => 'e',
+    01               => 'f',
+    true             => 'g',
+    1.2 /*comment*/  => 'h',
+    1e0              => 'i',
+    0_1              => 'j',
+    -1 + 2           => 'k',
+    3 * 0.5          => 'l',
+    01.00            => 'm',
+    (int) '1 penny'  => 'n',
+    15 < 200         => 'o',
+    "1"              => 'p',
+    1.               => 'q',
+    001.             => 'r',
+    (true) ? 1 : 0   => 's',
+    ! false          => 't',
+    (string) true    => 'u',
+];
+
+/* testAllEleven */
+$everythingEleven = [
+    11                 => 'a',
+    11.0               => 'b',
+    '11'               => 'c',
+    0b1011             => 'd',
+    0Xb                => 'e',
+    013                => 'f',
+    11.8               => 'g',
+    1.1e1              => 'h',
+    1_1                => 'i',
+    0_13               => 'j',
+    -1 + 12            => 'k',
+    22 / /*comment*/ 2 => 'l',
+    0011.0011          => 'm',
+    (int) '11 lane'    => 'n',
+    "11"               => 'o',
+    11.                => 'p',
+    35 % 12            => 'q',
+];
+
+/* testAllStringAbc */
+$textualStringKeyVariations = [
+    'abc'      => 1,
+    'ab' . 'c' => 4,
+    <<<EOT
+abc
+EOT
+               => 5,
+    <<< 'NOW'
+abc
+NOW
+               => 6,
+    "abc"      => 7,
+];

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\AbstractSniffs\AbstractArrayDeclaration;
+
+use PHPCSUtils\Tests\AbstractSniffs\AbstractArrayDeclaration\ArrayDeclarationSniffTestDouble;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Arrays;
+use PHPCSUtils\Utils\PassedParameters;
+
+/**
+ * Tests for the \PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff::getActualArrayKey() method.
+ *
+ * @covers \PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff::getActualArrayKey
+ *
+ * @group abstracts
+ *
+ * @since 1.0.0
+ */
+class GetActualArrayKeyTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test retrieving the actual array key.
+     *
+     * @dataProvider dataGetActualArrayKey
+     *
+     * @param string     $testMarker   The comment which prefaces the target token in the test file.
+     * @param int|string $expected     The expected key value for (nearly) all keys in this array.
+     * @param int        $expectedFrom The 1-based array index from which all keys are expected to be the same.
+     *
+     * @return void
+     */
+    public function testGetActualArrayKey($testMarker, $expected, $expectedFrom)
+    {
+        $testObj         = new ArrayDeclarationSniffTestDouble();
+        $testObj->tokens = self::$phpcsFile->getTokens();
+
+        $stackPtr   = $this->getTargetToken($testMarker, [\T_ARRAY, \T_OPEN_SHORT_ARRAY]);
+        $arrayItems = PassedParameters::getParameters(self::$phpcsFile, $stackPtr);
+
+        foreach ($arrayItems as $itemNr => $arrayItem) {
+            if ($itemNr < $expectedFrom) {
+                continue;
+            }
+
+            $arrowPtr = Arrays::getDoubleArrowPtr(self::$phpcsFile, $arrayItem['start'], $arrayItem['end']);
+            if ($arrowPtr !== false) {
+                $result = $testObj->getActualArrayKey(self::$phpcsFile, $arrayItem['start'], ($arrowPtr - 1));
+                $this->assertSame(
+                    $expected,
+                    $result,
+                    'Failed: actual key ' . $result . ' is not the same as the expected key ' . $expected
+                        . ' for item number ' . $itemNr
+                );
+            }
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetActualArrayKey() For the array format.
+     *
+     * @return array
+     */
+    public function dataGetActualArrayKey()
+    {
+        return [
+            'unsupported-key-types' => [
+                '/* testAllVoid */',
+                null,
+                0,
+            ],
+            'keys-all-empty-string' => [
+                '/* testAllEmptyString */',
+                '',
+                0,
+            ],
+            'keys-all-integer-zero' => [
+                '/* testAllZero */',
+                0,
+                0,
+            ],
+            'keys-all-integer-one' => [
+                '/* testAllOne */',
+                1,
+                1,
+            ],
+            'keys-all-integer-eleven' => [
+                '/* testAllEleven */',
+                11,
+                0,
+            ],
+            'keys-all-string-abc' => [
+                '/* testAllStringAbc */',
+                'abc',
+                0,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## New `Abstracts\AbstractArrayDeclarationSniff`

New abstract sniff to examine array declarations.

This abstract sets up a number of helpful properties for the array and then calls the following methods from the `processArray()` method:
* `processOpenClose()` to examine the array opener and closer.
    This method will be called independently of whether the array has items or not.
* And then for each individual array item:
    - `processKey()` and `processArrow()` for array items with an index key; or `processNoKey()` for array items without one.
    - `processValue()`
    - `processComma()` (this method _may_ not be called for the last array item if it is not followed by a comma.

Aside from the `process()` method which sets up the properties, all other methods can be overloaded and/or ignored in concrete sniff implementations.
Returning `true` from any of the methods will short-circuit the loop and exit the sniff early.

The properties available to the methods in the child class are:
* `$stackPtr` containing the stack pointer to the array keyword/short array open bracket.
* `$tokens` containing the token stack of the current file.
* `$arrayOpener` containing the stack pointer to the array open parenthesis/short array open bracket.
* `$arrayCloser` containing the stack pointer to the array closer parenthesis/short array close bracket.
* `$arrayItems` containing a multi-dimentional array with information on each array item.
* `$itemCount` containing the number of items found in the array.
* `$singleLine` containing whether or not the array single line or multi-line.

Includes extensive unit tests for the abstract sniff behaviour.

## Abstracts\AbstractArrayDeclarationSniff: new `getActualArrayKey()` method

This is a helper method which can optionally be used from the `processKey()` method to retrieve the actual array key value based on the array key rules used in PHP.

* Array keys can only be integers or strings.
* Purely numeric (integer) string keys will automatically be cast to integer.

Dynamic array keys using variables, constants or function calls to set the key are ignored.

The method will return the integer or string array key or void for when the array key could not be determined.

Includes dedicated unit tests.