### PR TITLE
Composer: allow installation with PHPCS 4.x for testing purposes + Travis test it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,9 @@ jobs:
     - php: 7.2
       env: PHPCS_VERSION="3.2.0"
 
+    - php: 7.4
+      env: PHPCS_VERSION="4.0.x-dev@dev"
+
     - php: "nightly"
       env: PHPCS_VERSION="n/a" LINT=1
 
@@ -132,6 +135,7 @@ jobs:
   allow_failures:
     # Allow failures for unstable builds.
     - php: "nightly"
+    - env: PHPCS_VERSION="4.0.x-dev@dev"
 
 
 before_install:

--- a/Tests/BackCompat/Helper/GetVersionTest.php
+++ b/Tests/BackCompat/Helper/GetVersionTest.php
@@ -32,7 +32,7 @@ class GetVersionTest extends TestCase
      *
      * @var string
      */
-    const DEVMASTER = '3.5.3';
+    const DEVMASTER = '3.5.4';
 
     /**
      * Test the method.
@@ -54,6 +54,8 @@ class GetVersionTest extends TestCase
 
         if ($expected === 'dev-master') {
             $this->assertTrue(\version_compare(self::DEVMASTER, $result, '<='));
+        } elseif ($expected === '4.0.x-dev@dev') {
+            $this->assertTrue(\version_compare('4.0.0', $result, '=='));
         } else {
             $this->assertSame($expected, $result);
         }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^2.6.0 || ^3.1.0",
+        "squizlabs/php_codesniffer" : "^2.6.0 || ^3.1.0 || 4.0.x-dev@dev",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.3 || ^0.4.1 || ^0.5 || ^0.6.2"
     },
     "require-dev" : {


### PR DESCRIPTION
## Composer: allow installation with PHPCS 4.x for testing purposes

Until PHPCS 4.x has been released, PHPCSUtils does not formally support it, though an effort will be made to keep up with the changes and anticipate potential compatibility issues.

For testing purposes, installation of PHPCSUtils with PHPCS 4.x-dev should already be supported though.

## Travis: add a test run against PHPCS 4.x-dev

Start testing against PHPCS 4.x-dev, for which development has started, to get early warning about cross-version compatibility issues which need fixing.

The build against `4.x-dev` has been added to `allow_failures` for now.

## Tests: Helper::getVersion(): update to allow for PHPCS 4.x-dev
