### PR TITLE
CI: switch to fork of Parallel-lint package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.3 || ^0.4.1 || ^0.5 || ^0.6.2"
     },
     "require-dev" : {
-        "jakub-onderka/php-parallel-lint": "^1.0",
-        "jakub-onderka/php-console-highlighter": "^0.4",
+        "php-parallel-lint/php-parallel-lint": "^1.1.0",
+        "php-parallel-lint/php-console-highlighter": "^0.4",
         "phpunit/phpunit" : "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "conflict": {
@@ -46,7 +46,7 @@
     },
     "scripts" : {
         "lint": [
-            "@php ./vendor/jakub-onderka/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
         ],
         "install-devcs": [
             "composer require phpcsstandards/phpcsdevcs:\"^1.0\" --no-suggest --update-no-dev"


### PR DESCRIPTION
... as the original appears not to be maintained anymore and is not compatible with PHP 7.4.