### PR TITLE
Utils\Numbers: replace `$unsupportedPHPCSVersions` with `UNSUPPORTED_VERSION`

### DIFF
--- a/PHPCSUtils/Utils/Numbers.php
+++ b/PHPCSUtils/Utils/Numbers.php
@@ -120,12 +120,12 @@ class Numbers
      * PHPCS versions in which the backfill for PHP 7.4 numeric literal separators is broken.
      *
      * @since 1.0.0
+     * @since 1.0.0-alpha2 Changed from a property to a class constant.
+     *                     Changed from an array to a string.
      *
-     * @var array
+     * @var string
      */
-    public static $unsupportedPHPCSVersions = [
-        '3.5.3' => true,
-    ];
+    const UNSUPPORTED_PHPCS_VERSION = '3.5.3';
 
     /**
      * Valid tokens which could be part of a numeric literal sequence in PHP < 7.4.
@@ -177,7 +177,6 @@ class Numbers
      */
     public static function getCompleteNumber(File $phpcsFile, $stackPtr)
     {
-
         static $php74, $phpcsVersion, $phpcsWithBackfill;
 
         $tokens = $phpcsFile->getTokens();
@@ -193,8 +192,7 @@ class Numbers
         if (isset($php74, $phpcsVersion, $phpcsWithBackfill) === false) {
             $php74             = \version_compare(\PHP_VERSION_ID, '70399', '>');
             $phpcsVersion      = Helper::getVersion();
-            $maxUnsupported    = \max(\array_keys(self::$unsupportedPHPCSVersions));
-            $phpcsWithBackfill = \version_compare($phpcsVersion, $maxUnsupported, '>');
+            $phpcsWithBackfill = \version_compare($phpcsVersion, self::UNSUPPORTED_PHPCS_VERSION, '>');
         }
 
         /*
@@ -203,7 +201,7 @@ class Numbers
          *
          * @link https://github.com/squizlabs/PHP_CodeSniffer/issues/2546
          */
-        if (isset(self::$unsupportedPHPCSVersions[$phpcsVersion]) === true) {
+        if (\version_compare($phpcsVersion, self::UNSUPPORTED_PHPCS_VERSION, '==') === true) {
             throw new RuntimeException('The ' . __METHOD__ . '() method does not support PHPCS ' . $phpcsVersion);
         }
 

--- a/Tests/Utils/Numbers/GetCompleteNumberTest.php
+++ b/Tests/Utils/Numbers/GetCompleteNumberTest.php
@@ -60,8 +60,7 @@ class GetCompleteNumberTest extends UtilityMethodTestCase
 
         self::$phpcsVersion   = Helper::getVersion();
         self::$php74OrHigher  = \version_compare(\PHP_VERSION_ID, '70399', '>');
-        $maxUnsupported       = \max(\array_keys(Numbers::$unsupportedPHPCSVersions));
-        self::$usableBackfill = \version_compare(self::$phpcsVersion, $maxUnsupported, '>');
+        self::$usableBackfill = \version_compare(self::$phpcsVersion, Numbers::UNSUPPORTED_PHPCS_VERSION, '>');
     }
 
     /**
@@ -85,7 +84,7 @@ class GetCompleteNumberTest extends UtilityMethodTestCase
     public function testUnsupportedPhpcsException()
     {
         self::setUpStaticProperties();
-        if (isset(Numbers::$unsupportedPHPCSVersions[self::$phpcsVersion]) === false) {
+        if (\version_compare(self::$phpcsVersion, Numbers::UNSUPPORTED_PHPCS_VERSION, '!=') === true) {
             $this->markTestSkipped('Test specific to a limited set of PHPCS versions');
         }
 
@@ -111,7 +110,7 @@ class GetCompleteNumberTest extends UtilityMethodTestCase
     {
         // Skip the test(s) on unsupported PHPCS versions.
         self::setUpStaticProperties();
-        if (isset(Numbers::$unsupportedPHPCSVersions[self::$phpcsVersion]) === true) {
+        if (\version_compare(self::$phpcsVersion, Numbers::UNSUPPORTED_PHPCS_VERSION, '==') === true) {
             $this->markTestSkipped(
                 'PHPCS ' . self::$phpcsVersion . ' is not supported due to buggy numeric string literal backfill.'
             );

--- a/Tests/Utils/Operators/IsUnaryPlusMinusTest.php
+++ b/Tests/Utils/Operators/IsUnaryPlusMinusTest.php
@@ -72,9 +72,7 @@ class IsUnaryPlusMinusTest extends UtilityMethodTestCase
                 $this->markTestSkipped($skipMessage);
             }
 
-            $phpcsVersion           = Helper::getVersion();
-            $minVersionWithBackfill = \min(\array_keys(Numbers::$unsupportedPHPCSVersions));
-            if (\version_compare($phpcsVersion, $minVersionWithBackfill, '>=') === true) {
+            if (\version_compare(Helper::getVersion(), Numbers::UNSUPPORTED_PHPCS_VERSION, '>=') === true) {
                 $this->markTestSkipped($skipMessage);
             }
         }


### PR DESCRIPTION
As the fix for the broken backfill in PHPCS 3.5.3 was released in PHPCS 3.5.4, there is only one PHPCS version which is unsupported.

This negates the need for an array, making it possible to use a class constant instead which should be less risky as it cannot be overloaded.

Includes adjusting all places in the code base which were using the property to use the constant instead.