### PR TITLE
Operators::isReference(): bug fix - closure return by reference not recognized

### DIFF
--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -57,6 +57,8 @@ class Operators
      * Determine if the passed token is a reference operator.
      *
      * Main differences with the PHPCS version:
+     * - Bug fixed: the `&` for a closure declared to return by reference was not recognized as
+     *   a reference. {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/2977 Open PR upstream}
      * - Defensive coding against incorrect calls to this method.
      * - Improved handling of select tokenizer errors involving short lists/short arrays.
      *
@@ -83,6 +85,7 @@ class Operators
         $tokenBefore = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
         if ($tokens[$tokenBefore]['code'] === \T_FUNCTION
+            || $tokens[$tokenBefore]['code'] === T_CLOSURE
             || FunctionDeclarations::isArrowFunction($phpcsFile, $tokenBefore) === true
         ) {
             // Function returns a reference.

--- a/Tests/Utils/Operators/IsReferenceDiffTest.inc
+++ b/Tests/Utils/Operators/IsReferenceDiffTest.inc
@@ -11,3 +11,6 @@ if ($foo) {}
 /* testTokenizerIssue1284PHPCSlt280C */
 if ($foo) {}
 [&$a, $b];
+
+/* testClosureReturnByReference */
+$closure = function &($param) use ($value) {};

--- a/Tests/Utils/Operators/IsReferenceDiffTest.php
+++ b/Tests/Utils/Operators/IsReferenceDiffTest.php
@@ -85,6 +85,10 @@ class IsReferenceDiffDiffTest extends UtilityMethodTestCase
                 '/* testTokenizerIssue1284PHPCSlt280C */',
                 true,
             ],
+            'closure-return-by-reference' => [
+                '/* testClosureReturnByReference */',
+                true,
+            ],
         ];
     }
 }


### PR DESCRIPTION
The `&` in a closure declared to return by reference was not recognized as a reference.

Fixed now.

Includes unit test.

The same fix has also been pulled upstream: squizlabs/php_codesniffer#2977