### PR TITLE
BCFile::isReference(): sync with upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Notes:
 * New [`PHPCSUtils\Utils\UseStatements::splitAndMergeImportUseStatement()`](https://phpcsutils.com/phpdoc/classes/PHPCSUtils-Utils-UseStatements.html#method_splitAndMergeImportUseStatement) method. [#117](https://github.com/PHPCSStandards/PHPCSUtils/pull/117)
 
 #### PHPCS Backcompat
-* `BCFile::getMethodProperties()`: support for "static" as a return type (PHP 8). [#134](https://github.com/PHPCSStandards/PHPCSUtils/pull/134)
+* `BCFile::getMethodProperties()`: support for "static" as a return type (PHP 8). [#134](https://github.com/PHPCSStandards/PHPCSUtils/pull/134) [PHPCS#2952](https://github.com/squizlabs/PHP_CodeSniffer/pull/2952)
 
 #### TestUtils
 * [`UtilityMethodTestCase`]: new public `$phpcsVersion` property for use in tests. [#107](https://github.com/PHPCSStandards/PHPCSUtils/pull/107)
@@ -99,6 +99,7 @@ Notes:
 
 #### PHPCS Backcompat
 * `BCFile::findEndOfStatement()`: now supports arrow functions when used as a function argument, in line with the same change made in PHPCS 3.5.5. [#143](https://github.com/PHPCSStandards/PHPCSUtils/pull/143)
+* `BcFile::isReference()`: bug fix, the reference operator was not recognized as such for closures declared to return by reference. [#160](https://github.com/PHPCSStandards/PHPCSUtils/pull/160) [PHPCS#2977](https://github.com/squizlabs/PHP_CodeSniffer/pull/2977)
 
 #### Utils
 * `FunctionDeclarations::getArrowFunctionOpenClose()`: now supports arrow functions when used as a function argument, in line with the same change made in PHPCS 3.5.5. [#143](https://github.com/PHPCSStandards/PHPCSUtils/pull/143)

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -976,6 +976,8 @@ class BCFile
      *                - References to class properties with `self::`, `parent::`, `static::`,
      *                  `namespace\ClassName::`, `classname::` were not recognized as references.
      * - PHPCS 3.5.3: Added support for PHP 7.4 `T_FN` arrow functions returning by reference.
+     * - PHPCS 3.5.6: Bug fix: the reference operator for closures declared to return by reference was
+     *                not recognized as a reference. PHPCS#2977.
      *
      * @see \PHP_CodeSniffer\Files\File::isReference() Original source.
      * @see \PHPCSUtils\Utils\Operators::isReference() PHPCSUtils native improved version.
@@ -1000,6 +1002,7 @@ class BCFile
         $tokenBefore = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
         if ($tokens[$tokenBefore]['code'] === T_FUNCTION
+            || $tokens[$tokenBefore]['code'] === T_CLOSURE
             || FunctionDeclarations::isArrowFunction($phpcsFile, $tokenBefore) === true
         ) {
             // Function returns a reference.

--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -59,9 +59,6 @@ class Operators
      * Determine if the passed token is a reference operator.
      *
      * Main differences with the PHPCS version:
-     * - Bug fixed: the reference operator for closures declared to return by reference was not
-     *   recognized as a reference.
-     *   {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/2977 Open PR upstream}
      * - Defensive coding against incorrect calls to this method.
      * - Improved handling of select tokenizer errors involving short lists/short arrays.
      *

--- a/Tests/BackCompat/BCFile/IsReferenceTest.inc
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.inc
@@ -165,3 +165,6 @@ $closure = function() use (&$var){};
 
 /* testArrowFunctionReturnByReference */
 fn&($x) => $x;
+
+/* testClosureReturnByReference */
+$closure = function &($param) use ($value) {};

--- a/Tests/BackCompat/BCFile/IsReferenceTest.php
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.php
@@ -312,6 +312,10 @@ class IsReferenceTest extends UtilityMethodTestCase
                 '/* testArrowFunctionReturnByReference */',
                 true,
             ],
+            [
+                '/* testClosureReturnByReference */',
+                true,
+            ],
         ];
     }
 }

--- a/Tests/Utils/Operators/IsReferenceDiffTest.inc
+++ b/Tests/Utils/Operators/IsReferenceDiffTest.inc
@@ -11,6 +11,3 @@ if ($foo) {}
 /* testTokenizerIssue1284PHPCSlt280C */
 if ($foo) {}
 [&$a, $b];
-
-/* testClosureReturnByReference */
-$closure = function &($param) use ($value) {};

--- a/Tests/Utils/Operators/IsReferenceDiffTest.php
+++ b/Tests/Utils/Operators/IsReferenceDiffTest.php
@@ -85,10 +85,6 @@ class IsReferenceDiffDiffTest extends UtilityMethodTestCase
                 '/* testTokenizerIssue1284PHPCSlt280C */',
                 true,
             ],
-            'closure-return-by-reference' => [
-                '/* testClosureReturnByReference */',
-                true,
-            ],
         ];
     }
 }


### PR DESCRIPTION
The bugfix for closures declared to return by reference as previously already fixed in the `Operators::isReference()` method, has now also been fixed upstream.

This synces the repo for the upstream fix:
* Apply the fix to the `BCFile::isReference()` method.
* Move the unit test from the test `Diff` file to the `BCFile::isReference()` test case file.

Includes adding a changelog entry to include this in the 1.0.0-alpha3 release.

Refs:
* #142
* squizlabs/php_codesniffer#2977