### PR TITLE
Revert "PHPUnit: be strict about covers annotations"

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,6 @@
     backupGlobals="true"
     bootstrap="./Tests/bootstrap.php"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutCoversAnnotation="true"
     colors="true"
     forceCoversAnnotation="true">
 


### PR DESCRIPTION
Bit too strict and too fiddly for my liking.

This reverts commit cf90bbcc895e3c2482aa9f66bb94858deb6050fe.