### PR TITLE
ObjectDeclarations::getName(): bug fix for functions returning by reference

### DIFF
--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -120,6 +120,7 @@ class ObjectDeclarations
         $exclude   = Tokens::$emptyTokens;
         $exclude[] = \T_OPEN_PARENTHESIS;
         $exclude[] = \T_OPEN_CURLY_BRACKET;
+        $exclude[] = \T_BITWISE_AND;
 
         $nameStart = $phpcsFile->findNext($exclude, ($stackPtr + 1), $stopPoint, true);
         if ($nameStart === false) {

--- a/Tests/BackCompat/BCFile/GetDeclarationNameTest.inc
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameTest.inc
@@ -27,6 +27,9 @@ $class = new class extends SomeClass {
 /* testFunction */
 function functionName() {}
 
+/* testFunctionReturnByRef */
+function & functionNameByRef();
+
 /* testClass */
 abstract class ClassName {
     /* testMethod */
@@ -34,6 +37,9 @@ abstract class ClassName {
 
     /* testAbstractMethod */
     abstract protected function abstractMethodName();
+
+    /* testMethodReturnByRef */
+    private function &MethodNameByRef();
 }
 
 /* testExtendedClass */

--- a/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
@@ -133,6 +133,10 @@ class GetDeclarationNameTest extends UtilityMethodTestCase
                 '/* testFunction */',
                 'functionName',
             ],
+            'function-return-by-reference' => [
+                '/* testFunctionReturnByRef */',
+                'functionNameByRef',
+            ],
             'class' => [
                 '/* testClass */',
                 'ClassName',
@@ -144,6 +148,10 @@ class GetDeclarationNameTest extends UtilityMethodTestCase
             'abstract-method' => [
                 '/* testAbstractMethod */',
                 'abstractMethodName',
+            ],
+            'method-return-by-reference' => [
+                '/* testMethodReturnByRef */',
+                'MethodNameByRef',
             ],
             'extended-class' => [
                 '/* testExtendedClass */',


### PR DESCRIPTION
Includes unit tests.