### PR TITLE
Docs: update since tags

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -538,6 +538,7 @@ class BCFile
      *
      * @since 1.0.0
      * @since 1.0.0-alpha2 Added BC support for PHP 7.4 arrow functions.
+     * @since 1.0.0-alpha3 Added support for PHP 8.0 static return type (expected in future PHPCS release).
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the function token to

--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -64,6 +64,7 @@ class BCTokens
      * Token types that are comments containing PHPCS instructions.
      *
      * @since 1.0.0
+     * @since 1.0.0-alpha3 Visibility changed from `protected` to `private`.
      *
      * @var string[]
      */
@@ -79,6 +80,7 @@ class BCTokens
      * Tokens that open class and object scopes.
      *
      * @since 1.0.0
+     * @since 1.0.0-alpha3 Visibility changed from `protected` to `private`.
      *
      * @var array <int|string> => <int|string>
      */
@@ -93,6 +95,7 @@ class BCTokens
      * Tokens that represent text strings.
      *
      * @since 1.0.0
+     * @since 1.0.0-alpha3 Visibility changed from `protected` to `private`.
      *
      * @var array <int|string> => <int|string>
      */

--- a/PHPCSUtils/BackCompat/Helper.php
+++ b/PHPCSUtils/BackCompat/Helper.php
@@ -173,7 +173,7 @@ class Helper
      * Get the applicable (file) encoding as passed to PHP_CodeSniffer from the
      * command-line or the ruleset.
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha3
      *
      * @param \PHP_CodeSniffer\Files\File|null $phpcsFile Optional. The current file being processed.
      *

--- a/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+++ b/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
@@ -103,7 +103,7 @@ abstract class UtilityMethodTestCase extends TestCase
     /**
      * The PHPCS version the tests are being run on.
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha3
      *
      * @var string
      */
@@ -275,7 +275,7 @@ abstract class UtilityMethodTestCase extends TestCase
      * Note: This is a PHPUnit cross-version compatible {@see \PHPUnit\Framework\TestCase::setUp()}
      * method.
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha3
      *
      * @before
      *

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -204,7 +204,7 @@ class Collections
      *
      * @link https://www.php.net/language.constants.predefined PHP Manual on magic constants
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha3
      *
      * @var array <int|string> => <int|string>
      */
@@ -289,7 +289,7 @@ class Collections
      *
      * @link https://www.php.net/language.oop5.paamayim-nekudotayim PHP Manual on OO forwarding calls
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha3
      *
      * @var array <int|string> => <int|string>
      */
@@ -307,7 +307,7 @@ class Collections
      * echo namespace\Sub\ClassName::method();
      * ```
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha3
      *
      * @var array <int|string> => <int|string>
      */
@@ -520,7 +520,7 @@ class Collections
      *
      * Note: this is a method, not a property as the `T_FN` token for arrow functions may not exist.
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha2
      *
      * @return array <int|string> => <int|string>
      */
@@ -549,7 +549,7 @@ class Collections
      *
      * @see \PHPCSUtils\Tokens\Collections::functionDeclarationTokensBC() Related method (PHPCS 2.6.0+).
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha3
      *
      * @return array <int|string> => <int|string>
      */
@@ -590,7 +590,7 @@ class Collections
      * @see \PHPCSUtils\Tokens\Collections::functionDeclarationTokens() Related method (PHPCS 3.5.3+).
      * @see \PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction()   Arrow function verification.
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha3
      *
      * @return array <int|string> => <int|string>
      */
@@ -622,7 +622,7 @@ class Collections
      *
      * @see \PHPCSUtils\Tokens\Collections::$parameterTypeTokens Related property (PHPCS 3.3.0+).
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha3
      *
      * @return array <int|string> => <int|string>
      */
@@ -654,7 +654,7 @@ class Collections
      *
      * @see \PHPCSUtils\Tokens\Collections::$propertyTypeTokens Related property (PHPCS 3.3.0+).
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha3
      *
      * @return array <int|string> => <int|string>
      */
@@ -680,7 +680,7 @@ class Collections
      *
      * @see \PHPCSUtils\Tokens\Collections::$returnTypeTokens Related property (PHPCS 3.5.4+).
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha3
      *
      * @return array <int|string> => <int|string>
      */

--- a/PHPCSUtils/Utils/ControlStructures.php
+++ b/PHPCSUtils/Utils/ControlStructures.php
@@ -348,7 +348,7 @@ class ControlStructures
     /**
      * Retrieve the exception(s) being caught in a CATCH condition.
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha3
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the token we are checking.

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -176,6 +176,7 @@ class FunctionDeclarations
      *
      * @since 1.0.0
      * @since 1.0.0-alpha2 Added BC support for PHP 7.4 arrow functions.
+     * @since 1.0.0-alpha3 Added support for PHP 8.0 static return type.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the function token to

--- a/PHPCSUtils/Utils/Lists.php
+++ b/PHPCSUtils/Utils/Lists.php
@@ -292,6 +292,8 @@ class Lists
      * ```
      *
      * @since 1.0.0
+     * @since 1.0.0-alpha3 The returned value has been simplified with sensible defaults and always
+     *                     available keys.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the function token

--- a/PHPCSUtils/Utils/NamingConventions.php
+++ b/PHPCSUtils/Utils/NamingConventions.php
@@ -22,7 +22,7 @@ namespace PHPCSUtils\Utils;
  * - {@link https://www.php.net/language.variables.basics variable} names;
  * - {@link https://www.php.net/language.constants constant} names.
  *
- * @since 1.0.0
+ * @since 1.0.0-alpha3
  */
 class NamingConventions
 {

--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -368,7 +368,7 @@ class UseStatements
      * @see \PHPCSUtils\AbstractSniffs\AbstractFileContextSniff
      * @see \PHPCSUtils\Utils\UseStatements::splitImportUseStatement()
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha3
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile             The file where this token was found.
      * @param int                         $stackPtr              The position in the stack of the `T_USE` token.


### PR DESCRIPTION
### Docs: use the alpha version nr in `@since`

Until 1.0.0 (stable) has been released, it is important to know in which alpha certain things were introduced.

Once 1.0.0 comes out, these should be reverted to read `1.0.0`.

### Docs: add some `@since` changelog entries where relevant.

