### PR TITLE
Docs: improvements for better rendering in PHPDocumentor

### DIFF
--- a/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
+++ b/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
@@ -68,10 +68,14 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
      * A multi-dimentional array with information on each array item.
      *
      * The array index is 1-based and contains the following information on each array item:
-     * - 'start' : The stack pointer to the first token in the array item.
-     * - 'end'   : The stack pointer to the last token in the array item.
-     * - 'raw'   : A string with the contents of all tokens between `start` and `end`.
-     * - 'clean' : Same as `raw`, but all comment tokens have been stripped out.
+     * ```php
+     * 1 => array(
+     *   'start' => int,    // The stack pointer to the first token in the array item.
+     *   'end'   => int,    // The stack pointer to the last token in the array item.
+     *   'raw'   => string, // A string with the contents of all tokens between `start` and `end`.
+     *   'clean' => string, // Same as `raw`, but all comment tokens have been stripped out.
+     * )
+     * ```
      *
      * @since 1.0.0
      *
@@ -163,7 +167,7 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
      * Processes this test when one of its tokens is encountered.
      *
      * This method fills the properties with relevant information for examining the array
-     * and then passes off to the `processArray()` method.
+     * and then passes off to the {@see AbstractArrayDeclarationSniff::processArray()} method.
      *
      * @since 1.0.0
      *
@@ -290,9 +294,9 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
      * @param int                         $openPtr   The position of the array opener token in the token stack.
      * @param int                         $closePtr  The position of the array closer token in the token stack.
      *
-     * @return true|void Returning `true` will short-circuit the sniff and stop processing.
+     * @return true|void Returning `TRUE` will short-circuit the sniff and stop processing.
      *                   In effect, this means that the sniff will not examine the individual
-     *                   array items if `true` is returned.
+     *                   array items if `TRUE` is returned.
      */
     public function processOpenClose(File $phpcsFile, $openPtr, $closePtr)
     {
@@ -321,7 +325,7 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
      * @param int                         $itemNr    Which item in the array is being handled.
      *                                               1-based, i.e. the first item is item 1, the second 2 etc.
      *
-     * @return true|void Returning `true` will short-circuit the array item loop and stop processing.
+     * @return true|void Returning `TRUE` will short-circuit the array item loop and stop processing.
      *                   In effect, this means that the sniff will not examine the double arrow, the array
      *                   value or comma for this array item and will not process any array items after this one.
      */
@@ -351,7 +355,7 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
      * @param int                         $itemNr    Which item in the array is being handled.
      *                                               1-based, i.e. the first item is item 1, the second 2 etc.
      *
-     * @return true|void Returning `true` will short-circuit the array item loop and stop processing.
+     * @return true|void Returning `TRUE` will short-circuit the array item loop and stop processing.
      *                   In effect, this means that the sniff will not examine the array value or
      *                   comma for this array item and will not process any array items after this one.
      */
@@ -374,7 +378,7 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
      * @param int                         $itemNr    Which item in the array is being handled.
      *                                               1-based, i.e. the first item is item 1, the second 2 etc.
      *
-     * @return true|void Returning `true` will short-circuit the array item loop and stop processing.
+     * @return true|void Returning `TRUE` will short-circuit the array item loop and stop processing.
      *                   In effect, this means that the sniff will not examine the array value or
      *                   comma for this array item and will not process any array items after this one.
      */
@@ -403,7 +407,7 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
      * @param int                         $itemNr    Which item in the array is being handled.
      *                                               1-based, i.e. the first item is item 1, the second 2 etc.
      *
-     * @return true|void Returning `true` will short-circuit the array item loop and stop processing.
+     * @return true|void Returning `TRUE` will short-circuit the array item loop and stop processing.
      *                   In effect, this means that the sniff will not examine the comma for this
      *                   array item and will not process any array items after this one.
      */
@@ -426,7 +430,7 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
      * @param int                         $itemNr    Which item in the array is being handled.
      *                                               1-based, i.e. the first item is item 1, the second 2 etc.
      *
-     * @return true|void Returning `true` will short-circuit the array item loop and stop processing.
+     * @return true|void Returning `TRUE` will short-circuit the array item loop and stop processing.
      *                   In effect, this means that the sniff will not process any array items
      *                   after this one.
      */

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -86,26 +86,27 @@ class BCFile
     /**
      * Returns the declaration names for classes, interfaces, traits, and functions.
      *
-     * PHPCS cross-version compatible version of the File::getDeclarationName() method.
+     * PHPCS cross-version compatible version of the `File::getDeclarationName()` method.
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - PHPCS 2.8.0: Returns null when passed an anonymous class. Previously, the method
-     *                would throw a "token not of an accepted type" exception.
-     * - PHPCS 2.9.0: Returns null when passed a PHP closure. Previously, the method
-     *                would throw a "token not of an accepted type" exception.
+     * - PHPCS 2.8.0: Returns `null` when passed an anonymous class. Previously, the method
+     *                would throw a "_token not of an accepted type_" exception.
+     * - PHPCS 2.9.0: Returns `null` when passed a PHP closure. Previously, the method
+     *                would throw a "_token not of an accepted type_" exception.
      * - PHPCS 3.0.0: Added support for ES6 class/method syntax.
      * - PHPCS 3.0.0: The Exception thrown changed from a `PHP_CodeSniffer_Exception` to
      *                `\PHP_CodeSniffer\Exceptions\RuntimeException`.
      * - PHPCS 3.5.3: Allow for functions to be called `fn` for backwards compatibility.
-     *                Related to PHP 7.4 T_FN arrow functions.
+     *                Related to PHP 7.4 `T_FN` arrow functions.
      * - PHPCS 3.5.5: Remove arrow function work-around which is no longer needed due to
      *                a change in the tokenization of arrow functions.
      *
-     * Note: For ES6 classes in combination with PHPCS 2.x, passing a `T_STRING` token to
-     *       this method will be accepted for JS files.
-     * Note: Support for JS ES6 method syntax has not been back-filled for PHPCS < 3.0.0.
-     *       and sniffing JS files is not officially supported by PHPCSUtils.
+     * Note:
+     * - For ES6 classes in combination with PHPCS 2.x, passing a `T_STRING` token to
+     *   this method will be accepted for JS files.
+     * - Support for JS ES6 method syntax has not been back-filled for PHPCS < 3.0.0.
+     *   and sniffing JS files is not officially supported by PHPCSUtils.
      *
      * @see \PHP_CodeSniffer\Files\File::getDeclarationName() Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::getName()   PHPCSUtils native improved version.
@@ -119,11 +120,11 @@ class BCFile
      *                                               trait, or function.
      *
      * @return string|null The name of the class, interface, trait, or function;
-     *                     or NULL if the function or class is anonymous or
+     *                     or `NULL` if the function or class is anonymous or
      *                     in case of a parse error/live coding.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified token is not of type
-     *                                                      T_FUNCTION, T_CLASS, T_TRAIT, or T_INTERFACE.
+     *                                                      `T_FUNCTION`, `T_CLASS`, `T_TRAIT`, or `T_INTERFACE`.
      */
     public static function getDeclarationName(File $phpcsFile, $stackPtr)
     {
@@ -184,74 +185,75 @@ class BCFile
     /**
      * Returns the method parameters for the specified function token.
      *
-     * Also supports passing in a USE token for a closure use group.
+     * Also supports passing in a `T_USE` token for a closure use group.
      *
      * Each parameter is in the following format:
-     *
-     * <code>
-     *   0 => array(
-     *         'name'                => '$var',  // The variable name.
-     *         'token'               => integer, // The stack pointer to the variable name.
-     *         'content'             => string,  // The full content of the variable definition.
-     *         'pass_by_reference'   => boolean, // Is the variable passed by reference?
-     *         'reference_token'     => integer, // The stack pointer to the reference operator
-     *                                           // or FALSE if the param is not passed by reference.
-     *         'variable_length'     => boolean, // Is the param of variable length through use of `...` ?
-     *         'variadic_token'      => integer, // The stack pointer to the ... operator
-     *                                           // or FALSE if the param is not variable length.
-     *         'type_hint'           => string,  // The type hint for the variable.
-     *         'type_hint_token'     => integer, // The stack pointer to the start of the type hint
-     *                                           // or FALSE if there is no type hint.
-     *         'type_hint_end_token' => integer, // The stack pointer to the end of the type hint
-     *                                           // or FALSE if there is no type hint.
-     *         'nullable_type'       => boolean, // TRUE if the var type is nullable.
-     *         'comma_token'         => integer, // The stack pointer to the comma after the param
-     *                                           // or FALSE if this is the last param.
-     *        )
-     * </code>
+     * ```php
+     * 0 => array(
+     *   'name'                => '$var',  // The variable name.
+     *   'token'               => integer, // The stack pointer to the variable name.
+     *   'content'             => string,  // The full content of the variable definition.
+     *   'pass_by_reference'   => boolean, // Is the variable passed by reference?
+     *   'reference_token'     => integer, // The stack pointer to the reference operator
+     *                                     // or FALSE if the param is not passed by reference.
+     *   'variable_length'     => boolean, // Is the param of variable length through use of `...` ?
+     *   'variadic_token'      => integer, // The stack pointer to the ... operator
+     *                                     // or FALSE if the param is not variable length.
+     *   'type_hint'           => string,  // The type hint for the variable.
+     *   'type_hint_token'     => integer, // The stack pointer to the start of the type hint
+     *                                     // or FALSE if there is no type hint.
+     *   'type_hint_end_token' => integer, // The stack pointer to the end of the type hint
+     *                                     // or FALSE if there is no type hint.
+     *   'nullable_type'       => boolean, // TRUE if the var type is nullable.
+     *   'comma_token'         => integer, // The stack pointer to the comma after the param
+     *                                     // or FALSE if this is the last param.
+     * )
+     * ```
      *
      * Parameters with default values have the following additional array indexes:
-     *         'default'             => string,  // The full content of the default value.
-     *         'default_token'       => integer, // The stack pointer to the start of the default value.
-     *         'default_equal_token' => integer, // The stack pointer to the equals sign.
+     * ```php
+     *   'default'             => string,  // The full content of the default value.
+     *   'default_token'       => integer, // The stack pointer to the start of the default value.
+     *   'default_equal_token' => integer, // The stack pointer to the equals sign.
+     * ```
      *
-     * PHPCS cross-version compatible version of the File::getMethodParameters() method.
+     * PHPCS cross-version compatible version of the `File::getMethodParameters()` method.
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
      * - PHPCS 2.8.0: Now recognises `self` as a valid type declaration.
-     * - PHPCS 2.8.0: The return array now contains a new "token" index containing the stack pointer
+     * - PHPCS 2.8.0: The return array now contains a new `"token"` index containing the stack pointer
      *                to the variable.
-     * - PHPCS 2.8.0: The return array now contains a new "content" index containing the raw content
+     * - PHPCS 2.8.0: The return array now contains a new `"content"` index containing the raw content
      *                of the param definition.
      * - PHPCS 2.8.0: Added support for nullable types.
-     *                - The return array now contains a new "nullable_type" index set to true or false
-     *                  for each method parameter.
+     *                The return array now contains a new `"nullable_type"` index set to `true` or `false`
+     *                for each method parameter.
      * - PHPCS 2.8.0: Added support for closures.
      * - PHPCS 3.0.0: The Exception thrown changed from a `PHP_CodeSniffer_Exception` to
      *                `\PHP_CodeSniffer\Exceptions\TokenizerException`.
-     * - PHPCS 3.3.0: The return array now contains a new "type_hint_token" array index.
-     *                - Provides the position in the token stack of the first token in the type declaration.
+     * - PHPCS 3.3.0: The return array now contains a new `"type_hint_token"` array index.
+     *                Provides the position in the token stack of the first token in the type declaration.
      * - PHPCS 3.3.1: Fixed incompatibility with PHP 7.3.
      * - PHPCS 3.5.0: The Exception thrown changed from a `\PHP_CodeSniffer\Exceptions\TokenizerException`
      *                to `\PHP_CodeSniffer\Exceptions\RuntimeException`.
      * - PHPCS 3.5.0: Added support for closure USE groups.
      * - PHPCS 3.5.0: The return array now contains yet more more information.
      *                - If a type hint is specified, the position of the last token in the hint will be
-     *                  set in a "type_hint_end_token" array index.
+     *                  set in a `"type_hint_end_token"` array index.
      *                - If a default is specified, the position of the first token in the default value
-     *                  will be set in a "default_token" array index.
+     *                  will be set in a `"default_token"` array index.
      *                - If a default is specified, the position of the equals sign will be set in a
-     *                  "default_equal_token" array index.
+     *                  `"default_equal_token"` array index.
      *                - If the param is not the last, the position of the comma will be set in a
-     *                  "comma_token" array index.
+     *                  `"comma_token"` array index.
      *                - If the param is passed by reference, the position of the reference operator
-     *                  will be set in a "reference_token" array index.
+     *                  will be set in a `"reference_token"` array index.
      *                - If the param is variable length, the position of the variadic operator will
-     *                  be set in a "variadic_token" array index.
-     * - PHPCS 3.5.3: Fixed a bug where the "type_hint_end_token" array index for a type hinted
+     *                  be set in a `"variadic_token"` array index.
+     * - PHPCS 3.5.3: Fixed a bug where the `"type_hint_end_token"` array index for a type hinted
      *                parameter would bleed through to the next (non-type hinted) parameter.
-     * - PHPCS 3.5.3: Added support for PHP 7.4 T_FN arrow functions.
+     * - PHPCS 3.5.3: Added support for PHP 7.4 `T_FN` arrow functions.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodParameters()      Original source.
      * @see \PHPCSUtils\Utils\FunctionDeclarations::getParameters() PHPCSUtils native improved version.
@@ -265,9 +267,9 @@ class BCFile
      *
      * @return array
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified $stackPtr is not of
-     *                                                      type T_FUNCTION, T_CLOSURE, T_USE,
-     *                                                      or T_FN.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified `$stackPtr` is not of
+     *                                                      type `T_FUNCTION`, `T_CLOSURE`, `T_USE`,
+     *                                                      or `T_FN`.
      */
     public static function getMethodParameters(File $phpcsFile, $stackPtr)
     {
@@ -494,42 +496,42 @@ class BCFile
      * Returns the visibility and implementation properties of a method.
      *
      * The format of the return value is:
-     * <code>
-     *   array(
-     *    'scope'                => 'public', // Public, private, or protected
-     *    'scope_specified'      => true,     // TRUE if the scope keyword was found.
-     *    'return_type'          => '',       // The return type of the method.
-     *    'return_type_token'    => integer,  // The stack pointer to the start of the return type
-     *                                        // or FALSE if there is no return type.
-     *    'nullable_return_type' => false,    // TRUE if the return type is nullable.
-     *    'is_abstract'          => false,    // TRUE if the abstract keyword was found.
-     *    'is_final'             => false,    // TRUE if the final keyword was found.
-     *    'is_static'            => false,    // TRUE if the static keyword was found.
-     *    'has_body'             => false,    // TRUE if the method has a body
-     *   );
-     * </code>
+     * ```php
+     * array(
+     *   'scope'                => 'public', // Public, private, or protected
+     *   'scope_specified'      => true,     // TRUE if the scope keyword was found.
+     *   'return_type'          => '',       // The return type of the method.
+     *   'return_type_token'    => integer,  // The stack pointer to the start of the return type
+     *                                       // or FALSE if there is no return type.
+     *   'nullable_return_type' => false,    // TRUE if the return type is nullable.
+     *   'is_abstract'          => false,    // TRUE if the abstract keyword was found.
+     *   'is_final'             => false,    // TRUE if the final keyword was found.
+     *   'is_static'            => false,    // TRUE if the static keyword was found.
+     *   'has_body'             => false,    // TRUE if the method has a body
+     * );
+     * ```
      *
-     * PHPCS cross-version compatible version of the File::getMethodProperties() method.
+     * PHPCS cross-version compatible version of the `File::getMethodProperties()` method.
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - PHPCS 3.0.0: Removed the `is_closure` array index which was always `false` anyway.
+     * - PHPCS 3.0.0: Removed the `"is_closure"` array index which was always `false` anyway.
      * - PHPCS 3.0.0: The Exception thrown changed from a `PHP_CodeSniffer_Exception` to
      *                `\PHP_CodeSniffer\Exceptions\TokenizerException`.
-     * - PHPCS 3.3.0: New `return_type`, `return_type_token` and `nullable_return_type` array indexes.
-     *                - The `return_type` index contains the return type of the function or closer,
+     * - PHPCS 3.3.0: New `"return_type"`, `"return_type_token"` and `"nullable_return_type"` array indexes.
+     *                - The `"return_type"` index contains the return type of the function or closer,
      *                  or a blank string if not specified.
      *                - If the return type is nullable, the return type will contain the leading `?`.
-     *                - A `nullable_return_type` array index in the return value will also be set to `true`.
+     *                - A `"nullable_return_type"` array index in the return value will also be set to `true`.
      *                - If the return type contains namespace information, it will be cleaned of
      *                  whitespace and comments.
      *                - To access the original return value string, use the main tokens array.
-     * - PHPCS 3.4.0: New `has_body` array index.
-     *                - `false` if the method has no body (as with abstract and interface methods)
-     *                  or `true` otherwise.
+     * - PHPCS 3.4.0: New `"has_body"` array index.
+     *                `false` if the method has no body (as with abstract and interface methods)
+     *                or `true` otherwise.
      * - PHPCS 3.5.0: The Exception thrown changed from a `\PHP_CodeSniffer\Exceptions\TokenizerException`
      *                to `\PHP_CodeSniffer\Exceptions\RuntimeException`.
-     * - PHPCS 3.5.3: Added support for PHP 7.4 T_FN arrow functions.
+     * - PHPCS 3.5.3: Added support for PHP 7.4 `T_FN` arrow functions.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodProperties()      Original source.
      * @see \PHPCSUtils\Utils\FunctionDeclarations::getProperties() PHPCSUtils native improved version.
@@ -544,7 +546,7 @@ class BCFile
      * @return array
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      T_FUNCTION, T_CLOSURE, or T_FN token.
+     *                                                      `T_FUNCTION`, `T_CLOSURE`, or `T_FN` token.
      */
     public static function getMethodProperties(File $phpcsFile, $stackPtr)
     {
@@ -699,39 +701,38 @@ class BCFile
      * Returns the visibility and implementation properties of a class member var.
      *
      * The format of the return value is:
+     * ```php
+     * array(
+     *   'scope'           => string,  // Public, private, or protected.
+     *   'scope_specified' => boolean, // TRUE if the scope was explicitly specified.
+     *   'is_static'       => boolean, // TRUE if the static keyword was found.
+     *   'type'            => string,  // The type of the var (empty if no type specified).
+     *   'type_token'      => integer, // The stack pointer to the start of the type
+     *                                 // or FALSE if there is no type.
+     *   'type_end_token'  => integer, // The stack pointer to the end of the type
+     *                                 // or FALSE if there is no type.
+     *   'nullable_type'   => boolean, // TRUE if the type is nullable.
+     * );
+     * ```
      *
-     * <code>
-     *   array(
-     *    'scope'           => string,  // Public, private, or protected.
-     *    'scope_specified' => boolean, // TRUE if the scope was explicitly specified.
-     *    'is_static'       => boolean, // TRUE if the static keyword was found.
-     *    'type'            => string,  // The type of the var (empty if no type specified).
-     *    'type_token'      => integer, // The stack pointer to the start of the type
-     *                                  // or FALSE if there is no type.
-     *    'type_end_token'  => integer, // The stack pointer to the end of the type
-     *                                  // or FALSE if there is no type.
-     *    'nullable_type'   => boolean, // TRUE if the type is nullable.
-     *   );
-     * </code>
-     *
-     * PHPCS cross-version compatible version of the File::getMemberProperties() method.
+     * PHPCS cross-version compatible version of the `File::getMemberProperties()  method.
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
      * - PHPCS 3.0.0: The Exception thrown changed from a `PHP_CodeSniffer_Exception` to
      *                `\PHP_CodeSniffer\Exceptions\TokenizerException`.
      * - PHPCS 3.4.0: Fixed method params being recognized as properties, PHPCS#2214.
-     * - PHPCS 3.5.0: New `type`, `type_token`, `type_end_token` and `nullable_type` array indexes.
-     *                - The `type` index contains the type of the member var, or a blank string
+     * - PHPCS 3.5.0: New `"type"`, `"type_token"`, `"type_end_token"` and `"nullable_type"` array indexes.
+     *                - The `"type"` index contains the type of the member var, or a blank string
      *                  if not specified.
-     *                - If the type is nullable, `type` will contain the leading `?`.
+     *                - If the type is nullable, `"type"` will contain the leading `?`.
      *                - If a type is specified, the position of the first token in the type will
-     *                  be set in a `type_token` array index.
+     *                  be set in a `"type_token"` array index.
      *                - If a type is specified, the position of the last token in the type will
-     *                  be set in a `type_end_token` array index.
-     *                - If the type is nullable, a `nullable_type` array index will also be set to TRUE.
+     *                  be set in a `"type_end_token"` array index.
+     *                - If the type is nullable, a `"nullable_type"` array index will also be set to `true`.
      *                - If the type contains namespace information, it will be cleaned of whitespace
-     *                  and comments in the `type` value.
+     *                  and comments in the `"type"` value.
      * - PHPCS 3.5.0: The Exception thrown changed from a `\PHP_CodeSniffer\Exceptions\TokenizerException`
      *                to `\PHP_CodeSniffer\Exceptions\RuntimeException`.
      *
@@ -741,13 +742,13 @@ class BCFile
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position in the stack of the T_VARIABLE token to
+     * @param int                         $stackPtr  The position in the stack of the `T_VARIABLE` token to
      *                                               acquire the properties for.
      *
      * @return array
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      T_VARIABLE token, or if the position is not
+     *                                                      `T_VARIABLE` token, or if the position is not
      *                                                      a class member variable.
      */
     public static function getMemberProperties(File $phpcsFile, $stackPtr)
@@ -887,14 +888,14 @@ class BCFile
      * Returns the implementation properties of a class.
      *
      * The format of the return value is:
-     * <code>
-     *   array(
-     *    'is_abstract' => false, // true if the abstract keyword was found.
-     *    'is_final'    => false, // true if the final keyword was found.
-     *   );
-     * </code>
+     * ```php
+     * array(
+     *   'is_abstract' => false, // TRUE if the abstract keyword was found.
+     *   'is_final'    => false, // TRUE if the final keyword was found.
+     * );
+     * ```
      *
-     * PHPCS cross-version compatible version of the File::getClassProperties() method.
+     * PHPCS cross-version compatible version of the `File::getClassProperties()` method.
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.3.0.
@@ -909,13 +910,13 @@ class BCFile
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position in the stack of the T_CLASS
+     * @param int                         $stackPtr  The position in the stack of the `T_CLASS`
      *                                               token to acquire the properties for.
      *
      * @return array
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      T_CLASS token.
+     *                                                      `T_CLASS` token.
      */
     public static function getClassProperties(File $phpcsFile, $stackPtr)
     {
@@ -961,7 +962,7 @@ class BCFile
     /**
      * Determine if the passed token is a reference operator.
      *
-     * PHPCS cross-version compatible version of the File::isReference() method.
+     * PHPCS cross-version compatible version of the `File::isReference()` method.
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
@@ -973,7 +974,7 @@ class BCFile
      *                - New by reference was not recognized as a reference.
      *                - References to class properties with `self::`, `parent::`, `static::`,
      *                  `namespace\ClassName::`, `classname::` were not recognized as references.
-     * - PHPCS 3.5.3: Added support for PHP 7.4 T_FN arrow functions returning by reference.
+     * - PHPCS 3.5.3: Added support for PHP 7.4 `T_FN` arrow functions returning by reference.
      *
      * @see \PHP_CodeSniffer\Files\File::isReference() Original source.
      * @see \PHPCSUtils\Utils\Operators::isReference() PHPCSUtils native improved version.
@@ -982,10 +983,10 @@ class BCFile
      * @since 1.0.0-alpha2 Added BC support for PHP 7.4 arrow functions.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the T_BITWISE_AND token.
+     * @param int                         $stackPtr  The position of the `T_BITWISE_AND` token.
      *
-     * @return bool TRUE if the specified token position represents a reference.
-     *              FALSE if the token represents a bitwise operator.
+     * @return bool `TRUE` if the specified token position represents a reference.
+     *              `FALSE` if the token represents a bitwise operator.
      */
     public static function isReference(File $phpcsFile, $stackPtr)
     {
@@ -1106,15 +1107,16 @@ class BCFile
      * Returns the content of the tokens from the specified start position in
      * the token stack for the specified length.
      *
-     * PHPCS cross-version compatible version of the File::getTokensAsString() method.
+     * PHPCS cross-version compatible version of the `File::getTokensAsString()` method.
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
      * - PHPCS 3.3.0: New `$origContent` parameter to optionally return original
      *                (non tab-replaced) content.
-     * - PHPCS 3.4.0: - Now throws a `RuntimeException` if the $start param is invalid.
+     * - PHPCS 3.4.0:
+     *                - Now throws a `RuntimeException` if the `$start` param is invalid.
      *                  This stops an infinite loop when the function is passed invalid data.
-     *                - If the $length param is invalid, an empty string will be returned.
+     *                - If the `$length` param is invalid, an empty string will be returned.
      *
      * @see \PHP_CodeSniffer\Files\File::getTokensAsString() Original source.
      * @see \PHPCSUtils\Utils\GetTokensAsString              Related set of functions.
@@ -1165,12 +1167,12 @@ class BCFile
     /**
      * Returns the position of the first non-whitespace token in a statement.
      *
-     * PHPCS cross-version compatible version of the File::findStartOfStatement() method.
+     * PHPCS cross-version compatible version of the `File::findStartOfStatement()` method.
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.1.0.
      * - PHPCS 2.6.2: New optional `$ignore` parameter to selectively ignore stop points.
-     * - PHPCS 3.5.5: Added support for PHP 7.4 T_FN arrow functions.
+     * - PHPCS 3.5.5: Added support for PHP 7.4 `T_FN` arrow functions.
      *
      * @see \PHP_CodeSniffer\Files\File::findStartOfStatement() Original source.
      *
@@ -1242,7 +1244,7 @@ class BCFile
     /**
      * Returns the position of the last non-whitespace token in a statement.
      *
-     * PHPCS cross-version compatible version of the File::findEndOfStatement() method.
+     * PHPCS cross-version compatible version of the `File::findEndOfStatement()  method.
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.1.0.
@@ -1250,9 +1252,9 @@ class BCFile
      * - PHPCS 2.7.1: Improved handling of short arrays, PHPCS #1203.
      * - PHPCS 3.3.0: Bug fix: end of statement detection when passed a scope opener, PHPCS #1863.
      * - PHPCS 3.5.0: Improved handling of group use statements.
-     * - PHPCS 3.5.3: Added support for PHP 7.4 T_FN arrow functions.
-     * - PHPCS 3.5.4: Improved support for PHP 7.4 T_FN arrow functions.
-     * - PHPCS 3.5.5: Improved support for PHP 7.4 T_FN arrow functions, PHPCS #2895.
+     * - PHPCS 3.5.3: Added support for PHP 7.4 `T_FN` arrow functions.
+     * - PHPCS 3.5.4: Improved support for PHP 7.4 `T_FN` arrow functions.
+     * - PHPCS 3.5.5: Improved support for PHP 7.4 `T_FN` arrow functions, PHPCS #2895.
      *
      * @see \PHP_CodeSniffer\Files\File::findEndOfStatement() Original source.
      *
@@ -1364,7 +1366,7 @@ class BCFile
     /**
      * Determine if the passed token has a condition of one of the passed types.
      *
-     * PHPCS cross-version compatible version of the File::hasCondition() method.
+     * PHPCS cross-version compatible version of the `File::hasCondition()` method.
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
@@ -1389,7 +1391,7 @@ class BCFile
     /**
      * Return the position of the condition for the passed token.
      *
-     * PHPCS cross-version compatible version of the File::getCondition() method.
+     * PHPCS cross-version compatible version of the `File::getCondition()` method.
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.3.0.
@@ -1400,17 +1402,17 @@ class BCFile
      * @see \PHPCSUtils\Utils\Conditions::getCondition() More versatile alternative.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha2 Added support for the PHPCS 3.5.4 $first parameter.
+     * @since 1.0.0-alpha2 Added support for the PHPCS 3.5.4 `$first` parameter.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the token we are checking.
      * @param int|string                  $type      The type of token to search for.
-     * @param bool                        $first     If TRUE, will return the matched condition
+     * @param bool                        $first     If `true`, will return the matched condition
      *                                               furthest away from the passed token.
-     *                                               If FALSE, will return the matched condition
+     *                                               If `false`, will return the matched condition
      *                                               closest to the passed token.
      *
-     * @return int|false Integer stack pointer to the condition or FALSE if the token
+     * @return int|false Integer stack pointer to the condition or `FALSE` if the token
      *                   does not have the condition.
      */
     public static function getCondition(File $phpcsFile, $stackPtr, $type, $first = true)
@@ -1445,7 +1447,7 @@ class BCFile
      * Returns the name of the class that the specified class extends.
      * (works for classes, anonymous classes and interfaces)
      *
-     * PHPCS cross-version compatible version of the File::findExtendedClassName() method.
+     * PHPCS cross-version compatible version of the `File::findExtendedClassName()` method.
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.2.0.
@@ -1462,7 +1464,7 @@ class BCFile
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The stack position of the class or interface.
      *
-     * @return string|false The extended class name or FALSE on error or if there
+     * @return string|false The extended class name or `FALSE` on error or if there
      *                      is no extended class name.
      */
     public static function findExtendedClassName(File $phpcsFile, $stackPtr)
@@ -1511,7 +1513,7 @@ class BCFile
     /**
      * Returns the names of the interfaces that the specified class implements.
      *
-     * PHPCS cross-version compatible version of the File::findImplementedInterfaceNames() method.
+     * PHPCS cross-version compatible version of the `File::findImplementedInterfaceNames()` method.
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.7.0.
@@ -1525,7 +1527,7 @@ class BCFile
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The stack position of the class.
      *
-     * @return array|false Array with names of the implemented interfaces or FALSE on
+     * @return array|false Array with names of the implemented interfaces or `FALSE` on
      *                     error or if there are no implemented interface names.
      */
     public static function findImplementedInterfaceNames(File $phpcsFile, $stackPtr)

--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -32,9 +32,9 @@ use PHP_CodeSniffer\Util\Tokens;
  * across PHPCS versions.
  *
  * The names of the PHPCS native token arrays translate one-on-one to the methods in this class:
- * `PHP_CodeSniffer\Util\Tokens::$emptyTokens` => `PHPCSUtils\BackCompat\BCTokens::emptyTokens()`
- * `PHP_CodeSniffer\Util\Tokens::$operators`   => `PHPCSUtils\BackCompat\BCTokens::operators()`
- * ... etc
+ * - `PHP_CodeSniffer\Util\Tokens::$emptyTokens` => `PHPCSUtils\BackCompat\BCTokens::emptyTokens()`
+ * - `PHP_CodeSniffer\Util\Tokens::$operators`   => `PHPCSUtils\BackCompat\BCTokens::operators()`
+ * - ... etc
  *
  * The order of the tokens in the arrays may differ between the PHPCS native token arrays and
  * the token arrays returned by this class.

--- a/PHPCSUtils/BackCompat/Helper.php
+++ b/PHPCSUtils/BackCompat/Helper.php
@@ -62,7 +62,7 @@ class Helper
      * @since 1.0.0
      *
      * @param string                  $key    The name of the config value.
-     * @param string|null             $value  The value to set. If null, the config entry
+     * @param string|null             $value  The value to set. If `null`, the config entry
      *                                        is deleted, reverting it to the default value.
      * @param bool                    $temp   Set this config data temporarily for this script run.
      *                                        This will not write the config data to the config file.
@@ -212,13 +212,13 @@ class Helper
     }
 
     /**
-     * Check whether the `--ignore-annotations` option has been used.
+     * Check whether the "--ignore-annotations" option is in effect.
      *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File|null $phpcsFile Optional. The current file being processed.
      *
-     * @return bool True if annotations should be ignored, false otherwise.
+     * @return bool `TRUE` if annotations should be ignored, `FALSE` otherwise.
      */
     public static function ignoreAnnotations(File $phpcsFile = null)
     {

--- a/PHPCSUtils/Fixers/SpacesFixer.php
+++ b/PHPCSUtils/Fixers/SpacesFixer.php
@@ -30,18 +30,19 @@ class SpacesFixer
      * Note:
      * - This method will not auto-fix if there is anything but whitespace between the two
      *   tokens. In that case, it will throw a non-fixable error/warning.
-     * - If 'newline' is expected and _no_ new line is encountered, a new line will be added,
+     * - If `'newline'` is expected and _no_ new line is encountered, a new line will be added,
      *   but no assumptions will be made about the intended indentation of the code.
      *   This should be handled by a (separate) indentation sniff.
-     * - If 'newline' is expected and multiple new lines are encountered, this will be accepted
+     * - If `'newline'` is expected and multiple new lines are encountered, this will be accepted
      *   as valid.
      *   No assumptions are made about whether additional blank lines are allowed or not.
-     *   If _exactly_ one line is desired, combine this Fixer with the BlankLineFixer.
+     *   If _exactly_ one line is desired, combine this fixer with the {@see \PHPCSUtils\Fixers\BlankLineFixer}
+     *   (upcoming).
      * - The fixer will not leave behind any trailing spaces on the original line when fixing
-     *   to 'newline', but it will not correct _existing_ trailing spaces when there already
+     *   to `'newline'`, but it will not correct _existing_ trailing spaces when there already
      *   is a new line in place.
      * - This method can optionally record a metric for this check which will be displayed
-     *   when the end-user requests the `info` report.
+     *   when the end-user requests the "info" report.
      *
      * @since 1.0.0
      *
@@ -49,29 +50,29 @@ class SpacesFixer
      * @param int                         $stackPtr       The position of the token which should be used
      *                                                    when reporting an issue.
      * @param int                         $secondPtr      The stack pointer to the second token.
-     *                                                    This token can be before or after the $stackPtr,
-     *                                                    but should only be seperated from the $stackPtr
+     *                                                    This token can be before or after the `$stackPtr`,
+     *                                                    but should only be seperated from the `$stackPtr`
      *                                                    by whitespace and/or comments/annotations.
      * @param string|int                  $expectedSpaces Number of spaces to enforce.
      *                                                    Valid values:
-     *                                                    - (int) Number of spaces. Must be 0 or more.
-     *                                                    - (string) 'newline'.
-     * @param string                      $errorTemplate  Error message template. This string should contain
-     *                                                    two placeholders:
-     *                                                    %1$s = expected spaces phrase.
-     *                                                    %2$s = found spaces phrase.
-     *                                                    Note: _The replacement phrase will be in human
-     *                                                    readable English and include "spaces"/"new line",
-     *                                                    so no need to include that in the template._
+     *                                                    - (int) Number of spaces. Must be `0` or more.
+     *                                                    - (string) `'newline'`.
+     * @param string                      $errorTemplate  Error message template.
+     *                                                    Note: _The placeholder replacement phrase will be
+     *                                                    in human readable English and include "spaces"/
+     *                                                    "new line", so no need to include that in the template._
+     *                                                    This string should contain two placeholders:
+     *                                                    - `%1$s` = expected spaces phrase.
+     *                                                    - `%2$s` = found spaces phrase.
      * @param string                      $errorCode      A violation code unique to the sniff message.
-     *                                                    Defaults to `Found`.
+     *                                                    Defaults to `"Found"`.
      *                                                    It is strongly recommended to change this if
      *                                                    this fixer is used for different errors in the
      *                                                    same sniff.
      * @param string                      $errorType      Optional. Whether to report the issue as a
-     *                                                    `warning` or an `error`. Defaults to `error`.
+     *                                                    `"warning"` or an `"error"`. Defaults to `"error"`.
      * @param int                         $errorSeverity  Optional. The severity level for this message.
-     *                                                    A value of 0 will be converted into the default
+     *                                                    A value of `0` will be converted into the default
      *                                                    severity level.
      * @param string                      $metricName     Optional. The name of the metric to record.
      *                                                    This can be a short description phrase.
@@ -81,7 +82,7 @@ class SpacesFixer
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the tokens passed do not exist or are whitespace
      *                                                      tokens.
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If $expectedSpaces is not a valid value.
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If `$expectedSpaces` is not a valid value.
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the tokens passed are separated by more than just
      *                                                      empty (whitespace + comments/annotations) tokens.
      */

--- a/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+++ b/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
@@ -25,7 +25,7 @@ use ReflectionClass;
  * autoload file is included in the test bootstrap. For more information about that, please consult
  * the project's {@link https://github.com/PHPCSStandards/PHPCSUtils/blob/develop/README.md README}.
  *
- * To allow for testing of tab vs space content, the tabWidth is set to `4` by default.
+ * To allow for testing of tab vs space content, the `tabWidth` is set to `4` by default.
  *
  * Typical usage:
  *
@@ -58,38 +58,39 @@ use ReflectionClass;
  *      *
  *      * @return void
  *      * /
- *    public function testMyMethod($commentString, $expected)
- *    {
- *        $stackPtr = $this->getTargetToken($commentString, [\T_TOKEN_CONSTANT, \T_ANOTHER_TOKEN]);
- *        $class    = new ClassUnderTest();
- *        $result   = $class->MyMethod(self::$phpcsFile, $stackPtr);
- *        // Or for static utility methods:
- *        $result   = ClassUnderTest::MyMethod(self::$phpcsFile, $stackPtr);
+ *     public function testMyMethod($commentString, $expected)
+ *     {
+ *         $stackPtr = $this->getTargetToken($commentString, [\T_TOKEN_CONSTANT, \T_ANOTHER_TOKEN]);
+ *         $class    = new ClassUnderTest();
+ *         $result   = $class->MyMethod(self::$phpcsFile, $stackPtr);
+ *         // Or for static utility methods:
+ *         $result   = ClassUnderTest::MyMethod(self::$phpcsFile, $stackPtr);
  *
- *        $this->assertSame($expected, $result);
- *    }
+ *         $this->assertSame($expected, $result);
+ *     }
  *
- *    /**
- *     * Data Provider.
- *     *
- *     * @see ClassUnderTestUnitTest::testMyMethod() For the array format.
- *     *
- *     * @return array
- *     * /
- *    public function dataMyMethod()
- *    {
- *        return array(
- *            array('/* testTestCaseDescription * /', false),
- *        );
- *    }
+ *     /**
+ *      * Data Provider.
+ *      *
+ *      * @see ClassUnderTestUnitTest::testMyMethod() For the array format.
+ *      *
+ *      * @return array
+ *      * /
+ *     public function dataMyMethod()
+ *     {
+ *         return array(
+ *             array('/* testTestCaseDescription * /', false),
+ *         );
+ *     }
  * }
  * ```
  *
  * Note:
  * - Remove the space between the comment closers `* /` for a working example.
  * - Each test case separator comment MUST start with `/* test`.
- *   This is to allow the `getTargetToken()` method to distinquish between the
- *   test separation comments and comments which may be part of the test case.
+ *   This is to allow the {@see UtilityMethodTestCase::getTargetToken()} method to
+ *   distinquish between the test separation comments and comments which may be part
+ *   of the test case.
  * - The test case file and unit test file should be placed in the same directory.
  * - For working examples using this abstract class, have a look at the unit tests
  *   for the PHPCSUtils utility functions themselves.
@@ -111,8 +112,8 @@ abstract class UtilityMethodTestCase extends TestCase
     /**
      * The file extension of the test case file (without leading dot).
      *
-     * This allows concrete test classes to overrule the default `inc` with, for instance,
-     * `js` or `css` when applicable.
+     * This allows concrete test classes to overrule the default `"inc"` with, for instance,
+     * `"js"` or `"css"` when applicable.
      *
      * @since 1.0.0
      *
@@ -125,7 +126,7 @@ abstract class UtilityMethodTestCase extends TestCase
      *
      * Optional. If left empty, the case file will be presumed to be in
      * the same directory and named the same as the test class, but with an
-     * `inc` file extension.
+     * `"inc"` file extension.
      *
      * @since 1.0.0
      *
@@ -145,7 +146,7 @@ abstract class UtilityMethodTestCase extends TestCase
     protected static $tabWidth = 4;
 
     /**
-     * The {@see \PHP_CodeSniffer\Files\File} object containing the parsed contents of the test case file.
+     * The \PHP_CodeSniffer\Files\File object containing the parsed contents of the test case file.
      *
      * @since 1.0.0
      *
@@ -171,7 +172,7 @@ abstract class UtilityMethodTestCase extends TestCase
      * Initialize PHPCS & tokenize the test case file.
      *
      * The test case file for a unit test class has to be in the same directory
-     * directory and use the same file name as the test class, using the .inc extension
+     * directory and use the same file name as the test class, using the `.inc` extension
      * or be explicitly set using the {@see UtilityMethodTestCase::$fileExtension}/
      * {@see UtilityMethodTestCase::$caseFile} properties.
      *
@@ -313,7 +314,7 @@ abstract class UtilityMethodTestCase extends TestCase
     /**
      * Get the token pointer for a target token based on a specific comment.
      *
-     * Note: the test delimiter comment MUST start with "/* test" to allow this function to
+     * Note: the test delimiter comment MUST start with `/* test` to allow this function to
      * distinguish between comments used *in* a test and test delimiters.
      *
      * If the delimiter comment is not found, the test will automatically be failed.

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -245,7 +245,7 @@ class Collections
     ];
 
     /**
-     * OO structures which can use the `extends` keyword.
+     * OO structures which can use the "extends" keyword.
      *
      * @since 1.0.0
      *
@@ -258,7 +258,7 @@ class Collections
     ];
 
     /**
-     * OO structures which can use the `implements` keyword.
+     * OO structures which can use the "implements" keyword.
      *
      * @since 1.0.0
      *
@@ -302,7 +302,10 @@ class Collections
     /**
      * Tokens types which can be encountered in the fully/partially qualified name of an OO structure.
      *
-     * Example: `echo namespace\Sub\ClassName::method();`
+     * Example:
+     * ```php
+     * echo namespace\Sub\ClassName::method();
+     * ```
      *
      * @since 1.0.0
      *
@@ -332,7 +335,7 @@ class Collections
     /**
      * Token types which can be encountered in a parameter type declaration.
      *
-     * Sister-property to the `Collections::parameterTypeTokensBC()` method.
+     * Sister-property to the {@see Collections::parameterTypeTokensBC()} method.
      * The property supports PHPCS 3.3.0 and up.
      * The method supports PHPCS 2.6.0 and up.
      *
@@ -375,7 +378,7 @@ class Collections
     /**
      * Token types which can be encountered in a property type declaration.
      *
-     * Sister-property to the `Collections::propertyTypeTokensBC()` method.
+     * Sister-property to the {@see Collections::propertyTypeTokensBC()} method.
      * The property supports PHPCS 3.3.0 and up.
      * The method supports PHPCS 2.6.0 and up.
      *
@@ -403,7 +406,7 @@ class Collections
     /**
      * Token types which can be encountered in a return type declaration.
      *
-     * Sister-property to the `Collections::returnTypeTokensBC()` method.
+     * Sister-property to the {@see Collections::returnTypeTokensBC()} method.
      * The property supports PHPCS 3.5.4 and up.
      * The method supports PHPCS 2.6.0 and up.
      *
@@ -540,9 +543,9 @@ class Collections
      *
      * Note: this is a method, not a property as the `T_FN` token for arrow functions may not exist.
      *
-     * Sister-method to the `functionDeclarationTokensBC()` method.
+     * Sister-method to the {@see Collections::functionDeclarationTokensBC()} method.
      * This  method supports PHPCS 3.5.3 and up.
-     * The `functionDeclarationTokensBC()` method supports PHPCS 2.6.0 and up.
+     * The {@see Collections::functionDeclarationTokensBC()} method supports PHPCS 2.6.0 and up.
      *
      * @see \PHPCSUtils\Tokens\Collections::functionDeclarationTokensBC() Related method (PHPCS 2.6.0+).
      *
@@ -570,14 +573,15 @@ class Collections
      *
      * Note: this is a method, not a property as the `T_FN` token for arrow functions may not exist.
      *
-     * Sister-method to the `functionDeclarationTokens()` method.
-     * The `functionDeclarationTokens()` method supports PHPCS 3.5.3 and up.
+     * Sister-method to the {@see Collections::functionDeclarationTokens()} method.
+     * The {@see Collections::functionDeclarationTokens()} method supports PHPCS 3.5.3 and up.
      * This method supports PHPCS 2.6.0 and up.
      *
      * Notable difference:
-     * This method accounts for when the `T_FN` token doesn't exist.
-     * Note: if this method is used, the `FunctionDeclarations::isArrowFunction() method
-     * needs to be used on arrow function tokens to verify whether it really is an arrow function
+     * - This method accounts for when the `T_FN` token doesn't exist.
+     *
+     * Note: if this method is used, the {@see \PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction()}
+     * method needs to be used on arrow function tokens to verify whether it really is an arrow function
      * declaration or not.
      *
      * It is recommended to use the {@see Collections::functionDeclarationTokens()} method instead of
@@ -605,13 +609,13 @@ class Collections
     /**
      * Token types which can be encountered in a parameter type declaration (cross-version).
      *
-     * Sister-method to the `$parameterTypeTokens` property.
+     * Sister-method to the {@see Collections::$parameterTypeTokens} property.
      * The property supports PHPCS 3.3.0 and up.
      * The method supports PHPCS 2.6.0 and up.
      *
      * Notable difference:
-     * The method will include the `T_ARRAY_HINT` token when used with PHPCS 2.x and 3.x.
-     * This token constant will no longer exist in PHPCS 4.x.
+     * - The method will include the `T_ARRAY_HINT` token when used with PHPCS 2.x and 3.x.
+     *   This token constant will no longer exist in PHPCS 4.x.
      *
      * It is recommended to use the property instead of the method if a standard supports does
      * not need to support PHPCS < 3.3.0.
@@ -637,13 +641,13 @@ class Collections
     /**
      * Token types which can be encountered in a property type declaration (cross-version).
      *
-     * Sister-method to the `$propertyTypeTokens` property.
+     * Sister-method to the {@see Collections::$propertyTypeTokens} property.
      * The property supports PHPCS 3.3.0 and up.
      * The method supports PHPCS 2.6.0 and up.
      *
      * Notable difference:
-     * The method will include the `T_ARRAY_HINT` token when used with PHPCS 2.x and 3.x.
-     * This token constant will no longer exist in PHPCS 4.x.
+     * - The method will include the `T_ARRAY_HINT` token when used with PHPCS 2.x and 3.x.
+     *   This token constant will no longer exist in PHPCS 4.x.
      *
      * It is recommended to use the property instead of the method if a standard supports does
      * not need to support PHPCS < 3.3.0.
@@ -662,7 +666,7 @@ class Collections
     /**
      * Token types which can be encountered in a return type declaration (cross-version).
      *
-     * Sister-property to the `Collections::returnTypeTokensBC()` method.
+     * Sister-property to the {@see Collections::returnTypeTokensBC()} method.
      * The property supports PHPCS 3.5.4 and up.
      * The method supports PHPCS 2.6.0 and up.
      *

--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -44,7 +44,7 @@ class Arrays
     ];
 
     /**
-     * Determine whether a `T_OPEN/CLOSE_SHORT_ARRAY` token is a short array construct
+     * Determine whether a T_OPEN/CLOSE_SHORT_ARRAY token is a short array construct
      * and not a short list.
      *
      * This method also accepts `T_OPEN/CLOSE_SQUARE_BRACKET` tokens to allow it to be
@@ -56,8 +56,8 @@ class Arrays
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the short array bracket token.
      *
-     * @return bool True if the token passed is the open/close bracket of a short array.
-     *              False if the token is a short list bracket, a plain square bracket
+     * @return bool `TRUE` if the token passed is the open/close bracket of a short array.
+     *              `FALSE` if the token is a short list bracket, a plain square bracket
      *              or not one of the accepted tokens.
      */
     public static function isShortArray(File $phpcsFile, $stackPtr)
@@ -183,9 +183,9 @@ class Arrays
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
-     * @param int                         $stackPtr     The position of the T_ARRAY or T_OPEN_SHORT_ARRAY
+     * @param int                         $stackPtr     The position of the `T_ARRAY` or `T_OPEN_SHORT_ARRAY`
      *                                                  token in the stack.
-     * @param true|null                   $isShortArray Short-circuit the short array check for T_OPEN_SHORT_ARRAY
+     * @param true|null                   $isShortArray Short-circuit the short array check for `T_OPEN_SHORT_ARRAY`
      *                                                  tokens if it isn't necessary.
      *                                                  Efficiency tweak for when this has already been established,
      *                                                  i.e. when encountering a nested array while walking the
@@ -256,7 +256,7 @@ class Arrays
      * @param int                         $start     Stack pointer to the start of the array item.
      * @param int                         $end       Stack pointer to the last token in the array item.
      *
-     * @return int|false Stack pointer to the double arrow if this array item has a key or false otherwise.
+     * @return int|false Stack pointer to the double arrow if this array item has a key; or `FALSE` otherwise.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the start or end positions are invalid.
      */

--- a/PHPCSUtils/Utils/Conditions.php
+++ b/PHPCSUtils/Utils/Conditions.php
@@ -39,7 +39,7 @@ class Conditions
      *
      * @since 1.0.0
      * @since 1.0.0-alpha2 The `$reverse` parameter has been renamed to `$first` and the meaning of the
-     *                     boolean reversed (true = first, false = last, was: true = last, false = first)
+     *                     boolean reversed (`true` = first, `false` = last, was: `true` = last, `false` = first)
      *                     to be in line with PHPCS itself which added the `$first` parameter in v 3.5.4
      *                     to allow for the same/similar functionality as `$reverse` already offered.
      *
@@ -47,10 +47,10 @@ class Conditions
      * @param int                         $stackPtr  The position of the token we are checking.
      * @param int|string|array            $types     Optional. The type(s) of tokens to search for.
      * @param bool                        $first     Optional. Whether to search for the first (outermost)
-     *                                               (true) or the last (innermost) condition (false) of
+     *                                               (`true`) or the last (innermost) condition (`false`) of
      *                                               the specified type(s).
      *
-     * @return int|false Integer stack pointer to the condition or FALSE if the token
+     * @return int|false Integer stack pointer to the condition; or `FALSE` if the token
      *                   does not have the condition or has no conditions at all.
      */
     public static function getCondition(File $phpcsFile, $stackPtr, $types = [], $first = true)
@@ -130,7 +130,7 @@ class Conditions
      * @param int                         $stackPtr  The position of the token we are checking.
      * @param int|string|array            $types     Optional. The type(s) of tokens to search for.
      *
-     * @return int|false Integer stack pointer to the condition; or `false` if the token
+     * @return int|false Integer stack pointer to the condition; or `FALSE` if the token
      *                   does not have the condition or has no conditions at all.
      */
     public static function getFirstCondition(File $phpcsFile, $stackPtr, $types = [])
@@ -150,7 +150,7 @@ class Conditions
      * @param int                         $stackPtr  The position of the token we are checking.
      * @param int|string|array            $types     Optional. The type(s) of tokens to search for.
      *
-     * @return int|false Integer stack pointer to the condition; or `false` if the token
+     * @return int|false Integer stack pointer to the condition; or `FALSE` if the token
      *                   does not have the condition or has no conditions at all.
      */
     public static function getLastCondition(File $phpcsFile, $stackPtr, $types = [])

--- a/PHPCSUtils/Utils/ControlStructures.php
+++ b/PHPCSUtils/Utils/ControlStructures.php
@@ -26,8 +26,10 @@ class ControlStructures
     /**
      * Check whether a control structure has a body.
      *
-     * Some control structures - `while`, `for` and `declare` - can be declared without a body, like
-     * `while (++$i < 10);`.
+     * Some control structures - `while`, `for` and `declare` - can be declared without a body, like:
+     * ```php
+     * while (++$i < 10);
+     * ```
      *
      * All other control structures will always have a body, though the body may be empty, where "empty" means:
      * no _code_ is found in the body. If a control structure body only contains a comment, it will be
@@ -41,9 +43,9 @@ class ControlStructures
      *                                                still be considered as having a body.
      *                                                Defaults to `true`.
      *
-     * @return bool True when the control structure has a body, or when `$allowEmpty` is set to `false`
+     * @return bool `TRUE` when the control structure has a body, or in case `$allowEmpty` is set to `FALSE`:
      *              when it has a non-empty body.
-     *              False in all other cases, including when a non-control structure token has been passed.
+     *              `FALSE` in all other cases, including when a non-control structure token has been passed.
      */
     public static function hasBody(File $phpcsFile, $stackPtr, $allowEmpty = true)
     {
@@ -147,7 +149,7 @@ class ControlStructures
     }
 
     /**
-     * Check whether an IF or ELSE token is part of an `else if`.
+     * Check whether an IF or ELSE token is part of an "else if".
      *
      * @since 1.0.0
      *
@@ -197,7 +199,7 @@ class ControlStructures
     }
 
     /**
-     * Get the scope opener and closer for a `declare` statement.
+     * Get the scope opener and closer for a DECLARE statement.
      *
      * A `declare` statement can be:
      * - applied to the rest of the file, like `declare(ticks=1);`
@@ -347,14 +349,13 @@ class ControlStructures
      * Retrieve the exception(s) being caught in a CATCH condition.
      *
      * The returned array will contain the following information for each caught exception:
-     *
-     * <code>
-     *   0 => array(
-     *         'type'           => string,  // The type declaration for the exception being caught.
-     *         'type_token'     => integer, // The stack pointer to the start of the type declaration.
-     *         'type_end_token' => integer, // The stack pointer to the end of the type declaration.
-     *        )
-     * </code>
+     * ```php
+     * 0 => array(
+     *   'type'           => string,  // The type declaration for the exception being caught.
+     *   'type_token'     => integer, // The stack pointer to the start of the type declaration.
+     *   'type_end_token' => integer, // The stack pointer to the end of the type declaration.
+     * )
+     * ```
      *
      * @since 1.0.0
      *

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -146,11 +146,11 @@ class FunctionDeclarations
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the function keyword token.
      *
-     * @return string|null The name of the function; or NULL if the passed token doesn't exist,
+     * @return string|null The name of the function; or `NULL` if the passed token doesn't exist,
      *                     the function is anonymous or in case of a parse error/live coding.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified token is not of type
-     *                                                      T_FUNCTION.
+     *                                                      `T_FUNCTION`.
      */
     public static function getName(File $phpcsFile, $stackPtr)
     {
@@ -161,31 +161,31 @@ class FunctionDeclarations
      * Retrieves the visibility and implementation properties of a method.
      *
      * The format of the return value is:
-     * <code>
-     *   array(
-     *    'scope'                 => 'public', // Public, private, or protected
-     *    'scope_specified'       => true,     // TRUE if the scope keyword was found.
-     *    'return_type'           => '',       // The return type of the method.
-     *    'return_type_token'     => integer,  // The stack pointer to the start of the return type
-     *                                         // or FALSE if there is no return type.
-     *    'return_type_end_token' => integer,  // The stack pointer to the end of the return type
-     *                                         // or FALSE if there is no return type.
-     *    'nullable_return_type'  => false,    // TRUE if the return type is nullable.
-     *    'is_abstract'           => false,    // TRUE if the abstract keyword was found.
-     *    'is_final'              => false,    // TRUE if the final keyword was found.
-     *    'is_static'             => false,    // TRUE if the static keyword was found.
-     *    'has_body'              => false,    // TRUE if the method has a body
-     *   );
-     * </code>
+     * ```php
+     * array(
+     *   'scope'                 => 'public', // Public, private, or protected
+     *   'scope_specified'       => true,     // TRUE if the scope keyword was found.
+     *   'return_type'           => '',       // The return type of the method.
+     *   'return_type_token'     => integer,  // The stack pointer to the start of the return type
+     *                                        // or FALSE if there is no return type.
+     *   'return_type_end_token' => integer,  // The stack pointer to the end of the return type
+     *                                        // or FALSE if there is no return type.
+     *   'nullable_return_type'  => false,    // TRUE if the return type is nullable.
+     *   'is_abstract'           => false,    // TRUE if the abstract keyword was found.
+     *   'is_final'              => false,    // TRUE if the final keyword was found.
+     *   'is_static'             => false,    // TRUE if the static keyword was found.
+     *   'has_body'              => false,    // TRUE if the method has a body
+     * );
+     * ```
      *
      * Main differences with the PHPCS version:
      * - Bugs fixed:
      *   - Handling of PHPCS annotations.
-     *   - `has_body` index could be set to `true` for functions without body in the case of
+     *   - `"has_body"` index could be set to `true` for functions without body in the case of
      *      parse errors or live coding.
      * - Defensive coding against incorrect calls to this method.
      * - More efficient checking whether a function has a body.
-     * - New `return_type_end_token` (int|false) array index.
+     * - New `"return_type_end_token"` (int|false) array index.
      * - To allow for backward compatible handling of arrow functions, this method will also accept
      *   `T_STRING` tokens and examine them to check if these are arrow functions.
      *
@@ -339,40 +339,42 @@ class FunctionDeclarations
     /**
      * Retrieves the method parameters for the specified function token.
      *
-     * Also supports passing in a USE token for a closure use group.
+     * Also supports passing in a `T_USE` token for a closure use group.
      *
      * The returned array will contain the following information for each parameter:
      *
-     * <code>
-     *   0 => array(
-     *         'name'                => '$var',  // The variable name.
-     *         'token'               => integer, // The stack pointer to the variable name.
-     *         'content'             => string,  // The full content of the variable definition.
-     *         'pass_by_reference'   => boolean, // Is the variable passed by reference?
-     *         'reference_token'     => integer, // The stack pointer to the reference operator
-     *                                           // or FALSE if the param is not passed by reference.
-     *         'variable_length'     => boolean, // Is the param of variable length through use of `...` ?
-     *         'variadic_token'      => integer, // The stack pointer to the ... operator
-     *                                           // or FALSE if the param is not variable length.
-     *         'type_hint'           => string,  // The type hint for the variable.
-     *         'type_hint_token'     => integer, // The stack pointer to the start of the type hint
-     *                                           // or FALSE if there is no type hint.
-     *         'type_hint_end_token' => integer, // The stack pointer to the end of the type hint
-     *                                           // or FALSE if there is no type hint.
-     *         'nullable_type'       => boolean, // TRUE if the var type is nullable.
-     *         'comma_token'         => integer, // The stack pointer to the comma after the param
-     *                                           // or FALSE if this is the last param.
-     *        )
-     * </code>
+     * ```php
+     * 0 => array(
+     *   'name'                => '$var',  // The variable name.
+     *   'token'               => integer, // The stack pointer to the variable name.
+     *   'content'             => string,  // The full content of the variable definition.
+     *   'pass_by_reference'   => boolean, // Is the variable passed by reference?
+     *   'reference_token'     => integer, // The stack pointer to the reference operator
+     *                                     // or FALSE if the param is not passed by reference.
+     *   'variable_length'     => boolean, // Is the param of variable length through use of `...` ?
+     *   'variadic_token'      => integer, // The stack pointer to the ... operator
+     *                                     // or FALSE if the param is not variable length.
+     *   'type_hint'           => string,  // The type hint for the variable.
+     *   'type_hint_token'     => integer, // The stack pointer to the start of the type hint
+     *                                     // or FALSE if there is no type hint.
+     *   'type_hint_end_token' => integer, // The stack pointer to the end of the type hint
+     *                                     // or FALSE if there is no type hint.
+     *   'nullable_type'       => boolean, // TRUE if the var type is nullable.
+     *   'comma_token'         => integer, // The stack pointer to the comma after the param
+     *                                     // or FALSE if this is the last param.
+     * )
+     * ```
      *
      * Parameters with default values have the following additional array indexes:
-     *         'default'             => string,  // The full content of the default value.
-     *         'default_token'       => integer, // The stack pointer to the start of the default value.
-     *         'default_equal_token' => integer, // The stack pointer to the equals sign.
+     * ```php
+     *   'default'             => string,  // The full content of the default value.
+     *   'default_token'       => integer, // The stack pointer to the start of the default value.
+     *   'default_equal_token' => integer, // The stack pointer to the equals sign.
+     * ```
      *
      * Main differences with the PHPCS version:
      * - Defensive coding against incorrect calls to this method.
-     * - More efficient and more stable checking whether a T_USE token is a closure use.
+     * - More efficient and more stable checking whether a `T_USE` token is a closure use.
      * - More efficient and more stable looping of the default value.
      * - Clearer exception message when a non-closure use token was passed to the function.
      * - To allow for backward compatible handling of arrow functions, this method will also accept
@@ -391,7 +393,7 @@ class FunctionDeclarations
      * @return array
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified $stackPtr is not of
-     *                                                      type T_FUNCTION, T_CLOSURE or T_USE,
+     *                                                      type `T_FUNCTION`, `T_CLOSURE` or `T_USE`,
      *                                                      nor an arrow function.
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If a passed `T_USE` token is not a closure
      *                                                      use token.
@@ -587,13 +589,13 @@ class FunctionDeclarations
      * Check if an arbitrary token is the "fn" keyword for a PHP 7.4 arrow function.
      *
      * Helper function for cross-version compatibility with both PHP as well as PHPCS.
-     * - PHP 7.4+ will tokenize most tokens with the content "fn" as T_FN, even when it isn't an arrow function.
-     * - PHPCS < 3.5.3 will tokenize arrow functions keywords as T_STRING.
+     * - PHP 7.4+ will tokenize most tokens with the content "fn" as `T_FN`, even when it isn't an arrow function.
+     * - PHPCS < 3.5.3 will tokenize arrow functions keywords as `T_STRING`.
      * - PHPCS 3.5.3/3.5.4 will tokenize the keyword differently depending on which PHP version is used
-     *   and similar to PHP will tokenize most tokens with the content "fn" as T_FN, even when it's not an
+     *   and similar to PHP will tokenize most tokens with the content "fn" as `T_FN`, even when it's not an
      *   arrow function.
-     *   Note: the tokens tokenized by PHPCS 3.5.3 - 3.5.4 as T_FN are not 100% the same as those tokenized
-     *   by PHP 7.4+ as T_FN.
+     *   > Note: the tokens tokenized by PHPCS 3.5.3 - 3.5.4 as `T_FN` are not 100% the same as those tokenized
+     *   by PHP 7.4+ as `T_FN`.
      *
      * Either way, the `T_FN` token is not a reliable search vector for finding or examining
      * arrow functions, at least not until PHPCS 3.5.5.
@@ -613,7 +615,7 @@ class FunctionDeclarations
      *                                               T_STRING token as those are the only two
      *                                               tokens which can be the arrow function keyword.
      *
-     * @return bool TRUE if the token is the "fn" keyword for an arrow function. FALSE when it's not
+     * @return bool `TRUE` if the token is the "fn" keyword for an arrow function. `FALSE` when it's not
      *              or in case of live coding/parse error.
      */
     public static function isArrowFunction(File $phpcsFile, $stackPtr)
@@ -658,19 +660,19 @@ class FunctionDeclarations
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
      * @param int                         $stackPtr  The token to retrieve the openers/closers for.
-     *                                               Typically a T_FN or T_STRING token as those are the
+     *                                               Typically a `T_FN` or `T_STRING` token as those are the
      *                                               only two tokens which can be the arrow function keyword.
      *
-     * @return array|false An array with the token pointers or FALSE if this is not an arrow function.
+     * @return array|false An array with the token pointers or `FALSE` if this is not an arrow function.
      *                     The format of the return value is:
-     *                     <code>
+     *                     ```php
      *                     array(
      *                       'parenthesis_opener' => integer, // Stack pointer to the parenthesis opener.
      *                       'parenthesis_closer' => integer, // Stack pointer to the parenthesis closer.
      *                       'scope_opener'       => integer, // Stack pointer to the scope opener (arrow).
      *                       'scope_closer'       => integer, // Stack pointer to the scope closer.
      *                     )
-     *                     </code>
+     *                     ```
      */
     public static function getArrowFunctionOpenClose(File $phpcsFile, $stackPtr)
     {
@@ -830,7 +832,7 @@ class FunctionDeclarations
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
-     * @param int                         $stackPtr  The T_FUNCTION token to check.
+     * @param int                         $stackPtr  The `T_FUNCTION` token to check.
      *
      * @return bool
      */
@@ -877,7 +879,7 @@ class FunctionDeclarations
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
-     * @param int                         $stackPtr  The T_FUNCTION token to check.
+     * @param int                         $stackPtr  The `T_FUNCTION` token to check.
      *
      * @return bool
      */
@@ -920,7 +922,7 @@ class FunctionDeclarations
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
-     * @param int                         $stackPtr  The T_FUNCTION token to check.
+     * @param int                         $stackPtr  The `T_FUNCTION` token to check.
      *
      * @return bool
      */
@@ -984,7 +986,7 @@ class FunctionDeclarations
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
-     * @param int                         $stackPtr  The T_FUNCTION token to check.
+     * @param int                         $stackPtr  The `T_FUNCTION` token to check.
      *
      * @return bool
      */

--- a/PHPCSUtils/Utils/GetTokensAsString.php
+++ b/PHPCSUtils/Utils/GetTokensAsString.php
@@ -168,7 +168,7 @@ class GetTokensAsString
      * @param int                         $start         The position to start from in the token stack.
      * @param int                         $end           The position to end at in the token stack (inclusive).
      * @param bool                        $stripComments Whether comments should be stripped from the contents.
-     *                                                   Defaults to false.
+     *                                                   Defaults to `false`.
      *
      * @return string The token contents with compacted whitespace and optionally stripped off comments.
      *
@@ -190,11 +190,11 @@ class GetTokensAsString
      * @param int                         $end             The position to end at in the token stack (inclusive).
      * @param bool                        $origContent     Whether the original content or the tab replaced
      *                                                     content should be used.
-     *                                                     Defaults to false (= tabs replaced with spaces).
+     *                                                     Defaults to `false` (= tabs replaced with spaces).
      * @param bool                        $stripComments   Whether comments should be stripped from the contents.
-     *                                                     Defaults to false.
+     *                                                     Defaults to `false`.
      * @param bool                        $stripWhitespace Whether whitespace should be stripped from the contents.
-     *                                                     Defaults to false.
+     *                                                     Defaults to `false`.
      * @param bool                        $compact         Whether all consecutive whitespace tokens should be
      *                                                     replaced with a single space. Defaults to `false`.
      *

--- a/PHPCSUtils/Utils/Lists.php
+++ b/PHPCSUtils/Utils/Lists.php
@@ -47,7 +47,7 @@ class Lists
     ];
 
     /**
-     * Determine whether a `T_OPEN/CLOSE_SHORT_ARRAY` token is a short list() construct.
+     * Determine whether a T_OPEN/CLOSE_SHORT_ARRAY token is a short list() construct.
      *
      * This method also accepts `T_OPEN/CLOSE_SQUARE_BRACKET` tokens to allow it to be
      * PHPCS cross-version compatible as the short array tokenizing has been plagued by
@@ -58,8 +58,8 @@ class Lists
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the short array bracket token.
      *
-     * @return bool True if the token passed is the open/close bracket of a short list.
-     *              False if the token is a short array bracket or plain square bracket
+     * @return bool `TRUE` if the token passed is the open/close bracket of a short list.
+     *              `FALSE` if the token is a short array bracket or plain square bracket
      *              or not one of the accepted tokens.
      */
     public static function isShortList(File $phpcsFile, $stackPtr)
@@ -254,37 +254,42 @@ class Lists
      *
      * The returned array will contain the following basic information for each assignment:
      *
-     * <code>
-     *   0 => array(
-     *         'raw'                  => string,       // The full content of the variable definition, including
-     *                                                 // whitespace and comments.
-     *                                                 // This may be an empty string when a list
-     *                                                 // item is being skipped.
-     *         'assignment'           => string,       // The content of the assignment part, _cleaned of comments_.
-     *                                                 // This may be an empty string for an empty list item;
-     *                                                 // it could also be a nested list represented as a string.
-     *         'is_empty'             => bool,         // Whether this is an empty list item, i.e. the
-     *                                                 // second item in `list($a, , $b)`.
-     *         'is_nested_list'       => bool,         // Whether this is a nested list.
-     *         'variable'             => string|false, // The base variable being assigned to or
-     *                                                 // FALSE in case of a nested list or a variable variable.
-     *                                                 // I.e. `$a` in `list($a['key'])`.
-     *         'assignment_token'     => int|false,    // The start pointer for the assignment.
-     *                                                 // For a nested list, this will be the pointer to the `list`
-     *                                                 // keyword or the open square bracket in case of a short list.
-     *         'assignment_end_token' => int|false,    // The end pointer for the assignment.
-     *         'assign_by_reference'  => bool,         // Is the variable assigned by reference?
-     *         'reference_token'      => int|false,    // The stack pointer to the reference operator;
-     *                                                 // or FALSE when not a reference assignment.
-     * </code>
+     * ```php
+     * 0 => array(
+     *   'raw'                  => string,       // The full content of the variable definition,
+     *                                           // including whitespace and comments.
+     *                                           // This may be an empty string when a list
+     *                                           // item is being skipped.
+     *   'assignment'           => string,       // The content of the assignment part,
+     *                                           // cleaned of comments.
+     *                                           // This may be an empty string for an empty
+     *                                           // list item; it could also be a nested list
+     *                                           // represented as a string.
+     *   'is_empty'             => bool,         // Whether this is an empty list item, i.e.
+     *                                           // the second item in `list($a, , $b)`.
+     *   'is_nested_list'       => bool,         // Whether this is a nested list.
+     *   'variable'             => string|false, // The base variable being assigned to; or
+     *                                           // FALSE in case of a nested list or
+     *                                           // a variable variable.
+     *                                           // I.e. `$a` in `list($a['key'])`.
+     *   'assignment_token'     => int|false,    // The start pointer for the assignment.
+     *                                           // For a nested list, this will be the pointer
+     *                                           // to the `list` keyword or the open square
+     *                                           // bracket in case of a short list.
+     *   'assignment_end_token' => int|false,    // The end pointer for the assignment.
+     *   'assign_by_reference'  => bool,         // Is the variable assigned by reference?
+     *   'reference_token'      => int|false,    // The stack pointer to the reference operator;
+     *                                           // or FALSE when not a reference assignment.
+     * )
+     * ```
      *
      * Assignments with keys will have the following additional array indexes set:
-     * <code>
-     *         'key'                 => string, // The content of the key, cleaned of comments.
-     *         'key_token'           => int,    // The stack pointer to the start of the key.
-     *         'key_end_token'       => int,    // The stack pointer to the end of the key.
-     *         'double_arrow_token'  => int,    // The stack pointer to the double arrow.
-     * </code>
+     * ```php
+     *   'key'                 => string, // The content of the key, cleaned of comments.
+     *   'key_token'           => int,    // The stack pointer to the start of the key.
+     *   'key_end_token'       => int,    // The stack pointer to the end of the key.
+     *   'double_arrow_token'  => int,    // The stack pointer to the double arrow.
+     * ```
      *
      * @since 1.0.0
      *

--- a/PHPCSUtils/Utils/Namespaces.php
+++ b/PHPCSUtils/Utils/Namespaces.php
@@ -37,15 +37,15 @@ class Namespaces
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the T_NAMESPACE token.
+     * @param int                         $stackPtr  The position of the `T_NAMESPACE` token.
      *
      * @return string Either `'declaration'`, `'operator'` or an empty string.
      *                An empty string will be returned if it couldn't be
-     *                reliably determined what the T_NAMESPACE token is used for,
+     *                reliably determined what the `T_NAMESPACE` token is used for,
      *                which, in most cases, will mean the code contains a parse/fatal error.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is
-     *                                                      not a T_NAMESPACE token.
+     *                                                      not a `T_NAMESPACE` token.
      */
     public static function getType(File $phpcsFile, $stackPtr)
     {
@@ -119,13 +119,13 @@ class Namespaces
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of a T_NAMESPACE token.
+     * @param int                         $stackPtr  The position of a `T_NAMESPACE` token.
      *
-     * @return bool True if the token passed is the keyword for a namespace declaration.
-     *              False if not.
+     * @return bool `TRUE` if the token passed is the keyword for a namespace declaration.
+     *              `FALSE` if not.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is
-     *                                                      not a T_NAMESPACE token.
+     *                                                      not a `T_NAMESPACE` token.
      */
     public static function isDeclaration(File $phpcsFile, $stackPtr)
     {
@@ -141,12 +141,12 @@ class Namespaces
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of a T_NAMESPACE token.
+     * @param int                         $stackPtr  The position of a `T_NAMESPACE` token.
      *
-     * @return bool True if the namespace token passed is used as an operator. False if not.
+     * @return bool `TRUE` if the namespace token passed is used as an operator. `FALSE` if not.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is
-     *                                                      not a T_NAMESPACE token.
+     *                                                      not a `T_NAMESPACE` token.
      */
     public static function isOperator(File $phpcsFile, $stackPtr)
     {
@@ -162,15 +162,15 @@ class Namespaces
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of a T_NAMESPACE token.
+     * @param int                         $stackPtr  The position of a `T_NAMESPACE` token.
      * @param bool                        $clean     Optional. Whether to get the name stripped
      *                                               of potentially interlaced whitespace and/or
-     *                                               comments. Defaults to true.
+     *                                               comments. Defaults to `true`.
      *
-     * @return string|false The namespace name, or false if the specified position is not a
-     *                      T_NAMESPACE token, the token points to a namespace operator
+     * @return string|false The namespace name; or `FALSE` if the specified position is not a
+     *                      `T_NAMESPACE` token, the token points to a namespace operator
      *                      or when parse errors are encountered/during live coding.
-     *                      Note: The name can be an empty string for a valid global
+     *                      > Note: The name can be an empty string for a valid global
      *                      namespace declaration.
      */
     public static function getDeclaredName(File $phpcsFile, $stackPtr, $clean = true)
@@ -209,12 +209,12 @@ class Namespaces
     /**
      * Determine the namespace an arbitrary token lives in.
      *
-     * Note: when a namespace declaration token or a token which is part of the namespace
-     * name is passed to this method, the result will be `false` as technically, these tokens
-     * are not _within_ a namespace.
-     *
-     * Note: this method has no opinion on whether the token passed is actually _subject_
-     * to namespacing.
+     * Take note:
+     * 1. When a namespace declaration token or a token which is part of the namespace
+     *    name is passed to this method, the result will be `false` as technically, these tokens
+     *    are not _within_ a namespace.
+     * 2. This method has no opinion on whether the token passed is actually _subject_
+     *    to namespacing.
      *
      * @since 1.0.0
      *
@@ -223,7 +223,7 @@ class Namespaces
      *                                               the namespace.
      *
      * @return int|false Token pointer to the namespace keyword for the applicable namespace
-     *                   declaration; or `false` if it couldn't be determined or
+     *                   declaration; or `FALSE` if it couldn't be determined or
      *                   if no namespace applies.
      */
     public static function findNamespacePtr(File $phpcsFile, $stackPtr)

--- a/PHPCSUtils/Utils/NamingConventions.php
+++ b/PHPCSUtils/Utils/NamingConventions.php
@@ -81,7 +81,8 @@ class NamingConventions
      * when comparing namespace, class/trait/interface and function names.
      *
      * Variable and constant names in PHP are case-sensitive, except for constants explicitely
-     * declared case-insensitive using the third parameter for `define()`.
+     * declared case-insensitive using the third parameter for
+     * {@link https://www.php.net/function.define `define()`}.
      *
      * All other names are case-insensitive for the most part, but as it's PHP, not completely.
      * Basically ASCII chars used are case-insensitive, but anything from 0x80 up is case-sensitive.
@@ -97,7 +98,7 @@ class NamingConventions
      * @param string $nameA The first identifier name.
      * @param string $nameB The second identifier name.
      *
-     * @return bool TRUE if these names would be considered the same in PHP, FALSE otherwise.
+     * @return bool `TRUE` if these names would be considered the same in PHP; `FALSE` otherwise.
      */
     public static function isEqual($nameA, $nameB)
     {

--- a/PHPCSUtils/Utils/Numbers.php
+++ b/PHPCSUtils/Utils/Numbers.php
@@ -165,18 +165,29 @@ class Numbers
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of a T_LNUMBER or T_DNUMBER token.
      *
-     * @return array An array with the following information about the number:
-     *               - 'orig_content' string The (potentially concatenated) original content of the tokens;
-     *               - 'content'      string The (potentially concatenated) content, underscore(s) removed;
-     *               - 'code'         int    The token code of the number, either T_LNUMBER or T_DNUMBER.
-     *               - 'type'         string The token type, either 'T_LNUMBER' or 'T_DNUMBER'.
-     *               - 'decimal'      string The decimal value of the number;
-     *               - 'last_token'   int    The stackPtr to the last token which was part of the number;
-     *                                       This will be the same as the original stackPtr if it is not
-     *                                       a PHP 7.4 number with underscores.
+     * @return array An array with information about the number.
+     *               The format of the array return value is:
+     *               ```php
+     *               array(
+     *                 'orig_content' => string, // The (potentially concatenated) original
+     *                                           // content of the tokens;
+     *                 'content'      => string, // The (potentially concatenated) content,
+     *                                           // underscore(s) removed;
+     *                 'code'         => int,    // The token code of the number, either
+     *                                           // T_LNUMBER or T_DNUMBER.
+     *                 'type'         => string, // The token type, either 'T_LNUMBER'
+     *                                           // or 'T_DNUMBER'.
+     *                 'decimal'      => string, // The decimal value of the number;
+     *                 'last_token'   => int,    // The stackPtr to the last token which was
+     *                                           // part of the number.
+     *                                           // This will be the same as the original
+     *                                           // stackPtr if it is not a PHP 7.4 number
+     *                                           // with underscores.
+     *               )
+     *               ```
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified token is not of type
-     *                                                      T_LNUMBER or T_DNUMBER.
+     *                                                      `T_LNUMBER` or `T_DNUMBER`.
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If this function is called in combination
      *                                                      with an unsupported PHPCS version.
      */
@@ -323,9 +334,9 @@ class Numbers
      *
      * @param string $string Arbitrary token content string.
      *
-     * @return string|false Decimal number as a string or false if the passed parameter
+     * @return string|false Decimal number as a string or `FALSE` if the passed parameter
      *                      was not a numeric string.
-     *                      Note: floating point numbers with exponent will not be expanded,
+     *                      > Note: floating point numbers with exponent will not be expanded,
      *                      but returned as-is.
      */
     public static function getDecimalValue($string)

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -32,10 +32,6 @@ class ObjectDeclarations
     /**
      * Retrieves the declaration name for classes, interfaces, traits, and functions.
      *
-     * Note: For ES6 classes in combination with PHPCS 2.x, passing a `T_STRING` token to
-     *       this method will be accepted for JS files.
-     * Note: support for JS ES6 method syntax has not (yet) been back-filled for PHPCS < 3.0.0.
-     *
      * Main differences with the PHPCS version:
      * - Defensive coding against incorrect calls to this method.
      * - Improved handling of invalid names, like names starting with a number.
@@ -46,6 +42,11 @@ class ObjectDeclarations
      *   being extended/interface being implemented.
      *   Using this version of the utility method, either the complete name (invalid or not) will
      *   be returned or `null` in case of no name (parse error).
+     *
+     * Note:
+     * - For ES6 classes in combination with PHPCS 2.x, passing a `T_STRING` token to
+     *   this method will be accepted for JS files.
+     * - Support for JS ES6 method syntax has not been back-filled for PHPCS < 3.0.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getDeclarationName()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getDeclarationName() Cross-version compatible version of the original.
@@ -58,11 +59,11 @@ class ObjectDeclarations
      *                                               trait, or function.
      *
      * @return string|null The name of the class, interface, trait, or function;
-     *                     or NULL if the passed token doesn't exist, the function or
+     *                     or `NULL` if the passed token doesn't exist, the function or
      *                     class is anonymous or in case of a parse error/live coding.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified token is not of type
-     *                                                      T_FUNCTION, T_CLASS, T_TRAIT, or T_INTERFACE.
+     *                                                      `T_FUNCTION`, `T_CLASS`, `T_TRAIT`, or `T_INTERFACE`.
      */
     public static function getName(File $phpcsFile, $stackPtr)
     {
@@ -153,12 +154,12 @@ class ObjectDeclarations
      * Retrieves the implementation properties of a class.
      *
      * The format of the return value is:
-     * <code>
-     *   array(
-     *    'is_abstract' => false, // true if the abstract keyword was found.
-     *    'is_final'    => false, // true if the final keyword was found.
-     *   );
-     * </code>
+     * ```php
+     * array(
+     *   'is_abstract' => false, // TRUE if the abstract keyword was found.
+     *   'is_final'    => false, // TRUE if the final keyword was found.
+     * );
+     * ```
      *
      * Main differences with the PHPCS version:
      * - Bugs fixed:
@@ -173,13 +174,13 @@ class ObjectDeclarations
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position in the stack of the T_CLASS
+     * @param int                         $stackPtr  The position in the stack of the `T_CLASS`
      *                                               token to acquire the properties for.
      *
      * @return array
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      T_CLASS token.
+     *                                                      `T_CLASS` token.
      */
     public static function getClassProperties(File $phpcsFile, $stackPtr)
     {
@@ -239,7 +240,7 @@ class ObjectDeclarations
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The stack position of the class or interface.
      *
-     * @return string|false The extended class name or FALSE on error or if there
+     * @return string|false The extended class name or `FALSE` on error or if there
      *                      is no extended class name.
      */
     public static function findExtendedClassName(File $phpcsFile, $stackPtr)
@@ -272,7 +273,7 @@ class ObjectDeclarations
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The stack position of the class.
      *
-     * @return array|false Array with names of the implemented interfaces or FALSE on
+     * @return array|false Array with names of the implemented interfaces or `FALSE` on
      *                     error or if there are no implemented interface names.
      */
     public static function findImplementedInterfaceNames(File $phpcsFile, $stackPtr)
@@ -290,7 +291,7 @@ class ObjectDeclarations
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
      * @param int                         $stackPtr  The stack position of the interface keyword.
      *
-     * @return array|false Array with names of the extended interfaces or FALSE on
+     * @return array|false Array with names of the extended interfaces or `FALSE` on
      *                     error or if there are no extended interface names.
      */
     public static function findExtendedInterfaceNames(File $phpcsFile, $stackPtr)
@@ -317,7 +318,7 @@ class ObjectDeclarations
      * @param array                       $allowedFor Array of OO types for which use of the keyword
      *                                                is allowed.
      *
-     * @return array|false Returns an array of names or false on error or when the object
+     * @return array|false Returns an array of names or `FALSE` on error or when the object
      *                     being declared does not extend/implement another object.
      */
     private static function findNames(File $phpcsFile, $stackPtr, $keyword, $allowedFor)

--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -72,10 +72,10 @@ class Operators
      * @since 1.0.0-alpha2 Added BC support for PHP 7.4 arrow functions.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the T_BITWISE_AND token.
+     * @param int                         $stackPtr  The position of the `T_BITWISE_AND` token.
      *
-     * @return bool TRUE if the specified token position represents a reference.
-     *              FALSE if the token represents a bitwise operator.
+     * @return bool `TRUE` if the specified token position represents a reference.
+     *              `FALSE` if the token represents a bitwise operator.
      */
     public static function isReference(File $phpcsFile, $stackPtr)
     {
@@ -181,8 +181,8 @@ class Operators
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the plus/minus token.
      *
-     * @return bool True if the token passed is a unary operator.
-     *              False otherwise, i.e. if the token is an arithmetic operator,
+     * @return bool `TRUE` if the token passed is a unary operator.
+     *              `FALSE` otherwise, i.e. if the token is an arithmetic operator,
      *              or if the token is not a `T_PLUS`/`T_MINUS` token.
      */
     public static function isUnaryPlusMinus(File $phpcsFile, $stackPtr)
@@ -242,7 +242,7 @@ class Operators
      * @param int                         $stackPtr  The position of the ternary then/else
      *                                               operator in the stack.
      *
-     * @return bool True if short ternary, or false otherwise.
+     * @return bool `TRUE` if short ternary; or `FALSE` otherwise.
      */
     public static function isShortTernary(File $phpcsFile, $stackPtr)
     {

--- a/PHPCSUtils/Utils/Orthography.php
+++ b/PHPCSUtils/Utils/Orthography.php
@@ -50,9 +50,9 @@ class Orthography
      *                       off a text string before passing it to this method.
      *                       Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.
      *
-     * @return bool True when the first character is a capital letter or a letter
+     * @return bool `TRUE` when the first character is a capital letter or a letter
      *              which doesn't have a concept of capitalization.
-     *              False otherwise, including for non-letter characters.
+     *              `FALSE` otherwise, including for non-letter characters.
      */
     public static function isFirstCharCapitalized($string)
     {
@@ -72,8 +72,8 @@ class Orthography
      *                       off a text string before passing it to this method.
      *                       Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.
      *
-     * @return bool True when the first character is a lowercase letter.
-     *              False otherwise, including for letters which don't have a concept of
+     * @return bool `TRUE` when the first character is a lowercase letter.
+     *              `FALSE` otherwise, including for letters which don't have a concept of
      *              capitalization and for non-letter characters.
      */
     public static function isFirstCharLowercase($string)
@@ -95,7 +95,7 @@ class Orthography
      *                             Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.
      * @param string $allowedChars Characters which are considered valid punctuation
      *                             to end the text string.
-     *                             Defaults to '.?!', i.e. a full stop, question mark
+     *                             Defaults to `'.?!'`, i.e. a full stop, question mark
      *                             or exclamation mark.
      *
      * @return bool

--- a/PHPCSUtils/Utils/Parentheses.php
+++ b/PHPCSUtils/Utils/Parentheses.php
@@ -34,7 +34,7 @@ class Parentheses
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
      * @param int                         $stackPtr  The position of `T_OPEN/CLOSE_PARENTHESIS` token.
      *
-     * @return int|false Integer stack pointer to the parentheses owner or false if the
+     * @return int|false Integer stack pointer to the parentheses owner; or `FALSE` if the
      *                   parenthesis does not have a (direct) owner or if the token passed
      *                   was not a parenthesis.
      */
@@ -97,7 +97,7 @@ class Parentheses
      * @param int|string|array            $validOwners Array of token constants for the owners
      *                                                 which should be considered valid.
      *
-     * @return bool True if the owner is within the list of `$validOwners`, false if not and
+     * @return bool `TRUE` if the owner is within the list of `$validOwners`; `FALSE` if not and
      *              if the parenthesis does not have a (direct) owner.
      */
     public static function isOwnerIn(File $phpcsFile, $stackPtr, $validOwners)
@@ -161,7 +161,7 @@ class Parentheses
      * @param int|string|array            $validOwners Array of token constants for the owners
      *                                                 which should be considered valid.
      *
-     * @return int|false Integer stack pointer to the parentheses opener or false if the token
+     * @return int|false Integer stack pointer to the parentheses opener; or `FALSE` if the token
      *                   does not have parentheses owned by any of the valid owners or if
      *                   the token is not nested in parentheses at all.
      */
@@ -184,7 +184,7 @@ class Parentheses
      * @param int|string|array            $validOwners Array of token constants for the owners
      *                                                 which should be considered valid.
      *
-     * @return int|false Integer stack pointer to the parentheses closer or false if the token
+     * @return int|false Integer stack pointer to the parentheses closer; or `FALSE` if the token
      *                   does not have parentheses owned by any of the valid owners or if
      *                   the token is not nested in parentheses at all.
      */
@@ -204,7 +204,7 @@ class Parentheses
      * arbitrary token is wrapped in, where the parentheses owner is within the set of valid owners.
      *
      * If no `$validOwners` are specified, the owner to the first set of parentheses surrounding
-     * the token will be returned or false if the first set of parentheses does not have an owner.
+     * the token will be returned or `false` if the first set of parentheses does not have an owner.
      *
      * @since 1.0.0
      *
@@ -213,7 +213,7 @@ class Parentheses
      * @param int|string|array            $validOwners Array of token constants for the owners
      *                                                 which should be considered valid.
      *
-     * @return int|false Integer stack pointer  to the parentheses owner or false if the token
+     * @return int|false Integer stack pointer to the parentheses owner; or `FALSE` if the token
      *                   does not have parentheses owned by any of the valid owners or if
      *                   the token is not nested in parentheses at all.
      */
@@ -241,7 +241,7 @@ class Parentheses
      * @param int|string|array            $validOwners Array of token constants for the owners
      *                                                 which should be considered valid.
      *
-     * @return int|false Integer stack pointer to the parentheses opener or false if the token
+     * @return int|false Integer stack pointer to the parentheses opener; or `FALSE` if the token
      *                   does not have parentheses owned by any of the valid owners or if
      *                   the token is not nested in parentheses at all.
      */
@@ -264,7 +264,7 @@ class Parentheses
      * @param int|string|array            $validOwners Array of token constants for the owners
      *                                                 which should be considered valid.
      *
-     * @return int|false Integer stack pointer to the parentheses closer or false if the token
+     * @return int|false Integer stack pointer to the parentheses closer; or `FALSE` if the token
      *                   does not have parentheses owned by any of the valid owners or if
      *                   the token is not nested in parentheses at all.
      */
@@ -284,7 +284,7 @@ class Parentheses
      * arbitrary token is wrapped in where the parentheses owner is within the set of valid owners.
      *
      * If no `$validOwners` are specified, the owner to the last set of parentheses surrounding
-     * the token will be returned or false if the last set of parentheses does not have an owner.
+     * the token will be returned or `false` if the last set of parentheses does not have an owner.
      *
      * @since 1.0.0
      *
@@ -293,7 +293,7 @@ class Parentheses
      * @param int|string|array            $validOwners Array of token constants for the owners
      *                                                 which should be considered valid.
      *
-     * @return int|false Integer stack pointer to the parentheses owner or false if the token
+     * @return int|false Integer stack pointer to the parentheses owner; or `FALSE` if the token
      *                   does not have parentheses owned by any of the valid owners or if
      *                   the token is not nested in parentheses at all.
      */
@@ -319,7 +319,7 @@ class Parentheses
      * @param int|string|array            $validOwners Array of token constants for the owners
      *                                                 which should be considered valid.
      *
-     * @return int|false Integer stack pointer to the valid parentheses owner or false if
+     * @return int|false Integer stack pointer to the valid parentheses owner; or `FALSE` if
      *                   the token was not wrapped in parentheses or if the outermost set
      *                   of parentheses in which the token is wrapped does not have an owner
      *                   within the set of owners considered valid.
@@ -347,7 +347,7 @@ class Parentheses
      * @param int|string|array            $validOwners Array of token constants for the owners
      *                                                 which should be considered valid.
      *
-     * @return int|false Integer stack pointer to the valid parentheses owner or false if
+     * @return int|false Integer stack pointer to the valid parentheses owner; or `FALSE` if
      *                   the token was not wrapped in parentheses or if the innermost set
      *                   of parentheses in which the token is wrapped does not have an owner
      *                   within the set of owners considered valid.
@@ -367,7 +367,7 @@ class Parentheses
      * Helper method. Retrieve the position of a parentheses opener for an arbitrary passed token.
      *
      * If no `$validOwners` are specified, the opener to the first set of parentheses surrounding
-     * the token - or if `$reverse=true`, the last set of parentheses - will be returned.
+     * the token - or if `$reverse = true`, the last set of parentheses - will be returned.
      *
      * @since 1.0.0
      *
@@ -376,10 +376,10 @@ class Parentheses
      * @param int|string|array            $validOwners Optional. Array of token constants for the owners
      *                                                 which should be considered valid.
      * @param bool                        $reverse     Optional. Whether to search for the first/outermost
-     *                                                 (false) or the last/innermost (true) set of
+     *                                                 (`false`) or the last/innermost (`true`) set of
      *                                                 parentheses with the specified owner(s).
      *
-     * @return int|false Integer stack pointer to the parentheses opener or false if the token
+     * @return int|false Integer stack pointer to the parentheses opener; or `FALSE` if the token
      *                   does not have parentheses owned by any of the valid owners or if
      *                   the token is not nested in parentheses at all.
      */

--- a/PHPCSUtils/Utils/PassedParameters.php
+++ b/PHPCSUtils/Utils/PassedParameters.php
@@ -64,21 +64,21 @@ class PassedParameters
     /**
      * Checks if any parameters have been passed.
      *
-     * - If passed a T_STRING or T_VARIABLE stack pointer, it will treat it as a function call.
-     *   If a T_STRING or T_VARIABLE which is *not* a function call is passed, the behaviour is
+     * - If passed a `T_STRING` or `T_VARIABLE` stack pointer, it will treat it as a function call.
+     *   If a `T_STRING` or `T_VARIABLE` which is *not* a function call is passed, the behaviour is
      *   undetermined.
-     * - If passed a T_SELF or T_STATIC stack pointer, it will accept it as a
+     * - If passed a `T_SELF` or `T_STATIC` stack pointer, it will accept it as a
      *   function call when used like `new self()`.
-     * - If passed a T_ARRAY or T_OPEN_SHORT_ARRAY stack pointer, it will detect
+     * - If passed a `T_ARRAY` or `T_OPEN_SHORT_ARRAY` stack pointer, it will detect
      *   whether the array has values or is empty.
-     * - If passed a T_ISSET or T_UNSET stack pointer, it will detect whether those
+     * - If passed a `T_ISSET` or `T_UNSET` stack pointer, it will detect whether those
      *   language constructs have "parameters".
      *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
-     * @param int                         $stackPtr  The position of the T_STRING, T_VARIABLE, T_ARRAY,
-     *                                               T_OPEN_SHORT_ARRAY, T_ISSET, or T_UNSET token.
+     * @param int                         $stackPtr  The position of the `T_STRING`, `T_VARIABLE`, `T_ARRAY`,
+     *                                               `T_OPEN_SHORT_ARRAY`, `T_ISSET`, or `T_UNSET` token.
      *
      * @return bool
      *
@@ -154,14 +154,13 @@ class PassedParameters
     /**
      * Get information on all parameters passed.
      *
-     * See {@see PHPCSUtils\Utils\PassedParameters::hasParameters()} for information on the supported
-     * constructs.
+     * See {@see PassedParameters::hasParameters()} for information on the supported constructs.
      *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
-     * @param int                         $stackPtr  The position of the T_STRING, T_VARIABLE, T_ARRAY,
-     *                                               T_OPEN_SHORT_ARRAY, T_ISSET, or T_UNSET token.
+     * @param int                         $stackPtr  The position of the `T_STRING`, `T_VARIABLE`, `T_ARRAY`,
+     *                                               `T_OPEN_SHORT_ARRAY`, `T_ISSET`, or `T_UNSET` token.
      *
      * @return array A multi-dimentional array information on each parameter/array item.
      *               The information gathered about each parameter/array item is in the following format:
@@ -277,18 +276,17 @@ class PassedParameters
     /**
      * Get information on a specific parameter passed.
      *
-     * See {@see PHPCSUtils\Utils\PassedParameters::hasParameters()} for information on the supported
-     * constructs.
+     * See {@see PassedParameters::hasParameters()} for information on the supported constructs.
      *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
-     * @param int                         $stackPtr    The position of the T_STRING, T_VARIABLE, T_ARRAY,
-     *                                                 T_OPEN_SHORT_ARRAY, T_ISSET or T_UNSET token.
+     * @param int                         $stackPtr    The position of the `T_STRING`, `T_VARIABLE`, `T_ARRAY`,
+     *                                                 `T_OPEN_SHORT_ARRAY`, `T_ISSET` or `T_UNSET` token.
      * @param int                         $paramOffset The 1-based index position of the parameter to retrieve.
      *
      * @return array|false Array with information on the parameter/array item at the specified offset.
-     *                     Or `false` if the specified parameter/array item is not found.
+     *                     Or `FALSE` if the specified parameter/array item is not found.
      *                     The format of the return value is:
      *                     ```php
      *                     array(
@@ -316,14 +314,13 @@ class PassedParameters
     /**
      * Count the number of parameters which have been passed.
      *
-     * See {@see PHPCSUtils\Utils\PassedParameters::hasParameters()} for information on the supported
-     * constructs.
+     * See {@see PassedParameters::hasParameters()} for information on the supported constructs.
      *
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
-     * @param int                         $stackPtr  The position of the T_STRING, T_VARIABLE, T_ARRAY,
-     *                                               T_OPEN_SHORT_ARRAY, T_ISSET or T_UNSET token.
+     * @param int                         $stackPtr  The position of the `T_STRING`, `T_VARIABLE`, `T_ARRAY`,
+     *                                               `T_OPEN_SHORT_ARRAY`, `T_ISSET` or `T_UNSET` token.
      *
      * @return int
      *

--- a/PHPCSUtils/Utils/Scopes.php
+++ b/PHPCSUtils/Utils/Scopes.php
@@ -36,7 +36,7 @@ class Scopes
      * @param int|string|array            $validScopes Array of token constants representing
      *                                                 the scopes considered valid.
      *
-     * @return int|false Integer stack pointer to the valid direct scope or false if
+     * @return int|false Integer stack pointer to the valid direct scope; or `FALSE` if
      *                   no valid direct scope was found.
      */
     public static function validDirectScope(File $phpcsFile, $stackPtr, $validScopes)
@@ -56,7 +56,7 @@ class Scopes
     }
 
     /**
-     * Check whether a `T_CONST` token is a class/interface constant declaration.
+     * Check whether a T_CONST token is a class/interface constant declaration.
      *
      * @since 1.0.0
      *
@@ -82,7 +82,7 @@ class Scopes
     }
 
     /**
-     * Check whether a `T_VARIABLE` token is a class/trait property declaration.
+     * Check whether a T_VARIABLE token is a class/trait property declaration.
      *
      * @since 1.0.0
      *
@@ -116,7 +116,7 @@ class Scopes
     }
 
     /**
-     * Check whether a `T_FUNCTION` token is a class/interface/trait method declaration.
+     * Check whether a T_FUNCTION token is a class/interface/trait method declaration.
      *
      * @since 1.0.0
      *

--- a/PHPCSUtils/Utils/TextStrings.php
+++ b/PHPCSUtils/Utils/TextStrings.php
@@ -41,7 +41,7 @@ class TextStrings
      *                                                 or to a Nowdoc/Heredoc opener.
      * @param bool                        $stripQuotes Optional. Whether to strip text delimiter
      *                                                 quotes off the resulting text string.
-     *                                                 Defaults to true.
+     *                                                 Defaults to `true`.
      *
      * @return string The complete text string.
      *
@@ -115,10 +115,10 @@ class TextStrings
     /**
      * Strip text delimiter quotes from an arbitrary string.
      *
-     * Intended for use with the "contents" of a T_CONSTANT_ENCAPSED_STRING / T_DOUBLE_QUOTED_STRING.
+     * Intended for use with the "contents" of a `T_CONSTANT_ENCAPSED_STRING` / `T_DOUBLE_QUOTED_STRING`.
      *
-     * Prevents stripping mis-matched quotes.
-     * Prevents stripping quotes from the textual content of the string.
+     * - Prevents stripping mis-matched quotes.
+     * - Prevents stripping quotes from the textual content of the string.
      *
      * @since 1.0.0
      *

--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -31,16 +31,16 @@ class UseStatements
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the T_USE token.
+     * @param int                         $stackPtr  The position of the `T_USE` token.
      *
-     * @return string Either 'closure', 'import' or 'trait'.
+     * @return string Either `'closure'`, `'import'` or `'trait'`.
      *                An empty string will be returned if the token is used in an
      *                invalid context or if it couldn't be reliably determined what
      *                the `T_USE` token is used for. An empty string being returned will
      *                normally mean the code being examined contains a parse error.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      T_USE token.
+     *                                                      `T_USE` token.
      */
     public static function getType(File $phpcsFile, $stackPtr)
     {
@@ -88,13 +88,13 @@ class UseStatements
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the T_USE token.
+     * @param int                         $stackPtr  The position of the `T_USE` token.
      *
-     * @return bool True if the token passed is a closure use statement.
-     *              False if it's not.
+     * @return bool `TRUE` if the token passed is a closure use statement.
+     *              `FALSE` if it's not.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      T_USE token.
+     *                                                      `T_USE` token.
      */
     public static function isClosureUse(File $phpcsFile, $stackPtr)
     {
@@ -107,13 +107,13 @@ class UseStatements
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the T_USE token.
+     * @param int                         $stackPtr  The position of the `T_USE` token.
      *
-     * @return bool True if the token passed is an import use statement.
-     *              False if it's not.
+     * @return bool `TRUE` if the token passed is an import use statement.
+     *              `FALSE` if it's not.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      T_USE token.
+     *                                                      `T_USE` token.
      */
     public static function isImportUse(File $phpcsFile, $stackPtr)
     {
@@ -126,13 +126,13 @@ class UseStatements
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the T_USE token.
+     * @param int                         $stackPtr  The position of the `T_USE` token.
      *
-     * @return bool True if the token passed is a trait use statement.
-     *              False if it's not.
+     * @return bool `TRUE` if the token passed is a trait use statement.
+     *              `FALSE` if it's not.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      T_USE token.
+     *                                                      `T_USE` token.
      */
     public static function isTraitUse(File $phpcsFile, $stackPtr)
     {
@@ -147,26 +147,33 @@ class UseStatements
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
-     * @param int                         $stackPtr  The position in the stack of the T_USE token.
+     * @param int                         $stackPtr  The position in the stack of the `T_USE` token.
      *
      * @return array A multi-level array containing information about the use statement.
-     *               The first level is 'name', 'function' and 'const'. These keys will always exist.
+     *               The first level is `'name'`, `'function'` and `'const'`. These keys will always exist.
      *               If any statements are found for any of these categories, the second level
      *               will contain the alias/name as the key and the full original use name as the
      *               value for each of the found imports or an empty array if no imports were found
      *               in this use statement for a particular category.
      *
      *               For example, for this function group use statement:
-     *               `use function Vendor\Package\{LevelA\Name as Alias, LevelB\Another_Name}`
+     *               ```php
+     *               use function Vendor\Package\{
+     *                   LevelA\Name as Alias,
+     *                   LevelB\Another_Name,
+     *               };
+     *               ```
      *               the return value would look like this:
-     *               `[
-     *                 'name'     => [],
-     *                 'function' => [
+     *               ```php
+     *               array(
+     *                 'name'     => array(),
+     *                 'function' => array(
      *                   'Alias'        => 'Vendor\Package\LevelA\Name',
      *                   'Another_Name' => 'Vendor\Package\LevelB\Another_Name',
-     *                 ],
-     *                 'const'    => [],
-     *               ]`
+     *                 ),
+     *                 'const'    => array(),
+     *               )
+     *               ```
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
      *                                                      `T_USE` token.
@@ -364,11 +371,12 @@ class UseStatements
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile             The file where this token was found.
-     * @param int                         $stackPtr              The position in the stack of the T_USE token.
+     * @param int                         $stackPtr              The position in the stack of the `T_USE` token.
      * @param array                       $previousUseStatements The import `use` statements collected so far.
-     *                                                           This should be either the output of a previous
-     *                                                           call to this method or the output of an earlier
-     *                                                           call to the UseStatements::splitImportUseStatement()
+     *                                                           This should be either the output of a
+     *                                                           previous call to this method or the output of
+     *                                                           an earlier call to the
+     *                                                           {@see UseStatements::splitImportUseStatement()}
      *                                                           method.
      *
      * @return array A multi-level array containing information about the current `use` statement combined with

--- a/PHPCSUtils/Utils/Variables.php
+++ b/PHPCSUtils/Utils/Variables.php
@@ -76,24 +76,23 @@ class Variables
      * Retrieve the visibility and implementation properties of a class member variable.
      *
      * The format of the return value is:
-     *
-     * <code>
-     *   array(
-     *    'scope'           => string,  // Public, private, or protected.
-     *    'scope_specified' => boolean, // TRUE if the scope was explicitly specified.
-     *    'is_static'       => boolean, // TRUE if the static keyword was found.
-     *    'type'            => string,  // The type of the var (empty if no type specified).
-     *    'type_token'      => integer, // The stack pointer to the start of the type
-     *                                  // or FALSE if there is no type.
-     *    'type_end_token'  => integer, // The stack pointer to the end of the type
-     *                                  // or FALSE if there is no type.
-     *    'nullable_type'   => boolean, // TRUE if the type is nullable.
-     *   );
-     * </code>
+     * ```php
+     * array(
+     *   'scope'           => string,  // Public, private, or protected.
+     *   'scope_specified' => boolean, // TRUE if the scope was explicitly specified.
+     *   'is_static'       => boolean, // TRUE if the static keyword was found.
+     *   'type'            => string,  // The type of the var (empty if no type specified).
+     *   'type_token'      => integer, // The stack pointer to the start of the type
+     *                                 // or FALSE if there is no type.
+     *   'type_end_token'  => integer, // The stack pointer to the end of the type
+     *                                 // or FALSE if there is no type.
+     *   'nullable_type'   => boolean, // TRUE if the type is nullable.
+     * );
+     * ```
      *
      * Main differences with the PHPCS version:
      * - Removed the parse error warning for properties in interfaces.
-     *   This will now throw the same "$stackPtr is not a class member var" runtime exception as
+     *   This will now throw the same _"$stackPtr is not a class member var"_ runtime exception as
      *   other non-property variables passed to the method.
      * - Defensive coding against incorrect calls to this method.
      *
@@ -103,13 +102,13 @@ class Variables
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position in the stack of the T_VARIABLE token to
-     *                                               acquire the properties for.
+     * @param int                         $stackPtr  The position in the stack of the `T_VARIABLE` token
+     *                                               to acquire the properties for.
      *
      * @return array
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      T_VARIABLE token.
+     *                                                      `T_VARIABLE` token.
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
      *                                                      class member variable.
      */
@@ -220,8 +219,8 @@ class Variables
      *
      * @param string $name The full variable name with or without leading dollar sign.
      *                     This allows for passing an array key variable name, such as
-     *                     '_GET' retrieved from $GLOBALS['_GET'].
-     *                     Note: when passing an array key, string quotes are expected
+     *                     `'_GET'` retrieved from `$GLOBALS['_GET']`.
+     *                     > Note: when passing an array key, string quotes are expected
      *                     to have been stripped already.
      *                     Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.
      *
@@ -242,14 +241,15 @@ class Variables
      * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
-     * @param int                         $stackPtr  The position in the stack of a T_VARIABLE
-     *                                               token or of the T_CONSTANT_ENCAPSED_STRING
+     * @param int                         $stackPtr  The position in the stack of a `T_VARIABLE`
+     *                                               token or of the `T_CONSTANT_ENCAPSED_STRING`
      *                                               array key to a variable in `$GLOBALS`.
      *
-     * @return bool True if this points to a superglobal. False when not.
-     *              Includes returning `false` when an unsupported token has been passed,
-     *              when a `T_CONSTANT_ENCAPSED_STRING` has been passed which is not an array
-     *              index key; or when it is, but is not an index to the `$GLOBALS` variable.
+     * @return bool `TRUE` if this points to a superglobal; `FALSE` when not.
+     *              > Note: This includes returning `FALSE` when an unsupported token has
+     *              been passed, when a `T_CONSTANT_ENCAPSED_STRING` has been passed which
+     *              is not an array index key; or when it is, but is not an index to the
+     *              `$GLOBALS` variable.
      */
     public static function isSuperglobal(File $phpcsFile, $stackPtr)
     {
@@ -297,8 +297,8 @@ class Variables
      *
      * @param string $name The full variable name with or without leading dollar sign.
      *                     This allows for passing an array key variable name, such as
-     *                     '_GET' retrieved from $GLOBALS['_GET'].
-     *                     Note: when passing an array key, string quotes are expected
+     *                     `'_GET'` retrieved from `$GLOBALS['_GET']`.
+     *                     > Note: when passing an array key, string quotes are expected
      *                     to have been stripped already.
      *                     Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.
      *

--- a/phpcsutils-autoload.php
+++ b/phpcsutils-autoload.php
@@ -8,7 +8,7 @@
  * - If an external standard only supports PHPCS >= 3.1.0 and uses the PHPCS
  *   native unit test framework, this file does not need to be included.
  *
- * - When PHPCS 2.x support is desired, include the "PHPCS23Utils" standard
+ * - When PHPCS 2.x support is desired, include the `"PHPCS23Utils"` standard
  *   in the ruleset of the external standard and this file will be included
  *   automatically.
  *   Including this file will allow PHPCSUtils to work in both PHPCS 2.x
@@ -17,7 +17,7 @@
  * - If an external standard uses its own unit test setup, this file should
  *   be included from the unit test bootstrap file.
  *
- * - If an external standard uses the PHPCSUtils `UtilityMethodTestCase`
+ * - If an external standard uses the PHPCSUtils {@see PHPCSUtils\TestUtils\UtilityMethodTestCase}
  *   class to test their own utility methods, this file should be included from
  *   the unit test bootstrap file.
  *


### PR DESCRIPTION
* Remove markdown from DocBlock summaries as it's not supported.
* Add backticks around inline code elements in long descriptions and tag descriptions.
* Add markdown where relevant in long descriptions and tag descriptions to improve readability of the rendered output.
* Add inline `{@see ...}` tags to create links to other documented elements.
* Add inline `{@link ...}` tags.
* Replace `<code>` tags with code block syntax.
* Lower the amount of indentation used in code blocks for more readable rendering.
* Replace singular backticks for multi-line code blocks with triple backticks, to allow for rendering as a proper code block instead of inline.
* Replace some semi-lists with list syntax supported via markdown for better rendering.
* Replace some list like return value array definitions with code blocks for better rendering.
* Make some "Note:"  remarks use blockquote syntax to draw more attention to them.
* Use uppercase true/false/null in `@return` tags to make them more easily readable at a glance.