### PR TITLE
ControlStructures/IsElseIfTest: bug fix

### DIFF
--- a/Tests/Utils/ControlStructures/IsElseIfTest.php
+++ b/Tests/Utils/ControlStructures/IsElseIfTest.php
@@ -112,15 +112,15 @@ class IsElseIfTest extends UtilityMethodTestCase
             ],
 
             'inline-if' => [
-                '/* testAlternativeIf */',
+                '/* testInlineIf */',
                 false,
             ],
             'inline-elseif' => [
-                '/* testAlternativeElseIf */',
+                '/* testInlineElseIf */',
                 true,
             ],
             'inline-else' => [
-                '/* testAlternativeElse */',
+                '/* testInlineElse */',
                 false,
             ],
 


### PR DESCRIPTION
Three tests were using the wrong test markers.

In effect these three cases were therefore not being tested. Fixed now.