### PR TITLE
Namespaces::getType(): improve detection of namespace keyword as operator

### DIFF
--- a/Tests/Utils/Namespaces/NamespaceTypeTest.inc
+++ b/Tests/Utils/Namespaces/NamespaceTypeTest.inc
@@ -28,10 +28,23 @@ function closedScope() {
     echo namespace\ClassName::method();
 
     while( true ) {
-		/* testNamespaceOperatorInParentheses */
-	    function_call( namespace\ClassName::$property );
-	}
+        /* testNamespaceOperatorInParentheses */
+        function_call( namespace\ClassName::$property );
+    }
 }
+
+/* testNamespaceOperatorGlobalNamespaceStartOfStatementFunctionCall */
+namespace\functionCall();
+
+/* testNamespaceOperatorGlobalNamespaceStartOfStatementCombiWithNonConfusingToken1 */
+namespace\CONSTANT === 'test' or die();
+
+/* testNamespaceOperatorGlobalNamespaceStartOfStatementCombiWithNonConfusingToken2 */
+namespace\ClassName::$property++;
+
+/* testNamespaceOperatorGlobalNamespaceStartOfStatementCombiWithNonConfusingToken3 */
+namespace\CONSTANT['key'];
+
 
 /* testParseErrorScopedNamespaceDeclaration */
 function testScope() {

--- a/Tests/Utils/Namespaces/NamespaceTypeTest.php
+++ b/Tests/Utils/Namespaces/NamespaceTypeTest.php
@@ -156,6 +156,34 @@ class NamespaceTypeTest extends UtilityMethodTestCase
                     'operator'    => true,
                 ],
             ],
+            'namespace-operator-global-namespace-start-of-statement-function-call' => [
+                '/* testNamespaceOperatorGlobalNamespaceStartOfStatementFunctionCall */',
+                [
+                    'declaration' => false,
+                    'operator'    => true,
+                ],
+            ],
+            'namespace-operator-global-namespace-start-of-statement-with-non-confusing-token-1' => [
+                '/* testNamespaceOperatorGlobalNamespaceStartOfStatementCombiWithNonConfusingToken1 */',
+                [
+                    'declaration' => false,
+                    'operator'    => true,
+                ],
+            ],
+            'namespace-operator-global-namespace-start-of-statement-with-non-confusing-token-2' => [
+                '/* testNamespaceOperatorGlobalNamespaceStartOfStatementCombiWithNonConfusingToken2 */',
+                [
+                    'declaration' => false,
+                    'operator'    => true,
+                ],
+            ],
+            'namespace-operator-global-namespace-start-of-statement-with-non-confusing-token-3' => [
+                '/* testNamespaceOperatorGlobalNamespaceStartOfStatementCombiWithNonConfusingToken3 */',
+                [
+                    'declaration' => false,
+                    'operator'    => true,
+                ],
+            ],
             'parse-error-scoped-namespace-declaration' => [
                 '/* testParseErrorScopedNamespaceDeclaration */',
                 [


### PR DESCRIPTION
When the `namespace` keyword is used in the global namespace, it is less easy to determine with 100% certainty whether it used for a declaration or as an operator, especially when taking into account potential coding errors, such as the use of reserved keywords in the namespace name and/or a leading backslash used in a namespace declaration.

This PR hardens the code and will more often correctly detect whether the namespace keyword is used as an operator when used in the global namespace.

Includes unit tests.