### PR TITLE
Arrays::getDoubleArrowPtr(): work around tokenizer bug in PHPCS 3.5.4

### DIFF
--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -265,7 +265,8 @@ class Arrays
             );
         }
 
-        $targets  = self::$doubleArrowTargets + Collections::$closedScopes;
+        $targets  = self::$doubleArrowTargets;
+        $targets += Collections::$closedScopes;
         $targets += Collections::arrowFunctionTokensBC();
 
         $doubleArrow = ($start - 1);
@@ -282,6 +283,14 @@ class Arrays
             }
 
             if ($tokens[$doubleArrow]['code'] === \T_DOUBLE_ARROW) {
+                return $doubleArrow;
+            }
+
+            /*
+             * BC: work-around a bug in PHPCS 3.5.4 where the double arrow is incorrectly tokenized as T_STRING.
+             * @link https://github.com/squizlabs/PHP_CodeSniffer/issues/2865
+             */
+            if ($tokens[$doubleArrow]['code'] === \T_STRING && $tokens[$doubleArrow]['content'] === '=>') {
                 return $doubleArrow;
             }
 

--- a/Tests/Utils/Arrays/GetDoubleArrowPtrTest.inc
+++ b/Tests/Utils/Arrays/GetDoubleArrowPtrTest.inc
@@ -81,6 +81,9 @@ $array = [
     /* testTstringKeyNotFnFunction */
     CONSTANT_NAME => 'value',
 
-    /* testPropertyAccessPHPCS353-354 */
+    /* testKeyPropertyAccessFnPHPCS353-354 */
     ($obj->fn) => 'value',
+
+    /* testDoubleArrowTokenizedAsTstring-PHPCS2865 */
+    $obj->fn => 'value',
 ];

--- a/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
+++ b/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
@@ -210,8 +210,12 @@ class GetDoubleArrowPtrTest extends UtilityMethodTestCase
             ],
             // Test specifically for PHPCS 3.5.3 and 3.5.4 in which all "fn" tokens were tokenized as T_FN.
             'test-arrow-access-to-property-named-fn-as-key-phpcs-3.5.3-3.5.4' => [
-                '/* testPropertyAccessPHPCS353-354 */',
+                '/* testKeyPropertyAccessFnPHPCS353-354 */',
                 12,
+            ],
+            'test-double-arrow-incorrectly-tokenized-phpcs-issue-2865' => [
+                '/* testDoubleArrowTokenizedAsTstring-PHPCS2865 */',
+                10,
             ],
         ];
     }


### PR DESCRIPTION
The double arrow directly after a `fn` would be tokenized as `T_STRING` in PHPCS 3.5.4.

Fixed now.

Includes unit test.

Ref: squizlabs/PHP_CodeSniffer#2865