### PR TITLE
ControlStructures::getCaughtExceptions(): add test with PHP8 non-capturing catch

### DIFF
--- a/PHPCSUtils/Utils/ControlStructures.php
+++ b/PHPCSUtils/Utils/ControlStructures.php
@@ -383,7 +383,7 @@ class ControlStructures
         $firstToken = null;
         $lastToken  = null;
 
-        for ($i = ($opener + 1); $i < $closer; $i++) {
+        for ($i = ($opener + 1); $i <= $closer; $i++) {
             if (isset(Tokens::$emptyTokens[$tokens[$i]['code']])) {
                 continue;
             }

--- a/Tests/Utils/ControlStructures/GetCaughtExceptionsTest.inc
+++ b/Tests/Utils/ControlStructures/GetCaughtExceptionsTest.inc
@@ -27,6 +27,9 @@ try {
 /* testMultiCatchCompoundNames */
 } catch (\NS\RuntimeException | My\ParseErrorException | namespace \ AnotherException $e) {
 
+/* testPHP8NonCapturingCatch */
+} catch (RuntimeException | AnotherException) {
+
 /* testLiveCoding */
 // Intentional parse error.
 } catch (

--- a/Tests/Utils/ControlStructures/GetCaughtExceptionsTest.php
+++ b/Tests/Utils/ControlStructures/GetCaughtExceptionsTest.php
@@ -197,6 +197,21 @@ class GetCaughtExceptionsTest extends UtilityMethodTestCase
                     ],
                 ],
             ],
+            'non-capturing-catch' => [
+                'target'        => '/* testPHP8NonCapturingCatch */',
+                'expected'      => [
+                    [
+                        'type'           => 'RuntimeException',
+                        'type_token'     => 3,
+                        'type_end_token' => 3,
+                    ],
+                    [
+                        'type'           => 'AnotherException',
+                        'type_token'     => 7,
+                        'type_end_token' => 7,
+                    ],
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
PHP 8 will introduce non-capturing catch statements.

This tiny fix makes sure the method can handle these correctly.

Includes unit test.

Ref: https://wiki.php.net/rfc/non-capturing_catches