### PR TITLE
Improve support for arrow functions / sync with phpcs 3.5.5/6

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -1251,6 +1251,7 @@ class BCFile
      * - PHPCS 3.5.0: Improved handling of group use statements.
      * - PHPCS 3.5.3: Added support for PHP 7.4 T_FN arrow functions.
      * - PHPCS 3.5.4: Improved support for PHP 7.4 T_FN arrow functions.
+     * - PHPCS 3.5.5: Improved support for PHP 7.4 T_FN arrow functions, PHPCS #2895.
      *
      * @see \PHP_CodeSniffer\Files\File::findEndOfStatement() Original source.
      *
@@ -1288,7 +1289,6 @@ class BCFile
         }
 
         $lastNotEmpty = $start;
-
         for ($i = $start; $i < $phpcsFile->numTokens; $i++) {
             if ($i !== $start && isset($endTokens[$tokens[$i]['code']]) === true) {
                 // Found the end of the statement.
@@ -1311,6 +1311,8 @@ class BCFile
                 || $i === $tokens[$i]['scope_condition'])
             ) {
                 if ($tokens[$i]['type'] === 'T_FN') {
+                    $lastNotEmpty = $tokens[$i]['scope_closer'];
+
                     // Minus 1 as the closer can be shared.
                     $i = ($tokens[$i]['scope_closer'] - 1);
                     continue;
@@ -1342,8 +1344,11 @@ class BCFile
                         return $arrowFunctionOpenClose['scope_closer'];
                     }
 
+                    $lastNotEmpty = $arrowFunctionOpenClose['scope_closer'];
+
                     // Minus 1 as the closer can be shared.
                     $i = ($arrowFunctionOpenClose['scope_closer'] - 1);
+                    continue;
                 }
             }
 

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -765,6 +765,8 @@ class FunctionDeclarations
 
             if (isset($tokens[$scopeCloser]['scope_closer']) === true
                 && $tokens[$scopeCloser]['code'] !== \T_INLINE_ELSE
+                && $tokens[$scopeCloser]['code'] !== \T_END_HEREDOC
+                && $tokens[$scopeCloser]['code'] !== \T_END_NOWDOC
             ) {
                 // We minus 1 here in case the closer can be shared with us.
                 $scopeCloser = ($tokens[$scopeCloser]['scope_closer'] - 1);

--- a/Tests/BackCompat/BCFile/FindEndOfStatementTest.inc
+++ b/Tests/BackCompat/BCFile/FindEndOfStatementTest.inc
@@ -42,4 +42,14 @@ static fn ($a) => $a;
 /* testArrowFunctionReturnValue */
 fn(): array => [a($a, $b)];
 
+$foo = foo(
+    /* testArrowFunctionAsArgument */
+    fn() => bar()
+);
+
+$foo = foo(
+    /* testArrowFunctionWithArrayAsArgument */
+    fn() => [$row[0], $row[3]]
+);
+
 return 0;

--- a/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
@@ -207,4 +207,33 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
 
         $this->assertSame(($start + 18), $found);
     }
+
+    /**
+     * Test arrow function used as a function argument.
+     *
+     * @return void
+     */
+    public function testArrowFunctionAsArgument()
+    {
+        $start = $this->getTargetToken('/* testArrowFunctionAsArgument */', Collections::arrowFunctionTokensBC());
+        $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
+
+        $this->assertSame(($start + 8), $found);
+    }
+
+    /**
+     * Test arrow function with arrays used as a function argument.
+     *
+     * @return void
+     */
+    public function testArrowFunctionWithArrayAsArgument()
+    {
+        $start = $this->getTargetToken(
+            '/* testArrowFunctionWithArrayAsArgument */',
+            Collections::arrowFunctionTokensBC()
+        );
+        $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
+
+        $this->assertSame(($start + 17), $found);
+    }
 }

--- a/Tests/Utils/FunctionDeclarations/IsArrowFunction2926Test.inc
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunction2926Test.inc
@@ -1,0 +1,11 @@
+<?php
+
+/* testHeredoc */
+$fn1 = fn() => <<<HTML
+fn
+HTML;
+
+/* testNowdoc */
+$fn1 = fn() => <<<'HTML'
+fn
+HTML;

--- a/Tests/Utils/FunctionDeclarations/IsArrowFunction2926Test.php
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunction2926Test.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\FunctionDeclarations;
+
+use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\FunctionDeclarations;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction() and the
+ * \PHPCSUtils\Utils\FunctionDeclarations::getArrowFunctionOpenClose() methods for
+ * a particular situation which will hang the tokenizer.
+ *
+ * These tests are based on the `Tokenizer/BackfillFnTokenTest` file in PHPCS itself.
+ *
+ * @link https://github.com/squizlabs/php_codesniffer/issues/2926
+ *
+ * @covers \PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction
+ * @covers \PHPCSUtils\Utils\FunctionDeclarations::getArrowFunctionOpenClose
+ *
+ * @group functiondeclarations
+ *
+ * @since 1.0.0
+ */
+class IsArrowFunction2926Test extends UtilityMethodTestCase
+{
+
+    /**
+     * PHPCS versions in which the tokenizer will hang for these particular test cases.
+     *
+     * @var array
+     */
+    private $unsupportedPHPCSVersions = [
+        '3.5.3' => true,
+        '3.5.4' => true,
+        '3.5.5' => true,
+    ];
+
+    /**
+     * Whether the test case file has been tokenized.
+     *
+     * Efficiency tweak as the tokenization is done in "before" not in "before class"
+     * for this test.
+     *
+     * @var bool
+     */
+    private static $tokenized = false;
+
+    /**
+     * Do NOT Initialize PHPCS & tokenize the test case file.
+     *
+     * Skip tokenizing the test case file on "before class" as at that time, we can't skip the test
+     * yet if the PHPCS version in incompatible and it would hang the Tokenizer (and therefore
+     * the test) if it is.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        // Skip the tokenizing of the test case file at this time.
+    }
+
+    /**
+     * Initialize PHPCS & tokenize the test case file on compatible PHPCS versions.
+     *
+     * Skip this test on PHPCS versions on which the Tokenizer will hang.
+     *
+     * @before
+     *
+     * @return void
+     */
+    public function setUpTestFileForReal()
+    {
+        $phpcsVersion = Helper::getVersion();
+
+        if (isset($this->unsupportedPHPCSVersions[$phpcsVersion]) === true) {
+            $this->markTestSkipped("Issue 2926 can not be tested on PHPCS $phpcsVersion as the Tokenizer will hang.");
+        }
+
+        if (self::$tokenized === false) {
+            parent::setUpTestFile();
+            self::$tokenized = true;
+        }
+    }
+
+    /**
+     * Test correctly detecting arrow functions.
+     *
+     * @dataProvider dataArrowFunction
+     *
+     * @param string $testMarker    The comment which prefaces the target token in the test file.
+     * @param array  $expected      The expected return value for the respective functions.
+     * @param array  $targetContent The content for the target token to look for in case there could
+     *                              be confusion.
+     *
+     * @return void
+     */
+    public function testIsArrowFunction($testMarker, $expected, $targetContent = null)
+    {
+        $targets  = Collections::arrowFunctionTokensBC();
+        $stackPtr = $this->getTargetToken($testMarker, $targets, $targetContent);
+        $result   = FunctionDeclarations::isArrowFunction(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected['is'], $result);
+    }
+
+    /**
+     * Test correctly detecting arrow functions.
+     *
+     * @dataProvider dataArrowFunction
+     *
+     * @param string $testMarker    The comment which prefaces the target token in the test file.
+     * @param array  $expected      The expected return value for the respective functions.
+     * @param string $targetContent The content for the target token to look for in case there could
+     *                              be confusion.
+     *
+     * @return void
+     */
+    public function testGetArrowFunctionOpenClose($testMarker, $expected, $targetContent = 'fn')
+    {
+        $targets  = Collections::arrowFunctionTokensBC();
+        $stackPtr = $this->getTargetToken($testMarker, $targets, $targetContent);
+
+        // Change from offsets to absolute token positions.
+        if ($expected['get'] != false) {
+            foreach ($expected['get'] as $key => $value) {
+                $expected['get'][$key] += $stackPtr;
+            }
+        }
+
+        $result = FunctionDeclarations::getArrowFunctionOpenClose(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected['get'], $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsArrowFunction()           For the array format.
+     * @see testgetArrowFunctionOpenClose() For the array format.
+     *
+     * @return array
+     */
+    public function dataArrowFunction()
+    {
+        return [
+            'arrow-function-returning-heredoc' => [
+                '/* testHeredoc */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 2,
+                        'scope_opener'       => 4,
+                        'scope_closer'       => 9,
+                    ],
+                ],
+            ],
+            'arrow-function-returning-nowdoc' => [
+                '/* testNowdoc */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 2,
+                        'scope_opener'       => 4,
+                        'scope_closer'       => 9,
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.inc
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.inc
@@ -88,6 +88,16 @@ array_map(
 /* testTernary */
 $fn = fn($a) => $a ? /* testTernaryThen */ fn() : string => 'a' : /* testTernaryElse */ fn() : string => 'b';
 
+$foo = foo(
+    /* testArrowFunctionAsArgument */
+    fn() => bar()
+);
+
+$foo = foo(
+    /* testArrowFunctionWithArrayAsArgument */
+    fn() => [$row[0], $row[3]]
+);
+
 /* testConstantDeclaration */
 const FN = 'a';
 

--- a/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
@@ -456,6 +456,30 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
                     ],
                 ],
             ],
+            'arrow-function-as-function-call-argument' => [
+                '/* testArrowFunctionAsArgument */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 2,
+                        'scope_opener'       => 4,
+                        'scope_closer'       => 8,
+                    ],
+                ],
+            ],
+            'arrow-function-as-function-call-argument-with-array-return' => [
+                '/* testArrowFunctionWithArrayAsArgument */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 2,
+                        'scope_opener'       => 4,
+                        'scope_closer'       => 17,
+                    ],
+                ],
+            ],
             'arrow-function-nested-in-method' => [
                 '/* testNestedInMethod */',
                 [


### PR DESCRIPTION
Follow up on #77 and #79 

This syncs in additional changes from PHPCS upstream as released in PHPCS 3.5.5 and to be released in PHPCS 3.5.6 in the handling and recognition of arrow functions.

## Commit Summary

### FunctionDeclarations::getArrowFunctionOpenClose(): arrow functions as function argument

Allow for arrow functions being used as function argument as per upstream commit [291401](https://github.com/squizlabs/PHP_CodeSniffer/commit/2914011675cd13f8a7d5eae16ed1d5ee4f0e701d) which is included in PHPCS 3.5.5.

Also see: squizlabs/PHP_CodeSniffer#2895 and squizlabs/PHP_CodeSniffer#2523

### BCFile::findEndOfStatement(): arrow functions as function argument

Allow for arrow functions being used as function argument as per upstream commit [291401](https://github.com/squizlabs/PHP_CodeSniffer/commit/2914011675cd13f8a7d5eae16ed1d5ee4f0e701d) which is included in PHPCS 3.5.5.

Also see: squizlabs/PHP_CodeSniffer#2895 and squizlabs/PHP_CodeSniffer#2523

### FunctionDeclarations::getArrowFunctionOpenClose(): allow for returning heredoc/nowdoc

... as per upstream commit [ce62dee](https://github.com/squizlabs/PHP_CodeSniffer/commit/ce62dee92da3b038a399a99353fc055b39d2853e) which will be included in PHPCS 3.5.6.

Also see: squizlabs/PHP_CodeSniffer#2926

As the PHPCS Tokenizer will hang completely when it encounters an arrow function with a heredoc/nowdoc return in PHPCS 3.5.3-3.5.5, this change needs a separate test file as these tests need to be skipped on those PHPCS versions.

