### PR TITLE
Add support for arrow functions

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -238,6 +238,7 @@ class BCFile
      *                  be set in a "variadic_token" array index.
      * - PHPCS 3.5.3: Fixed a bug where the "type_hint_end_token" array index for a type hinted
      *                parameter would bleed through to the next (non-type hinted) parameter.
+     * - PHPCS 3.5.3: Added support for PHP 7.4 T_FN arrow functions.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodParameters()      Original source.
      * @see \PHPCSUtils\Utils\FunctionDeclarations::getParameters() PHPCSUtils native improved version.
@@ -251,7 +252,8 @@ class BCFile
      * @return array
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified $stackPtr is not of
-     *                                                      type T_FUNCTION, T_CLOSURE, or T_USE.
+     *                                                      type T_FUNCTION, T_CLOSURE, T_USE,
+     *                                                      or T_FN.
      */
     public static function getMethodParameters(File $phpcsFile, $stackPtr)
     {
@@ -260,8 +262,9 @@ class BCFile
         if ($tokens[$stackPtr]['code'] !== T_FUNCTION
             && $tokens[$stackPtr]['code'] !== T_CLOSURE
             && $tokens[$stackPtr]['code'] !== T_USE
+            && $tokens[$stackPtr]['code'] !== T_FN
         ) {
-            throw new RuntimeException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_USE');
+            throw new RuntimeException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_USE or T_FN');
         }
 
         if ($tokens[$stackPtr]['code'] === T_USE) {

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -929,6 +929,7 @@ class BCFile
      * @see \PHPCSUtils\Utils\Operators::isReference() PHPCSUtils native improved version.
      *
      * @since 1.0.0
+     * @since 1.0.0-alpha2 Added BC support for PHP 7.4 arrow functions.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the T_BITWISE_AND token.
@@ -947,7 +948,7 @@ class BCFile
         $tokenBefore = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
         if ($tokens[$tokenBefore]['code'] === T_FUNCTION
-            || $tokens[$tokenBefore]['code'] === T_FN
+            || FunctionDeclarations::isArrowFunction($phpcsFile, $tokenBefore) === true
         ) {
             // Function returns a reference.
             return true;

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -107,6 +107,7 @@ class BCFile
      * @see \PHPCSUtils\Utils\ObjectDeclarations::getName()   PHPCSUtils native improved version.
      *
      * @since 1.0.0
+     * @since 1.0.0-alpha2 Added BC support for PHP 7.4 arrow functions.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the declaration token
@@ -158,7 +159,7 @@ class BCFile
         $content = null;
         for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
             if ($tokens[$i]['code'] === T_STRING
-                || $tokens[$i]['code'] === T_FN
+                || $tokens[$i]['type'] === 'T_FN'
             ) {
                 /*
                  * BC: In PHPCS 2.6.0, in case of live coding, the last token in a file will be tokenized

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1244,6 +1244,8 @@ class BCFile
      * - PHPCS 2.7.1: Improved handling of short arrays, PHPCS #1203.
      * - PHPCS 3.3.0: Bug fix: end of statement detection when passed a scope opener, PHPCS #1863.
      * - PHPCS 3.5.0: Improved handling of group use statements.
+     * - PHPCS 3.5.3: Added support for PHP 7.4 T_FN arrow functions.
+     * - PHPCS 3.5.4: Improved support for PHP 7.4 T_FN arrow functions.
      *
      * @see \PHP_CodeSniffer\Files\File::findEndOfStatement() Original source.
      *
@@ -1302,6 +1304,11 @@ class BCFile
                 && ($i === $tokens[$i]['scope_opener']
                 || $i === $tokens[$i]['scope_condition'])
             ) {
+                if ($tokens[$i]['code'] === T_FN) {
+                    $i = ($tokens[$i]['scope_closer'] - 1);
+                    continue;
+                }
+
                 if ($i === $start && isset(Tokens::$scopeOpeners[$tokens[$i]['code']]) === true) {
                     return $tokens[$i]['scope_closer'];
                 }

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -923,6 +923,7 @@ class BCFile
      *                - New by reference was not recognized as a reference.
      *                - References to class properties with `self::`, `parent::`, `static::`,
      *                  `namespace\ClassName::`, `classname::` were not recognized as references.
+     * - PHPCS 3.5.3: Added support for PHP 7.4 T_FN arrow functions returning by reference.
      *
      * @see \PHP_CodeSniffer\Files\File::isReference() Original source.
      * @see \PHPCSUtils\Utils\Operators::isReference() PHPCSUtils native improved version.
@@ -945,7 +946,9 @@ class BCFile
 
         $tokenBefore = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
-        if ($tokens[$tokenBefore]['code'] === T_FUNCTION) {
+        if ($tokens[$tokenBefore]['code'] === T_FUNCTION
+            || $tokens[$tokenBefore]['code'] === T_FN
+        ) {
             // Function returns a reference.
             return true;
         }

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1167,10 +1167,12 @@ class BCFile
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.1.0.
      * - PHPCS 2.6.2: New optional `$ignore` parameter to selectively ignore stop points.
+     * - PHPCS 3.5.5: Added support for PHP 7.4 T_FN arrow functions.
      *
      * @see \PHP_CodeSniffer\Files\File::findStartOfStatement() Original source.
      *
      * @since 1.0.0
+     * @since 1.0.0-alpha2 Added BC support for PHP 7.4 arrow functions.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $start     The position to start searching from in the token stack.
@@ -1209,6 +1211,7 @@ class BCFile
 
             if (isset($tokens[$i]['scope_opener']) === true
                 && $i === $tokens[$i]['scope_closer']
+                && $tokens[$i]['code'] !== T_CLOSE_PARENTHESIS
             ) {
                 // Found the end of the previous scope block.
                 return $lastNotEmpty;

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -96,6 +96,8 @@ class BCFile
      * - PHPCS 3.0.0: Added support for ES6 class/method syntax.
      * - PHPCS 3.0.0: The Exception thrown changed from a `PHP_CodeSniffer_Exception` to
      *                `\PHP_CodeSniffer\Exceptions\RuntimeException`.
+     * - PHPCS 3.5.3: Allow for functions to be called `fn` for backwards compatibility.
+     *                Related to PHP 7.4 T_FN arrow functions.
      *
      * Note: For ES6 classes in combination with PHPCS 2.x, passing a `T_STRING` token to
      *       this method will be accepted for JS files.
@@ -155,7 +157,9 @@ class BCFile
 
         $content = null;
         for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
-            if ($tokens[$i]['code'] === T_STRING) {
+            if ($tokens[$i]['code'] === T_STRING
+                || $tokens[$i]['code'] === T_FN
+            ) {
                 /*
                  * BC: In PHPCS 2.6.0, in case of live coding, the last token in a file will be tokenized
                  * as T_STRING, but won't have the `content` index set.

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -308,7 +308,8 @@ class Collections
         \T_PARENT       => \T_PARENT,
         \T_NS_SEPARATOR => \T_NS_SEPARATOR,
         \T_RETURN_TYPE  => \T_RETURN_TYPE, // PHPCS 2.4.0 < 3.3.0.
-        \T_ARRAY_HINT   => \T_ARRAY_HINT, // PHPCS < 2.8.0.
+        \T_ARRAY_HINT   => \T_ARRAY_HINT, // PHPCS < 2.8.0 / PHPCS < 3.5.3 for arrow functions.
+        \T_ARRAY        => \T_ARRAY, // PHPCS < 3.5.4 for select arrow functions.
     ];
 
     /**

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -533,6 +533,264 @@ class FunctionDeclarations
     }
 
     /**
+     * Check if an arbitrary token is a PHP 7.4 arrow function keyword token.
+     *
+     * Helper function for backward-compatibility with PHP < 7.4 in combination with PHPCS < 3.5.3/4
+     * in which the `T_FN` token is not yet backfilled.
+     *
+     * Note: While this function can determine whether a token should be regarded as `T_FN`, if the
+     * token isn't a PHP native `T_FN` or backfilled `T_FN` token, the token will still not have
+     * the `parenthesis_owner`, `parenthesis_opener`, `parenthesis_closer`, `scope_owner`
+     * `scope_opener` or `scope_closer` keys assigned in the tokens array.
+     * Use the `FunctionDeclarations::getArrowFunctionOpenClose()` utility method to retrieve
+     * these when they're needed.
+     *
+     * @see \PHPCSUtils\Utils\FunctionDeclarations::getArrowFunctionOpenClose()
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The token to check. Typically a T_FN or
+     *                                               T_STRING token as those are the only two
+     *                                               tokens which can be the arrow function keyword.
+     *
+     * @return bool
+     */
+    public static function isArrowFunction(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        if (isset($tokens[$stackPtr]) === false) {
+            return false;
+        }
+
+        if ($tokens[$stackPtr]['type'] === 'T_FN') {
+            // Either PHP 7.4 or PHPCS 3.5.3+. Check if this is not a real function called "fn".
+            $prevNonEmpty = $phpcsFile->findPrevious(
+                Tokens::$emptyTokens + [\T_BITWISE_AND],
+                ($stackPtr - 1),
+                null,
+                true
+            );
+            if ($tokens[$prevNonEmpty]['code'] === \T_FUNCTION) {
+                return false;
+            }
+
+            return true;
+        }
+
+        if (\defined('T_FN') === true) {
+            // If the token exists and isn't used, it's not an arrow function.
+            return false;
+        }
+
+        if ($tokens[$stackPtr]['code'] !== \T_STRING
+            || \strtolower($tokens[$stackPtr]['content']) !== 'fn'
+        ) {
+            return false;
+        }
+
+        $nextNonEmpty = $phpcsFile->findNext((Tokens::$emptyTokens + [\T_BITWISE_AND]), ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false
+            || ($tokens[$nextNonEmpty]['code'] === \T_OPEN_PARENTHESIS
+            // Make sure it is not a real function called "fn".
+            && (isset($tokens[$nextNonEmpty]['parenthesis_owner']) === false
+            || $tokens[$tokens[$nextNonEmpty]['parenthesis_owner']]['code'] !== \T_FUNCTION))
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Retrieve the parenthesis opener, parenthesis closer, the scope opener and the scope closer
+     * for an arrow function.
+     *
+     * Helper function for backward-compatibility with PHP < 7.4 in combination with PHPCS < 3.5.3/4
+     * in which the `T_FN` token is not yet backfilled and does not have parenthesis opener/closer
+     * nor scope opener/closer indexes assigned in the `$tokens` array.
+     *
+     * Note: The backfill in PHPCS 3.5.3 is incomplete and this function will - in a limited set of
+     * circumstances - not work on PHPCS 3.5.3.
+     * As PHPCS 3.5.3 is not supported by PHPCSUtils due to the broken PHP 7.4 numeric literals backfill
+     * anyway, this will not be fixed.
+     *
+     * @see \PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction()
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The token to retrieve the opener/closers for.
+     *                                               Typically a T_FN or T_STRING token as those are the
+     *                                               only two tokens which can be the arrow function keyword.
+     *
+     * @return array An array with the token pointers or an empty array if this is not an arrow function.
+     *               The format of the return value is:
+     *               <code>
+     *               array(
+     *                 'parenthesis_opener' => integer|false, // Stack pointer or false if undetermined.
+     *                 'parenthesis_closer' => integer|false, // Stack pointer or false if undetermined.
+     *                 'scope_opener'       => integer|false, // Stack pointer or false if undetermined.
+     *                 'scope_closer'       => integer|false, // Stack pointer or false if undetermined.
+     *               )
+     *               </code>
+     */
+    public static function getArrowFunctionOpenClose(File $phpcsFile, $stackPtr)
+    {
+        if (self::isArrowFunction($phpcsFile, $stackPtr) === false) {
+            return [];
+        }
+
+        $returnValue = [
+            'parenthesis_opener' => false,
+            'parenthesis_closer' => false,
+            'scope_opener'       => false,
+            'scope_closer'       => false,
+        ];
+
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['type'] === 'T_FN'
+            && \version_compare(Helper::getVersion(), '3.5.3', '>=') === true
+        ) {
+            if (isset($tokens[$stackPtr]['parenthesis_opener']) === true) {
+                $returnValue['parenthesis_opener'] = $tokens[$stackPtr]['parenthesis_opener'];
+            }
+
+            if (isset($tokens[$stackPtr]['parenthesis_closer']) === true) {
+                $returnValue['parenthesis_closer'] = $tokens[$stackPtr]['parenthesis_closer'];
+            }
+
+            if (isset($tokens[$stackPtr]['scope_opener']) === true) {
+                $returnValue['scope_opener'] = $tokens[$stackPtr]['scope_opener'];
+            }
+
+            if (isset($tokens[$stackPtr]['scope_closer']) === true) {
+                $returnValue['scope_closer'] = $tokens[$stackPtr]['scope_closer'];
+            }
+
+            return $returnValue;
+        }
+
+        /*
+         * Either a T_STRING token pre-PHP 7.4, or T_FN on PHP 7.4, in combination with PHPCS < 3.5.3.
+         * Now see about finding the relevant arrow function tokens.
+         */
+        $nextNonEmpty = $phpcsFile->findNext(
+            (Tokens::$emptyTokens + [\T_BITWISE_AND]),
+            ($stackPtr + 1),
+            null,
+            true
+        );
+        if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS) {
+            return $returnValue;
+        }
+
+        $returnValue['parenthesis_opener'] = $nextNonEmpty;
+        if (isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false) {
+            return $returnValue;
+        }
+
+        $returnValue['parenthesis_closer'] = $tokens[$nextNonEmpty]['parenthesis_closer'];
+
+        $ignore                 = Tokens::$emptyTokens;
+        $ignore                += Collections::$returnTypeTokens;
+        $ignore[\T_COLON]       = \T_COLON;
+        $ignore[\T_INLINE_ELSE] = \T_INLINE_ELSE; // PHPCS < 2.9.1.
+        $ignore[\T_INLINE_THEN] = \T_INLINE_THEN; // PHPCS < 2.9.1.
+
+        if (\defined('T_NULLABLE') === true) {
+            $ignore[\T_NULLABLE] = \T_NULLABLE;
+        }
+
+        $arrow = $phpcsFile->findNext(
+            $ignore,
+            ($tokens[$nextNonEmpty]['parenthesis_closer'] + 1),
+            null,
+            true
+        );
+
+        if ($arrow === false
+            || $tokens[$arrow]['code'] !== \T_DOUBLE_ARROW
+        ) {
+            return $returnValue;
+        }
+
+        $returnValue['scope_opener'] = $arrow;
+
+        $endTokens = [
+            \T_COLON                => true,
+            \T_COMMA                => true,
+            \T_SEMICOLON            => true,
+            \T_CLOSE_PARENTHESIS    => true,
+            \T_CLOSE_SQUARE_BRACKET => true,
+            \T_CLOSE_CURLY_BRACKET  => true,
+            \T_CLOSE_SHORT_ARRAY    => true,
+            \T_OPEN_TAG             => true,
+            \T_CLOSE_TAG            => true,
+        ];
+
+        $inTernary = false;
+
+        for ($scopeCloser = ($arrow + 1); $scopeCloser < $phpcsFile->numTokens; $scopeCloser++) {
+            if (isset($endTokens[$tokens[$scopeCloser]['code']]) === true
+                && ($tokens[$scopeCloser]['code'] !== \T_COLON || $inTernary === false)
+            ) {
+                break;
+            }
+
+            if ($tokens[$scopeCloser]['type'] === 'T_FN'
+                || ($tokens[$scopeCloser]['code'] === \T_STRING
+                && $tokens[$scopeCloser]['content'] === 'fn')
+            ) {
+                $nested = self::getArrowFunctionOpenClose($phpcsFile, $scopeCloser);
+                if (isset($nested['scope_closer']) && $nested['scope_closer'] !== false) {
+                    // We minus 1 here in case the closer can be shared with us.
+                    $scopeCloser = ($nested['scope_closer'] - 1);
+                    continue;
+                }
+            }
+
+            if (isset($tokens[$scopeCloser]['scope_closer']) === true
+                && $tokens[$scopeCloser]['code'] !== \T_INLINE_ELSE
+            ) {
+                // We minus 1 here in case the closer can be shared with us.
+                $scopeCloser = ($tokens[$scopeCloser]['scope_closer'] - 1);
+                continue;
+            }
+
+            if (isset($tokens[$scopeCloser]['parenthesis_closer']) === true) {
+                $scopeCloser = $tokens[$scopeCloser]['parenthesis_closer'];
+                continue;
+            }
+
+            if (isset($tokens[$scopeCloser]['bracket_closer']) === true) {
+                $scopeCloser = $tokens[$scopeCloser]['bracket_closer'];
+                continue;
+            }
+
+            if ($tokens[$scopeCloser]['code'] === \T_INLINE_THEN) {
+                $inTernary = true;
+                continue;
+            }
+
+            if ($tokens[$scopeCloser]['code'] === \T_INLINE_ELSE) {
+                if ($inTernary === false) {
+                    break;
+                }
+
+                $inTernary = false;
+            }
+        }
+
+        if ($scopeCloser !== $phpcsFile->numTokens) {
+            $returnValue['scope_closer'] = $scopeCloser;
+        }
+
+        return $returnValue;
+    }
+
+    /**
      * Checks if a given function is a PHP magic function.
      *
      * @todo Add check for the function declaration being namespaced!

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -179,7 +179,7 @@ class FunctionDeclarations
      * @return array
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      T_FUNCTION or a T_CLOSURE token.
+     *                                                      T_FUNCTION, T_CLOSURE, or T_FN token.
      */
     public static function getProperties(File $phpcsFile, $stackPtr)
     {
@@ -187,9 +187,10 @@ class FunctionDeclarations
 
         if (isset($tokens[$stackPtr]) === false
             || ($tokens[$stackPtr]['code'] !== \T_FUNCTION
-                && $tokens[$stackPtr]['code'] !== \T_CLOSURE)
+                && $tokens[$stackPtr]['code'] !== \T_CLOSURE
+                && $tokens[$stackPtr]['code'] !== \T_FN)
         ) {
-            throw new RuntimeException('$stackPtr must be of type T_FUNCTION or T_CLOSURE');
+            throw new RuntimeException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_FN');
         }
 
         if ($tokens[$stackPtr]['code'] === \T_FUNCTION) {

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -348,7 +348,8 @@ class FunctionDeclarations
      * @return array
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified $stackPtr is not of
-     *                                                      type T_FUNCTION, T_CLOSURE, or T_USE.
+     *                                                      type T_FUNCTION, T_CLOSURE, T_USE,
+     *                                                      or T_FN.
      */
     public static function getParameters(File $phpcsFile, $stackPtr)
     {
@@ -357,9 +358,10 @@ class FunctionDeclarations
         if (isset($tokens[$stackPtr]) === false
             || ($tokens[$stackPtr]['code'] !== \T_FUNCTION
                 && $tokens[$stackPtr]['code'] !== \T_CLOSURE
-                && $tokens[$stackPtr]['code'] !== \T_USE)
+                && $tokens[$stackPtr]['code'] !== \T_USE
+                && $tokens[$stackPtr]['code'] !== \T_FN)
         ) {
-            throw new RuntimeException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_USE');
+            throw new RuntimeException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_USE or T_FN');
         }
 
         if ($tokens[$stackPtr]['code'] === \T_USE) {

--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -63,6 +63,7 @@ class Operators
      * @see \PHPCSUtils\BackCompat\BCFile::isReference() Cross-version compatible version of the original.
      *
      * @since 1.0.0
+     * @since 1.0.0-alpha2 Added BC support for PHP 7.4 arrow functions.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the T_BITWISE_AND token.
@@ -81,7 +82,7 @@ class Operators
         $tokenBefore = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
         if ($tokens[$tokenBefore]['code'] === \T_FUNCTION
-            || $tokens[$tokenBefore]['code'] === \T_FN
+            || FunctionDeclarations::isArrowFunction($phpcsFile, $tokenBefore) === true
         ) {
             // Function returns a reference.
             return true;

--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -80,7 +80,9 @@ class Operators
 
         $tokenBefore = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
-        if ($tokens[$tokenBefore]['code'] === \T_FUNCTION) {
+        if ($tokens[$tokenBefore]['code'] === \T_FUNCTION
+            || $tokens[$tokenBefore]['code'] === \T_FN
+        ) {
             // Function returns a reference.
             return true;
         }

--- a/PHPCSUtils/Utils/Parentheses.php
+++ b/PHPCSUtils/Utils/Parentheses.php
@@ -13,6 +13,7 @@ namespace PHPCSUtils\Utils;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Utils\FunctionDeclarations;
 
 /**
  * Utility functions for use when examining parenthesis tokens and arbitrary tokens wrapped in
@@ -27,6 +28,7 @@ class Parentheses
      * Get the pointer to the parentheses owner of an open/close parenthesis.
      *
      * @since 1.0.0
+     * @since 1.0.0-alpha2 Added BC support for PHP 7.4 arrow functions.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
      * @param int                         $stackPtr  The position of `T_OPEN/CLOSE_PARENTHESIS` token.
@@ -45,11 +47,14 @@ class Parentheses
 
         /*
          * `T_LIST` and `T_ANON_CLASS` only became parentheses owners in PHPCS 3.5.0.
+         * `T_FN` was only backfilled in PHPCS 3.5.3/4.
+         * - On PHP 7.4 with PHPCS < 3.5.3, T_FN will not yet be a parentheses owner.
+         * - On PHP < 7.4 with PHPCS < 3.5.3, T_FN will be tokenized as T_STRING and not yet be a parentheses owner.
          *
          * {@internal As the 'parenthesis_owner' index is only set on parentheses, we didn't need to do any
          * input validation before, but now we do.}
          */
-        if (\version_compare(Helper::getVersion(), '3.5.0', '>=') === true) {
+        if (\version_compare(Helper::getVersion(), '3.5.4', '>=') === true) {
             return false;
         }
 
@@ -69,7 +74,9 @@ class Parentheses
             && ($tokens[$prevNonEmpty]['code'] === \T_LIST
             || $tokens[$prevNonEmpty]['code'] === \T_ANON_CLASS
             // Work-around: anon classes were, in certain circumstances, tokenized as T_CLASS prior to PHPCS 3.4.0.
-            || $tokens[$prevNonEmpty]['code'] === \T_CLASS)
+            || $tokens[$prevNonEmpty]['code'] === \T_CLASS
+            // Possibly an arrow function.
+            || FunctionDeclarations::isArrowFunction($phpcsFile, $prevNonEmpty) === true)
         ) {
             return $prevNonEmpty;
         }
@@ -82,6 +89,7 @@ class Parentheses
      * set of valid owners.
      *
      * @since 1.0.0
+     * @since 1.0.0-alpha2 Added BC support for PHP 7.4 arrow functions.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
      * @param int                         $stackPtr    The position of `T_OPEN/CLOSE_PARENTHESIS` token.
@@ -109,6 +117,13 @@ class Parentheses
          */
         if (\in_array(\T_ANON_CLASS, $validOwners, true)) {
             $validOwners[] = \T_CLASS;
+        }
+
+        /*
+         * Allow for T_FN token being tokenized as T_STRING before PHPCS 3.5.3.
+         */
+        if (\defined('T_FN') && \in_array(\T_FN, $validOwners, true)) {
+            $validOwners[] = \T_STRING;
         }
 
         return \in_array($tokens[$owner]['code'], $validOwners, true);

--- a/Tests/BackCompat/BCFile/FindEndOfStatementTest.inc
+++ b/Tests/BackCompat/BCFile/FindEndOfStatementTest.inc
@@ -29,3 +29,17 @@ $a = new Datetime;
 
 /* testUseGroup */
 use Vendor\Package\{ClassA as A, ClassB, ClassC as C};
+
+$a = [
+    /* testArrowFunctionArrayValue */
+    'a' => fn() => return 1,
+    'b' => fn() => return 1,
+];
+
+/* testStaticArrowFunction */
+static fn ($a) => $a;
+
+/* testArrowFunctionReturnValue */
+fn(): array => [a($a, $b)];
+
+return 0;

--- a/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
@@ -179,4 +179,48 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
         $tokens = self::$phpcsFile->getTokens();
         $this->assertSame($tokens[($start + 23)], $tokens[$found]);
     }
+
+    /**
+     * Test arrow function as array value.
+     *
+     * @return void
+     */
+    public function testArrowFunctionArrayValue()
+    {
+        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testArrowFunctionArrayValue */') + 7);
+        $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
+
+        $tokens = self::$phpcsFile->getTokens();
+        $this->assertSame($tokens[($start + 9)], $tokens[$found]);
+    }
+
+    /**
+     * Test static arrow function.
+     *
+     * @return void
+     */
+    public function testStaticArrowFunction()
+    {
+        $static = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testStaticArrowFunction */') + 2);
+        $fn     = self::$phpcsFile->findNext(T_FN, ($static + 1));
+
+        $endOfStatementStatic = BCFile::findEndOfStatement(self::$phpcsFile, $static);
+        $endOfStatementFn     = BCFile::findEndOfStatement(self::$phpcsFile, $fn);
+
+        $this->assertSame($endOfStatementFn, $endOfStatementStatic);
+    }
+
+    /**
+     * Test arrow function with return value.
+     *
+     * @return void
+     */
+    public function testArrowFunctionReturnValue()
+    {
+        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testArrowFunctionReturnValue */') + 2);
+        $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
+
+        $tokens = self::$phpcsFile->getTokens();
+        $this->assertSame(($start + 18), $found);
+    }
 }

--- a/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
@@ -25,6 +25,7 @@
 namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
 use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
 /**
@@ -201,8 +202,13 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
      */
     public function testStaticArrowFunction()
     {
+        $fnTargets = [\T_STRING];
+        if (\defined('T_FN') === true) {
+            $fnTargets[] = \T_FN;
+        }
+
         $static = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testStaticArrowFunction */') + 2);
-        $fn     = self::$phpcsFile->findNext(T_FN, ($static + 1));
+        $fn     = self::$phpcsFile->findNext($fnTargets, ($static + 1));
 
         $endOfStatementStatic = BCFile::findEndOfStatement(self::$phpcsFile, $static);
         $endOfStatementFn     = BCFile::findEndOfStatement(self::$phpcsFile, $fn);
@@ -217,6 +223,12 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
      */
     public function testArrowFunctionReturnValue()
     {
+        // Skip this test on unsupported PHPCS version.
+        if (\version_compare(Helper::getVersion(), '3.5.3', '==') === true) {
+            $this->markTestSkipped(
+                'PHPCS 3.5.3 is not supported for this specific test due to a buggy arrow functions backfill.'
+            );
+        }
         $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testArrowFunctionReturnValue */') + 2);
         $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 

--- a/Tests/BackCompat/BCFile/FindStartOfStatementTest.inc
+++ b/Tests/BackCompat/BCFile/FindStartOfStatementTest.inc
@@ -1,0 +1,12 @@
+<?php
+
+$value = [
+    /* testPrecededByArrowFunctionInArray - Expected */
+    Url::make('View Song', fn($song) => $song->url())
+        /* testPrecededByArrowFunctionInArray */
+        ->onlyOnDetail(),
+
+    new Panel('Information', [
+        Text::make('Title')
+    ]),
+];

--- a/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCFile;
+
+use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+
+/**
+ * Tests for the \PHPCSUtils\BackCompat\BCFile::findStartOfStatement method.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCFile::findStartOfStatement
+ *
+ * @since 1.0.0
+ */
+class FindStartOfStatementTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test object call on result of static function call with arrow function as parameter and wrapped within an array.
+     *
+     * @link https://github.com/squizlabs/php_codesniffer/issues/2849
+     * @link https://github.com/squizlabs/PHP_CodeSniffer/commit/fbf67efc3fc0c2a355f5585d49f4f6fe160ff2f9
+     *
+     * @return void
+     */
+    public function testObjectCallPrecededByArrowFunctionAsFunctionCallParameterInArray()
+    {
+        $expected = $this->getTargetToken('/* testPrecededByArrowFunctionInArray - Expected */', \T_STRING, 'Url');
+
+        $start = $this->getTargetToken('/* testPrecededByArrowFunctionInArray */', \T_STRING, 'onlyOnDetail');
+        $found = BCFile::findStartOfStatement(self::$phpcsFile, $start);
+
+        $this->assertSame($expected, $found);
+    }
+}

--- a/Tests/BackCompat/BCFile/GetDeclarationNameTest.inc
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameTest.inc
@@ -60,6 +60,9 @@ class /* comment */
 // phpcs:ignore Standard.Cat.SniffName -- for reasons
     ClassWithCommentsAndNewLines {}
 
+/* testFunctionFn */
+function fn() {}
+
 /* testLiveCoding */
 // Intentional parse error. This has to be the last test in the file.
 function // Comment.

--- a/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
@@ -173,6 +173,10 @@ class GetDeclarationNameTest extends UtilityMethodTestCase
                 '/* testClassWithCommentsAndNewLines */',
                 'ClassWithCommentsAndNewLines',
             ],
+            'function-named-fn' => [
+                '/* testFunctionFn */',
+                'fn',
+            ],
         ];
     }
 }

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
@@ -53,6 +53,9 @@ function defaultValues($var1=1, $var2='value') {}
 /* testBitwiseAndConstantExpressionDefaultValue */
 function myFunction($a = 10 & 20) {}
 
+/* testArrowFunction */
+fn(int $a, ...$b) => $b;
+
 /* testArrayDefaultValues */
 function arrayDefaultValues($var1 = [], $var2 = array(1, 2, 3) ) {}
 

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
@@ -56,6 +56,9 @@ function myFunction($a = 10 & 20) {}
 /* testArrowFunction */
 fn(int $a, ...$b) => $b;
 
+/* testArrowFunctionReturnByRef */
+fn&(?string $a) => $b;
+
 /* testArrayDefaultValues */
 function arrayDefaultValues($var1 = [], $var2 = array(1, 2, 3) ) {}
 
@@ -94,6 +97,21 @@ class testAllTypes {
     ) {}
 }
 
+/* testArrowFunctionWithAllTypes */
+$fn = fn(
+    ?ClassName $a,
+    self $b,
+    parent $c,
+    object $d,
+    ?int $e,
+    string &$f,
+    iterable $g,
+    bool $h = true,
+    callable $i = 'is_null',
+    float $j = 1.1,
+    array ...$k
+) => $something;
+
 /* testMessyDeclaration */
 function messyDeclaration(
     // comment
@@ -121,3 +139,7 @@ function() use( $foo, $bar ) {}
 
 /* testInvalidUse */
 function() use {} // Intentional parse error.
+
+/* testArrowFunctionLiveCoding */
+// Intentional parse error. This has to be the last test in the file.
+$fn = fn

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
@@ -61,6 +61,12 @@ interface MyInterface
     function myFunction();
 }
 
+$result = array_map(
+    /* testArrowFunction */
+    static fn(int $number) : int => $number + 1,
+    $numbers
+);
+
 /* testNotAFunction */
 return true;
 

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
@@ -74,3 +74,13 @@ return true;
 function foo() : array {
     echo $foo;
 }
+
+/* testArrowFunctionArrayReturnValue */
+$fn = fn(): array => [a($a, $b)];
+
+/* testArrowFunctionReturnByRef */
+fn&(?string $a) : ?string => $b;
+
+/* testArrowFunctionLiveCoding */
+// Intentional parse error. This has to be the last test in the file.
+$fn = fn

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -21,6 +21,7 @@
 namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
 use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
 /**
@@ -397,7 +398,12 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => true,
         ];
 
-        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+        $arrowTokenType = T_STRING;
+        if (defined('T_FN') === true) {
+            $arrowTokenType = T_FN;
+        }
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenType);
     }
 
     /**
@@ -425,16 +431,109 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     }
 
     /**
+     * Test handling of incorrect tokenization of array return type declarations for arrow functions
+     * in a very specific code sample in PHPCS < 3.5.4.
+     *
+     * @link https://github.com/squizlabs/PHP_CodeSniffer/issues/2773
+     *
+     * @return void
+     */
+    public function testArrowFunctionArrayReturnValue()
+    {
+        // Skip this test on unsupported PHPCS versions.
+        if (\version_compare(Helper::getVersion(), '3.5.3', '==') === true) {
+            $this->markTestSkipped(
+                'PHPCS 3.5.3 is not supported for this specific test due to a buggy arrow functions backfill.'
+            );
+        }
+
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => 'array',
+            'return_type_token'    => 5, // Offset from the T_FN token.
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $arrowTokenType = T_STRING;
+        if (defined('T_FN') === true) {
+            $arrowTokenType = T_FN;
+        }
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenType);
+    }
+
+    /**
+     * Test handling of an arrow function returning by reference.
+     *
+     * @return void
+     */
+    public function testArrowFunctionReturnByRef()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => '?string',
+            'return_type_token'    => 12,
+            'nullable_return_type' => true,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $arrowTokenType = T_STRING;
+        if (defined('T_FN') === true) {
+            $arrowTokenType = T_FN;
+        }
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenType);
+    }
+
+    /**
+     * Test an arrow function live coding/parse error.
+     *
+     * @return void
+     */
+    public function testArrowFunctionLiveCoding()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => '',
+            'return_type_token'    => false,
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $arrowTokenType = T_STRING;
+        if (defined('T_FN') === true) {
+            $arrowTokenType = T_FN;
+        }
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenType);
+    }
+
+    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.
      * @param array  $expected      The expected function output.
+     * @param array  $targetType    Optional. The token type to search for after $commentString.
+     *                              Defaults to the function/closure tokens.
      *
      * @return void
      */
-    protected function getMethodPropertiesTestHelper($commentString, $expected)
+    protected function getMethodPropertiesTestHelper($commentString, $expected, $targetType = [T_FUNCTION, T_CLOSURE])
     {
-        $function = $this->getTargetToken($commentString, [T_FUNCTION, T_CLOSURE, T_FN]);
+        $function = $this->getTargetToken($commentString, $targetType);
         $found    = BCFile::getMethodProperties(self::$phpcsFile, $function);
 
         if ($expected['return_type_token'] !== false) {

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -42,7 +42,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
      */
     public function testNotAFunctionException()
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION or T_CLOSURE');
+        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_FN');
 
         $next = $this->getTargetToken('/* testNotAFunction */', T_RETURN);
         BCFile::getMethodProperties(self::$phpcsFile, $next);
@@ -379,6 +379,28 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     }
 
     /**
+     * Test a static arrow function.
+     *
+     * @return void
+     */
+    public function testArrowFunction()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => 'int',
+            'return_type_token'    => 9, // Offset from the T_FN token.
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => true,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Test for incorrect tokenization of array return type declarations in PHPCS < 2.8.0.
      *
      * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/1264
@@ -412,7 +434,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
      */
     protected function getMethodPropertiesTestHelper($commentString, $expected)
     {
-        $function = $this->getTargetToken($commentString, [T_FUNCTION, T_CLOSURE]);
+        $function = $this->getTargetToken($commentString, [T_FUNCTION, T_CLOSURE, T_FN]);
         $found    = BCFile::getMethodProperties(self::$phpcsFile, $function);
 
         if ($expected['return_type_token'] !== false) {

--- a/Tests/BackCompat/BCFile/IsReferenceTest.inc
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.inc
@@ -162,3 +162,6 @@ functionCall( $something , &new Foobar() );
 
 /* testUseByReference */
 $closure = function() use (&$var){};
+
+/* testArrowFunctionReturnByReference */
+fn&($x) => $x;

--- a/Tests/BackCompat/BCFile/IsReferenceTest.php
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.php
@@ -308,6 +308,10 @@ class IsReferenceTest extends UtilityMethodTestCase
                 '/* testUseByReference */',
                 true,
             ],
+            [
+                '/* testArrowFunctionReturnByReference */',
+                true,
+            ],
         ];
     }
 }

--- a/Tests/Utils/Arrays/GetDoubleArrowPtrTest.inc
+++ b/Tests/Utils/Arrays/GetDoubleArrowPtrTest.inc
@@ -71,4 +71,13 @@ $array = [
 
     /* testArrowKeyClosureYieldWithKey */
     function() { yield 'k' => $x }() => 'value',
+
+    /* testFnFunctionWithKey */
+    'fn' => fn ($x) => yield 'k' => $x,
+
+    /* testNoArrowValueFnFunction */
+    fn ($x) => yield 'k' => $x,
+
+    /* testTstringKeyNotFnFunction */
+    CONSTANT_NAME => 'value',
 ];

--- a/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
+++ b/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
@@ -196,6 +196,18 @@ class GetDoubleArrowPtrTest extends UtilityMethodTestCase
                 '/* testArrowKeyClosureYieldWithKey */',
                 24,
             ],
+            'test-arrow-value-fn-function' => [
+                '/* testFnFunctionWithKey */',
+                8,
+            ],
+            'test-no-arrow-value-fn-function' => [
+                '/* testNoArrowValueFnFunction */',
+                false,
+            ],
+            'test-arrow-tstring-key-not-fn-function' => [
+                '/* testTstringKeyNotFnFunction */',
+                8,
+            ],
         ];
     }
 }

--- a/Tests/Utils/FunctionDeclarations/GetParametersTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersTest.php
@@ -88,7 +88,7 @@ class GetParametersTest extends BCFile_GetMethodParametersTest
      *
      * @return void
      */
-    public function testNoParams($commentString, $targetTokenType = [\T_FUNCTION, \T_CLOSURE, \T_FN])
+    public function testNoParams($commentString, $targetTokenType = [\T_FUNCTION, \T_CLOSURE])
     {
         $target = $this->getTargetToken($commentString, $targetTokenType);
         $result = FunctionDeclarations::getParameters(self::$phpcsFile, $target);
@@ -106,11 +106,8 @@ class GetParametersTest extends BCFile_GetMethodParametersTest
      *
      * @return void
      */
-    protected function getMethodParametersTestHelper(
-        $commentString,
-        $expected,
-        $targetType = [\T_FUNCTION, \T_CLOSURE, \T_FN]
-    ) {
+    protected function getMethodParametersTestHelper($commentString, $expected, $targetType = [\T_FUNCTION, \T_CLOSURE])
+    {
         $target = $this->getTargetToken($commentString, $targetType);
         $found  = FunctionDeclarations::getParameters(self::$phpcsFile, $target);
 

--- a/Tests/Utils/FunctionDeclarations/GetParametersTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersTest.php
@@ -54,7 +54,7 @@ class GetParametersTest extends BCFile_GetMethodParametersTest
      */
     public function testUnexpectedTokenException()
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_USE');
+        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_USE or T_FN');
 
         $next = $this->getTargetToken('/* testNotAFunction */', [\T_INTERFACE]);
         FunctionDeclarations::getParameters(self::$phpcsFile, $next);
@@ -88,7 +88,7 @@ class GetParametersTest extends BCFile_GetMethodParametersTest
      *
      * @return void
      */
-    public function testNoParams($commentString, $targetTokenType = [\T_FUNCTION, \T_CLOSURE])
+    public function testNoParams($commentString, $targetTokenType = [\T_FUNCTION, \T_CLOSURE, \T_FN])
     {
         $target = $this->getTargetToken($commentString, $targetTokenType);
         $result = FunctionDeclarations::getParameters(self::$phpcsFile, $target);
@@ -106,8 +106,11 @@ class GetParametersTest extends BCFile_GetMethodParametersTest
      *
      * @return void
      */
-    protected function getMethodParametersTestHelper($commentString, $expected, $targetType = [\T_FUNCTION, \T_CLOSURE])
-    {
+    protected function getMethodParametersTestHelper(
+        $commentString,
+        $expected,
+        $targetType = [\T_FUNCTION, \T_CLOSURE, \T_FN]
+    ) {
         $target = $this->getTargetToken($commentString, $targetType);
         $found  = FunctionDeclarations::getParameters(self::$phpcsFile, $target);
 

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesTest.php
@@ -61,6 +61,33 @@ class GetPropertiesTest extends BCFile_GetMethodPropertiesTest
     }
 
     /**
+     * Test a arrow function live coding/parse error.
+     *
+     * @return void
+     */
+    public function testArrowFunctionLiveCoding()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => '',
+            'return_type_token'    => false,
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => false, // Different from original.
+        ];
+
+        $arrowTokenType = \T_STRING;
+        if (\defined('T_FN') === true) {
+            $arrowTokenType = \T_FN;
+        }
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenType);
+    }
+
+    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesTest.php
@@ -65,12 +65,14 @@ class GetPropertiesTest extends BCFile_GetMethodPropertiesTest
      *
      * @param string $commentString The comment which preceeds the test.
      * @param array  $expected      The expected function output.
+     * @param array  $targetType    Optional. The token type to search for after $commentString.
+     *                              Defaults to the function/closure tokens.
      *
      * @return void
      */
-    protected function getMethodPropertiesTestHelper($commentString, $expected)
+    protected function getMethodPropertiesTestHelper($commentString, $expected, $targetType = [\T_FUNCTION, \T_CLOSURE])
     {
-        $function = $this->getTargetToken($commentString, [\T_FUNCTION, \T_CLOSURE, \T_FN]);
+        $function = $this->getTargetToken($commentString, $targetType);
         $found    = FunctionDeclarations::getProperties(self::$phpcsFile, $function);
 
         if ($expected['return_type_token'] !== false) {

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesTest.php
@@ -54,7 +54,7 @@ class GetPropertiesTest extends BCFile_GetMethodPropertiesTest
      */
     public function testNotAFunctionException()
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION or T_CLOSURE');
+        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_FN');
 
         $next = $this->getTargetToken('/* testNotAFunction */', \T_RETURN);
         FunctionDeclarations::getProperties(self::$phpcsFile, $next);
@@ -70,7 +70,7 @@ class GetPropertiesTest extends BCFile_GetMethodPropertiesTest
      */
     protected function getMethodPropertiesTestHelper($commentString, $expected)
     {
-        $function = $this->getTargetToken($commentString, [\T_FUNCTION, \T_CLOSURE]);
+        $function = $this->getTargetToken($commentString, [\T_FUNCTION, \T_CLOSURE, \T_FN]);
         $found    = FunctionDeclarations::getProperties(self::$phpcsFile, $function);
 
         if ($expected['return_type_token'] !== false) {

--- a/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.inc
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.inc
@@ -1,0 +1,85 @@
+<?php
+
+/* testNotTheRightContent */
+function_call();
+
+/* testNotAnArrowFunction */
+const FN = true;
+
+/* testStandard */
+$fn1 = fn($x) => $x + $y;
+
+/* testMixedCase */
+$fn1 = Fn($x) => $x + $y;
+
+/* testWhitespace */
+$fn1 = fn ($x) => $x + $y;
+
+/* testComment */
+$fn1 = fn /* comment here */ ($x) => $x + $y;
+
+/* testFunctionName */
+function &fn() {}
+
+/* testNestedOuter */
+$fn = fn($x) => /* testNestedInner */ fn($y) => $x * $y + $z;
+
+/* testFunctionCall */
+$extended = fn($c) => $callable($factory($c), $c);
+
+/* testChainedFunctionCall */
+$result = Collection::from([1, 2])
+    ->map(fn($v) => $v * 2)
+    ->reduce(/* testFunctionArgument */ fn($tmp, $v) => $tmp + $v, 0);
+
+/* testClosure */
+$extended = fn($c) => $callable(function() {
+    for ($x = 1; $x < 10; $x++) {
+        echo $x;
+    }
+
+    echo 'done';
+}, $c);
+
+$result = array_map(
+    /* testReturnTypeNullableInt */
+    static fn(int $number) : ?int => $number + 1,
+    $numbers
+);
+
+/* testReturnTypeNamespacedClass */
+$fn = fn($x) : ?\My\NS\ClassName => $x;
+
+/* testReturnTypeArray */
+$fn = fn($x) : array => $x;
+
+/* testReturnTypeArrayBug2773 */
+$fn = fn(): array => [a($a, $b)];
+
+array_map(
+    /* testMoreArrayTypeDeclarations */
+    static fn (array $value): array => array_filter($value),
+    []
+);
+
+/* testReturnTypeCallable */
+$fn = fn($x) : callable => $x;
+
+/* testReturnTypeSelf */
+$fn = fn($x) : ?self => $x;
+
+/* testReference */
+fn&($x) => $x;
+
+/* testGrouped */
+(fn($x) => $x) + $y;
+
+/* testYield */
+$a = fn($x) => yield 'k' => $x;
+
+/* testTernary */
+$fn = fn($a) => $a ? /* testTernaryThen */ fn() : string => 'a' : /* testTernaryElse */ fn() : string => 'b';
+
+/* testLiveCoding */
+// Intentional parse error. This has to be the last test in the file.
+$fn = fn

--- a/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
@@ -1,0 +1,467 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\FunctionDeclarations;
+
+use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\FunctionDeclarations;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction() and the
+ * \PHPCSUtils\Utils\FunctionDeclarations::getArrowFunctionOpenClose() methods.
+ *
+ * These tests are loosely based on the `Tokenizer/BackfillFnTokenTest` file in PHPCS itself.
+ *
+ * @group functiondeclarations
+ *
+ * @since 1.0.0
+ */
+class IsArrowFunctionTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test that the function returns false when passed a non-existent token.
+     *
+     * @covers \PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $result = FunctionDeclarations::isArrowFunction(self::$phpcsFile, 10000);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test that the function returns false when passed a token which definitely is not an arrow function.
+     *
+     * @covers \PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction
+     *
+     * @return void
+     */
+    public function testUnsupportedToken()
+    {
+        $stackPtr = $this->getTargetToken('/* testNotAnArrowFunction */', \T_CONST);
+
+        $result = FunctionDeclarations::isArrowFunction(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test that the function returns false when passed a T_STRING token without `fn` as content.
+     *
+     * @covers \PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction
+     *
+     * @return void
+     */
+    public function testTStringNotFn()
+    {
+        $stackPtr = $this->getTargetToken('/* testNotTheRightContent */', \T_STRING);
+
+        $result = FunctionDeclarations::isArrowFunction(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test correctly detecting arrow functions.
+     *
+     * @dataProvider dataArrowFunction
+     * @covers       \PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction
+     *
+     * @param string $testMarker    The comment which prefaces the target token in the test file.
+     * @param array  $expected      The expected return value for the respective functions.
+     * @param array  $targetContent The content for the target token to look for in case there could
+     *                              be confusion.
+     *
+     * @return void
+     */
+    public function testIsArrowFunction($testMarker, $expected, $targetContent = null)
+    {
+        $targets = [\T_STRING];
+        if (\defined('T_FN') === true) {
+            $targets[] = \T_FN;
+        }
+
+        $stackPtr = $this->getTargetToken($testMarker, $targets, $targetContent);
+        $result   = FunctionDeclarations::isArrowFunction(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected['is'], $result);
+    }
+
+    /**
+     * Test correctly detecting arrow functions.
+     *
+     * @dataProvider dataArrowFunction
+     * @covers       \PHPCSUtils\Utils\FunctionDeclarations::getArrowFunctionOpenClose
+     *
+     * @param string $testMarker    The comment which prefaces the target token in the test file.
+     * @param array  $expected      The expected return value for the respective functions.
+     * @param string $targetContent The content for the target token to look for in case there could
+     *                              be confusion.
+     * @param bool   $maybeSkip     Whether the test should be skipped on PHPCS 3.5.3 due to a broken
+     *                              upstream backfill.
+     *
+     * @return void
+     */
+    public function testGetArrowFunctionOpenClose($testMarker, $expected, $targetContent = null, $maybeSkip = false)
+    {
+        // Skip specific test(s) on unsupported PHPCS versions.
+        if ($maybeSkip === true && \version_compare(Helper::getVersion(), '3.5.3', '==') === true) {
+            $this->markTestSkipped(
+                'PHPCS 3.5.3 is not supported for this specific test due to a buggy arrow functions backfill.'
+            );
+        }
+
+        $targets = [\T_STRING];
+        if (\defined('T_FN') === true) {
+            $targets[] = \T_FN;
+        }
+
+        $stackPtr = $this->getTargetToken($testMarker, $targets, $targetContent);
+
+        // Change from offsets to absolute token positions.
+        foreach ($expected['get'] as $key => $value) {
+            if ($value === false) {
+                continue;
+            }
+
+            $expected['get'][$key] += $stackPtr;
+        }
+
+        $result = FunctionDeclarations::getArrowFunctionOpenClose(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected['get'], $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsArrowFunction()           For the array format.
+     * @see testgetArrowFunctionOpenClose() For the array format.
+     *
+     * @return array
+     */
+    public function dataArrowFunction()
+    {
+        return [
+            /*
+             * This particular case tests the "no open parenthesis after" condition in PHPCS < 3.5.3
+             * and the "fn defined but not used" condition in PHPCS 3.5.3+.
+             */
+            'const-declaration-not-an-arrow-function' => [
+                '/* testNotAnArrowFunction */',
+                [
+                    'is'  => false,
+                    'get' => [],
+                ],
+            ],
+            'arrow-function-standard' => [
+                '/* testStandard */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 3,
+                        'scope_opener'       => 5,
+                        'scope_closer'       => 12,
+                    ],
+                ],
+            ],
+            'arrow-function-mixed-case' => [
+                '/* testMixedCase */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 3,
+                        'scope_opener'       => 5,
+                        'scope_closer'       => 12,
+                    ],
+                ],
+            ],
+            'arrow-function-with-whitespace' => [
+                '/* testWhitespace */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 2,
+                        'parenthesis_closer' => 4,
+                        'scope_opener'       => 6,
+                        'scope_closer'       => 13,
+                    ],
+                ],
+            ],
+            'arrow-function-with-comment' => [
+                '/* testComment */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 4,
+                        'parenthesis_closer' => 6,
+                        'scope_opener'       => 8,
+                        'scope_closer'       => 15,
+                    ],
+                ],
+            ],
+            'real-function-called-fn' => [
+                '/* testFunctionName */',
+                [
+                    'is'  => false,
+                    'get' => [],
+                ],
+            ],
+            'arrow-function-nested-outer' => [
+                '/* testNestedOuter */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 3,
+                        'scope_opener'       => 5,
+                        'scope_closer'       => 25,
+                    ],
+                ],
+            ],
+            'arrow-function-nested-inner' => [
+                '/* testNestedInner */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 3,
+                        'scope_opener'       => 5,
+                        'scope_closer'       => 16,
+                    ],
+                ],
+            ],
+            'arrow-function-function-call' => [
+                '/* testFunctionCall */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 3,
+                        'scope_opener'       => 5,
+                        'scope_closer'       => 17,
+                    ],
+                ],
+            ],
+            'arrow-function-chained-function-call' => [
+                '/* testChainedFunctionCall */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 3,
+                        'scope_opener'       => 5,
+                        'scope_closer'       => 12,
+                    ],
+                ],
+                'fn',
+            ],
+            'arrow-function-as-function-argument' => [
+                '/* testFunctionArgument */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 6,
+                        'scope_opener'       => 8,
+                        'scope_closer'       => 15,
+                    ],
+                ],
+            ],
+            'arrow-function-nested-closure' => [
+                '/* testClosure */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 3,
+                        'scope_opener'       => 5,
+                        'scope_closer'       => 60,
+                    ],
+                ],
+            ],
+            'arrow-function-with-return-type-nullable-int' => [
+                '/* testReturnTypeNullableInt */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 5,
+                        'scope_opener'       => 12,
+                        'scope_closer'       => 19,
+                    ],
+                ],
+            ],
+            'arrow-function-with-return-type-nullable-namespaced-class' => [
+                '/* testReturnTypeNamespacedClass */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 3,
+                        'scope_opener'       => 15,
+                        'scope_closer'       => 18,
+                    ],
+                ],
+            ],
+            'arrow-function-with-return-type-array' => [
+                '/* testReturnTypeArray */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 3,
+                        'scope_opener'       => 9,
+                        'scope_closer'       => 12,
+                    ],
+                ],
+            ],
+            'arrow-function-with-return-type-array-bug-2773' => [
+                '/* testReturnTypeArrayBug2773 */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 2,
+                        'scope_opener'       => 7,
+                        'scope_closer'       => 18,
+                    ],
+                ],
+                null,
+                true,
+            ],
+            'arrow-function-with-array-param-and-return-type' => [
+                '/* testMoreArrayTypeDeclarations */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 2,
+                        'parenthesis_closer' => 6,
+                        'scope_opener'       => 11,
+                        'scope_closer'       => 17,
+                    ],
+                ],
+                null,
+                true,
+            ],
+            'arrow-function-with-return-type-callable' => [
+                '/* testReturnTypeCallable */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 3,
+                        'scope_opener'       => 9,
+                        'scope_closer'       => 12,
+                    ],
+                ],
+            ],
+            'arrow-function-with-return-type-nullable-self' => [
+                '/* testReturnTypeSelf */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 3,
+                        'scope_opener'       => 10,
+                        'scope_closer'       => 13,
+                    ],
+                ],
+            ],
+            'arrow-function-with-reference' => [
+                '/* testReference */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 2,
+                        'parenthesis_closer' => 4,
+                        'scope_opener'       => 6,
+                        'scope_closer'       => 9,
+                    ],
+                ],
+            ],
+            'arrow-function-within-parenthesis' => [
+                '/* testGrouped */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 3,
+                        'scope_opener'       => 5,
+                        'scope_closer'       => 8,
+                    ],
+                ],
+            ],
+            'arrow-function-with-yield-in-value' => [
+                '/* testYield */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 3,
+                        'scope_opener'       => 5,
+                        'scope_closer'       => 14,
+                    ],
+                ],
+            ],
+            'arrow-function-with-ternary-content' => [
+                '/* testTernary */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 3,
+                        'scope_opener'       => 5,
+                        'scope_closer'       => 40,
+                    ],
+                ],
+            ],
+            'arrow-function-with-ternary-content-after-then' => [
+                '/* testTernaryThen */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 2,
+                        'scope_opener'       => 8,
+                        'scope_closer'       => 12,
+                    ],
+                ],
+            ],
+            'arrow-function-with-ternary-content-after-else' => [
+                '/* testTernaryElse */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 2,
+                        'scope_opener'       => 8,
+                        'scope_closer'       => 11,
+                    ],
+                ],
+            ],
+
+            'live-coding' => [
+                '/* testLiveCoding */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => false,
+                        'parenthesis_closer' => false,
+                        'scope_opener'       => false,
+                        'scope_closer'       => false,
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/Parentheses/ParenthesesTest.inc
+++ b/Tests/Utils/Parentheses/ParenthesesTest.inc
@@ -38,6 +38,12 @@ $anonClass = new class(
 /* testListOnCloseParens */
 list($a, $b) = $array;
 
+/* testArrayFunctionCallWithArrowFunctionParam */
+$value = array(ClassName::functionCall('Text', fn($param) => $param->get()));
+
+/* testFunctionNamedFn */
+function fn() {}
+
 /* testNoOwnerOnCloseParens */
 $a = ($b + $c);
 

--- a/Tests/Utils/PassedParameters/GetParametersTest.inc
+++ b/Tests/Utils/PassedParameters/GetParametersTest.inc
@@ -96,6 +96,13 @@ $array = [
     },
 ];
 
+/* testLongArrayArrowFunctionWithYield */
+$array = array(
+          1 => '1',
+          2 => fn ($x) => yield 'a' => $x,
+          3 => '3',
+         );
+
 /* testVariableFunctionCall */
 $closure($a, (1 + 20), $a & $b );
 

--- a/Tests/Utils/PassedParameters/GetParametersTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersTest.php
@@ -411,6 +411,29 @@ class GetParametersTest extends UtilityMethodTestCase
                 ],
             ],
 
+            // Array arrow function and yield.
+            'long-array-nested-arrow-function-with-yield' => [
+                '/* testLongArrayArrowFunctionWithYield */',
+                \T_ARRAY,
+                [
+                    1 => [
+                        'start' => 2,
+                        'end'   => 8,
+                        'raw'   => '1 => \'1\'',
+                    ],
+                    2 => [
+                        'start' => 10,
+                        'end'   => 30,
+                        'raw'   => '2 => fn ($x) => yield \'a\' => $x',
+                    ],
+                    3 => [
+                        'start' => 32,
+                        'end'   => 38,
+                        'raw'   => '3 => \'3\'',
+                    ],
+                ],
+            ],
+
             // Function calling closure in variable.
             'variable-function-call' => [
                 '/* testVariableFunctionCall */',


### PR DESCRIPTION
This adds support for the PHP 7.4 arrow functions to all relevant utility methods, including back-porting support down to PHPCS 2.6.0 (in as far as possible without the `T_FN` token existing).

These changes are in line with the support for arrow functions as added in PHPCS itself in PHPCS 3.5.3 and 3.5.4.

Also see: squizlabs/PHP_CodeSniffer#2523

To aid both the utility methods in PHPCSUtils as well as sniffs in external standards, two new methods are being introduced:
* `FunctionDeclarations::isArrowFunction()`
* `FunctionDeclarations::getArrowFunctionOpenClose()`

More about both can be found in the below commit summary.

Fixes #3

## Commit summary

### Tokens\Collections: add `T_ARRAY` to $returnTypeTokens

PHPCS does not adjust the return type token for arrow functions to `T_STRING` until PHPCS 3.5.3/4.
Depening on the PHPCS version and the specific code, an `array` return type token for an arrow function may be tokenized as `T_ARRAY_HINT` or `T_ARRAY`.

### Utils\FunctionDeclarations: new arrow function helper utilities

This introduces two new utilities to allow for detecting and analyzing PHP 7.4 arrow functions.

The arrow function tokens - the PHP native `T_FN` and the PHPCS native `T_FN_ARROW` - where backfilled/introduced in PHPCS 3.5.3/4, including assigning parentheses owner/opener/closer and scope owner/opener/closer tokens to the relevant related tokens.

The utility functions in this commit back-fills this functionality for use with older PHPCS versions.

**Note**: this does mean that sniffs which target functions, will need to add both the `T_FN`, as well as the `T_STRING` token to their `register()` method and need to pass any `T_STRING` tokens onto these utility functions before processing the token.

Functions:
* `isArrowFunction()` to detect whether an arbitrary (`T_FN`/`T_STRING`) token is in actual fact an arrow function keyword.
* `getArrowFunctionOpenClose()` to retrieve the token pointers to the open parenthesis, close parenthesis, scope opener and scope closer for arrow functions.

Generally speaking, a sniff should only need to call one of these functions depending on what information is needed.

Includes dedicated unit tests.

The tests are loosely based on the `Tokenizer/BackfillFnTokenTest` file in PHPCS itself.

Note: in a limited set of very specific circumstances, the backfill in PHPCS 3.5.3 is broken.
While the `isArrowFunction()` will still give correct results in that case, the `getArrowFunctionOpenClose()` function will not.
As PHPCS 3.5.3 is explicitly not supported by PHPCSUtils due to the broken backfill of PHP 7.4 numeric literals, no fixes will be added to work-around the broken backfill for arrow functions in PHPCS 3.5.3.

Related ticket in PHPCS itself:
* squizlabs/PHP_CodeSniffer#2523

Related commits in PHPCS itself:
* squizlabs/PHP_CodeSniffer@8fedf8c
* squizlabs/PHP_CodeSniffer@51afb54
* squizlabs/PHP_CodeSniffer@ae3ffc7
* squizlabs/PHP_CodeSniffer@0b498ad
* squizlabs/PHP_CodeSniffer@30b5457
* squizlabs/PHP_CodeSniffer@0e4fe74

### BCFile/Operators::isReference(): allow for arrow functions returning by reference

... for backwards compatibility to the `BCFile::isReference()` and the sister-method `Operators::isReference()` as per upstream commit squizlabs/PHP_CodeSniffer@96e69bb which was included in PHPCS 3.5.3.

### BCFile/Operators::isReference(): fix backward compatibility with PHPCS < 3.5.3

### BCFile/FunctionDeclarations::get[Method]Parameters(): add support for arrow functions

Add support for arrow functions to the `BCFile::getMethodParameters()` and the sister-method `FunctionDeclarations::getParameters()` as per upstream commit squizlabs/PHP_CodeSniffer@b74e813 which was included in PHPCS 3.5.3.

### BCFile/FunctionDeclarations::get[Method]Parameters(): fix backward compatibility with PHPCS < 3.5.3

* Use the `FunctionDeclarations::isArrowFunction()` utility to determine whether a token is an arrow function, rather than relying on the existence of a token which wasn't backfilled until PHPCS 3.5.3.
* Stabilize the unit test for when the `T_FN` token is not yet backfilled.
* Add a unit test covering all supported parameter types.
* Add a unit test covering arrow functions returning by reference.
* Add a unit test for handling of live coding/parse errors.

### BCFile/FunctionDeclarations::get[Method]Properties(): add support for arrow functions

Add support for arrow functions to the `BCFile::getMethodProperties()` and the sister-method `FunctionDeclarations::getProperties()` as per upstream commit squizlabs/PHP_CodeSniffer@c8fca56 which was included in PHPCS 3.5.3.

### BCFile/FunctionDeclarations::get[Method]Properties(): fix backward compatibility with PHPCS < 3.5.3

* Use the `FunctionDeclarations::getArrowFunctionOpenClose()` utility to determine whether a token is an arrow function and what the relevant opener/closer tokens are, rather than relying on the existence of a token which wasn't backfilled until PHPCS 3.5.3/4.
* Stabilize the unit test for when the `T_FN` token is not yet backfilled.
* Add a unit test covering arrow functions returning by reference.
* Add a unit test for upstream issue squizlabs/PHP_CodeSniffer#2773.
    This particular test will be skipped on PHPCS 3.5.3 as it won't pass due to the incomplete backfill in PHPCS 3.5.3.
    As PHPCS 3.5.3 is not supported by PHPCSUtils, this will not be fixed.
* Add a unit test for handling of live coding/parse errors.
* Add toggle for the double arrow token to use depending on the PHPCS version as per upstream commit squizlabs/PHP_CodeSniffer@bbd6f63.

### FunctionDeclaration::getProperties(): document bug fix - 'has_body' = `false` for unfinished arrow functions

The `fn` for a potential arrow function will be tokenized as `T_FN`, even when there are no parenthesis and there is no function body, like during live coding or in case of a parse error.

In that case, IMO, the `has_body` index key should be set to `false`.

This is in line with the behaviour of the `FunctionDeclaration::getProperties()` function for other function constructs (and in contrast to the behaviour of the `BCFile::getMethodProperties()` function).

Also see: 1983715

### BCFile::getDeclarationName(): allow functions to be called "fn"

... for backwards compatibility.

As per upstream commit squizlabs/PHP_CodeSniffer@37dda44 which was included in PHPCS 3.5.3.

Includes new unit test.

### BCFile::getDeclarationName(): fix backward compatibility with PHPCS < 3.5.3

### BCFile::findEndOfStatement(): add support for arrow functions

* Add support for arrow functions to the `BCFile::findEndOfStatement()`  method as per upstream commit squizlabs/PHP_CodeSniffer@bf642b2 which was included in PHPCS 3.5.3.
* Improve support for arrow functions in the `BCFile::findEndOfStatement()`  method as per upstream commit squizlabs/PHP_CodeSniffer@1be4196 which  was included in PHPCS 3.5.4.
* Add additional unit test as per upstream commit squizlabs/PHP_CodeSniffer@30b5457 which was included in PHPCS 3.5.4.


### BCFile::findEndOfStatement(): fix backward compatibility with PHPCS < 3.5.3/3.5.4

### BCFile::findStartOfStatement(): add support for arrow functions

* Add support for arrow functions to the `BCFile::findStartOfStatement()`  method as per upstream commit squizlabs/PHP_CodeSniffer@fbf67ef which will be included in PHPCS 3.5.5.

Also see: squizlabs/PHP_CodeSniffer#2523 and squizlabs/PHP_CodeSniffer#2849

Includes adding an initial unit test file for the `BCFile::findStartOfStatement()`  method which was, so far, untested.
The initial unit test only (intentionally) covers the current change.

### Arrays::getDoubleArrowPtr(): handle arrow functions

In PHPCS 3.5.3+, the double arrow for arrow functions is tokenized as `T_FN_ARROW` and will not confuse this utility method anymore.

However, for PHPCS < 3.5.3 in combination with PHP 7.4, the `fn` keyword will be tokenized as `T_FN`, however, the double arrow will still tokenize as `T_DOUBLE_ARROW`.
And for PHPCS < 3.5.3 in combination with PHP 7.4, the `fn` keyword will be tokenized as `T_STRING` and the double arrow will tokenize as `T_DOUBLE_ARROW`.

Both of these would cause incorrect results for this function.

As far as I can see, arrow functions are not usable in an array key, so basically, we know that there will be no (array) arrow as soon as we encounter a `T_FN` token of a `T_STRING` token which is an arrow function.

Includes unit tests.

Related: squizlabs/PHP_CodeSniffer#2703

### PassedParameters: add unit test with arrow function

### Parentheses::getOwner()/isOwnerIn(): add support for arrow functions

Allow for the `PHPCSUtils\Utils\Parentheses::getOwner()` and `PHPCSUtils\Utils\Parentheses::isOwnerIn()` methods to recognize arrow functions as parentheses owners in PHP < 7.4 and PHPCS < 3.5.3/4.

Includes unit tests.