### PR TITLE
CI: fix CS check not always running

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,7 +12,7 @@
     <file>.</file>
 
     <!-- Exclude PHPDoc structure files. -->
-    <exclude-pattern>*/build/*</exclude-pattern>
+    <exclude-pattern>*/build/docs/structure/*</exclude-pattern>
 
     <!-- Exclude Composer vendor directory. -->
     <exclude-pattern>*/vendor/*</exclude-pattern>


### PR DESCRIPTION
Travis clones into a `/home/travis/build/...` directory, so the `build` exclusion for the PHPDoc structure files-only, was now causing all files to be excluded.
Making this exclusion more specific fixes it.