### PR TITLE
Tokens\Collections::$returnTypeTokens: allow for "static" (PHP 8)

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -423,6 +423,7 @@ class Collections
         \T_CALLABLE     => \T_CALLABLE,
         \T_SELF         => \T_SELF,
         \T_PARENT       => \T_PARENT,
+        \T_STATIC       => \T_STATIC,
         \T_NS_SEPARATOR => \T_NS_SEPARATOR,
     ];
 

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
@@ -67,6 +67,13 @@ $result = array_map(
     $numbers
 );
 
+class ReturnMe {
+    /* testReturnTypeStatic */
+    private function myFunction(): static {
+        return $this;
+    }
+}
+
 /* testNotAFunction */
 return true;
 

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -434,6 +434,28 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     }
 
     /**
+     * Test a function with return type "static".
+     *
+     * @return void
+     */
+    public function testReturnTypeStatic()
+    {
+        $expected = [
+            'scope'                => 'private',
+            'scope_specified'      => true,
+            'return_type'          => 'static',
+            'return_type_token'    => 7, // Offset from the T_FUNCTION token.
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Test for incorrect tokenization of array return type declarations in PHPCS < 2.8.0.
      *
      * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/1264


### PR DESCRIPTION
As of PHP 8.0, `static` can be used as a return type for function declarations.

Ref: https://wiki.php.net/rfc/static_return_type

Includes adding a unit test for the `BCFile::getMethodProperties()`/`FunctionDeclarations::getProperties()` methods to safeguard this.

Sister-PR to the upstream squizlabs/PHP_CodeSniffer#2952