### PR TITLE
Composer: update dev dependency version allowances

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7"
     },
     "require-dev" : {
-        "php-parallel-lint/php-parallel-lint": "^1.1.0",
-        "php-parallel-lint/php-console-highlighter": "^0.4",
+        "php-parallel-lint/php-parallel-lint": "^1.2.0",
+        "php-parallel-lint/php-console-highlighter": "^0.5",
         "phpunit/phpunit" : "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "conflict": {


### PR DESCRIPTION
* Version 1.2.0 of PHP Parallel Lint has been released.
* Version 0.5 of PHP Console Highlighter has been released.

Especially that last one needs an update to the `composer.json` for it to be allowed to be installed.