### PR TITLE
Docs: one `@throws` per exception thrown

### DIFF
--- a/PHPCSUtils/Utils/ControlStructures.php
+++ b/PHPCSUtils/Utils/ControlStructures.php
@@ -363,9 +363,10 @@ class ControlStructures
      *
      * @return array
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified $stackPtr is not of
-     *                                                      type T_CATCH, doesn't exist or in case
-     *                                                      of a parse error.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified `$stackPtr` is not of
+     *                                                      type `T_CATCH` or doesn't exist.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If no parenthesis opener or closer can be
+     *                                                      determined (parse error).
      */
     public static function getCaughtExceptions(File $phpcsFile, $stackPtr)
     {

--- a/PHPCSUtils/Utils/TextStrings.php
+++ b/PHPCSUtils/Utils/TextStrings.php
@@ -46,8 +46,9 @@ class TextStrings
      * @return string The complete text string.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      valid text string token or if the
-     *                                                      token is not the first text string token.
+     *                                                      valid text string token.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified token is not the _first_
+     *                                                      token in a text string.
      */
     public static function getCompleteTextString(File $phpcsFile, $stackPtr, $stripQuotes = true)
     {

--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -169,7 +169,9 @@ class UseStatements
      *               ]`
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      T_USE token or not an import use statement.
+     *                                                      `T_USE` token.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the `T_USE` token is not for an import
+     *                                                      use statement.
      */
     public static function splitImportUseStatement(File $phpcsFile, $stackPtr)
     {

--- a/PHPCSUtils/Utils/Variables.php
+++ b/PHPCSUtils/Utils/Variables.php
@@ -109,8 +109,9 @@ class Variables
      * @return array
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      T_VARIABLE token, or if the position is not
-     *                                                      a class member variable.
+     *                                                      T_VARIABLE token.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
+     *                                                      class member variable.
      */
     public static function getMemberProperties(File $phpcsFile, $stackPtr)
     {


### PR DESCRIPTION
As per the recommendation in [PSR 19](https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc-tags.md#514-throws), have one `@throws` tag for each exception thrown, even when they are of the same type.