### PR TITLE
FunctionDeclarations::isMagicFunction(): bug fix for nested functions

### DIFF
--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -16,7 +16,6 @@ use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tokens\Collections;
-use PHPCSUtils\Utils\Conditions;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\ObjectDeclarations;
 use PHPCSUtils\Utils\Scopes;
@@ -819,7 +818,7 @@ class FunctionDeclarations
             return false;
         }
 
-        if (Conditions::hasCondition($phpcsFile, $stackPtr, BCTokens::ooScopeTokens()) === true) {
+        if (Scopes::isOOMethod($phpcsFile, $stackPtr) === true) {
             return false;
         }
 

--- a/Tests/Utils/FunctionDeclarations/SpecialFunctionsTest.inc
+++ b/Tests/Utils/FunctionDeclarations/SpecialFunctionsTest.inc
@@ -94,3 +94,16 @@ interface MagicInterface
     /* testMethodInInterfaceNotMagicName */
     function __myFunction();
 }
+
+// Verify that nested functions are correctly seen as declared in the global namespace.
+class FunctionsDeclaredNestedInMethod extends \SoapClient {
+    /* testNonMagicMethod */
+    public function methodName() {
+        /* testNestedFunctionDeclarationMagicFunction */
+        function __autoload($class) {}
+        /* testNestedFunctionDeclarationNonMagicFunction */
+        function __isset() {}
+        /* testNestedFunctionDeclarationNonSpecialFunction */
+        function __getLastResponse() {}
+    }
+}

--- a/Tests/Utils/FunctionDeclarations/SpecialFunctionsTest.php
+++ b/Tests/Utils/FunctionDeclarations/SpecialFunctionsTest.php
@@ -391,6 +391,43 @@ class SpecialFunctionsTest extends UtilityMethodTestCase
                     'special'  => false,
                 ],
             ],
+
+            'NonMagicMethod' => [
+                '/* testNonMagicMethod */',
+                [
+                    'function' => false,
+                    'method'   => false,
+                    'double'   => false,
+                    'special'  => false,
+                ],
+            ],
+            'NestedFunctionDeclarationMagicFunction' => [
+                '/* testNestedFunctionDeclarationMagicFunction */',
+                [
+                    'function' => true,
+                    'method'   => false,
+                    'double'   => false,
+                    'special'  => false,
+                ],
+            ],
+            'NestedFunctionDeclarationNonMagicFunction' => [
+                '/* testNestedFunctionDeclarationNonMagicFunction */',
+                [
+                    'function' => false,
+                    'method'   => false,
+                    'double'   => false,
+                    'special'  => false,
+                ],
+            ],
+            'NestedFunctionDeclarationNonSpecialFunction' => [
+                '/* testNestedFunctionDeclarationNonSpecialFunction */',
+                [
+                    'function' => false,
+                    'method'   => false,
+                    'double'   => false,
+                    'special'  => false,
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
Function declarations nested in a class method declare the function in the global namespace.
See: https://3v4l.org/R32Sl

This was not handled correctly by the function so far. Fixed now.

Includes unit tests covering the fix.