### PR TITLE
Tests: abstract the assertAttributeSame backfill out to a trait

### DIFF
--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
@@ -10,10 +10,8 @@
 
 namespace PHPCSUtils\Tests\AbstractSniffs\AbstractArrayDeclaration;
 
-use Exception;
+use PHPCSUtils\Tests\AssertAttributeSame;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
-use ReflectionException;
-use ReflectionObject;
 
 /**
  * Tests for the \PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff class.
@@ -26,6 +24,8 @@ use ReflectionObject;
  */
 class AbstractArrayDeclarationSniffTest extends UtilityMethodTestCase
 {
+    // Backfill for the assertAttributeSame() method on PHPUnit 9.x.
+    use AssertAttributeSame;
 
     /**
      * List of methods in the abstract which should be mocked.
@@ -639,73 +639,5 @@ class AbstractArrayDeclarationSniffTest extends UtilityMethodTestCase
             ->willReturn(true);
 
         $mockObj->process(self::$phpcsFile, $target);
-    }
-
-    /**
-     * PHPUnit cross-version helper method to test the value of the class properties.
-     *
-     * @param mixed  $expected      Expected property value.
-     * @param string $attributeName The name of the property to check.
-     * @param object $actualObject  The object on which to check the property value.
-     * @param string $message       Optional. Custom error message.
-     *
-     * @return void
-     */
-    public function assertAttributeValueSame($expected, $attributeName, $actualObject, $message = '')
-    {
-        // Will throw a warning on PHPUnit 8, but will still work.
-        if (\method_exists($this, 'assertAttributeSame')) {
-            parent::assertAttributeSame($expected, $attributeName, $actualObject, $message);
-            return;
-        }
-
-        // PHPUnit 9.0+.
-        try {
-            $actual = $this->getObjectAttributeValue($actualObject, $attributeName);
-        } catch (Exception $e) {
-            $this->fail($e->getMessage());
-        }
-
-        $this->assertSame($expected, $actual, $message);
-    }
-
-    /**
-     * Retrieve the value of an object's attribute.
-     * This also works for attributes that are declared protected or private.
-     *
-     * @param object|string $object        The object or class on which to check the property value.
-     * @param string        $attributeName The name of the property to check.
-     *
-     * @return mixed Property value.
-     *
-     * @throws \Exception
-     */
-    public static function getObjectAttributeValue($object, $attributeName)
-    {
-        $reflector = new ReflectionObject($object);
-
-        do {
-            try {
-                $attribute = $reflector->getProperty($attributeName);
-
-                if (!$attribute || $attribute->isPublic()) {
-                    return $object->$attributeName;
-                }
-
-                $attribute->setAccessible(true);
-                $value = $attribute->getValue($object);
-                $attribute->setAccessible(false);
-
-                return $value;
-            } catch (ReflectionException $e) {
-            }
-        } while ($reflector = $reflector->getParentClass());
-
-        throw new Exception(
-            \sprintf(
-                'Attribute "%s" not found in object.',
-                $attributeName
-            )
-        );
     }
 }

--- a/Tests/AssertAttributeSame.php
+++ b/Tests/AssertAttributeSame.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests;
+
+use Exception;
+use ReflectionException;
+use ReflectionObject;
+
+/**
+ * PHPUnit cross-version compatibility helper.
+ *
+ * Backfills the PHPUnit native `assertAttributeSame()` method in PHPUnit 9.x and above in which
+ * the method was removed. Use `assertAttributeValueSame()` instead of `assertAttributeSame()`
+ * for cross-version compatibility.
+ *
+ * @since 1.0.0
+ */
+trait AssertAttributeSame
+{
+
+    /**
+     * PHPUnit cross-version helper method to test the value of class properties.
+     *
+     * @param mixed  $expected      Expected property value.
+     * @param string $attributeName The name of the property to check.
+     * @param object $actualObject  The object on which to check the property value.
+     * @param string $message       Optional. Custom error message.
+     *
+     * @return void
+     */
+    public function assertAttributeValueSame($expected, $attributeName, $actualObject, $message = '')
+    {
+        // Will throw a warning on PHPUnit 8, but will still work.
+        if (\method_exists($this, 'assertAttributeSame')) {
+            $this->assertAttributeSame($expected, $attributeName, $actualObject, $message);
+            return;
+        }
+
+        // PHPUnit 9.0+.
+        try {
+            $actual = $this->getObjectAttributeValue($actualObject, $attributeName);
+        } catch (Exception $e) {
+            $this->fail($e->getMessage());
+        }
+
+        $this->assertSame($expected, $actual, $message);
+    }
+
+    /**
+     * Retrieve the value of an object's attribute.
+     * This also works for attributes that are declared protected or private.
+     *
+     * @param object|string $object        The object or class on which to check the property value.
+     * @param string        $attributeName The name of the property to check.
+     *
+     * @return mixed Property value.
+     *
+     * @throws \Exception
+     */
+    public static function getObjectAttributeValue($object, $attributeName)
+    {
+        $reflector = new ReflectionObject($object);
+
+        do {
+            try {
+                $attribute = $reflector->getProperty($attributeName);
+
+                if (!$attribute || $attribute->isPublic()) {
+                    return $object->$attributeName;
+                }
+
+                $attribute->setAccessible(true);
+                $value = $attribute->getValue($object);
+                $attribute->setAccessible(false);
+
+                return $value;
+            } catch (ReflectionException $e) {
+            }
+        } while ($reflector = $reflector->getParentClass());
+
+        throw new Exception(
+            \sprintf(
+                'Attribute "%s" not found in object.',
+                $attributeName
+            )
+        );
+    }
+}


### PR DESCRIPTION
... to allow use of this functionality in other tests.

At some point in the future this may be (should probably be) abstracted out altogether to a separate package or to the `TestUtils`, but I need to think about that a little more.
For now, setting it up as a `trait` solves the more immediate pressing issue.