### PR TITLE
New Fixers\SpacesFixer class

### DIFF
--- a/PHPCSUtils/Fixers/SpacesFixer.php
+++ b/PHPCSUtils/Fixers/SpacesFixer.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Fixers;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\Numbers;
+
+/**
+ * Utility to check and, if necessary, fix the whitespace between two tokens.
+ *
+ * @since 1.0.0
+ */
+class SpacesFixer
+{
+
+    /**
+     * Check the whitespace between two tokens, throw an error if it doesn't match the
+     * expected whitespace and if relevant, fix it.
+     *
+     * Note:
+     * - This method will not auto-fix if there is anything but whitespace between the two
+     *   tokens. In that case, it will throw a non-fixable error/warning.
+     * - If 'newline' is expected and _no_ new line is encountered, a new line will be added,
+     *   but no assumptions will be made about the intended indentation of the code.
+     *   This should be handled by a (separate) indentation sniff.
+     * - If 'newline' is expected and multiple new lines are encountered, this will be accepted
+     *   as valid.
+     *   No assumptions are made about whether additional blank lines are allowed or not.
+     *   If _exactly_ one line is desired, combine this Fixer with the BlankLineFixer.
+     * - The fixer will not leave behind any trailing spaces on the original line when fixing
+     *   to 'newline', but it will not correct _existing_ trailing spaces when there already
+     *   is a new line in place.
+     * - This method can optionally record a metric for this check which will be displayed
+     *   when the end-user requests the `info` report.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile      The file being scanned.
+     * @param int                         $stackPtr       The position of the token which should be used
+     *                                                    when reporting an issue.
+     * @param int                         $secondPtr      The stack pointer to the second token.
+     *                                                    This token can be before or after the $stackPtr,
+     *                                                    but should only be seperated from the $stackPtr
+     *                                                    by whitespace and/or comments/annotations.
+     * @param string|int                  $expectedSpaces Number of spaces to enforce.
+     *                                                    Valid values:
+     *                                                    - (int) Number of spaces. Must be 0 or more.
+     *                                                    - (string) 'newline'.
+     * @param string                      $errorTemplate  Error message template. This string should contain
+     *                                                    two placeholders:
+     *                                                    %1$s = expected spaces phrase.
+     *                                                    %2$s = found spaces phrase.
+     *                                                    Note: _The replacement phrase will be in human
+     *                                                    readable English and include "spaces"/"new line",
+     *                                                    so no need to include that in the template._
+     * @param string                      $errorCode      A violation code unique to the sniff message.
+     *                                                    Defaults to `Found`.
+     *                                                    It is strongly recommended to change this if
+     *                                                    this fixer is used for different errors in the
+     *                                                    same sniff.
+     * @param string                      $errorType      Optional. Whether to report the issue as a
+     *                                                    `warning` or an `error`. Defaults to `error`.
+     * @param string                      $errorSeverity  Optional. The severity level for this message.
+     *                                                    A value of 0 will be converted into the default
+     *                                                    severity level.
+     * @param string                      $metricName     Optional. The name of the metric to record.
+     *                                                    This can be a short description phrase.
+     *                                                    Leave empty to not record metrics.
+     *
+     * @return void
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the tokens passed do not exist or are whitespace
+     *                                                      tokens.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If $expectedSpaces is not a valid value.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the tokens passed are separated by more than just
+     *                                                      empty (whitespace + comments/annotations) tokens.
+     */
+    public static function checkAndFix(
+        File $phpcsFile,
+        $stackPtr,
+        $secondPtr,
+        $expectedSpaces,
+        $errorTemplate,
+        $errorCode = 'Found',
+        $errorType = 'error',
+        $errorSeverity = 0,
+        $metricName = ''
+    ) {
+        $tokens = $phpcsFile->getTokens();
+
+        /*
+         * Validate the received function input.
+         */
+
+        if (isset($tokens[$stackPtr], $tokens[$secondPtr]) === false
+            || $tokens[$stackPtr]['code'] === \T_WHITESPACE
+            || $tokens[$secondPtr]['code'] === \T_WHITESPACE
+        ) {
+            throw new RuntimeException('The $stackPtr and the $secondPtr token must exist and not be whitespace');
+        }
+
+        $expected = false;
+        if ($expectedSpaces === 'newline') {
+            $expected = $expectedSpaces;
+        } elseif (\is_int($expectedSpaces) === true && $expectedSpaces >= 0) {
+            $expected = $expectedSpaces;
+        } elseif (\is_string($expectedSpaces) === true && Numbers::isDecimalInt($expectedSpaces) === true) {
+            $expected = (int) $expectedSpaces;
+        }
+
+        if ($expected === false) {
+            throw new RuntimeException(
+                'The $expectedSpaces setting should be either "newline", 0 or a positive integer'
+            );
+        }
+
+        $ptrA = $stackPtr;
+        $ptrB = $secondPtr;
+        if ($stackPtr > $secondPtr) {
+            $ptrA = $secondPtr;
+            $ptrB = $stackPtr;
+        }
+
+        $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($ptrA + 1), null, true);
+        if ($nextNonEmpty < $ptrB) {
+            throw new RuntimeException(
+                'The $stackPtr and the $secondPtr token must be adjacent tokens separated only'
+                    . ' by whitespace and/or comments'
+            );
+        }
+
+        /*
+         * Determine how many spaces are between the two tokens.
+         */
+
+        $found       = 0;
+        $foundPhrase = 'no spaces';
+        if (($ptrA + 1) !== $ptrB) {
+            if ($tokens[$ptrA]['line'] !== $tokens[$ptrB]['line']) {
+                $found       = 'newline';
+                $foundPhrase = 'a new line';
+                if (($tokens[$ptrA]['line'] + 1) !== $tokens[$ptrB]['line']) {
+                    $foundPhrase = 'multiple new lines';
+                }
+            } elseif ($tokens[($ptrA + 1)]['code'] === \T_WHITESPACE) {
+                $found       = $tokens[($ptrA + 1)]['length'];
+                $foundPhrase = $found . (($found === 1) ? ' space' : ' spaces');
+            } else {
+                $found       = 'non-whitespace tokens';
+                $foundPhrase = 'non-whitespace tokens';
+            }
+        }
+
+        if ($metricName !== '') {
+            $phpcsFile->recordMetric($stackPtr, $metricName, $foundPhrase);
+        }
+
+        if ($found === $expected) {
+            return;
+        }
+
+        /*
+         * Handle the violation message.
+         */
+
+        $expectedPhrase = 'no space';
+        if ($expected === 'newline') {
+            $expectedPhrase = 'a new line';
+        } elseif ($expected === 1) {
+            $expectedPhrase = $expected . ' space';
+        } elseif ($expected > 1) {
+            $expectedPhrase = $expected . ' spaces';
+        }
+
+        $fixable           = true;
+        $nextNonWhitespace = $phpcsFile->findNext(\T_WHITESPACE, ($ptrA + 1), null, true);
+        if ($nextNonWhitespace !== $ptrB) {
+            // Comment found between the tokens and we don't know where it should go, so don't auto-fix.
+            $fixable = false;
+        }
+
+        if ($found === 'newline'
+            && $tokens[$ptrA]['code'] === \T_COMMENT
+            && \substr($tokens[$ptrA]['content'], -2) !== '*/'
+        ) {
+            /*
+             * $ptrA is a slash-style trailing comment, removing the new line would comment out
+             * the code, so don't auto-fix.
+             */
+            $fixable = false;
+        }
+
+        $method  = 'add';
+        $method .= ($fixable === true) ? 'Fixable' : '';
+        $method .= ($errorType === 'error') ? 'Error' : 'Warning';
+
+        $recorded = $phpcsFile->$method(
+            $errorTemplate,
+            $stackPtr,
+            $errorCode,
+            [$expectedPhrase, $foundPhrase],
+            $errorSeverity
+        );
+
+        if ($fixable === false || $recorded === false) {
+            return;
+        }
+
+        /*
+         * Fix the violation.
+         */
+
+        $phpcsFile->fixer->beginChangeset();
+
+        /*
+         * Remove existing whitespace. No need to check if it's whitespace as otherwise the fixer
+         * wouldn't have kicked in.
+         */
+        for ($i = ($ptrA + 1); $i < $ptrB; $i++) {
+            $phpcsFile->fixer->replaceToken($i, '');
+        }
+
+        // If necessary: add the correct amount whitespace.
+        if ($expected !== 0) {
+            if ($expected === 'newline') {
+                $phpcsFile->fixer->addContent($ptrA, $phpcsFile->eolChar);
+            } else {
+                $replacement = $tokens[$ptrA]['content'] . \str_repeat(' ', $expected);
+                $phpcsFile->fixer->replaceToken($ptrA, $replacement);
+            }
+        }
+
+        $phpcsFile->fixer->endChangeset();
+    }
+}

--- a/Tests/Fixers/SpacesFixer/SpacesFixerExceptionsTest.inc
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerExceptionsTest.inc
@@ -1,0 +1,7 @@
+<?php
+
+/* testPassingWhitespace1 */
+echo 'foo' /* testPassingWhitespace2 */  ;
+
+/* testPassingTokensWithSomethingBetween */
+echo 'foo' . 'bar';

--- a/Tests/Fixers/SpacesFixer/SpacesFixerExceptionsTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerExceptionsTest.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Fixers\SpacesFixer;
+
+use PHPCSUtils\Fixers\SpacesFixer;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+
+/**
+ * Tests for the exceptions thrown in the \PHPCSUtils\Fixers\SpacesFixer::checkAndFix() method.
+ *
+ * @covers \PHPCSUtils\Fixers\SpacesFixer::checkAndFix
+ *
+ * @group fixers
+ *
+ * @since 1.0.0
+ */
+class SpacesFixerExceptionsTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test passing a non-existent token pointer for the stackPtr token.
+     *
+     * @return void
+     */
+    public function testNonExistentFirstToken()
+    {
+        $this->expectPhpcsException('The $stackPtr and the $secondPtr token must exist and not be whitespace');
+
+        SpacesFixer::checkAndFix(self::$phpcsFile, 10000, 10, 0, 'Dummy');
+    }
+
+    /**
+     * Test passing a non-existent token pointer for the second token.
+     *
+     * @return void
+     */
+    public function testNonExistentSecondToken()
+    {
+        $this->expectPhpcsException('The $stackPtr and the $secondPtr token must exist and not be whitespace');
+
+        SpacesFixer::checkAndFix(self::$phpcsFile, 10, 10000, 0, 'Dummy');
+    }
+
+    /**
+     * Test passing whitespace for the stackPtr token.
+     *
+     * @return void
+     */
+    public function testFirstTokenWhitespace()
+    {
+        $this->expectPhpcsException('The $stackPtr and the $secondPtr token must exist and not be whitespace');
+
+        $stackPtr = $this->getTargetToken('/* testPassingWhitespace1 */', \T_WHITESPACE);
+        SpacesFixer::checkAndFix(self::$phpcsFile, $stackPtr, 10, 0, 'Dummy');
+    }
+
+    /**
+     * Test passing whitespace for the second token.
+     *
+     * @return void
+     */
+    public function testSecondTokenWhitespace()
+    {
+        $this->expectPhpcsException('The $stackPtr and the $secondPtr token must exist and not be whitespace');
+
+        $secondPtr = $this->getTargetToken('/* testPassingWhitespace2 */', \T_WHITESPACE);
+        SpacesFixer::checkAndFix(self::$phpcsFile, 10, $secondPtr, 0, 'Dummy');
+    }
+
+    /**
+     * Test passing non-adjacent tokens.
+     *
+     * @return void
+     */
+    public function testNonAdjacentTokens()
+    {
+        $this->expectPhpcsException(
+            'The $stackPtr and the $secondPtr token must be adjacent tokens separated only'
+                . ' by whitespace and/or comments'
+        );
+
+        $stackPtr  = $this->getTargetToken('/* testPassingTokensWithSomethingBetween */', \T_ECHO);
+        $secondPtr = $this->getTargetToken('/* testPassingTokensWithSomethingBetween */', \T_STRING_CONCAT);
+        SpacesFixer::checkAndFix(self::$phpcsFile, $stackPtr, $secondPtr, 0, 'Dummy');
+    }
+
+    /**
+     * Test passing non-adjacent tokens in reverse order.
+     *
+     * @return void
+     */
+    public function testNonAdjacentTokensReverseOrder()
+    {
+        $this->expectPhpcsException(
+            'The $stackPtr and the $secondPtr token must be adjacent tokens separated only'
+                . ' by whitespace and/or comments'
+        );
+
+        $stackPtr  = $this->getTargetToken('/* testPassingTokensWithSomethingBetween */', \T_ECHO);
+        $secondPtr = $this->getTargetToken('/* testPassingTokensWithSomethingBetween */', \T_STRING_CONCAT);
+        SpacesFixer::checkAndFix(self::$phpcsFile, $secondPtr, $stackPtr, 0, 'Dummy');
+    }
+
+    /**
+     * Test passing an negative integer value for spaces.
+     *
+     * @return void
+     */
+    public function testInvalidExpectedSpacesNegativeValue()
+    {
+        $this->expectPhpcsException('The $expectedSpaces setting should be either "newline", 0 or a positive integer');
+
+        $stackPtr  = $this->getTargetToken('/* testPassingWhitespace1 */', \T_ECHO);
+        $secondPtr = $this->getTargetToken('/* testPassingWhitespace1 */', \T_CONSTANT_ENCAPSED_STRING);
+        SpacesFixer::checkAndFix(self::$phpcsFile, $stackPtr, $secondPtr, -10, 'Dummy');
+    }
+
+    /**
+     * Test passing an value of a type which is not accepted for spaces.
+     *
+     * @return void
+     */
+    public function testInvalidExpectedSpacesUnexpectedType()
+    {
+        $this->expectPhpcsException('The $expectedSpaces setting should be either "newline", 0 or a positive integer');
+
+        $stackPtr  = $this->getTargetToken('/* testPassingWhitespace1 */', \T_ECHO);
+        $secondPtr = $this->getTargetToken('/* testPassingWhitespace1 */', \T_CONSTANT_ENCAPSED_STRING);
+        SpacesFixer::checkAndFix(self::$phpcsFile, $stackPtr, $secondPtr, false, 'Dummy');
+    }
+
+    /**
+     * Test passing a non-decimal string value for spaces.
+     *
+     * @return void
+     */
+    public function testInvalidExpectedSpacesNonDecimalString()
+    {
+        $this->expectPhpcsException('The $expectedSpaces setting should be either "newline", 0 or a positive integer');
+
+        $stackPtr  = $this->getTargetToken('/* testPassingWhitespace1 */', \T_ECHO);
+        $secondPtr = $this->getTargetToken('/* testPassingWhitespace1 */', \T_CONSTANT_ENCAPSED_STRING);
+        SpacesFixer::checkAndFix(self::$phpcsFile, $stackPtr, $secondPtr, ' ', 'Dummy');
+    }
+}

--- a/Tests/Fixers/SpacesFixer/SpacesFixerNewlineTest.inc.fixed
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerNewlineTest.inc.fixed
@@ -1,0 +1,38 @@
+<?php
+
+/* testNoSpace */
+$foo = array
+();
+
+/* testOneSpace */
+$foo = array
+();
+
+/* testTwoSpaces */
+$foo = array
+();
+
+/* testMultipleSpaces */
+$foo = array
+();
+
+/* testNewlineAndTrailingSpaces */
+$foo = array    
+       ();
+
+/* testMultipleNewlinesAndSpaces */
+$foo = array
+
+
+
+            ();
+
+/* testCommentNoSpace */
+$foo = array/*comment*/();
+
+/* testCommentAndSpaces */
+$foo = array /*comment*/   ();
+
+/* testCommentAndNewline */
+$foo = array //comment
+    ();

--- a/Tests/Fixers/SpacesFixer/SpacesFixerNewlineTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerNewlineTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Fixers\SpacesFixer;
+
+use PHPCSUtils\Tests\Fixers\SpacesFixer\SpacesFixerNoSpaceTest;
+
+/**
+ * Tests for the \PHPCSUtils\Fixers\SpacesFixer::checkAndFix() method.
+ *
+ * @covers \PHPCSUtils\Fixers\SpacesFixer::checkAndFix
+ *
+ * @group fixers
+ *
+ * @since 1.0.0
+ */
+class SpacesFixerNewlineTest extends SpacesFixerNoSpaceTest
+{
+
+    /**
+     * Expected number of spaces to use for these tests.
+     *
+     * @var int|string
+     */
+    const SPACES = 'newline';
+
+    /**
+     * The expected replacement for the first placeholder.
+     *
+     * @var string
+     */
+    const MSG_REPLACEMENT_1 = 'a new line';
+
+    /**
+     * Dummy metric name to use for the test.
+     *
+     * @var string
+     */
+    const METRIC = 'testing';
+
+    /**
+     * The names of the test case(s) in compliance.
+     *
+     * @var array
+     */
+    protected $compliantCases = [
+        'newline-and-trailing-spaces',
+        'multiple-newlines-and-spaces',
+        'comment-and-new line',
+    ];
+
+    /**
+     * Full path to the fixed version of the test case file associated with this test class.
+     *
+     * @var string
+     */
+    protected static $fixedFile = '/SpacesFixerNewlineTest.inc.fixed';
+}

--- a/Tests/Fixers/SpacesFixer/SpacesFixerNoSpaceTest.inc.fixed
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerNoSpaceTest.inc.fixed
@@ -1,0 +1,29 @@
+<?php
+
+/* testNoSpace */
+$foo = array();
+
+/* testOneSpace */
+$foo = array();
+
+/* testTwoSpaces */
+$foo = array();
+
+/* testMultipleSpaces */
+$foo = array();
+
+/* testNewlineAndTrailingSpaces */
+$foo = array();
+
+/* testMultipleNewlinesAndSpaces */
+$foo = array();
+
+/* testCommentNoSpace */
+$foo = array/*comment*/();
+
+/* testCommentAndSpaces */
+$foo = array /*comment*/   ();
+
+/* testCommentAndNewline */
+$foo = array //comment
+    ();

--- a/Tests/Fixers/SpacesFixer/SpacesFixerNoSpaceTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerNoSpaceTest.php
@@ -1,0 +1,381 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Fixers\SpacesFixer;
+
+use PHPCSUtils\Fixers\SpacesFixer;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+
+/**
+ * Tests for the \PHPCSUtils\Fixers\SpacesFixer::checkAndFix() method.
+ *
+ * @covers \PHPCSUtils\Fixers\SpacesFixer::checkAndFix
+ *
+ * @group fixers
+ *
+ * @since 1.0.0
+ */
+class SpacesFixerNoSpaceTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Expected number of spaces to use for these tests.
+     *
+     * @var int|string
+     */
+    const SPACES = 0;
+
+    /**
+     * Dummy error message phrase to use for the test.
+     *
+     * @var string
+     */
+    const MSG = 'Expected: %s. Found: %s';
+
+    /**
+     * The expected replacement for the first placeholder.
+     *
+     * @var string
+     */
+    const MSG_REPLACEMENT_1 = 'no space';
+
+    /**
+     * Dummy error code to use for the test.
+     *
+     * Using the dummy full error code to force it to record.
+     *
+     * @var string
+     */
+    const CODE = 'PHPCSUtils.SpacerFixer.Test.Found';
+
+    /**
+     * Dummy metric name to use for the test.
+     *
+     * @var string
+     */
+    const METRIC = 'metric name';
+
+    /**
+     * The names of the test case(s) in compliance.
+     *
+     * @var array
+     */
+    protected $compliantCases = ['no-space'];
+
+    /**
+     * Full path to the test case file associated with this test class.
+     *
+     * @var string
+     */
+    protected static $caseFile = '';
+
+    /**
+     * Full path to the fixed version of the test case file associated with this test class.
+     *
+     * @var string
+     */
+    protected static $fixedFile = '/SpacesFixerNoSpaceTest.inc.fixed';
+
+    /**
+     * Set the name of a sniff to pass to PHPCS to limit the run (and force it to record errors).
+     *
+     * @var array
+     */
+    protected static $selectedSniff = ['PHPCSUtils.SpacerFixer.Test'];
+
+    /**
+     * Initialize PHPCS & tokenize the test case file.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        self::$caseFile = __DIR__ . '/SpacesFixerTest.inc';
+        parent::setUpTestFile();
+    }
+
+    /**
+     * Test that no violation is reported for a test case complying with the correct number of spaces.
+     *
+     * @dataProvider dataCheckAndFixNoError
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   Expected error details (for the metric input).
+     *
+     * @return void
+     */
+    public function testCheckAndFixNoError($testMarker, $expected)
+    {
+        $stackPtr  = $this->getTargetToken($testMarker, \T_ARRAY);
+        $secondPtr = $this->getTargetToken($testMarker, \T_OPEN_PARENTHESIS);
+
+        /*
+         * Note: passing $stackPtr and $secondPtr in reverse order to make sure that case is
+         * covered by a test as well.
+         */
+        SpacesFixer::checkAndFix(
+            self::$phpcsFile,
+            $secondPtr,
+            $stackPtr,
+            static::SPACES,
+            static::MSG,
+            static::CODE,
+            'error',
+            0,
+            static::METRIC
+        );
+
+        $result = \array_merge(self::$phpcsFile->getErrors(), self::$phpcsFile->getWarnings());
+
+        // Expect no errors.
+        $this->assertCount(0, $result, 'Failed to assert that no violations were found');
+
+        // Check that the metric is recorded correctly.
+        $metrics = self::$phpcsFile->getMetrics();
+        $this->assertGreaterThanOrEqual(
+            1,
+            $metrics[static::METRIC]['values'][$expected['found']],
+            'Failed recorded metric check'
+        );
+    }
+
+    /**
+     * Data Provider.
+     *
+     * @see testCheckAndFixNoError() For the array format.
+     *
+     * @return array
+     */
+    public function dataCheckAndFixNoError()
+    {
+        $data     = [];
+        $baseData = $this->getAllData();
+
+        foreach ($this->compliantCases as $caseName) {
+            if (isset($baseData[$caseName])) {
+                $data[$caseName] = $baseData[$caseName];
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Test that violations are correctly reported.
+     *
+     * @dataProvider dataCheckAndFix
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   Expected error details.
+     * @param string $type       The message type to test: 'error' or 'warning'.
+     *
+     * @return void
+     */
+    public function testCheckAndFix($testMarker, $expected, $type)
+    {
+        $stackPtr  = $this->getTargetToken($testMarker, \T_ARRAY);
+        $secondPtr = $this->getTargetToken($testMarker, \T_OPEN_PARENTHESIS);
+
+        SpacesFixer::checkAndFix(
+            self::$phpcsFile,
+            $stackPtr,
+            $secondPtr,
+            static::SPACES,
+            static::MSG,
+            static::CODE,
+            $type,
+            0,
+            static::METRIC
+        );
+
+        if ($type === 'error') {
+            $result = self::$phpcsFile->getErrors();
+        } else {
+            $result = self::$phpcsFile->getWarnings();
+        }
+
+        $tokens = self::$phpcsFile->getTokens();
+
+        if (isset($result[$tokens[$stackPtr]['line']][$tokens[$stackPtr]['column']]) === false) {
+            $this->fail('Expected 1 violation. None found.');
+        }
+
+        $messages = $result[$tokens[$stackPtr]['line']][$tokens[$stackPtr]['column']];
+
+        // Expect one violation.
+        $this->assertCount(1, $messages, 'Expected 1 violation, found: ' . \count($messages));
+
+        /*
+         * Test the violation details.
+         */
+
+        $expectedMessage = \sprintf(static::MSG, static::MSG_REPLACEMENT_1, $expected['found']);
+        $this->assertSame($expectedMessage, $messages[0]['message'], 'Message comparison failed');
+
+        // PHPCS 2.x places `unknownSniff.` before the actual error code for utility tests with a dummy error code.
+        $errorCodeResult = \str_replace('unknownSniff.', '', $messages[0]['source']);
+        $this->assertSame(static::CODE, $errorCodeResult, 'Error code comparison failed');
+
+        $this->assertSame($expected['fixable'], $messages[0]['fixable'], 'Fixability comparison failed');
+
+        // Check that the metric is recorded correctly.
+        $metrics = self::$phpcsFile->getMetrics();
+        $this->assertGreaterThanOrEqual(
+            1,
+            $metrics[static::METRIC]['values'][$expected['found']],
+            'Failed recorded metric check'
+        );
+    }
+
+    /**
+     * Data Provider.
+     *
+     * @see testCheckAndFix() For the array format.
+     *
+     * @return array
+     */
+    public function dataCheckAndFix()
+    {
+        $data = $this->getAllData();
+
+        foreach ($this->compliantCases as $caseName) {
+            unset($data[$caseName]);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Test that the fixes are correctly made.
+     *
+     * @return void
+     */
+    public function testFixesMade()
+    {
+        self::$phpcsFile->fixer->startFile(self::$phpcsFile);
+        self::$phpcsFile->fixer->enabled = true;
+
+        $data = $this->getAllData();
+        foreach ($data as $dataset) {
+            $stackPtr  = $this->getTargetToken($dataset[0], \T_ARRAY);
+            $secondPtr = $this->getTargetToken($dataset[0], \T_OPEN_PARENTHESIS);
+
+            SpacesFixer::checkAndFix(
+                self::$phpcsFile,
+                $stackPtr,
+                $secondPtr,
+                static::SPACES,
+                static::MSG,
+                static::CODE,
+                $dataset[1],
+                0
+            );
+        }
+
+        $fixedFile = __DIR__ . static::$fixedFile;
+        $expected  = \file_get_contents($fixedFile);
+        $result    = self::$phpcsFile->fixer->getContents();
+
+        $this->assertSame(
+            $expected,
+            $result,
+            \sprintf(
+                'Fixed version of %s does not match expected version in %s',
+                \basename(static::$caseFile),
+                \basename($fixedFile)
+            )
+        );
+    }
+
+    /**
+     * Helper function holding the base data for the data providers.
+     *
+     * @return array
+     */
+    protected function getAllData()
+    {
+        return [
+            'no-space' => [
+                '/* testNoSpace */',
+                [
+                    'found'   => 'no spaces',
+                    'fixable' => true,
+                ],
+                'error',
+            ],
+            'one-space' => [
+                '/* testOneSpace */',
+                [
+                    'found'   => '1 space',
+                    'fixable' => true,
+                ],
+                'error',
+            ],
+            'two-spaces' => [
+                '/* testTwoSpaces */',
+                [
+                    'found'   => '2 spaces',
+                    'fixable' => true,
+                ],
+                'error',
+            ],
+            'multiple-spaces' => [
+                '/* testMultipleSpaces */',
+                [
+                    'found'   => '13 spaces',
+                    'fixable' => true,
+                ],
+                'warning',
+            ],
+            'newline-and-trailing-spaces' => [
+                '/* testNewlineAndTrailingSpaces */',
+                [
+                    'found'   => 'a new line',
+                    'fixable' => true,
+                ],
+                'error',
+            ],
+            'multiple-newlines-and-spaces' => [
+                '/* testMultipleNewlinesAndSpaces */',
+                [
+                    'found'   => 'multiple new lines',
+                    'fixable' => true,
+                ],
+                'error',
+            ],
+            'comment-no-space' => [
+                '/* testCommentNoSpace */',
+                [
+                    'found'   => 'non-whitespace tokens',
+                    'fixable' => false,
+                ],
+                'warning',
+            ],
+            'comment-and-space' => [
+                '/* testCommentAndSpaces */',
+                [
+                    'found'   => '1 space',
+                    'fixable' => false,
+                ],
+                'error',
+            ],
+            'comment-and-new line' => [
+                '/* testCommentAndNewline */',
+                [
+                    'found'   => 'a new line',
+                    'fixable' => false,
+                ],
+                'error',
+            ],
+        ];
+    }
+}

--- a/Tests/Fixers/SpacesFixer/SpacesFixerOneSpaceTest.inc.fixed
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerOneSpaceTest.inc.fixed
@@ -1,0 +1,29 @@
+<?php
+
+/* testNoSpace */
+$foo = array ();
+
+/* testOneSpace */
+$foo = array ();
+
+/* testTwoSpaces */
+$foo = array ();
+
+/* testMultipleSpaces */
+$foo = array ();
+
+/* testNewlineAndTrailingSpaces */
+$foo = array ();
+
+/* testMultipleNewlinesAndSpaces */
+$foo = array ();
+
+/* testCommentNoSpace */
+$foo = array/*comment*/();
+
+/* testCommentAndSpaces */
+$foo = array /*comment*/   ();
+
+/* testCommentAndNewline */
+$foo = array //comment
+    ();

--- a/Tests/Fixers/SpacesFixer/SpacesFixerOneSpaceTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerOneSpaceTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Fixers\SpacesFixer;
+
+use PHPCSUtils\Tests\Fixers\SpacesFixer\SpacesFixerNoSpaceTest;
+
+/**
+ * Tests for the \PHPCSUtils\Fixers\SpacesFixer::checkAndFix() method.
+ *
+ * @covers \PHPCSUtils\Fixers\SpacesFixer::checkAndFix
+ *
+ * @group fixers
+ *
+ * @since 1.0.0
+ */
+class SpacesFixerOneSpaceTest extends SpacesFixerNoSpaceTest
+{
+
+    /**
+     * Expected number of spaces to use for these tests.
+     *
+     * @var int|string
+     */
+    const SPACES = 1;
+
+    /**
+     * The expected replacement for the first placeholder.
+     *
+     * @var string
+     */
+    const MSG_REPLACEMENT_1 = '1 space';
+
+    /**
+     * Dummy metric name to use for the test.
+     *
+     * @var string
+     */
+    const METRIC = 'name of the metric';
+
+    /**
+     * The names of the test case(s) in compliance.
+     *
+     * @var array
+     */
+    protected $compliantCases = [
+        'one-space',
+        'comment-and-space',
+    ];
+
+    /**
+     * Full path to the fixed version of the test case file associated with this test class.
+     *
+     * @var string
+     */
+    protected static $fixedFile = '/SpacesFixerOneSpaceTest.inc.fixed';
+}

--- a/Tests/Fixers/SpacesFixer/SpacesFixerTest.inc
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerTest.inc
@@ -1,0 +1,34 @@
+<?php
+
+/* testNoSpace */
+$foo = array();
+
+/* testOneSpace */
+$foo = array ();
+
+/* testTwoSpaces */
+$foo = array  ();
+
+/* testMultipleSpaces */
+$foo = array             ();
+
+/* testNewlineAndTrailingSpaces */
+$foo = array    
+       ();
+
+/* testMultipleNewlinesAndSpaces */
+$foo = array
+
+
+
+            ();
+
+/* testCommentNoSpace */
+$foo = array/*comment*/();
+
+/* testCommentAndSpaces */
+$foo = array /*comment*/   ();
+
+/* testCommentAndNewline */
+$foo = array //comment
+    ();

--- a/Tests/Fixers/SpacesFixer/SpacesFixerTwoSpaceTest.inc.fixed
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerTwoSpaceTest.inc.fixed
@@ -1,0 +1,29 @@
+<?php
+
+/* testNoSpace */
+$foo = array  ();
+
+/* testOneSpace */
+$foo = array  ();
+
+/* testTwoSpaces */
+$foo = array  ();
+
+/* testMultipleSpaces */
+$foo = array  ();
+
+/* testNewlineAndTrailingSpaces */
+$foo = array  ();
+
+/* testMultipleNewlinesAndSpaces */
+$foo = array  ();
+
+/* testCommentNoSpace */
+$foo = array/*comment*/();
+
+/* testCommentAndSpaces */
+$foo = array /*comment*/   ();
+
+/* testCommentAndNewline */
+$foo = array //comment
+    ();

--- a/Tests/Fixers/SpacesFixer/SpacesFixerTwoSpaceTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerTwoSpaceTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Fixers\SpacesFixer;
+
+use PHPCSUtils\Tests\Fixers\SpacesFixer\SpacesFixerNoSpaceTest;
+
+/**
+ * Tests for the \PHPCSUtils\Fixers\SpacesFixer::checkAndFix() method.
+ *
+ * @covers \PHPCSUtils\Fixers\SpacesFixer::checkAndFix
+ *
+ * @group fixers
+ *
+ * @since 1.0.0
+ */
+class SpacesFixerTwoSpaceTest extends SpacesFixerNoSpaceTest
+{
+
+    /**
+     * Expected number of spaces to use for these tests.
+     *
+     * This also tests the handling of numeric strings passed for `$expectedSpaces`.
+     *
+     * @var int|string
+     */
+    const SPACES = '2';
+
+    /**
+     * The expected replacement for the first placeholder.
+     *
+     * @var string
+     */
+    const MSG_REPLACEMENT_1 = '2 spaces';
+
+    /**
+     * Dummy metric name to use for the test.
+     *
+     * @var string
+     */
+    const METRIC = 'name of the metric';
+
+    /**
+     * The names of the test case(s) in compliance.
+     *
+     * @var array
+     */
+    protected $compliantCases = ['two-spaces'];
+
+    /**
+     * Full path to the fixed version of the test case file associated with this test class.
+     *
+     * @var string
+     */
+    protected static $fixedFile = '/SpacesFixerTwoSpaceTest.inc.fixed';
+}

--- a/Tests/Fixers/SpacesFixer/TrailingCommentHandlingTest.inc
+++ b/Tests/Fixers/SpacesFixer/TrailingCommentHandlingTest.inc
@@ -1,0 +1,9 @@
+<?php
+
+/* testTrailingOpenCommentAsPtrA */
+$array = array( 1, 2, // comment
+    3, 4 );
+
+/* testTrailingClosedCommentAsPtrA */
+$array = array( 1, 2, /* comment */
+    3, 4 );

--- a/Tests/Fixers/SpacesFixer/TrailingCommentHandlingTest.inc.fixed
+++ b/Tests/Fixers/SpacesFixer/TrailingCommentHandlingTest.inc.fixed
@@ -1,0 +1,8 @@
+<?php
+
+/* testTrailingOpenCommentAsPtrA */
+$array = array( 1, 2, // comment
+    3, 4 );
+
+/* testTrailingClosedCommentAsPtrA */
+$array = array( 1, 2, /* comment */ 3, 4 );


### PR DESCRIPTION
This new class offers one versatile utility function `checkAndFix()` to - as the name implies - check and fix the spacing between two tokens.

It takes all the heavy lifting out of space fixes and should allow standards to get rid of a lot of duplicate code related to space fixing.

Notes:
- This method will not auto-fix if there is anything but whitespace between the two tokens. In that case, it will throw a non-fixable error/warning.
- If 'newline' is expected and _no_ new line is encountered, a new line will be added, but no assumptions will be made about the intended indentation of the code.
    This should be handled by a (separate) indentation sniff.
- If 'newline' is expected and multiple new lines are encountered, this will be accepted as valid.
    No assumptions are made about whether additional blank lines are allowed or not.
    If _exactly_ one line is desired, combine this Fixer with the (upcoming) `NewlinesFixer`.
- This method can optionally record a metric for this check which will be displayed when the end-user requests the `info` report.

Includes extensive unit tests.