### PR TITLE
UtilityMethodTestCase: auto-skip JS/CSS tests when using PHPCS 4.x

### DIFF
--- a/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+++ b/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
@@ -259,6 +259,28 @@ abstract class UtilityMethodTestCase extends TestCase
     }
 
     /**
+     * Skip JS and CSS related tests on PHPCS 4.x.
+     *
+     * @since 1.0.0
+     *
+     * @before
+     *
+     * @return void
+     */
+    public function skipJSCSSTestsOnPHPCS4()
+    {
+        if (static::$fileExtension !== 'js' && static::$fileExtension !== 'css') {
+            return;
+        }
+
+        if (\version_compare(self::$phpcsVersion, '3.99.99', '<=')) {
+            return;
+        }
+
+        $this->markTestSkipped('JS and CSS support has been removed in PHPCS 4.');
+    }
+
+    /**
      * Clean up after finished test.
      *
      * @since 1.0.0


### PR DESCRIPTION
This implements automatic test skipping for JS/CSS tests on PHPCS 4.x, on which support for JS/CSS has been dropped.

Ref: https://github.com/squizlabs/PHP_CodeSniffer/commit/ea52e7b48165edbcb96b10a0a5de04567e4d73f8