### PR TITLE
TestUtils\UtilityMethodTestCase: add new $phpcsVersion property

### DIFF
--- a/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+++ b/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
@@ -99,6 +99,15 @@ abstract class UtilityMethodTestCase extends TestCase
 {
 
     /**
+     * The PHPCS version the tests are being run on.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    protected static $phpcsVersion = '0';
+
+    /**
      * The file extension of the test case file (without leading dot).
      *
      * This allows concrete test classes to overrule the default `inc` with, for instance,
@@ -173,6 +182,8 @@ abstract class UtilityMethodTestCase extends TestCase
     {
         parent::setUpBeforeClass();
 
+        self::$phpcsVersion = Helper::getVersion();
+
         $caseFile = static::$caseFile;
         if (\is_string($caseFile) === false || $caseFile === '') {
             $testClass = \get_called_class();
@@ -186,7 +197,7 @@ abstract class UtilityMethodTestCase extends TestCase
 
         $contents = \file_get_contents($caseFile);
 
-        if (\version_compare(Helper::getVersion(), '2.99.99', '>')) {
+        if (\version_compare(self::$phpcsVersion, '2.99.99', '>')) {
             // PHPCS 3.x.
             $config = new \PHP_CodeSniffer\Config();
 

--- a/Tests/BackCompat/BCFile/GetDeclarationNameJSTest.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameJSTest.php
@@ -11,7 +11,6 @@
 namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
 use PHPCSUtils\BackCompat\BCFile;
-use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
 /**
@@ -135,7 +134,7 @@ class GetDeclarationNameJSTest extends UtilityMethodTestCase
      */
     public function testGetDeclarationNameES6Method()
     {
-        if (\version_compare(Helper::getVersion(), '3.0.0', '<') === true) {
+        if (\version_compare(static::$phpcsVersion, '3.0.0', '<') === true) {
             $this->markTestSkipped('Support for JS ES6 method has not been backfilled for PHPCS 2.x (yet)');
         }
 

--- a/Tests/BackCompat/Helper/GetCommandLineDataTest.php
+++ b/Tests/BackCompat/Helper/GetCommandLineDataTest.php
@@ -34,7 +34,7 @@ class GetCommandLineDataTest extends UtilityMethodTestCase
     {
         // Use the default values which are different across PHPCS versions.
         $expected = 'utf-8';
-        if (\version_compare(Helper::getVersion(), '2.99.99', '<=') === true) {
+        if (\version_compare(static::$phpcsVersion, '2.99.99', '<=') === true) {
             // Will effectively come down to `iso-8859-1`.
             $expected = null;
         }
@@ -68,7 +68,7 @@ class GetCommandLineDataTest extends UtilityMethodTestCase
         $result = Helper::getTabWidth(self::$phpcsFile);
         $this->assertSame(4, $result, 'Failed retrieving the default tab width');
 
-        if (\version_compare(Helper::getVersion(), '2.99.99', '>') === true) {
+        if (\version_compare(static::$phpcsVersion, '2.99.99', '>') === true) {
             // PHPCS 3.x.
             self::$phpcsFile->config->tabWidth = 2;
         } else {
@@ -80,7 +80,7 @@ class GetCommandLineDataTest extends UtilityMethodTestCase
         $this->assertSame(2, $result, 'Failed retrieving the custom set tab width');
 
         // Restore defaults before moving to the next test.
-        if (\version_compare(Helper::getVersion(), '2.99.99', '>') === true) {
+        if (\version_compare(static::$phpcsVersion, '2.99.99', '>') === true) {
             self::$phpcsFile->config->restoreDefaults();
         } else {
             self::$phpcsFile->phpcs->cli->setCommandLineValues(['--tab-width=4']);
@@ -96,7 +96,7 @@ class GetCommandLineDataTest extends UtilityMethodTestCase
      */
     public function testIgnoreAnnotationsV2()
     {
-        if (\version_compare(Helper::getVersion(), '2.99.99', '>') === true) {
+        if (\version_compare(static::$phpcsVersion, '2.99.99', '>') === true) {
             $this->markTestSkipped('Test only applicable to PHPCS 2.x');
         }
 
@@ -112,7 +112,7 @@ class GetCommandLineDataTest extends UtilityMethodTestCase
      */
     public function testIgnoreAnnotationsV3Default()
     {
-        if (\version_compare(Helper::getVersion(), '2.99.99', '<=') === true) {
+        if (\version_compare(static::$phpcsVersion, '2.99.99', '<=') === true) {
             $this->markTestSkipped('Test only applicable to PHPCS 3.x');
         }
 
@@ -135,7 +135,7 @@ class GetCommandLineDataTest extends UtilityMethodTestCase
      */
     public function testIgnoreAnnotationsV3SetViaMethod()
     {
-        if (\version_compare(Helper::getVersion(), '2.99.99', '<=') === true) {
+        if (\version_compare(static::$phpcsVersion, '2.99.99', '<=') === true) {
             $this->markTestSkipped('Test only applicable to PHPCS 3.x');
         }
 
@@ -157,7 +157,7 @@ class GetCommandLineDataTest extends UtilityMethodTestCase
      */
     public function testIgnoreAnnotationsV3SetViaProperty()
     {
-        if (\version_compare(Helper::getVersion(), '2.99.99', '<=') === true) {
+        if (\version_compare(static::$phpcsVersion, '2.99.99', '<=') === true) {
             $this->markTestSkipped('Test only applicable to PHPCS 3.x');
         }
 

--- a/Tests/Utils/Numbers/GetCompleteNumberTest.php
+++ b/Tests/Utils/Numbers/GetCompleteNumberTest.php
@@ -31,7 +31,7 @@ class GetCompleteNumberTest extends UtilityMethodTestCase
      *
      * @var string
      */
-    public static $phpcsVersion = null;
+    public static $phpcsVersion = '0';
 
     /**
      * Whether or not the tests are being run on PHP 7.4 or higher.
@@ -54,7 +54,7 @@ class GetCompleteNumberTest extends UtilityMethodTestCase
      */
     public static function setUpStaticProperties()
     {
-        if (isset(self::$phpcsVersion)) {
+        if (self::$phpcsVersion !== '0') {
             return;
         }
 
@@ -83,8 +83,7 @@ class GetCompleteNumberTest extends UtilityMethodTestCase
      */
     public function testUnsupportedPhpcsException()
     {
-        self::setUpStaticProperties();
-        if (\version_compare(self::$phpcsVersion, Numbers::UNSUPPORTED_PHPCS_VERSION, '!=') === true) {
+        if (\version_compare(static::$phpcsVersion, Numbers::UNSUPPORTED_PHPCS_VERSION, '!=') === true) {
             $this->markTestSkipped('Test specific to a limited set of PHPCS versions');
         }
 
@@ -109,10 +108,9 @@ class GetCompleteNumberTest extends UtilityMethodTestCase
     public function testGetCompleteNumber($testMarker, $expected)
     {
         // Skip the test(s) on unsupported PHPCS versions.
-        self::setUpStaticProperties();
-        if (\version_compare(self::$phpcsVersion, Numbers::UNSUPPORTED_PHPCS_VERSION, '==') === true) {
+        if (\version_compare(static::$phpcsVersion, Numbers::UNSUPPORTED_PHPCS_VERSION, '==') === true) {
             $this->markTestSkipped(
-                'PHPCS ' . self::$phpcsVersion . ' is not supported due to buggy numeric string literal backfill.'
+                'PHPCS ' . static::$phpcsVersion . ' is not supported due to buggy numeric string literal backfill.'
             );
         }
 

--- a/Tests/Utils/ObjectDeclarations/GetNameJSTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameJSTest.php
@@ -10,7 +10,6 @@
 
 namespace PHPCSUtils\Tests\Utils\ObjectDeclarations;
 
-use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tests\BackCompat\BCFile\GetDeclarationNameJSTest as BCFile_GetDeclarationNameJSTest;
 use PHPCSUtils\Utils\ObjectDeclarations;
 
@@ -113,7 +112,7 @@ class GetNameJSTest extends BCFile_GetDeclarationNameJSTest
      */
     public function testGetDeclarationNameES6Method()
     {
-        if (\version_compare(Helper::getVersion(), '3.0.0', '<') === true) {
+        if (\version_compare(static::$phpcsVersion, '3.0.0', '<') === true) {
             $this->markTestSkipped('Support for JS ES6 method has not been backfilled for PHPCS 2.x (yet)');
         }
 

--- a/Tests/Utils/Operators/IsUnaryPlusMinusTest.php
+++ b/Tests/Utils/Operators/IsUnaryPlusMinusTest.php
@@ -10,7 +10,6 @@
 
 namespace PHPCSUtils\Tests\Utils\Operators;
 
-use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 use PHPCSUtils\Utils\Numbers;
 use PHPCSUtils\Utils\Operators;
@@ -72,7 +71,7 @@ class IsUnaryPlusMinusTest extends UtilityMethodTestCase
                 $this->markTestSkipped($skipMessage);
             }
 
-            if (\version_compare(Helper::getVersion(), Numbers::UNSUPPORTED_PHPCS_VERSION, '>=') === true) {
+            if (\version_compare(static::$phpcsVersion, Numbers::UNSUPPORTED_PHPCS_VERSION, '>=') === true) {
                 $this->markTestSkipped($skipMessage);
             }
         }


### PR DESCRIPTION
## TestUtils\UtilityMethodTestCase: add new $phpcsVersion property

Tests will often enough need access to the PHPCS version on which the tests are being run.

This adds a `$phpcsVersion` property to the `PHPCSUtils\TestUtils\UtilityMethodTestCase` class to make that version number easily and always available.

**Note**: if the PHPCS version is needed within a data provider method for a test, `Helper::getVersion()` still needs to be used as the data providers are run before the `setUpBeforeClass()` type methods.

## Tests: implement use of the UtilityMethodTestCase::$phpcsVersion property

... in all relevant places in the existing tests.

