### PR TITLE
PHP 8.0: verified support for "mixed" type declarations

### DIFF
--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.inc
@@ -182,3 +182,12 @@ function_call( 'param', new class {
     /* testNestedMethodParam 2 */
     public function __construct( $open, $post_id ) {}
 }, 10, 2 );
+
+class PHP8Mixed {
+    /* testPHP8MixedTypeHint */
+    public static miXed $mixed;
+
+    /* testPHP8MixedTypeHintNullable */
+    // Intentional fatal error - nullability is not allowed with mixed, but that's not the concern of the method.
+    private ?mixed $nullableMixed;
+}

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -579,6 +579,30 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'nullable_type'   => false,
                 ],
             ],
+            [
+                '/* testPHP8MixedTypeHint */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                    'type'            => 'miXed',
+                    'type_token'      => -2, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'nullable_type'   => false,
+                ],
+            ],
+            [
+                '/* testPHP8MixedTypeHintNullable */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '?mixed',
+                    'type_token'      => -2, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'nullable_type'   => true,
+                ],
+            ],
         ];
     }
 

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
@@ -125,6 +125,13 @@ function messyDeclaration(
         & /*test*/ ... /* phpcs:ignore */ $c
 ) {}
 
+/* testPHP8MixedTypeHint */
+function mixedTypeHint(mixed &...$var1) {}
+
+/* testPHP8MixedTypeHintNullable */
+// Intentional fatal error - nullability is not allowed with mixed, but that's not the concern of the method.
+function mixedTypeHintNullable(?Mixed $var1) {}
+
 /* testFunctionCallFnPHPCS353-354 */
 $value = $obj->fn(true);
 

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -1192,6 +1192,58 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     }
 
     /**
+     * Verify recognition of PHP8 mixed type declaration.
+     *
+     * @return void
+     */
+    public function testPHP8MixedTypeHint()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 8, // Offset from the T_FUNCTION token.
+            'name'                => '$var1',
+            'content'             => 'mixed &...$var1',
+            'pass_by_reference'   => true,
+            'reference_token'     => 6, // Offset from the T_FUNCTION token.
+            'variable_length'     => true,
+            'variadic_token'      => 7, // Offset from the T_FUNCTION token.
+            'type_hint'           => 'mixed',
+            'type_hint_token'     => 4, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 4, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify recognition of PHP8 mixed type declaration with nullability.
+     *
+     * @return void
+     */
+    public function testPHP8MixedTypeHintNullable()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 7, // Offset from the T_FUNCTION token.
+            'name'                => '$var1',
+            'content'             => '?Mixed $var1',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '?Mixed',
+            'type_hint_token'     => 5, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 5, // Offset from the T_FUNCTION token.
+            'nullable_type'       => true,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Verify handling of a closure.
      *
      * @return void

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
@@ -74,6 +74,13 @@ class ReturnMe {
     }
 }
 
+/* testPHP8MixedTypeHint */
+function mixedTypeHint() :mixed {}
+
+/* testPHP8MixedTypeHintNullable */
+// Intentional fatal error - nullability is not allowed with mixed, but that's not the concern of the method.
+function mixedTypeHintNullable(): ?mixed {}
+
 /* testNotAFunction */
 return true;
 

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -456,6 +456,50 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     }
 
     /**
+     * Test a function with return type "mixed".
+     *
+     * @return void
+     */
+    public function testPHP8MixedTypeHint()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => 'mixed',
+            'return_type_token'    => 7, // Offset from the T_FUNCTION token.
+            'nullable_return_type' => false,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Test a function with return type "mixed" and nullability.
+     *
+     * @return void
+     */
+    public function testPHP8MixedTypeHintNullable()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => '?mixed',
+            'return_type_token'    => 8, // Offset from the T_FUNCTION token.
+            'nullable_return_type' => true,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Test for incorrect tokenization of array return type declarations in PHPCS < 2.8.0.
      *
      * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/1264


### PR DESCRIPTION
Added tests to the following methods to verify that the new `mixed` type declaration is handled correctly (hint: it is).

* `BCFile::getMethodParameters()`
* `FunctionDeclarations::getParameters()` (via `BCFile::getMethodParameters()`)
* `BCFile::getMethodProperties()`
* `FunctionDeclarations::getProperties()` (via `BCFile::getMethodProperties()`)
* `BCFile::getMemberProperties()`
* `Variables::getMemberProperties()` (via `BCFile::getMemberProperties()`)

