### PR TITLE
AbstractSniffs/AbstractArrayDeclarationSniff: improve handling of parse errors

### DIFF
--- a/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
+++ b/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
@@ -224,7 +224,12 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
         }
 
         foreach ($this->arrayItems as $itemNr => $arrayItem) {
-            $arrowPtr = Arrays::getDoubleArrowPtr($phpcsFile, $arrayItem['start'], $arrayItem['end']);
+            try {
+                $arrowPtr = Arrays::getDoubleArrowPtr($phpcsFile, $arrayItem['start'], $arrayItem['end']);
+            } catch (RuntimeException $e) {
+                // Parse error: empty array item. Ignore.
+                continue;
+            }
 
             if ($arrowPtr !== false) {
                 if ($this->processKey($phpcsFile, $arrayItem['start'], ($arrowPtr - 1), $itemNr) === true) {

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.inc
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.inc
@@ -21,6 +21,10 @@ $array = [
     'string' => 'string key',
 ];
 
+/* testEmptyArrayItem */
+// Intentional parse error.
+$array = array(1,, 'a' => 2);
+
 /* testShortCircuit */
 $array = [1, 'a' => 2, ];
 

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
@@ -383,6 +383,40 @@ class AbstractArrayDeclarationSniffTest extends UtilityMethodTestCase
     }
 
     /**
+     * Test the abstract sniff correctly ignores empty array items (parse error).
+     *
+     * @return void
+     */
+    public function testEmptyArrayItem()
+    {
+        $target = $this->getTargetToken(
+            '/* testEmptyArrayItem */',
+            [\T_ARRAY, \T_OPEN_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET]
+        );
+
+        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
+            ->setMethods($this->methodsToMock)
+            ->getMockForAbstractClass();
+
+        $mockObj->expects($this->once())
+            ->method('processOpenClose');
+
+        $mockObj->expects($this->exactly(1))
+            ->method('processKey');
+
+        $mockObj->expects($this->exactly(1))
+            ->method('processNoKey');
+
+        $mockObj->expects($this->exactly(2))
+            ->method('processValue');
+
+        $mockObj->expects($this->once())
+            ->method('processComma');
+
+        $mockObj->process(self::$phpcsFile, $target);
+    }
+
+    /**
      * Test short-circuiting the sniff on the call to processOpenClose().
      *
      * @return void


### PR DESCRIPTION
Empty array items are not allowed and will trigger a parse error, but the sniff should handle this gracefully.