### PR TITLE
PHPUnit: make the tests compatible with PHPUnit 9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev" : {
         "jakub-onderka/php-parallel-lint": "^1.0",
         "jakub-onderka/php-console-highlighter": "^0.4",
-        "phpunit/phpunit" : "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
+        "phpunit/phpunit" : "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "conflict": {
         "squizlabs/php_codesniffer": "3.5.3"


### PR DESCRIPTION
There is only one issue this test suite run into and that is the removal of the `assertAttributeSame()` method.
As for these properties I do deem it important to test the value, I have chosen to emulate the method for PHPUnit 9+.