### PR TITLE
BCFile/ObjectDeclarations::getDeclarationName(): compatibility with PHPCS 4.x

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -136,7 +136,8 @@ class BCFile
         /*
          * BC: Work-around JS ES6 classes not being tokenized as T_CLASS in PHPCS < 3.0.0.
          */
-        if ($phpcsFile->tokenizerType === 'JS'
+        if (isset($phpcsFile->tokenizerType)
+            && $phpcsFile->tokenizerType === 'JS'
             && $tokenCode === T_STRING
             && $tokens[$stackPtr]['content'] === 'class'
         ) {

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -78,7 +78,8 @@ class ObjectDeclarations
         /*
          * BC: Work-around JS ES6 classes not being tokenized as T_CLASS in PHPCS < 3.0.0.
          */
-        if ($phpcsFile->tokenizerType === 'JS'
+        if (isset($phpcsFile->tokenizerType)
+            && $phpcsFile->tokenizerType === 'JS'
             && $tokenCode === \T_STRING
             && $tokens[$stackPtr]['content'] === 'class'
         ) {


### PR DESCRIPTION
PHPCS removes support for the JS and CSS tokenizers, which includes removing the `File::$tokenizerType` property.

This commit makes it so the `BCFile::getDeclarationName()` and the `ObjectDeclarations::getDeclarationName()` methods won't throw an error for the property not existing.

And just to be clear: while PHPCSUtils in combination with PHPCS 2.x and 3.x _may_ incidentally support JS/CSS, in combination with PHPCS 4.x, JS/CSS will explicitly not be supported.

Ref: https://github.com/squizlabs/PHP_CodeSniffer/commit/ea52e7b48165edbcb96b10a0a5de04567e4d73f8