### PR TITLE
Utils\UseStatements: add new `splitAndMergeImportUseStatement()` method

### DIFF
--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -344,4 +344,56 @@ class UseStatements
 
         return $statements;
     }
+
+    /**
+     * Split an import use statement into individual imports and merge it with an array of previously
+     * seen import use statements.
+     *
+     * Beware: this method should only be used to combine the import use statements found in *one* file.
+     * Do NOT combine the statements of multiple files as the result will be inaccurate and unreliable.
+     *
+     * In most cases when tempted to use this method, the AbstractFileContextSniff should be used instead.
+     *
+     * @see \PHPCSUtils\AbstractSniffs\AbstractFileContextSniff
+     * @see \PHPCSUtils\Utils\UseStatements::splitImportUseStatement()
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile             The file where this token was found.
+     * @param int                         $stackPtr              The position in the stack of the T_USE token.
+     * @param array                       $previousUseStatements The import `use` statements collected so far.
+     *                                                           This should be either the output of a previous
+     *                                                           call to this method or the output of an earlier
+     *                                                           call to the UseStatements::splitImportUseStatement()
+     *                                                           method.
+     *
+     * @return array A multi-level array containing information about the current `use` statement combined with
+     *               the previously collected `use` statement information.
+     */
+    public static function splitAndMergeImportUseStatement(File $phpcsFile, $stackPtr, $previousUseStatements)
+    {
+        try {
+            $useStatements = self::splitImportUseStatement($phpcsFile, $stackPtr);
+
+            if (isset($previousUseStatements['name']) === false) {
+                $previousUseStatements['name'] = $useStatements['name'];
+            } else {
+                $previousUseStatements['name'] += $useStatements['name'];
+            }
+            if (isset($previousUseStatements['function']) === false) {
+                $previousUseStatements['function'] = $useStatements['function'];
+            } else {
+                $previousUseStatements['function'] += $useStatements['function'];
+            }
+            if (isset($previousUseStatements['const']) === false) {
+                $previousUseStatements['const'] = $useStatements['const'];
+            } else {
+                $previousUseStatements['const'] += $useStatements['const'];
+            }
+        } catch (RuntimeException $e) {
+            // Not an import use statement.
+        }
+
+        return $previousUseStatements;
+    }
 }

--- a/Tests/Utils/UseStatements/SplitAndMergeImportUseStatementTest.inc
+++ b/Tests/Utils/UseStatements/SplitAndMergeImportUseStatementTest.inc
@@ -1,0 +1,24 @@
+<?php
+
+/* testUseNamePlainAliased */
+use MyNamespace \ YourClass as ClassAlias;
+
+/* testUseFunctionPlain */
+use function MyNamespace\myFunction;
+
+/* testUseConstPlain */
+use const MyNamespace\MY_CONST;
+
+/* testGroupUseMixed */
+use Some\NS\ {
+   ClassName,
+   function SubLevel\functionName,
+   const Constants\CONSTANT_NAME as SOME_CONSTANT,
+   function SubLevel\AnotherName,
+   AnotherLevel,
+};
+
+class Foo {
+    /* testTraitUse */
+    use MyNamespace\Bar;
+}

--- a/Tests/Utils/UseStatements/SplitAndMergeImportUseStatementTest.php
+++ b/Tests/Utils/UseStatements/SplitAndMergeImportUseStatementTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\UseStatements;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\UseStatements;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\UseStatements::splitAndMergeImportUseStatement() method.
+ *
+ * @covers \PHPCSUtils\Utils\UseStatements::splitAndMergeImportUseStatement
+ *
+ * @group usestatements
+ *
+ * @since 1.0.0
+ */
+class SplitAndMergeImportUseStatementTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test correctly splitting and merging a import `use` statements.
+     *
+     * @dataProvider dataSplitAndMergeImportUseStatement
+     *
+     * @param string $testMarker  The comment which prefaces the target token in the test file.
+     * @param array  $expected    The expected return value of the function.
+     * @param array  $previousUse Previous use statement parameter to pass to the method.
+     *
+     * @return void
+     */
+    public function testSplitAndMergeImportUseStatement($testMarker, $expected, $previousUse)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, \T_USE);
+        $result   = UseStatements::splitAndMergeImportUseStatement(self::$phpcsFile, $stackPtr, $previousUse);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testSplitAndMergeImportUseStatement() For the array format.
+     *
+     * @return array
+     */
+    public function dataSplitAndMergeImportUseStatement()
+    {
+        $data = [
+            'name-plain' => [
+                '/* testUseNamePlainAliased */',
+                [
+                    'name'     => ['ClassAlias' => 'MyNamespace\YourClass'],
+                    'function' => [],
+                    'const'    => [],
+                ],
+            ],
+            'function-plain' => [
+                '/* testUseFunctionPlain */',
+                [
+                    'name'     => ['ClassAlias' => 'MyNamespace\YourClass'],
+                    'function' => ['myFunction' => 'MyNamespace\myFunction'],
+                    'const'    => [],
+                ],
+            ],
+            'const-plain' => [
+                '/* testUseConstPlain */',
+                [
+                    'name'     => ['ClassAlias' => 'MyNamespace\YourClass'],
+                    'function' => ['myFunction' => 'MyNamespace\myFunction'],
+                    'const'    => ['MY_CONST' => 'MyNamespace\MY_CONST'],
+                ],
+            ],
+            'group-mixed' => [
+                '/* testGroupUseMixed */',
+                [
+                    'name'     => [
+                        'ClassAlias'   => 'MyNamespace\YourClass',
+                        'ClassName'    => 'Some\NS\ClassName',
+                        'AnotherLevel' => 'Some\NS\AnotherLevel',
+                    ],
+                    'function' => [
+                        'myFunction'   => 'MyNamespace\myFunction',
+                        'functionName' => 'Some\NS\SubLevel\functionName',
+                        'AnotherName'  => 'Some\NS\SubLevel\AnotherName',
+                    ],
+                    'const'    => [
+                        'MY_CONST'      => 'MyNamespace\MY_CONST',
+                        'SOME_CONSTANT' => 'Some\NS\Constants\CONSTANT_NAME',
+                    ],
+                ],
+            ],
+            'trait-use' => [
+                '/* testTraitUse */',
+                // Same as previous.
+                [
+                    'name'     => [
+                        'ClassAlias'   => 'MyNamespace\YourClass',
+                        'ClassName'    => 'Some\NS\ClassName',
+                        'AnotherLevel' => 'Some\NS\AnotherLevel',
+                    ],
+                    'function' => [
+                        'myFunction'   => 'MyNamespace\myFunction',
+                        'functionName' => 'Some\NS\SubLevel\functionName',
+                        'AnotherName'  => 'Some\NS\SubLevel\AnotherName',
+                    ],
+                    'const'    => [
+                        'MY_CONST'      => 'MyNamespace\MY_CONST',
+                        'SOME_CONSTANT' => 'Some\NS\Constants\CONSTANT_NAME',
+                    ],
+                ],
+            ],
+        ];
+
+        $previousUse = [];
+        foreach ($data as $key => $value) {
+            $data[$key][] = $previousUse;
+            $previousUse  = $value[1];
+        }
+
+        return $data;
+    }
+}


### PR DESCRIPTION
... which uses the `UseStatements::splitImportUseStatement()` method to retrieve the information on the current `use` import statement and merges the result with an array of previously seen import use statements.

Includes dedicated unit tests.