### PR TITLE
FindEndOfStatementTest: simplify the tests

### DIFF
--- a/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
@@ -43,11 +43,10 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
      */
     public function testSimpleAssignment()
     {
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testSimpleAssignment */') + 2);
+        $start = $this->getTargetToken('/* testSimpleAssignment */', T_VARIABLE);
         $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 5)], $tokens[$found]);
+        $this->assertSame(($start + 5), $found);
     }
 
     /**
@@ -57,11 +56,10 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
      */
     public function testControlStructure()
     {
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testControlStructure */') + 2);
+        $start = $this->getTargetToken('/* testControlStructure */', T_WHILE);
         $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 6)], $tokens[$found]);
+        $this->assertSame(($start + 6), $found);
     }
 
     /**
@@ -71,11 +69,10 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
      */
     public function testClosureAssignment()
     {
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testClosureAssignment */') + 2);
+        $start = $this->getTargetToken('/* testClosureAssignment */', T_VARIABLE, '$a');
         $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 13)], $tokens[$found]);
+        $this->assertSame(($start + 13), $found);
     }
 
     /**
@@ -86,25 +83,22 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
     public function testHeredocFunctionArg()
     {
         // Find the end of the function.
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testHeredocFunctionArg */') + 2);
+        $start = $this->getTargetToken('/* testHeredocFunctionArg */', T_STRING, 'myFunction');
         $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 10)], $tokens[$found]);
+        $this->assertSame(($start + 10), $found);
 
         // Find the end of the heredoc.
         $start += 2;
         $found  = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 4)], $tokens[$found]);
+        $this->assertSame(($start + 4), $found);
 
         // Find the end of the last arg.
         $start = ($found + 2);
         $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[$start], $tokens[$found]);
+        $this->assertSame($start, $found);
     }
 
     /**
@@ -115,25 +109,22 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
     public function testSwitch()
     {
         // Find the end of the switch.
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testSwitch */') + 2);
+        $start = $this->getTargetToken('/* testSwitch */', T_SWITCH);
         $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 28)], $tokens[$found]);
+        $this->assertSame(($start + 28), $found);
 
         // Find the end of the case.
         $start += 9;
         $found  = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 8)], $tokens[$found]);
+        $this->assertSame(($start + 8), $found);
 
         // Find the end of default case.
         $start += 11;
         $found  = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 6)], $tokens[$found]);
+        $this->assertSame(($start + 6), $found);
     }
 
     /**
@@ -144,25 +135,22 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
     public function testStatementAsArrayValue()
     {
         // Test short array syntax.
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testStatementAsArrayValue */') + 7);
+        $start = $this->getTargetToken('/* testStatementAsArrayValue */', T_NEW);
         $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 2)], $tokens[$found]);
+        $this->assertSame(($start + 2), $found);
 
         // Test long array syntax.
         $start += 12;
         $found  = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 2)], $tokens[$found]);
+        $this->assertSame(($start + 2), $found);
 
         // Test same statement outside of array.
         $start += 10;
         $found  = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 3)], $tokens[$found]);
+        $this->assertSame(($start + 3), $found);
     }
 
     /**
@@ -172,11 +160,10 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
      */
     public function testUseGroup()
     {
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testUseGroup */') + 2);
+        $start = $this->getTargetToken('/* testUseGroup */', T_USE);
         $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 23)], $tokens[$found]);
+        $this->assertSame(($start + 23), $found);
     }
 
     /**
@@ -186,11 +173,10 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
      */
     public function testArrowFunctionArrayValue()
     {
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testArrowFunctionArrayValue */') + 7);
+        $start = $this->getTargetToken('/* testArrowFunctionArrayValue */', Collections::arrowFunctionTokensBC());
         $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
-        $tokens = self::$phpcsFile->getTokens();
-        $this->assertSame($tokens[($start + 9)], $tokens[$found]);
+        $this->assertSame(($start + 9), $found);
     }
 
     /**
@@ -200,10 +186,8 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
      */
     public function testStaticArrowFunction()
     {
-        $fnTargets = Collections::arrowFunctionTokensBC();
-
-        $static = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testStaticArrowFunction */') + 2);
-        $fn     = self::$phpcsFile->findNext($fnTargets, ($static + 1));
+        $static = $this->getTargetToken('/* testStaticArrowFunction */', T_STATIC);
+        $fn     = $this->getTargetToken('/* testStaticArrowFunction */', Collections::arrowFunctionTokensBC());
 
         $endOfStatementStatic = BCFile::findEndOfStatement(self::$phpcsFile, $static);
         $endOfStatementFn     = BCFile::findEndOfStatement(self::$phpcsFile, $fn);
@@ -218,7 +202,7 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
      */
     public function testArrowFunctionReturnValue()
     {
-        $start = (self::$phpcsFile->findNext(T_COMMENT, 0, null, false, '/* testArrowFunctionReturnValue */') + 2);
+        $start = $this->getTargetToken('/* testArrowFunctionReturnValue */', Collections::arrowFunctionTokensBC());
         $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
         $this->assertSame(($start + 18), $found);


### PR DESCRIPTION
These are the same changes as pulled upstream in squizlabs/PHP_CodeSniffer 2866

* Use the `AbstractMethodUnitTest::getTargetToken()` method instead of doing a `findNext()` with a calculation.
    This makes the `$start` token retrieval more descriptive.
* Assert based on the token pointers, not the sub-array value.
    As for both the "expected" as well as "found" values, the token sub-array is retrieved from the same `$tokens` variable, if the token pointers are the same, the sub-arrays will be too, so doing the comparison based on the sub-array doesn't add any extra value to the test.
    Also: doing an array assertion is more expensive than doing a simple integer based assertion.
* Remove redundant calls to the `getTokens()` method.