### PR TITLE
Tokens\Collections: add $OOHierarchyKeywords property

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -261,6 +261,21 @@ class Collections
     ];
 
     /**
+     * Tokens types used for "forwarding" calls within OO structures.
+     *
+     * @link https://www.php.net/manual/en/language.oop5.paamayim-nekudotayim.php
+     *
+     * @since 1.0.0
+     *
+     * @var array <int|string> => <int|string>
+     */
+    public static $OOHierarchyKeywords = [
+        \T_PARENT => \T_PARENT,
+        \T_SELF   => \T_SELF,
+        \T_STATIC => \T_STATIC,
+    ];
+
+    /**
      * Tokens types which can be encountered in the fully/partially qualified name of an OO structure.
      *
      * Example: `echo namespace\Sub\ClassName::method();`

--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -149,9 +149,7 @@ class Operators
             } else {
                 $skip   = Tokens::$emptyTokens;
                 $skip  += Collections::$OONameTokens;
-                $skip[] = \T_SELF;
-                $skip[] = \T_PARENT;
-                $skip[] = \T_STATIC;
+                $skip  += Collections::$OOHierarchyKeywords;
                 $skip[] = \T_DOUBLE_COLON;
 
                 $nextSignificantAfter = $phpcsFile->findNext(


### PR DESCRIPTION
## Tokens\Collections: add $OOHierarchyKeywords property

... containing tokens representing the keywords to access properties or methods from inside a class definition.

Refs:
* https://www.php.net/manual/en/language.oop5.paamayim-nekudotayim.php
* https://www.php.net/manual/en/language.oop5.late-static-bindings.php

## Operators::isReference(): use the new `Collections::$OOHierarchyKeywords` property

