### PR TITLE
Helper::setConfigData(): PHPCS 4.x compatibility

### DIFF
--- a/Tests/BackCompat/Helper/ConfigDataTest.php
+++ b/Tests/BackCompat/Helper/ConfigDataTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\BackCompat\Helper;
 
+use PHP_CodeSniffer\Config;
 use PHPCSUtils\BackCompat\Helper;
 use PHPUnit\Framework\TestCase;
 
@@ -27,12 +28,41 @@ class ConfigDataTest extends TestCase
 {
 
     /**
-     * Test the getConfigData() and setConfigData() method.
+     * Test the getConfigData() and setConfigData() method when used in a cross-version compatible manner.
      *
      * @return void
      */
-    public function testConfigData()
+    public function testConfigData34()
     {
+        if (version_compare(Helper::getVersion(), '2.99.99', '<=') === true) {
+            $this->markTestSkipped('Test only applicable to PHPCS > 2.x');
+        }
+
+        $config   = new Config();
+        $original = Helper::getConfigData('arbitrary_name');
+        $expected = 'expected';
+
+        $return = Helper::setConfigData('arbitrary_name', $expected, true, $config);
+        $this->assertTrue($return);
+
+        $result = Helper::getConfigData('arbitrary_name');
+        $this->assertSame($expected, $result);
+
+        // Reset the value after the test.
+        Helper::setConfigData('arbitrary_name', $original, true, $config);
+    }
+
+    /**
+     * Test the getConfigData() and setConfigData() method when used in a non-PHPCS 4.x compatible manner.
+     *
+     * @return void
+     */
+    public function testConfigDataPHPCS23()
+    {
+        if (version_compare(Helper::getVersion(), '3.99.99', '>') === true) {
+            $this->markTestSkipped('Test only applicable to PHPCS < 4.x');
+        }
+
         $original = Helper::getConfigData('arbitrary_name');
         $expected = 'expected';
 
@@ -43,6 +73,32 @@ class ConfigDataTest extends TestCase
         $this->assertSame($expected, $result);
 
         // Reset the value after the test.
-        $return = Helper::setConfigData('arbitrary_name', $original, true);
+        Helper::setConfigData('arbitrary_name', $original, true);
+    }
+
+    /**
+     * Test the getConfigData() and setConfigData() method when used in a non-PHPCS 4.x compatible manner.
+     *
+     * @return void
+     */
+    public function testConfigDataPHPCS4Exception()
+    {
+        if (version_compare(Helper::getVersion(), '3.99.99', '<=') === true) {
+            $this->markTestSkipped('Test only applicable to PHPCS 4.x');
+        }
+
+        $msg       = 'Passing the $config parameter is required in PHPCS 4.x';
+        $exception = 'PHP_CodeSniffer\Exceptions\RuntimeException';
+
+        if (\method_exists($this, 'expectException')) {
+            // PHPUnit 5+.
+            $this->expectException($exception);
+            $this->expectExceptionMessage($msg);
+        } else {
+            // PHPUnit 4.
+            $this->setExpectedException($exception, $msg);
+        }
+
+        Helper::setConfigData('arbitrary_name', 'test', true);
     }
 }

--- a/Tests/BackCompat/Helper/GetCommandLineDataTest.php
+++ b/Tests/BackCompat/Helper/GetCommandLineDataTest.php
@@ -132,16 +132,21 @@ class GetCommandLineDataTest extends UtilityMethodTestCase
         $expected = \version_compare(static::$phpcsVersion, '2.99.99', '>') ? 'utf-8' : 'iso-8859-1';
         $this->assertSame($expected, $result, 'Failed retrieving the default encoding');
 
-        Helper::setConfigData('encoding', 'utf-16', true);
+        $config = null;
+        if (isset(self::$phpcsFile->config) === true) {
+            $config = self::$phpcsFile->config;
+        }
+
+        Helper::setConfigData('encoding', 'utf-16', true, $config);
 
         $result = Helper::getEncoding();
         $this->assertSame('utf-16', $result, 'Failed retrieving the custom set encoding');
 
         // Restore defaults before moving to the next test.
         if (\version_compare(static::$phpcsVersion, '2.99.99', '>') === true) {
-            Helper::setConfigData('encoding', 'utf-8', true);
+            Helper::setConfigData('encoding', 'utf-8', true, $config);
         } else {
-            Helper::setConfigData('encoding', 'iso-8859-1', true);
+            Helper::setConfigData('encoding', 'iso-8859-1', true, $config);
         }
     }
 
@@ -197,13 +202,18 @@ class GetCommandLineDataTest extends UtilityMethodTestCase
             $this->markTestSkipped('Test only applicable to PHPCS 3.x');
         }
 
-        Helper::setConfigData('annotations', false, true);
+        $config = null;
+        if (isset(self::$phpcsFile->config) === true) {
+            $config = self::$phpcsFile->config;
+        }
+
+        Helper::setConfigData('annotations', false, true, $config);
 
         $result = Helper::ignoreAnnotations();
         $this->assertTrue($result);
 
         // Restore defaults before moving to the next test.
-        Helper::setConfigData('annotations', true, true);
+        Helper::setConfigData('annotations', true, true, $config);
     }
 
     /**


### PR DESCRIPTION
As of PHPCS 4.x, the `PHP_CodeSniffer\Config::setConfigData()` method is no longer static.

Ref: https://github.com/squizlabs/PHP_CodeSniffer/commit/10a89a2c8c33a26466ccb3368a69a5e99549f80e

This commit adds a new `$config` parameter to the `Helper::setConfigData()` method which will be a required parameter for PHPCS 4.x.

Includes adjusted unit tests.