### PR TITLE
BackCompat\Helper: add `getEncoding()`helper method

### DIFF
--- a/PHPCSUtils/BackCompat/Helper.php
+++ b/PHPCSUtils/BackCompat/Helper.php
@@ -152,6 +152,48 @@ class Helper
     }
 
     /**
+     * Get the applicable (file) encoding as passed to PHP_CodeSniffer from the
+     * command-line or the ruleset.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile Optional. The current file being processed.
+     *
+     * @return string Encoding. Defaults to the PHPCS native default, which is 'utf-8'
+     *                for PHPCS 3.x and was 'iso-8859-1' for PHPCS 2.x.
+     */
+    public static function getEncoding(File $phpcsFile = null)
+    {
+        static $default;
+
+        if (isset($default) === false) {
+            $default = 'utf-8';
+            if (version_compare(self::getVersion(), '2.99.99', '<=') === true) {
+                // In PHPCS 2.x, the default encoding is `iso-8859-1`.
+                $default = 'iso-8859-1';
+            }
+        }
+
+        if ($phpcsFile instanceof File) {
+            // Most reliable.
+            $encoding = self::getCommandLineData($phpcsFile, 'encoding');
+            if ($encoding === null) {
+                $encoding = $default;
+            }
+
+            return $encoding;
+        }
+
+        // Less reliable.
+        $encoding = self::getConfigData('encoding');
+        if ($encoding === null) {
+            $encoding = $default;
+        }
+
+        return $encoding;
+    }
+
+    /**
      * Check whether the `--ignore-annotations` option has been used.
      *
      * @since 1.0.0

--- a/PHPCSUtils/Utils/Orthography.php
+++ b/PHPCSUtils/Utils/Orthography.php
@@ -102,7 +102,7 @@ class Orthography
         static $encoding;
 
         if (isset($encoding) === false) {
-            $encoding = Helper::getConfigData('encoding');
+            $encoding = Helper::getEncoding();
         }
 
         $string = \rtrim($string);

--- a/Tests/BackCompat/Helper/GetCommandLineDataTest.php
+++ b/Tests/BackCompat/Helper/GetCommandLineDataTest.php
@@ -88,6 +88,64 @@ class GetCommandLineDataTest extends UtilityMethodTestCase
     }
 
     /**
+     * Test the getEncoding() method.
+     *
+     * @covers \PHPCSUtils\BackCompat\Helper::getEncoding
+     *
+     * @return void
+     */
+    public function testGetEncoding()
+    {
+        $result   = Helper::getEncoding(self::$phpcsFile);
+        $expected = \version_compare(static::$phpcsVersion, '2.99.99', '>') ? 'utf-8' : 'iso-8859-1';
+        $this->assertSame($expected, $result, 'Failed retrieving the default encoding');
+
+        if (\version_compare(static::$phpcsVersion, '2.99.99', '>') === true) {
+            // PHPCS 3.x.
+            self::$phpcsFile->config->encoding = 'utf-16';
+        } else {
+            // PHPCS 2.x.
+            self::$phpcsFile->phpcs->cli->setCommandLineValues(['--encoding=utf-16']);
+        }
+
+        $result = Helper::getEncoding(self::$phpcsFile);
+        $this->assertSame('utf-16', $result, 'Failed retrieving the custom set encoding');
+
+        // Restore defaults before moving to the next test.
+        if (\version_compare(static::$phpcsVersion, '2.99.99', '>') === true) {
+            self::$phpcsFile->config->restoreDefaults();
+        } else {
+            self::$phpcsFile->phpcs->cli->setCommandLineValues(['--encoding=iso-8859-1']);
+        }
+    }
+
+    /**
+     * Test the getEncoding() method when not passing the PHPCS file parameter.
+     *
+     * @covers \PHPCSUtils\BackCompat\Helper::getEncoding
+     *
+     * @return void
+     */
+    public function testGetEncodingWithoutPHPCSFile()
+    {
+        $result   = Helper::getEncoding();
+        $expected = \version_compare(static::$phpcsVersion, '2.99.99', '>') ? 'utf-8' : 'iso-8859-1';
+        $this->assertSame($expected, $result, 'Failed retrieving the default encoding');
+
+        Helper::setConfigData('encoding', 'utf-16', true);
+
+        $result = Helper::getEncoding();
+        $this->assertSame('utf-16', $result, 'Failed retrieving the custom set encoding');
+
+        // Restore defaults before moving to the next test.
+        if (\version_compare(static::$phpcsVersion, '2.99.99', '>') === true) {
+            Helper::setConfigData('encoding', 'utf-8', true);
+        } else {
+            Helper::setConfigData('encoding', 'iso-8859-1', true);
+        }
+    }
+
+    /**
      * Test the ignoreAnnotations() method.
      *
      * @covers \PHPCSUtils\BackCompat\Helper::ignoreAnnotations


### PR DESCRIPTION
## BackCompat\Helper: add `getEncoding()`helper method

... to retrieve the file encoding a project supposedly uses. No check is done to see if the `encoding` set is actually correct for the files presented to PHPCS.

In PHPCS, the `encoding` can be set via `--config-set` or `--encoding` from the command-line or via a custom ruleset like `<arg name="encoding" value="utf-8"/>`.

The default encoding encoding used by PHPCS changed between PHPCS 2.x (`iso-8859-1`) and 3.x `utf-8`.

Using the `utf-8` file encoding is strongly advised for all PHP projects.

Includes minimal unit tests.

## Orthography::isLastCharPunctuation(): implement use of the ` Helper::getEncoding()` method

