### PR TITLE
Improve support for arrow functions / sync with phpcs 3.5.5

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1332,7 +1332,7 @@ class BCFile
                 if ($end !== false) {
                     $i = $end;
                 }
-            } elseif ($tokens[$i]['code'] === T_STRING || $tokens[$i]['type'] === 'T_FN') {
+            } elseif (isset(Collections::arrowFunctionTokensBC()[$tokens[$i]['code']]) === true) {
                 // Potentially a PHP 7.4 arrow function in combination with PHP < 7.4 or PHPCS < 3.5.3/3.5.4.
                 $arrowFunctionOpenClose = FunctionDeclarations::getArrowFunctionOpenClose($phpcsFile, $i);
                 if ($arrowFunctionOpenClose !== []

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -159,6 +159,7 @@ class BCFile
         $content = null;
         for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
             if ($tokens[$i]['code'] === T_STRING
+                // BC: PHPCS 3.5.3/3.5.4.
                 || $tokens[$i]['type'] === 'T_FN'
             ) {
                 /*

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -63,6 +63,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  *   array return type declarations.
  * - Typed properties were not recognized prior to PHPCS 3.5.0, including the
  *   `?` nullability token not being converted to `T_NULLABLE`.
+ * - Arrow functions were not recognized properly until PHPCS 3.5.3.
  * - General PHP cross-version incompatibilities.
  *
  * Most functions in this class will have a related twin-function in the relevant
@@ -98,6 +99,8 @@ class BCFile
      *                `\PHP_CodeSniffer\Exceptions\RuntimeException`.
      * - PHPCS 3.5.3: Allow for functions to be called `fn` for backwards compatibility.
      *                Related to PHP 7.4 T_FN arrow functions.
+     * - PHPCS 3.5.5: Remove arrow function work-around which is no longer needed due to
+     *                a change in the tokenization of arrow functions.
      *
      * Note: For ES6 classes in combination with PHPCS 2.x, passing a `T_STRING` token to
      *       this method will be accepted for JS files.
@@ -266,12 +269,13 @@ class BCFile
      */
     public static function getMethodParameters(File $phpcsFile, $stackPtr)
     {
-        $tokens = $phpcsFile->getTokens();
+        $tokens         = $phpcsFile->getTokens();
+        $arrowOpenClose = FunctionDeclarations::getArrowFunctionOpenClose($phpcsFile, $stackPtr);
 
         if ($tokens[$stackPtr]['code'] !== T_FUNCTION
             && $tokens[$stackPtr]['code'] !== T_CLOSURE
             && $tokens[$stackPtr]['code'] !== T_USE
-            && FunctionDeclarations::isArrowFunction($phpcsFile, $stackPtr) === false
+            && $arrowOpenClose === false
         ) {
             throw new RuntimeException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_USE or T_FN');
         }
@@ -281,15 +285,9 @@ class BCFile
             if ($opener === false || isset($tokens[$opener]['parenthesis_owner']) === true) {
                 throw new RuntimeException('$stackPtr was not a valid T_USE');
             }
-        } elseif ($tokens[$stackPtr]['code'] === \T_STRING || $tokens[$stackPtr]['type'] === 'T_FN') {
-            /*
-             * Arrow function in combination with PHP < 7.4 or PHPCS < 3.5.3.
-             */
-            $opener = $phpcsFile->findNext((Tokens::$emptyTokens + [\T_BITWISE_AND]), ($stackPtr + 1), null, true);
-            if ($opener === false || $tokens[$opener]['code'] !== T_OPEN_PARENTHESIS) {
-                // Live coding or syntax error, so no params to find.
-                return [];
-            }
+        } elseif ($arrowOpenClose !== false) {
+            // Arrow function in combination with PHP < 7.4 or PHPCS < 3.5.3/4/5.
+            $opener = $arrowOpenClose['parenthesis_opener'];
         } else {
             if (isset($tokens[$stackPtr]['parenthesis_opener']) === false) {
                 // Live coding or syntax error, so no params to find.
@@ -553,7 +551,7 @@ class BCFile
 
         if ($tokens[$stackPtr]['code'] !== T_FUNCTION
             && $tokens[$stackPtr]['code'] !== T_CLOSURE
-            && $arrowOpenClose === []
+            && $arrowOpenClose === false
         ) {
             throw new RuntimeException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_FN');
         }
@@ -623,7 +621,7 @@ class BCFile
         $parenthesisCloser = null;
         if (isset($tokens[$stackPtr]['parenthesis_closer']) === true) {
             $parenthesisCloser = $tokens[$stackPtr]['parenthesis_closer'];
-        } elseif ($arrowOpenClose !== [] && $arrowOpenClose['parenthesis_closer'] !== false) {
+        } elseif ($arrowOpenClose !== false) {
             // Arrow function in combination with PHP < 7.4 or PHPCS < 3.5.3.
             $parenthesisCloser = $arrowOpenClose['parenthesis_closer'];
         }
@@ -632,7 +630,7 @@ class BCFile
             $scopeOpener = null;
             if (isset($tokens[$stackPtr]['scope_opener']) === true) {
                 $scopeOpener = $tokens[$stackPtr]['scope_opener'];
-            } elseif ($arrowOpenClose !== [] && $arrowOpenClose['scope_opener'] !== false) {
+            } elseif ($arrowOpenClose !== false) {
                 // Arrow function in combination with PHP < 7.4 or PHPCS < 3.5.3.
                 $scopeOpener = $arrowOpenClose['scope_opener'];
             }
@@ -649,7 +647,7 @@ class BCFile
                     // Handle nullable tokens in PHPCS < 2.8.0.
                     || (defined('T_NULLABLE') === false && $tokens[$i]['code'] === T_INLINE_THEN)
                     // Handle nullable tokens with arrow functions in PHPCS 2.8.0 - 2.9.0.
-                    || ($arrowOpenClose !== [] && $tokens[$i]['code'] === T_INLINE_THEN
+                    || ($arrowOpenClose !== false && $tokens[$i]['code'] === T_INLINE_THEN
                         && version_compare(Helper::getVersion(), '2.9.1', '<') === true)
                 ) {
                     $nullableReturnType = true;
@@ -665,7 +663,7 @@ class BCFile
             }
 
             $bodyTokens = [T_OPEN_CURLY_BRACKET => T_OPEN_CURLY_BRACKET];
-            if ($arrowOpenClose !== []) {
+            if ($arrowOpenClose !== false) {
                 $bodyTokens = [T_DOUBLE_ARROW => T_DOUBLE_ARROW];
                 if (defined('T_FN_ARROW') === true) {
                     // PHPCS 3.5.3+.
@@ -1336,9 +1334,7 @@ class BCFile
             } elseif (isset(Collections::arrowFunctionTokensBC()[$tokens[$i]['code']]) === true) {
                 // Potentially a PHP 7.4 arrow function in combination with PHP < 7.4 or PHPCS < 3.5.3/3.5.4.
                 $arrowFunctionOpenClose = FunctionDeclarations::getArrowFunctionOpenClose($phpcsFile, $i);
-                if ($arrowFunctionOpenClose !== []
-                    && $arrowFunctionOpenClose['scope_closer'] !== false
-                ) {
+                if ($arrowFunctionOpenClose !== false) {
                     if ($i === $start) {
                         return $arrowFunctionOpenClose['scope_closer'];
                     }

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -393,4 +393,27 @@ class Collections
         \T_CONSTANT_ENCAPSED_STRING => \T_CONSTANT_ENCAPSED_STRING,
         \T_DOUBLE_QUOTED_STRING     => \T_DOUBLE_QUOTED_STRING,
     ];
+
+    /**
+     * Tokens which can represent the arrow function keyword.
+     *
+     * Note: this is a method, not a property as the `T_FN` token may not exist.
+     *
+     * @since 1.0.0
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function arrowFunctionTokensBC()
+    {
+        $tokens = [
+            \T_STRING => \T_STRING,
+        ];
+
+        if (\defined('T_FN') === true) {
+            // PHP 7.4 or PHPCS 3.5.3+.
+            $tokens[\T_FN] = \T_FN;
+        }
+
+        return $tokens;
+    }
 }

--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -263,10 +263,8 @@ class Arrays
             );
         }
 
-        $targets = self::$doubleArrowTargets + Collections::$closedScopes;
-        if (\defined('T_FN') === true) {
-            $targets[\T_FN] = \T_FN;
-        }
+        $targets  = self::$doubleArrowTargets + Collections::$closedScopes;
+        $targets += Collections::arrowFunctionTokensBC();
 
         $doubleArrow = ($start - 1);
         ++$end;

--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -292,7 +292,7 @@ class Arrays
             }
 
             // BC for PHP 7.4 arrow functions with PHPCS < 3.5.3.
-            if ($tokens[$doubleArrow]['code'] === \T_STRING
+            if (isset(Collections::arrowFunctionTokensBC()[$tokens[$doubleArrow]['code']]) === true
                 && FunctionDeclarations::isArrowFunction($phpcsFile, $doubleArrow) === false
             ) {
                 // Not an arrow function, continue looking.

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -395,7 +395,7 @@ class FunctionDeclarations
             ) {
                 throw new RuntimeException('$stackPtr was not a valid closure T_USE');
             }
-        } elseif ($tokens[$stackPtr]['code'] === \T_STRING || $tokens[$stackPtr]['type'] === 'T_FN') {
+        } elseif (isset(Collections::arrowFunctionTokensBC()[$tokens[$stackPtr]['code']]) === true) {
             /*
              * Arrow function in combination with PHP < 7.4 or PHPCS < 3.5.3.
              */

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -112,6 +112,25 @@ class FunctionDeclarations
     ];
 
     /**
+     * Tokens which can be the end token of an arrow function.
+     *
+     * @since 1.0.0
+     *
+     * @var array <int|string> => <true>
+     */
+    private static $arrowFunctionEndTokens = [
+        \T_COLON                => true,
+        \T_COMMA                => true,
+        \T_SEMICOLON            => true,
+        \T_CLOSE_PARENTHESIS    => true,
+        \T_CLOSE_SQUARE_BRACKET => true,
+        \T_CLOSE_CURLY_BRACKET  => true,
+        \T_CLOSE_SHORT_ARRAY    => true,
+        \T_OPEN_TAG             => true,
+        \T_CLOSE_TAG            => true,
+    ];
+
+    /**
      * Returns the declaration name for a function.
      *
      * Alias for the {@see \PHPCSUtils\Utils\ObjectDeclarations::getName()} method.
@@ -751,23 +770,10 @@ class FunctionDeclarations
         }
 
         $returnValue['scope_opener'] = $arrow;
-
-        $endTokens = [
-            \T_COLON                => true,
-            \T_COMMA                => true,
-            \T_SEMICOLON            => true,
-            \T_CLOSE_PARENTHESIS    => true,
-            \T_CLOSE_SQUARE_BRACKET => true,
-            \T_CLOSE_CURLY_BRACKET  => true,
-            \T_CLOSE_SHORT_ARRAY    => true,
-            \T_OPEN_TAG             => true,
-            \T_CLOSE_TAG            => true,
-        ];
-
-        $inTernary = false;
+        $inTernary                   = false;
 
         for ($scopeCloser = ($arrow + 1); $scopeCloser < $phpcsFile->numTokens; $scopeCloser++) {
-            if (isset($endTokens[$tokens[$scopeCloser]['code']]) === true
+            if (isset(self::$arrowFunctionEndTokens[$tokens[$scopeCloser]['code']]) === true
                 && ($tokens[$scopeCloser]['code'] !== \T_COLON || $inTernary === false)
             ) {
                 break;

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -586,19 +586,21 @@ class FunctionDeclarations
     }
 
     /**
-     * Check if an arbitrary token is a PHP 7.4 arrow function keyword token.
+     * Check if an arbitrary token is the "fn" keyword for a PHP 7.4 arrow function.
      *
-     * Helper function for backward-compatibility with PHP < 7.4 in combination with PHPCS < 3.5.3/4
-     * in which the `T_FN` token is not yet backfilled.
+     * Helper function for cross-version compatibility with both PHP as well as PHPCS.
+     * - PHP 7.4+ will tokenize most tokens with the content "fn" as T_FN, even when it isn't an arrow function.
+     * - PHPCS < 3.5.3 will tokenize arrow functions keywords as T_STRING.
+     * - PHPCS 3.5.3/3.5.4 will tokenize the keyword differently depending on which PHP version is used
+     *   and similar to PHP will tokenize most tokens with the content "fn" as T_FN, even when it's not an
+     *   arrow function.
+     *   Note: the tokens tokenized by PHPCS 3.5.3 - 3.5.4 as T_FN are not 100% the same as those tokenized
+     *   by PHP 7.4+ as T_FN.
      *
-     * Note: While this function can determine whether a token should be regarded as `T_FN`, if the
-     * token isn't a PHP native `T_FN` or backfilled `T_FN` token, the token will still not have
-     * the `parenthesis_owner`, `parenthesis_opener`, `parenthesis_closer`, `scope_owner`
-     * `scope_opener` or `scope_closer` keys assigned in the tokens array.
-     * Use the `FunctionDeclarations::getArrowFunctionOpenClose()` utility method to retrieve
-     * these when they're needed.
+     * Either way, the T_FN token is not a reliable indicator that something is in actual fact an arrow function.
+     * This function solves that and will give reliable results in the same way as this is now solved in PHPCS 3.5.5.
      *
-     * @see \PHPCSUtils\Utils\FunctionDeclarations::getArrowFunctionOpenClose()
+     * @see \PHPCSUtils\Utils\FunctionDeclarations::getArrowFunctionOpenClose() Related function.
      *
      * @since 1.0.0
      *
@@ -607,7 +609,8 @@ class FunctionDeclarations
      *                                               T_STRING token as those are the only two
      *                                               tokens which can be the arrow function keyword.
      *
-     * @return bool
+     * @return bool TRUE is the token is the "fn" keyword for an arrow function. FALSE when not or
+     *              in case of live coding/parse error.
      */
     public static function isArrowFunction(File $phpcsFile, $stackPtr)
     {
@@ -616,39 +619,20 @@ class FunctionDeclarations
             return false;
         }
 
-        if ($tokens[$stackPtr]['type'] === 'T_FN') {
-            // Either PHP 7.4 or PHPCS 3.5.3+. Check if this is not a real function called "fn".
-            $prevNonEmpty = $phpcsFile->findPrevious(
-                Tokens::$emptyTokens + [\T_BITWISE_AND],
-                ($stackPtr - 1),
-                null,
-                true
-            );
-            if ($tokens[$prevNonEmpty]['code'] === \T_FUNCTION) {
-                return false;
-            }
-
+        if ($tokens[$stackPtr]['type'] === 'T_FN'
+            && isset($tokens[$stackPtr]['scope_closer']) === true
+        ) {
             return true;
         }
 
-        if (\defined('T_FN') === true) {
-            // If the token exists and isn't used, it's not an arrow function.
-            return false;
-        }
-
-        if ($tokens[$stackPtr]['code'] !== \T_STRING
+        if (isset(Collections::arrowFunctionTokensBC()[$tokens[$stackPtr]['code']]) === false
             || \strtolower($tokens[$stackPtr]['content']) !== 'fn'
         ) {
             return false;
         }
 
-        $nextNonEmpty = $phpcsFile->findNext((Tokens::$emptyTokens + [\T_BITWISE_AND]), ($stackPtr + 1), null, true);
-        if ($nextNonEmpty === false
-            || ($tokens[$nextNonEmpty]['code'] === \T_OPEN_PARENTHESIS
-            // Make sure it is not a real function called "fn".
-            && (isset($tokens[$nextNonEmpty]['parenthesis_owner']) === false
-            || $tokens[$tokens[$nextNonEmpty]['parenthesis_owner']]['code'] !== \T_FUNCTION))
-        ) {
+        $openClose = self::getArrowFunctionOpenClose($phpcsFile, $stackPtr);
+        if ($openClose !== false && isset($openClose['scope_closer'])) {
             return true;
         }
 
@@ -659,76 +643,62 @@ class FunctionDeclarations
      * Retrieve the parenthesis opener, parenthesis closer, the scope opener and the scope closer
      * for an arrow function.
      *
-     * Helper function for backward-compatibility with PHP < 7.4 in combination with PHPCS < 3.5.3/4
-     * in which the `T_FN` token is not yet backfilled and does not have parenthesis opener/closer
-     * nor scope opener/closer indexes assigned in the `$tokens` array.
+     * Helper function for cross-version compatibility with both PHP as well as PHPCS.
+     * In PHPCS versions prior to PHPCS 3.5.3/3.5.4, the `T_FN` token is not yet backfilled
+     * and does not have parenthesis opener/closer nor scope opener/closer indexes assigned
+     * in the `$tokens` array.
      *
-     * Note: The backfill in PHPCS 3.5.3 is incomplete and this function will - in a limited set of
-     * circumstances - not work on PHPCS 3.5.3.
-     * As PHPCS 3.5.3 is not supported by PHPCSUtils due to the broken PHP 7.4 numeric literals backfill
-     * anyway, this will not be fixed.
-     *
-     * @see \PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction()
+     * @see \PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction() Related function.
      *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
-     * @param int                         $stackPtr  The token to retrieve the opener/closers for.
+     * @param int                         $stackPtr  The token to retrieve the openers/closers for.
      *                                               Typically a T_FN or T_STRING token as those are the
      *                                               only two tokens which can be the arrow function keyword.
      *
-     * @return array An array with the token pointers or an empty array if this is not an arrow function.
-     *               The format of the return value is:
-     *               <code>
-     *               array(
-     *                 'parenthesis_opener' => integer|false, // Stack pointer or false if undetermined.
-     *                 'parenthesis_closer' => integer|false, // Stack pointer or false if undetermined.
-     *                 'scope_opener'       => integer|false, // Stack pointer or false if undetermined.
-     *                 'scope_closer'       => integer|false, // Stack pointer or false if undetermined.
-     *               )
-     *               </code>
+     * @return array|false An array with the token pointers or FALSE if this is not an arrow function.
+     *                     The format of the return value is:
+     *                     <code>
+     *                     array(
+     *                       'parenthesis_opener' => integer, // Stack pointer to the parenthesis opener.
+     *                       'parenthesis_closer' => integer, // Stack pointer to the parenthesis closer.
+     *                       'scope_opener'       => integer, // Stack pointer to the scope opener (arrow).
+     *                       'scope_closer'       => integer, // Stack pointer to the scope closer.
+     *                     )
+     *                     </code>
      */
     public static function getArrowFunctionOpenClose(File $phpcsFile, $stackPtr)
     {
-        if (self::isArrowFunction($phpcsFile, $stackPtr) === false) {
-            return [];
-        }
-
-        $returnValue = [
-            'parenthesis_opener' => false,
-            'parenthesis_closer' => false,
-            'scope_opener'       => false,
-            'scope_closer'       => false,
-        ];
-
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[$stackPtr]['type'] === 'T_FN'
-            && \version_compare(Helper::getVersion(), '3.5.3', '>=') === true
+        if (isset($tokens[$stackPtr]) === false
+            || isset(Collections::arrowFunctionTokensBC()[$tokens[$stackPtr]['code']]) === false
+            || \strtolower($tokens[$stackPtr]['content']) !== 'fn'
         ) {
-            if (isset($tokens[$stackPtr]['parenthesis_opener']) === true) {
-                $returnValue['parenthesis_opener'] = $tokens[$stackPtr]['parenthesis_opener'];
-            }
+            return false;
+        }
 
-            if (isset($tokens[$stackPtr]['parenthesis_closer']) === true) {
-                $returnValue['parenthesis_closer'] = $tokens[$stackPtr]['parenthesis_closer'];
-            }
-
-            if (isset($tokens[$stackPtr]['scope_opener']) === true) {
-                $returnValue['scope_opener'] = $tokens[$stackPtr]['scope_opener'];
-            }
-
-            if (isset($tokens[$stackPtr]['scope_closer']) === true) {
-                $returnValue['scope_closer'] = $tokens[$stackPtr]['scope_closer'];
-            }
-
-            return $returnValue;
+        if ($tokens[$stackPtr]['type'] === 'T_FN'
+            && isset($tokens[$stackPtr]['scope_closer']) === true
+        ) {
+            // The keys will either all be set or none will be set, so no additional checks needed.
+            return [
+                'parenthesis_opener' => $tokens[$stackPtr]['parenthesis_opener'],
+                'parenthesis_closer' => $tokens[$stackPtr]['parenthesis_closer'],
+                'scope_opener'       => $tokens[$stackPtr]['scope_opener'],
+                'scope_closer'       => $tokens[$stackPtr]['scope_closer'],
+            ];
         }
 
         /*
-         * Either a T_STRING token pre-PHP 7.4, or T_FN on PHP 7.4, in combination with PHPCS < 3.5.3.
+         * This is either a T_STRING token pre-PHP 7.4, or T_FN on PHP 7.4 in combination
+         * with PHPCS < 3.5.3/4/5.
+         *
          * Now see about finding the relevant arrow function tokens.
          */
+        $returnValue = [];
+
         $nextNonEmpty = $phpcsFile->findNext(
             (Tokens::$emptyTokens + [\T_BITWISE_AND]),
             ($stackPtr + 1),
@@ -736,12 +706,12 @@ class FunctionDeclarations
             true
         );
         if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== \T_OPEN_PARENTHESIS) {
-            return $returnValue;
+            return false;
         }
 
         $returnValue['parenthesis_opener'] = $nextNonEmpty;
         if (isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false) {
-            return $returnValue;
+            return false;
         }
 
         $returnValue['parenthesis_closer'] = $tokens[$nextNonEmpty]['parenthesis_closer'];
@@ -749,8 +719,8 @@ class FunctionDeclarations
         $ignore                 = Tokens::$emptyTokens;
         $ignore                += Collections::$returnTypeTokens;
         $ignore[\T_COLON]       = \T_COLON;
-        $ignore[\T_INLINE_ELSE] = \T_INLINE_ELSE; // PHPCS < 2.9.1.
-        $ignore[\T_INLINE_THEN] = \T_INLINE_THEN; // PHPCS < 2.9.1.
+        $ignore[\T_INLINE_ELSE] = \T_INLINE_ELSE; // Return type colon on PHPCS < 2.9.1.
+        $ignore[\T_INLINE_THEN] = \T_INLINE_THEN; // Nullable type indicator on PHPCS < 2.9.1.
 
         if (\defined('T_NULLABLE') === true) {
             $ignore[\T_NULLABLE] = \T_NULLABLE;
@@ -764,9 +734,9 @@ class FunctionDeclarations
         );
 
         if ($arrow === false
-            || $tokens[$arrow]['code'] !== \T_DOUBLE_ARROW
+            || ($tokens[$arrow]['code'] !== \T_DOUBLE_ARROW && $tokens[$arrow]['type'] !== 'T_FN_ARROW')
         ) {
-            return $returnValue;
+            return false;
         }
 
         $returnValue['scope_opener'] = $arrow;
@@ -774,17 +744,15 @@ class FunctionDeclarations
 
         for ($scopeCloser = ($arrow + 1); $scopeCloser < $phpcsFile->numTokens; $scopeCloser++) {
             if (isset(self::$arrowFunctionEndTokens[$tokens[$scopeCloser]['code']]) === true
+                // BC for misidentified ternary else in some PHPCS versions.
                 && ($tokens[$scopeCloser]['code'] !== \T_COLON || $inTernary === false)
             ) {
                 break;
             }
 
-            if ($tokens[$scopeCloser]['type'] === 'T_FN'
-                || ($tokens[$scopeCloser]['code'] === \T_STRING
-                && $tokens[$scopeCloser]['content'] === 'fn')
-            ) {
+            if (isset(Collections::arrowFunctionTokensBC()[$tokens[$scopeCloser]['code']]) === true) {
                 $nested = self::getArrowFunctionOpenClose($phpcsFile, $scopeCloser);
-                if (isset($nested['scope_closer']) && $nested['scope_closer'] !== false) {
+                if ($nested !== false && isset($nested['scope_closer'])) {
                     // We minus 1 here in case the closer can be shared with us.
                     $scopeCloser = ($nested['scope_closer'] - 1);
                     continue;
@@ -823,9 +791,11 @@ class FunctionDeclarations
             }
         }
 
-        if ($scopeCloser !== $phpcsFile->numTokens) {
-            $returnValue['scope_closer'] = $scopeCloser;
+        if ($scopeCloser === $phpcsFile->numTokens) {
+            return false;
         }
+
+        $returnValue['scope_closer'] = $scopeCloser;
 
         return $returnValue;
     }

--- a/PHPCSUtils/Utils/Parentheses.php
+++ b/PHPCSUtils/Utils/Parentheses.php
@@ -48,7 +48,7 @@ class Parentheses
 
         /*
          * `T_LIST` and `T_ANON_CLASS` only became parentheses owners in PHPCS 3.5.0.
-         * `T_FN` was only backfilled in PHPCS 3.5.3/4.
+         * `T_FN` was only backfilled in PHPCS 3.5.3/4/5.
          * - On PHP 7.4 with PHPCS < 3.5.3, T_FN will not yet be a parentheses owner.
          * - On PHP < 7.4 with PHPCS < 3.5.3, T_FN will be tokenized as T_STRING and not yet be a parentheses owner.
          *

--- a/PHPCSUtils/Utils/Parentheses.php
+++ b/PHPCSUtils/Utils/Parentheses.php
@@ -13,6 +13,7 @@ namespace PHPCSUtils\Utils;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
 
 /**
@@ -123,7 +124,7 @@ class Parentheses
          * Allow for T_FN token being tokenized as T_STRING before PHPCS 3.5.3.
          */
         if (\defined('T_FN') && \in_array(\T_FN, $validOwners, true)) {
-            $validOwners[] = \T_STRING;
+            $validOwners += Collections::arrowFunctionTokensBC();
         }
 
         return \in_array($tokens[$owner]['code'], $validOwners, true);

--- a/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
@@ -25,7 +25,6 @@
 namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
 use PHPCSUtils\BackCompat\BCFile;
-use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 use PHPCSUtils\Tokens\Collections;
 
@@ -221,12 +220,6 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
      */
     public function testArrowFunctionReturnValue()
     {
-        // Skip this test on unsupported PHPCS version.
-        if (\version_compare(Helper::getVersion(), '3.5.3', '==') === true) {
-            $this->markTestSkipped(
-                'PHPCS 3.5.3 is not supported for this specific test due to a buggy arrow functions backfill.'
-            );
-        }
         $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testArrowFunctionReturnValue */') + 2);
         $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 

--- a/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
@@ -27,6 +27,7 @@ namespace PHPCSUtils\Tests\BackCompat\BCFile;
 use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tokens\Collections;
 
 /**
  * Tests for the \PHPCSUtils\BackCompat\BCFile::findEndOfStatement method.
@@ -202,10 +203,7 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
      */
     public function testStaticArrowFunction()
     {
-        $fnTargets = [\T_STRING];
-        if (\defined('T_FN') === true) {
-            $fnTargets[] = \T_FN;
-        }
+        $fnTargets = Collections::arrowFunctionTokensBC();
 
         $static = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testStaticArrowFunction */') + 2);
         $fn     = self::$phpcsFile->findNext($fnTargets, ($static + 1));

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
@@ -125,6 +125,9 @@ function messyDeclaration(
         & /*test*/ ... /* phpcs:ignore */ $c
 ) {}
 
+/* testFunctionCallFnPHPCS353-354 */
+$value = $obj->fn(true);
+
 /* testClosureNoParams */
 function() {}
 

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -25,6 +25,7 @@ namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
 use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tokens\Collections;
 
 /**
  * Tests for the \PHPCSUtils\BackCompat\BCFile::getMethodParameters method.
@@ -119,12 +120,9 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'ClosureUseNoParams' => ['/* testClosureUseNoParams */', T_USE],
         ];
 
-        $arrowTokenType = T_STRING;
-        if (defined('T_FN') === true) {
-            $arrowTokenType = T_FN;
-        }
+        $arrowTokenTypes = Collections::arrowFunctionTokensBC();
 
-        $data['ArrowFunctionLiveCoding'] = ['/* testArrowFunctionLiveCoding */', $arrowTokenType];
+        $data['ArrowFunctionLiveCoding'] = ['/* testArrowFunctionLiveCoding */', $arrowTokenTypes];
 
         return $data;
     }
@@ -457,11 +455,9 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'comma_token'         => false,
         ];
 
-        $arrowTokenType = T_STRING;
-        if (defined('T_FN') === true) {
-            $arrowTokenType = T_FN;
-        }
-        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenType);
+        $arrowTokenTypes = Collections::arrowFunctionTokensBC();
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenTypes);
     }
 
     /**
@@ -487,11 +483,9 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'comma_token'         => false,
         ];
 
-        $arrowTokenType = T_STRING;
-        if (defined('T_FN') === true) {
-            $arrowTokenType = T_FN;
-        }
-        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenType);
+        $arrowTokenTypes = Collections::arrowFunctionTokensBC();
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenTypes);
     }
 
     /**
@@ -1105,11 +1099,9 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'comma_token'         => false,
         ];
 
-        $arrowTokenType = T_STRING;
-        if (defined('T_FN') === true) {
-            $arrowTokenType = T_FN;
-        }
-        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenType);
+        $arrowTokenTypes = Collections::arrowFunctionTokensBC();
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenTypes);
     }
 
     /**

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -42,14 +42,44 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     /**
      * Test receiving an expected exception when a non function/use token is passed.
      *
+     * @dataProvider dataUnexpectedTokenException
+     *
+     * @param string $commentString   The comment which preceeds the test.
+     * @param array  $targetTokenType The token type to search for after $commentString.
+     *
      * @return void
      */
-    public function testUnexpectedTokenException()
+    public function testUnexpectedTokenException($commentString, $targetTokenType)
     {
         $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_USE or T_FN');
 
-        $next = $this->getTargetToken('/* testNotAFunction */', [T_INTERFACE]);
-        BCFile::getMethodParameters(self::$phpcsFile, $next);
+        $target = $this->getTargetToken($commentString, $targetTokenType);
+        BCFile::getMethodParameters(self::$phpcsFile, $target);
+    }
+
+    /**
+     * Data Provider.
+     *
+     * @see testUnexpectedTokenException() For the array format.
+     *
+     * @return array
+     */
+    public function dataUnexpectedTokenException()
+    {
+        return [
+            'interface' => [
+                '/* testNotAFunction */',
+                T_INTERFACE,
+            ],
+            'function-call-fn-phpcs-3.5.3-3.5.4' => [
+                '/* testFunctionCallFnPHPCS353-354 */',
+                Collections::arrowFunctionTokensBC(),
+            ],
+            'fn-live-coding' => [
+                '/* testArrowFunctionLiveCoding */',
+                Collections::arrowFunctionTokensBC(),
+            ],
+        ];
     }
 
     /**
@@ -114,17 +144,11 @@ class GetMethodParametersTest extends UtilityMethodTestCase
      */
     public function dataNoParams()
     {
-        $data = [
+        return [
             'FunctionNoParams'   => ['/* testFunctionNoParams */'],
             'ClosureNoParams'    => ['/* testClosureNoParams */'],
             'ClosureUseNoParams' => ['/* testClosureUseNoParams */', T_USE],
         ];
-
-        $arrowTokenTypes = Collections::arrowFunctionTokensBC();
-
-        $data['ArrowFunctionLiveCoding'] = ['/* testArrowFunctionLiveCoding */', $arrowTokenTypes];
-
-        return $data;
     }
 
     /**

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
@@ -81,6 +81,9 @@ $fn = fn(): array => [a($a, $b)];
 /* testArrowFunctionReturnByRef */
 fn&(?string $a) : ?string => $b;
 
+/* testFunctionCallFnPHPCS353-354 */
+$value = $obj->fn(true);
+
 /* testArrowFunctionLiveCoding */
 // Intentional parse error. This has to be the last test in the file.
 $fn = fn

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -23,6 +23,7 @@ namespace PHPCSUtils\Tests\BackCompat\BCFile;
 use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tokens\Collections;
 
 /**
  * Tests for the \PHPCSUtils\BackCompat\BCFile::getMethodProperties method.
@@ -398,12 +399,9 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => true,
         ];
 
-        $arrowTokenType = T_STRING;
-        if (defined('T_FN') === true) {
-            $arrowTokenType = T_FN;
-        }
+        $arrowTokenTypes = Collections::arrowFunctionTokensBC();
 
-        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenType);
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenTypes);
     }
 
     /**
@@ -459,12 +457,9 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => true,
         ];
 
-        $arrowTokenType = T_STRING;
-        if (defined('T_FN') === true) {
-            $arrowTokenType = T_FN;
-        }
+        $arrowTokenTypes = Collections::arrowFunctionTokensBC();
 
-        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenType);
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenTypes);
     }
 
     /**
@@ -486,12 +481,9 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => true,
         ];
 
-        $arrowTokenType = T_STRING;
-        if (defined('T_FN') === true) {
-            $arrowTokenType = T_FN;
-        }
+        $arrowTokenTypes = Collections::arrowFunctionTokensBC();
 
-        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenType);
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenTypes);
     }
 
     /**
@@ -513,12 +505,9 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'has_body'             => true,
         ];
 
-        $arrowTokenType = T_STRING;
-        if (defined('T_FN') === true) {
-            $arrowTokenType = T_FN;
-        }
+        $arrowTokenTypes = Collections::arrowFunctionTokensBC();
 
-        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenType);
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenTypes);
     }
 
     /**

--- a/Tests/Tokens/Collections/ArrowFunctionTokensBCTest.php
+++ b/Tests/Tokens/Collections/ArrowFunctionTokensBCTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::arrowFunctionTokensBC
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class ArrowFunctionTokensBCTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testArrowFunctionTokensBC()
+    {
+        $version  = Helper::getVersion();
+        $expected = [
+            \T_STRING => \T_STRING,
+        ];
+
+        if (\version_compare($version, '3.5.3', '>=') === true
+            || \version_compare(\PHP_VERSION_ID, '70399', '>=') === true
+        ) {
+            $expected[\T_FN] = \T_FN;
+        }
+
+        $this->assertSame($expected, Collections::ArrowFunctionTokensBC());
+    }
+}

--- a/Tests/Utils/Arrays/GetDoubleArrowPtrTest.inc
+++ b/Tests/Utils/Arrays/GetDoubleArrowPtrTest.inc
@@ -80,4 +80,7 @@ $array = [
 
     /* testTstringKeyNotFnFunction */
     CONSTANT_NAME => 'value',
+
+    /* testPropertyAccessPHPCS353-354 */
+    ($obj->fn) => 'value',
 ];

--- a/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
+++ b/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
@@ -208,6 +208,11 @@ class GetDoubleArrowPtrTest extends UtilityMethodTestCase
                 '/* testTstringKeyNotFnFunction */',
                 8,
             ],
+            // Test specifically for PHPCS 3.5.3 and 3.5.4 in which all "fn" tokens were tokenized as T_FN.
+            'test-arrow-access-to-property-named-fn-as-key-phpcs-3.5.3-3.5.4' => [
+                '/* testPropertyAccessPHPCS353-354 */',
+                12,
+            ],
         ];
     }
 }

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
@@ -35,7 +35,7 @@ class GetParametersDiffTest extends UtilityMethodTestCase
      */
     public function testNonExistentToken()
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_USE');
+        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION, T_CLOSURE or T_USE or an arrow function');
 
         FunctionDeclarations::getParameters(self::$phpcsFile, 10000);
     }

--- a/Tests/Utils/FunctionDeclarations/GetParametersTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersTest.php
@@ -50,13 +50,18 @@ class GetParametersTest extends BCFile_GetMethodParametersTest
     /**
      * Test receiving an expected exception when a non function/use token is passed.
      *
+     * @dataProvider dataUnexpectedTokenException
+     *
+     * @param string $commentString   The comment which preceeds the test.
+     * @param array  $targetTokenType The token type to search for after $commentString.
+     *
      * @return void
      */
-    public function testUnexpectedTokenException()
+    public function testUnexpectedTokenException($commentString, $targetTokenType)
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_USE or T_FN');
+        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION, T_CLOSURE or T_USE or an arrow function');
 
-        $next = $this->getTargetToken('/* testNotAFunction */', [\T_INTERFACE]);
+        $next = $this->getTargetToken($commentString, $targetTokenType);
         FunctionDeclarations::getParameters(self::$phpcsFile, $next);
     }
 

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
@@ -35,7 +35,7 @@ class GetPropertiesDiffTest extends UtilityMethodTestCase
      */
     public function testNonExistentToken()
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION or T_CLOSURE');
+        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or an arrow function');
 
         FunctionDeclarations::getProperties(self::$phpcsFile, 10000);
     }

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesTest.php
@@ -11,6 +11,7 @@
 namespace PHPCSUtils\Tests\Utils\FunctionDeclarations;
 
 use PHPCSUtils\Tests\BackCompat\BCFile\GetMethodPropertiesTest as BCFile_GetMethodPropertiesTest;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
 
 /**
@@ -79,12 +80,9 @@ class GetPropertiesTest extends BCFile_GetMethodPropertiesTest
             'has_body'             => false, // Different from original.
         ];
 
-        $arrowTokenType = \T_STRING;
-        if (\defined('T_FN') === true) {
-            $arrowTokenType = \T_FN;
-        }
+        $arrowTokenTypes = Collections::arrowFunctionTokensBC();
 
-        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenType);
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenTypes);
     }
 
     /**

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesTest.php
@@ -11,7 +11,6 @@
 namespace PHPCSUtils\Tests\Utils\FunctionDeclarations;
 
 use PHPCSUtils\Tests\BackCompat\BCFile\GetMethodPropertiesTest as BCFile_GetMethodPropertiesTest;
-use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
 
 /**
@@ -51,38 +50,19 @@ class GetPropertiesTest extends BCFile_GetMethodPropertiesTest
     /**
      * Test receiving an expected exception when a non function token is passed.
      *
-     * @return void
-     */
-    public function testNotAFunctionException()
-    {
-        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_FN');
-
-        $next = $this->getTargetToken('/* testNotAFunction */', \T_RETURN);
-        FunctionDeclarations::getProperties(self::$phpcsFile, $next);
-    }
-
-    /**
-     * Test a arrow function live coding/parse error.
+     * @dataProvider dataNotAFunctionException
+     *
+     * @param string $commentString   The comment which preceeds the test.
+     * @param array  $targetTokenType The token type to search for after $commentString.
      *
      * @return void
      */
-    public function testArrowFunctionLiveCoding()
+    public function testNotAFunctionException($commentString, $targetTokenType)
     {
-        $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '',
-            'return_type_token'    => false,
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => false, // Different from original.
-        ];
+        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or an arrow function');
 
-        $arrowTokenTypes = Collections::arrowFunctionTokensBC();
-
-        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected, $arrowTokenTypes);
+        $next = $this->getTargetToken($commentString, $targetTokenType);
+        FunctionDeclarations::getProperties(self::$phpcsFile, $next);
     }
 
     /**

--- a/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.inc
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.inc
@@ -3,9 +3,6 @@
 /* testNotTheRightContent */
 function_call();
 
-/* testNotAnArrowFunction */
-const FN = true;
-
 /* testStandard */
 $fn1 = fn($x) => $x + $y;
 
@@ -47,11 +44,37 @@ $result = array_map(
     $numbers
 );
 
+/* testReference */
+fn&($x) => $x;
+
+/* testGrouped */
+(fn($x) => $x) + $y;
+
+/* testArrayValue */
+$a = [
+    'a' => fn() => return 1,
+];
+
+/* testYield */
+$a = fn($x) => yield 'k' => $x;
+
 /* testReturnTypeNamespacedClass */
 $fn = fn($x) : ?\My\NS\ClassName => $x;
 
+/* testReturnTypeNullableFQNClass */
+$a = fn(?\DateTime $x) : ?\DateTime => $x;
+
+/* testReturnTypeSelf */
+$fn = fn(self $a) : ?self => $a;
+
+/* testReturnTypeParent */
+$fn = fn(parent $a) : parent => $a;
+
+/* testReturnTypeCallable */
+$fn = fn(callable $a) : callable => $a;
+
 /* testReturnTypeArray */
-$fn = fn($x) : array => $x;
+$fn = fn(array $a) : array => $a;
 
 /* testReturnTypeArrayBug2773 */
 $fn = fn(): array => [a($a, $b)];
@@ -62,23 +85,54 @@ array_map(
     []
 );
 
-/* testReturnTypeCallable */
-$fn = fn($x) : callable => $x;
-
-/* testReturnTypeSelf */
-$fn = fn($x) : ?self => $x;
-
-/* testReference */
-fn&($x) => $x;
-
-/* testGrouped */
-(fn($x) => $x) + $y;
-
-/* testYield */
-$a = fn($x) => yield 'k' => $x;
-
 /* testTernary */
 $fn = fn($a) => $a ? /* testTernaryThen */ fn() : string => 'a' : /* testTernaryElse */ fn() : string => 'b';
+
+/* testConstantDeclaration */
+const FN = 'a';
+
+/* testConstantDeclarationLower */
+const fn = 'a';
+
+class Foo {
+    /* testStaticMethodName */
+    public static function fn($param) {
+        /* testNestedInMethod */
+        $fn = fn($c) => $callable($factory($c), $c);
+    }
+
+    public function foo() {
+        /* testPropertyAssignment */
+        $this->fn = 'a';
+    }
+}
+
+$anon = new class() {
+    /* testAnonClassMethodName */
+    protected function fN($param) {
+    }
+}
+
+/* testNonArrowStaticMethodCall */
+$a = Foo::fn($param);
+
+/* testNonArrowConstantAccess */
+$a = MyClass::FN;
+
+/* testNonArrowConstantAccessDeref */
+$a = MyClass::Fn[$a];
+
+/* testNonArrowObjectMethodCall */
+$a = $obj->fn($param);
+
+/* testNonArrowObjectMethodCallUpper */
+$a = $obj->FN($param);
+
+/* testNonArrowNamespacedFunctionCall */
+$a = MyNS\Sub\Fn($param);
+
+/* testNonArrowNamespaceOperatorFunctionCall */
+$a = namespace\fn($param);
 
 /* testLiveCoding */
 // Intentional parse error. This has to be the last test in the file.

--- a/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
@@ -10,7 +10,6 @@
 
 namespace PHPCSUtils\Tests\Utils\FunctionDeclarations;
 
-use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
@@ -20,6 +19,9 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  * \PHPCSUtils\Utils\FunctionDeclarations::getArrowFunctionOpenClose() methods.
  *
  * These tests are loosely based on the `Tokenizer/BackfillFnTokenTest` file in PHPCS itself.
+ *
+ * @covers \PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction
+ * @covers \PHPCSUtils\Utils\FunctionDeclarations::getArrowFunctionOpenClose
  *
  * @group functiondeclarations
  *
@@ -31,35 +33,35 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
     /**
      * Test that the function returns false when passed a non-existent token.
      *
-     * @covers \PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction
-     *
      * @return void
      */
     public function testNonExistentToken()
     {
         $result = FunctionDeclarations::isArrowFunction(self::$phpcsFile, 10000);
-        $this->assertFalse($result);
+        $this->assertFalse($result, 'Failed isArrowFunction() test');
+
+        $result = FunctionDeclarations::getArrowFunctionOpenClose(self::$phpcsFile, 10000);
+        $this->assertFalse($result, 'Failed getArrowFunctionOpenClose() test');
     }
 
     /**
      * Test that the function returns false when passed a token which definitely is not an arrow function.
      *
-     * @covers \PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction
-     *
      * @return void
      */
     public function testUnsupportedToken()
     {
-        $stackPtr = $this->getTargetToken('/* testNotAnArrowFunction */', \T_CONST);
+        $stackPtr = $this->getTargetToken('/* testConstantDeclaration */', \T_CONST);
 
         $result = FunctionDeclarations::isArrowFunction(self::$phpcsFile, $stackPtr);
-        $this->assertFalse($result);
+        $this->assertFalse($result, 'Failed isArrowFunction() test');
+
+        $result = FunctionDeclarations::getArrowFunctionOpenClose(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result, 'Failed getArrowFunctionOpenClose() test');
     }
 
     /**
      * Test that the function returns false when passed a T_STRING token without `fn` as content.
-     *
-     * @covers \PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction
      *
      * @return void
      */
@@ -68,14 +70,16 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
         $stackPtr = $this->getTargetToken('/* testNotTheRightContent */', \T_STRING);
 
         $result = FunctionDeclarations::isArrowFunction(self::$phpcsFile, $stackPtr);
-        $this->assertFalse($result);
+        $this->assertFalse($result, 'Failed isArrowFunction() test');
+
+        $result = FunctionDeclarations::getArrowFunctionOpenClose(self::$phpcsFile, $stackPtr);
+        $this->assertFalse($result, 'Failed getArrowFunctionOpenClose() test');
     }
 
     /**
      * Test correctly detecting arrow functions.
      *
      * @dataProvider dataArrowFunction
-     * @covers       \PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction
      *
      * @param string $testMarker    The comment which prefaces the target token in the test file.
      * @param array  $expected      The expected return value for the respective functions.
@@ -96,36 +100,24 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
      * Test correctly detecting arrow functions.
      *
      * @dataProvider dataArrowFunction
-     * @covers       \PHPCSUtils\Utils\FunctionDeclarations::getArrowFunctionOpenClose
      *
      * @param string $testMarker    The comment which prefaces the target token in the test file.
      * @param array  $expected      The expected return value for the respective functions.
      * @param string $targetContent The content for the target token to look for in case there could
      *                              be confusion.
-     * @param bool   $maybeSkip     Whether the test should be skipped on PHPCS 3.5.3 due to a broken
-     *                              upstream backfill.
      *
      * @return void
      */
-    public function testGetArrowFunctionOpenClose($testMarker, $expected, $targetContent = null, $maybeSkip = false)
+    public function testGetArrowFunctionOpenClose($testMarker, $expected, $targetContent = 'fn')
     {
-        // Skip specific test(s) on unsupported PHPCS versions.
-        if ($maybeSkip === true && \version_compare(Helper::getVersion(), '3.5.3', '==') === true) {
-            $this->markTestSkipped(
-                'PHPCS 3.5.3 is not supported for this specific test due to a buggy arrow functions backfill.'
-            );
-        }
-
         $targets  = Collections::arrowFunctionTokensBC();
         $stackPtr = $this->getTargetToken($testMarker, $targets, $targetContent);
 
         // Change from offsets to absolute token positions.
-        foreach ($expected['get'] as $key => $value) {
-            if ($value === false) {
-                continue;
+        if ($expected['get'] != false) {
+            foreach ($expected['get'] as $key => $value) {
+                $expected['get'][$key] += $stackPtr;
             }
-
-            $expected['get'][$key] += $stackPtr;
         }
 
         $result = FunctionDeclarations::getArrowFunctionOpenClose(self::$phpcsFile, $stackPtr);
@@ -143,17 +135,6 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
     public function dataArrowFunction()
     {
         return [
-            /*
-             * This particular case tests the "no open parenthesis after" condition in PHPCS < 3.5.3
-             * and the "fn defined but not used" condition in PHPCS 3.5.3+.
-             */
-            'const-declaration-not-an-arrow-function' => [
-                '/* testNotAnArrowFunction */',
-                [
-                    'is'  => false,
-                    'get' => [],
-                ],
-            ],
             'arrow-function-standard' => [
                 '/* testStandard */',
                 [
@@ -177,6 +158,7 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
                         'scope_closer'       => 12,
                     ],
                 ],
+                'Fn',
             ],
             'arrow-function-with-whitespace' => [
                 '/* testWhitespace */',
@@ -202,11 +184,11 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
                     ],
                 ],
             ],
-            'real-function-called-fn' => [
+            'non-arrow-function-global-function-declaration' => [
                 '/* testFunctionName */',
                 [
                     'is'  => false,
-                    'get' => [],
+                    'get' => false,
                 ],
             ],
             'arrow-function-nested-outer' => [
@@ -294,6 +276,54 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
                     ],
                 ],
             ],
+            'arrow-function-with-reference' => [
+                '/* testReference */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 2,
+                        'parenthesis_closer' => 4,
+                        'scope_opener'       => 6,
+                        'scope_closer'       => 9,
+                    ],
+                ],
+            ],
+            'arrow-function-grouped-within-parenthesis' => [
+                '/* testGrouped */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 3,
+                        'scope_opener'       => 5,
+                        'scope_closer'       => 8,
+                    ],
+                ],
+            ],
+            'arrow-function-as-array-value' => [
+                '/* testArrayValue */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 2,
+                        'scope_opener'       => 4,
+                        'scope_closer'       => 9,
+                    ],
+                ],
+            ],
+            'arrow-function-with-yield-in-value' => [
+                '/* testYield */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 3,
+                        'scope_opener'       => 5,
+                        'scope_closer'       => 14,
+                    ],
+                ],
+            ],
             'arrow-function-with-return-type-nullable-namespaced-class' => [
                 '/* testReturnTypeNamespacedClass */',
                 [
@@ -306,15 +336,63 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
                     ],
                 ],
             ],
+            'arrow-function-with-fqn-class' => [
+                '/* testReturnTypeNullableFQNClass */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 7,
+                        'scope_opener'       => 15,
+                        'scope_closer'       => 18,
+                    ],
+                ],
+            ],
+            'arrow-function-with-return-type-nullable-self' => [
+                '/* testReturnTypeSelf */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 5,
+                        'scope_opener'       => 12,
+                        'scope_closer'       => 15,
+                    ],
+                ],
+            ],
+            'arrow-function-with-return-type-parent' => [
+                '/* testReturnTypeParent */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 5,
+                        'scope_opener'       => 11,
+                        'scope_closer'       => 14,
+                    ],
+                ],
+            ],
+            'arrow-function-with-return-type-callable' => [
+                '/* testReturnTypeCallable */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 5,
+                        'scope_opener'       => 11,
+                        'scope_closer'       => 14,
+                    ],
+                ],
+            ],
             'arrow-function-with-return-type-array' => [
                 '/* testReturnTypeArray */',
                 [
                     'is'  => true,
                     'get' => [
                         'parenthesis_opener' => 1,
-                        'parenthesis_closer' => 3,
-                        'scope_opener'       => 9,
-                        'scope_closer'       => 12,
+                        'parenthesis_closer' => 5,
+                        'scope_opener'       => 11,
+                        'scope_closer'       => 14,
                     ],
                 ],
             ],
@@ -329,8 +407,6 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
                         'scope_closer'       => 18,
                     ],
                 ],
-                null,
-                true,
             ],
             'arrow-function-with-array-param-and-return-type' => [
                 '/* testMoreArrayTypeDeclarations */',
@@ -341,68 +417,6 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
                         'parenthesis_closer' => 6,
                         'scope_opener'       => 11,
                         'scope_closer'       => 17,
-                    ],
-                ],
-                null,
-                true,
-            ],
-            'arrow-function-with-return-type-callable' => [
-                '/* testReturnTypeCallable */',
-                [
-                    'is'  => true,
-                    'get' => [
-                        'parenthesis_opener' => 1,
-                        'parenthesis_closer' => 3,
-                        'scope_opener'       => 9,
-                        'scope_closer'       => 12,
-                    ],
-                ],
-            ],
-            'arrow-function-with-return-type-nullable-self' => [
-                '/* testReturnTypeSelf */',
-                [
-                    'is'  => true,
-                    'get' => [
-                        'parenthesis_opener' => 1,
-                        'parenthesis_closer' => 3,
-                        'scope_opener'       => 10,
-                        'scope_closer'       => 13,
-                    ],
-                ],
-            ],
-            'arrow-function-with-reference' => [
-                '/* testReference */',
-                [
-                    'is'  => true,
-                    'get' => [
-                        'parenthesis_opener' => 2,
-                        'parenthesis_closer' => 4,
-                        'scope_opener'       => 6,
-                        'scope_closer'       => 9,
-                    ],
-                ],
-            ],
-            'arrow-function-within-parenthesis' => [
-                '/* testGrouped */',
-                [
-                    'is'  => true,
-                    'get' => [
-                        'parenthesis_opener' => 1,
-                        'parenthesis_closer' => 3,
-                        'scope_opener'       => 5,
-                        'scope_closer'       => 8,
-                    ],
-                ],
-            ],
-            'arrow-function-with-yield-in-value' => [
-                '/* testYield */',
-                [
-                    'is'  => true,
-                    'get' => [
-                        'parenthesis_opener' => 1,
-                        'parenthesis_closer' => 3,
-                        'scope_opener'       => 5,
-                        'scope_closer'       => 14,
                     ],
                 ],
             ],
@@ -442,17 +456,118 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
                     ],
                 ],
             ],
+            'arrow-function-nested-in-method' => [
+                '/* testNestedInMethod */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 3,
+                        'scope_opener'       => 5,
+                        'scope_closer'       => 17,
+                    ],
+                ],
+            ],
+
+            /*
+             * Use of the "fn" keyword when not an arrow function.
+             */
+            'non-arrow-function-const-declaration' => [
+                '/* testConstantDeclaration */',
+                [
+                    'is'  => false,
+                    'get' => false,
+                ],
+                'FN',
+            ],
+            'non-arrow-function-const-declaration-lowercase' => [
+                '/* testConstantDeclarationLower */',
+                [
+                    'is'  => false,
+                    'get' => false,
+                ],
+            ],
+            'non-arrow-function-static-method-declaration' => [
+                '/* testStaticMethodName */',
+                [
+                    'is'  => false,
+                    'get' => false,
+                ],
+            ],
+            'non-arrow-function-assignment-to-property' => [
+                '/* testPropertyAssignment */',
+                [
+                    'is'  => false,
+                    'get' => false,
+                ],
+            ],
+            'non-arrow-function-anon-class-method-declaration' => [
+                '/* testAnonClassMethodName */',
+                [
+                    'is'  => false,
+                    'get' => false,
+                ],
+                'fN',
+            ],
+            'non-arrow-function-call-to-static-method' => [
+                '/* testNonArrowStaticMethodCall */',
+                [
+                    'is'  => false,
+                    'get' => false,
+                ],
+            ],
+            'non-arrow-function-class-constant-access' => [
+                '/* testNonArrowConstantAccess */',
+                [
+                    'is'  => false,
+                    'get' => false,
+                ],
+                'FN',
+            ],
+            'non-arrow-function-class-constant-access-with-deref' => [
+                '/* testNonArrowConstantAccessDeref */',
+                [
+                    'is'  => false,
+                    'get' => false,
+                ],
+                'Fn',
+            ],
+            'non-arrow-function-call-to-object-method' => [
+                '/* testNonArrowObjectMethodCall */',
+                [
+                    'is'  => false,
+                    'get' => false,
+                ],
+            ],
+            'non-arrow-function-call-to-object-method-uppercase' => [
+                '/* testNonArrowObjectMethodCallUpper */',
+                [
+                    'is'  => false,
+                    'get' => false,
+                ],
+                'FN',
+            ],
+            'non-arrow-function-call-to-namespaced-function' => [
+                '/* testNonArrowNamespacedFunctionCall */',
+                [
+                    'is'  => false,
+                    'get' => false,
+                ],
+                'Fn',
+            ],
+            'non-arrow-function-call-to-namespaced-function-using-namespace-operator' => [
+                '/* testNonArrowNamespaceOperatorFunctionCall */',
+                [
+                    'is'  => false,
+                    'get' => false,
+                ],
+            ],
 
             'live-coding' => [
                 '/* testLiveCoding */',
                 [
-                    'is'  => true,
-                    'get' => [
-                        'parenthesis_opener' => false,
-                        'parenthesis_closer' => false,
-                        'scope_opener'       => false,
-                        'scope_closer'       => false,
-                    ],
+                    'is'  => false,
+                    'get' => false,
                 ],
             ],
         ];

--- a/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
@@ -12,6 +12,7 @@ namespace PHPCSUtils\Tests\Utils\FunctionDeclarations;
 
 use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
 
 /**
@@ -85,11 +86,7 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
      */
     public function testIsArrowFunction($testMarker, $expected, $targetContent = null)
     {
-        $targets = [\T_STRING];
-        if (\defined('T_FN') === true) {
-            $targets[] = \T_FN;
-        }
-
+        $targets  = Collections::arrowFunctionTokensBC();
         $stackPtr = $this->getTargetToken($testMarker, $targets, $targetContent);
         $result   = FunctionDeclarations::isArrowFunction(self::$phpcsFile, $stackPtr);
         $this->assertSame($expected['is'], $result);
@@ -119,11 +116,7 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
             );
         }
 
-        $targets = [\T_STRING];
-        if (\defined('T_FN') === true) {
-            $targets[] = \T_FN;
-        }
-
+        $targets  = Collections::arrowFunctionTokensBC();
         $stackPtr = $this->getTargetToken($testMarker, $targets, $targetContent);
 
         // Change from offsets to absolute token positions.

--- a/Tests/Utils/Parentheses/ParenthesesTest.inc
+++ b/Tests/Utils/Parentheses/ParenthesesTest.inc
@@ -47,6 +47,9 @@ function fn() {}
 /* testNoOwnerOnCloseParens */
 $a = ($b + $c);
 
+/* testFunctionCallFnPHPCS353-354 */
+$value = $obj->fn(true);
+
 // Intentional parse error. This has to be the last test in the file.
 /* testParseError */
 declare(ticks=1

--- a/Tests/Utils/Parentheses/ParenthesesTest.php
+++ b/Tests/Utils/Parentheses/ParenthesesTest.php
@@ -145,6 +145,10 @@ class ParenthesesTest extends UtilityMethodTestCase
             'code'    => \T_STRING,
             'content' => 'get',
         ],
+        'testMethodCalledFn-true' => [
+            'marker'  => '/* testFunctionCallFnPHPCS353-354 */',
+            'code'    => \T_TRUE,
+        ],
         'testParseError-1' => [
             'marker'  => '/* testParseError */',
             'code'    => \T_LNUMBER,
@@ -713,6 +717,23 @@ class ParenthesesTest extends UtilityMethodTestCase
                     'lastIfElseOwner'       => false,
                 ],
             ],
+            'testMethodCalledFn-true' => [
+                'testMethodCalledFn-true',
+                [
+                    'firstOpener'           => -1,
+                    'firstCloser'           => 1,
+                    'firstOwner'            => false,
+                    'firstScopeOwnerOpener' => false,
+                    'firstScopeOwnerCloser' => false,
+                    'firstScopeOwnerOwner'  => false,
+                    'lastOpener'            => -1,
+                    'lastCloser'            => 1,
+                    'lastOwner'             => false,
+                    'lastArrayOpener'       => false,
+                    'lastFunctionCloser'    => false,
+                    'lastIfElseOwner'       => false,
+                ],
+            ],
             'testParseError-1' => [
                 'testParseError-1',
                 [
@@ -903,6 +924,10 @@ class ParenthesesTest extends UtilityMethodTestCase
                     'T_ARRAY' => true,
                     'T_FN'    => true,
                 ],
+            ],
+            'testMethodCalledFn-true' => [
+                'testMethodCalledFn-true',
+                [],
             ],
             'testParseError-1' => [
                 'testParseError-1',

--- a/Tests/Utils/Parentheses/ParenthesesTest.php
+++ b/Tests/Utils/Parentheses/ParenthesesTest.php
@@ -12,6 +12,7 @@ namespace PHPCSUtils\Tests\Utils\Parentheses;
 
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Parentheses;
 
 /**
@@ -1070,10 +1071,7 @@ class ParenthesesTest extends UtilityMethodTestCase
      */
     public function dataLastOwnerIn()
     {
-        $arrowFunctionOwners = [\T_STRING];
-        if (\defined('T_FN') === true) {
-            $arrowFunctionOwners = [\T_FN];
-        }
+        $arrowFunctionOwners = Collections::arrowFunctionTokensBC();
 
         return [
             'testElseIfWithClosure-$a-closure' => [


### PR DESCRIPTION
Follow up on #77. 

This PR improves the support for arrow functions by:
* Adding a `PHPCSUtils\Tokens\Collections::arrowFunctionTokensBC()` method to retrieve the relevant tokens for the arrow function keyword in a PHPCS cross-version compatible manner.
* Improving the `FunctionDeclarations::isArrowFunction()` and `FunctionDeclarations::getArrowFunctionOpenClose()` to give more informative results.
    Previously, they would follow the tokenization to `T_FN` as per PHPCS 3.5.4.
    Now they will only return `true` / an array with the token pointers when the token passed actually represents an arrow function keyword token.
    - Includes changing the return type of the `FunctionDeclarations::getArrowFunctionOpenClose()` method to `array|false`.
        Previously the method would return either an empty array or an array with the four indexes set to either the found token pointers or `false`.
        Now the method will return `false` if the token passed is not an actual arrow function, or an array with all four indexes set to the relevant token pointers if it is.

This syncs the behaviour of these functions with the tokenization of arrow functions in PHPCS 3.5.5.


## Commit summary

### Tokens\Collections: add new `arrowFunctionTokensBC()` method

... to retrieve the tokens which can represent the arrow function keyword.

Includes unit tests.

### Implement use of the new `Collections::arrowFunctionTokensBC()` method

... in all applicable places.

### FunctionDeclarations::getArrowFunctionOpenClose(): move fixed array to property

### FunctionDeclarations::isArrowFunction()/getArrowFunctionOpenClose(): sync with PHPCS 3.5.5

This brings the `FunctionDeclarations::isArrowFunction()` and `FunctionDeclarations::getArrowFunctionOpenClose()` functions in line with the changes in PHPCS which will be released in PHPCS 3.5.5.

Note: the return value for the `FunctionDeclarations::getArrowFunctionOpenClose()` function has changed from `array` to `array|false`.
Previously, the function may return an empty array or an array with only some of the indexes set to `false`.
Now it will return `false` when this is not an arrow function or an array with all the indexes set to the relevant stack pointers when it _is_ an arrow function.

This should make the function return value easier to work with.

Includes extensive additional unit tests, as well as some changed unit tests, similar to the additional unit tests as pulled to PHPCS itself for these changes.

Related upstream commits:
* squizlabs/PHP_CodeSniffer@2e3a010
* squizlabs/PHP_CodeSniffer@ea810a2
* squizlabs/PHP_CodeSniffer@2adcb64
* squizlabs/PHP_CodeSniffer@3a62dd4
* squizlabs/PHP_CodeSniffer@6070b60

Related upstream issues/PRs:
* squizlabs/PHP_CodeSniffer#2523
* squizlabs/PHP_CodeSniffer#2859
* squizlabs/PHP_CodeSniffer#2860
* squizlabs/PHP_CodeSniffer#2863

### Improve on previous arrow function implementation in various utilities

* Change checking of the return value of the `FunctionDeclarations::getArrowFunctionOpenClose()` function.
    - This function now either returns `false` or a array with all indexes set to the relevant stack pointers.
* Improved the message of the `RuntimeException` for the `FunctionDeclarations::getParameters()` and the `FunctionDeclarations::getProperties()` methods.
* Update unit tests to reflect the change in tokenization of "fn" tokens.
* Remove test skipping for select arrow function related tests on select PHP/PHPCS versions.
    This is no longer needed.
* Add/improve documentation about arrow function support.

Includes a few additional unit tests to safeguard cross-version compatibility with PHPCS 3.5.3 and 3.5.4.

