### PR TITLE
BCFile::getCondition()/Conditions::getCondition(): sync with PHPCS 3.5.4 / new $first parameter

### DIFF
--- a/PHPCSUtils/Utils/Conditions.php
+++ b/PHPCSUtils/Utils/Conditions.php
@@ -26,31 +26,34 @@ class Conditions
     /**
      * Retrieve the position of a condition for the passed token.
      *
-     * If no types are specified, the first condition for the token - or if `$reverse=true`,
+     * If no types are specified, the first condition for the token - or if `$first=false`,
      * the last condition - will be returned.
      *
      * Main differences with the PHPCS version:
      * - The singular `$type` parameter has become the more flexible `$types` parameter allowing to
      *   search for several types of conditions in one go.
      * - The `$types` parameter is now optional.
-     * - Addition of the `$reverse` parameter.
      *
      * @see \PHP_CodeSniffer\Files\File::getCondition()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getCondition() Cross-version compatible version of the original.
      *
      * @since 1.0.0
+     * @since 1.0.0-alpha2 The `$reverse` parameter has been renamed to `$first` and the meaning of the
+     *                     boolean reversed (true = first, false = last, was: true = last, false = first)
+     *                     to be in line with PHPCS itself which added the `$first` parameter in v 3.5.4
+     *                     to allow for the same/similar functionality as `$reverse` already offered.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the token we are checking.
      * @param int|string|array            $types     Optional. The type(s) of tokens to search for.
-     * @param bool                        $reverse   Optional. Whether to search for the first (outermost)
-     *                                               (false) or the last (innermost) condition (true) of
+     * @param bool                        $first     Optional. Whether to search for the first (outermost)
+     *                                               (true) or the last (innermost) condition (false) of
      *                                               the specified type(s).
      *
      * @return int|false Integer stack pointer to the condition or FALSE if the token
      *                   does not have the condition.
      */
-    public static function getCondition(File $phpcsFile, $stackPtr, $types = [], $reverse = false)
+    public static function getCondition(File $phpcsFile, $stackPtr, $types = [], $first = true)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -69,7 +72,7 @@ class Conditions
 
         if (empty($types) === true) {
             // No types specified, just return the first/last condition pointer.
-            if ($reverse === true) {
+            if ($first === false) {
                 \end($conditions);
             } else {
                 \reset($conditions);
@@ -78,7 +81,7 @@ class Conditions
             return \key($conditions);
         }
 
-        if ($reverse === true) {
+        if ($first === false) {
             $conditions = \array_reverse($conditions, true);
         }
 
@@ -131,7 +134,7 @@ class Conditions
      */
     public static function getFirstCondition(File $phpcsFile, $stackPtr, $types = [])
     {
-        return self::getCondition($phpcsFile, $stackPtr, $types, false);
+        return self::getCondition($phpcsFile, $stackPtr, $types, true);
     }
 
     /**
@@ -150,6 +153,6 @@ class Conditions
      */
     public static function getLastCondition(File $phpcsFile, $stackPtr, $types = [])
     {
-        return self::getCondition($phpcsFile, $stackPtr, $types, true);
+        return self::getCondition($phpcsFile, $stackPtr, $types, false);
     }
 }

--- a/Tests/BackCompat/BCFile/GetConditionTest.php
+++ b/Tests/BackCompat/BCFile/GetConditionTest.php
@@ -305,6 +305,69 @@ class GetConditionTest extends UtilityMethodTestCase
     }
 
     /**
+     * Test retrieving a specific condition from a tokens "conditions" array.
+     *
+     * @dataProvider dataGetConditionReversed
+     *
+     * @param string $testMarker      The comment which prefaces the target token in the test file.
+     * @param array  $expectedResults Array with the condition token type to search for as key
+     *                                and the marker for the expected stack pointer result as a value.
+     *
+     * @return void
+     */
+    public function testGetConditionReversed($testMarker, $expectedResults)
+    {
+        $testClass = static::TEST_CLASS;
+        $stackPtr  = self::$testTokens[$testMarker];
+
+        // Add expected results for all test markers not listed in the data provider.
+        $expectedResults += $this->conditionDefaults;
+
+        foreach ($expectedResults as $conditionType => $expected) {
+            if ($expected !== false) {
+                $expected = self::$markerTokens[$expected];
+            }
+
+            $result = $testClass::getCondition(self::$phpcsFile, $stackPtr, \constant($conditionType), false);
+            $this->assertSame(
+                $expected,
+                $result,
+                "Assertion failed for test marker '{$testMarker}' with condition {$conditionType} (reversed)"
+            );
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * Only the conditions which are expected to be *found* need to be listed here.
+     * All other potential conditions will automatically also be tested and will expect
+     * `false` as a result.
+     *
+     * @see testGetConditionReversed() For the array format.
+     *
+     * @return array
+     */
+    public static function dataGetConditionReversed()
+    {
+        $data = self::dataGetCondition();
+
+        // Set up the data for the reversed results.
+        $data['testSeriouslyNestedMethod'][1]['T_IF'] = '/* condition 4: if */';
+
+        $data['testDeepestNested'][1]['T_FUNCTION'] = '/* condition 12: nested anonymous class method */';
+        $data['testDeepestNested'][1]['T_IF']       = '/* condition 10-1: if */';
+
+        $data['testInException'][1]['T_FUNCTION'] = '/* condition 6: class method */';
+        $data['testInException'][1]['T_IF']       = '/* condition 4: if */';
+
+        $data['testInDefault'][1]['T_FUNCTION'] = '/* condition 6: class method */';
+        $data['testInDefault'][1]['T_IF']       = '/* condition 4: if */';
+
+        return $data;
+    }
+
+    /**
      * Test whether a token has a condition of a certain type.
      *
      * @dataProvider dataHasCondition

--- a/Tests/Utils/Conditions/GetConditionTest.php
+++ b/Tests/Utils/Conditions/GetConditionTest.php
@@ -58,68 +58,6 @@ class GetConditionTest extends BCFile_GetConditionTest
     }
 
     /**
-     * Test retrieving a specific condition from a tokens "conditions" array.
-     *
-     * @dataProvider dataGetConditionReversed
-     *
-     * @param string $testMarker      The comment which prefaces the target token in the test file.
-     * @param array  $expectedResults Array with the condition token type to search for as key
-     *                                and the marker for the expected stack pointer result as a value.
-     *
-     * @return void
-     */
-    public function testGetConditionReversed($testMarker, $expectedResults)
-    {
-        $stackPtr = self::$testTokens[$testMarker];
-
-        // Add expected results for all test markers not listed in the data provider.
-        $expectedResults += $this->conditionDefaults;
-
-        foreach ($expectedResults as $conditionType => $expected) {
-            if ($expected !== false) {
-                $expected = self::$markerTokens[$expected];
-            }
-
-            $result = Conditions::getCondition(self::$phpcsFile, $stackPtr, \constant($conditionType), true);
-            $this->assertSame(
-                $expected,
-                $result,
-                "Assertion failed for test marker '{$testMarker}' with condition {$conditionType} (reversed)"
-            );
-        }
-    }
-
-    /**
-     * Data provider.
-     *
-     * Only the conditions which are expected to be *found* need to be listed here.
-     * All other potential conditions will automatically also be tested and will expect
-     * `false` as a result.
-     *
-     * @see testGetConditionReversed() For the array format.
-     *
-     * @return array
-     */
-    public static function dataGetConditionReversed()
-    {
-        $data = self::dataGetCondition();
-
-        // Set up the data for the reversed results.
-        $data['testSeriouslyNestedMethod'][1]['T_IF'] = '/* condition 4: if */';
-
-        $data['testDeepestNested'][1]['T_FUNCTION'] = '/* condition 12: nested anonymous class method */';
-        $data['testDeepestNested'][1]['T_IF']       = '/* condition 10-1: if */';
-
-        $data['testInException'][1]['T_FUNCTION'] = '/* condition 6: class method */';
-        $data['testInException'][1]['T_IF']       = '/* condition 4: if */';
-
-        $data['testInDefault'][1]['T_FUNCTION'] = '/* condition 6: class method */';
-        $data['testInDefault'][1]['T_IF']       = '/* condition 4: if */';
-
-        return $data;
-    }
-
-    /**
      * Test retrieving a specific condition from a token's "conditions" array,
      * with multiple allowed possibilities.
      *


### PR DESCRIPTION
PHPCS 3.5.4 introduces a new `$first` parameter to the `File::getCondition()` function.

The PHPCSUtils `Conditions::getCondition()` already had a parameter for the same - `$reverse`, though the boolean values used were also the reverse of how the new `$first` parameter is implemented.

As PHPCSUtils is still in `alpha`, I'm making the executive decision to rename the parameter for the `Conditions::getCondition()`  function to `$first`, including reversing the meaning of the boolean values, to stay in line with PHPCS itself.

* Includes adjusting any and all function calls in the existing codebase for the reversal of the meaning of the boolean.
* Includes moving the unit tests covering this parameter, which were already in place in the test file for the `Conditions::getCondition()` function, to the test file for the `BCFile::getCondition()` function.
The actual tests will be run for both functions now.

Refs:
* https://github.com/squizlabs/PHP_CodeSniffer/commit/77c5fa2cd0b2ceca49d1610f8a30b857fe0f0fb9.