### PR TITLE
UseStatements::getType(): work around a PHPCS 2.x issue

### DIFF
--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Utils\Conditions;
 use PHPCSUtils\Utils\Parentheses;
 
@@ -66,6 +67,14 @@ class UseStatements
         }
 
         $lastCondition = Conditions::getLastCondition($phpcsFile, $stackPtr);
+        if (($tokens[$lastCondition]['code'] === \T_CASE
+                || $tokens[$lastCondition]['code'] === \T_DEFAULT)
+            && \version_compare(Helper::getVersion(), '2.99.99', '<') === true
+            && Conditions::hasCondition($phpcsFile, $stackPtr, [\T_SWITCH]) === false
+        ) {
+            $lastCondition = Conditions::getLastCondition($phpcsFile, $lastCondition);
+        }
+
         if ($lastCondition === false || $tokens[$lastCondition]['code'] === \T_NAMESPACE) {
             // Global or scoped namespace and not a closure use statement.
             return 'import';

--- a/Tests/Utils/UseStatements/UseTypeTest.inc
+++ b/Tests/Utils/UseStatements/UseTypeTest.inc
@@ -48,6 +48,28 @@ interface InterfaceUsingTrait {
     use SomeTrait;
 }
 
+/*
+ * Test specific issue with PHPCS < 3 where the case/default parse errors below would cause them
+ * to have a case/default condition, though without a switch.
+ */
+use FoobarA as Case;
+/* testUseImportPHPCS2CaseNoSwitchA */
+use FoobarB as Foo;
+/* testUseImportPHPCS2CaseNoSwitchB */
+use FoobarC as Default;
+/* testUseImportPHPCS2DefaultNoSwitchA */
+use FoobarD as Bar;
+
+class PHPCS2ScopeConditionIssue {
+    use TraitA { oldfunction as case; }
+    /* testUseImportPHPCS2CaseNoSwitchC */
+    use TraitB { oldfunction as Baz; }
+    /* testUseImportPHPCS2CaseNoSwitchD */
+    use TraitC { oldfunction as default; }
+    /* testUseImportPHPCS2DefaultNoSwitchB */
+    use TraitD { oldfunction as Fool; }
+}
+
 // Intentional parse error. Live coding. This has to be the last test in the file.
 /* testLiveCoding */
 use

--- a/Tests/Utils/UseStatements/UseTypeTest.php
+++ b/Tests/Utils/UseStatements/UseTypeTest.php
@@ -209,6 +209,57 @@ class UseTypeTest extends UtilityMethodTestCase
                     'trait'   => false,
                 ],
             ],
+
+            // Tests related to a specific issue with scope setting in PHPCS 2.x.
+            'parse-error-import-use-case-no-switch-1' => [
+                '/* testUseImportPHPCS2CaseNoSwitchA */',
+                [
+                    'closure' => false,
+                    'import'  => true,
+                    'trait'   => false,
+                ],
+            ],
+            'parse-error-import-use-case-no-switch-2' => [
+                '/* testUseImportPHPCS2CaseNoSwitchB */',
+                [
+                    'closure' => false,
+                    'import'  => true,
+                    'trait'   => false,
+                ],
+            ],
+            'parse-error-import-use-default-no-switch' => [
+                '/* testUseImportPHPCS2DefaultNoSwitchA */',
+                [
+                    'closure' => false,
+                    'import'  => true,
+                    'trait'   => false,
+                ],
+            ],
+            'parse-error-trait-use-case-no-switch-1' => [
+                '/* testUseImportPHPCS2CaseNoSwitchC */',
+                [
+                    'closure' => false,
+                    'import'  => false,
+                    'trait'   => true,
+                ],
+            ],
+            'parse-error-trait-use-case-no-switch-2' => [
+                '/* testUseImportPHPCS2CaseNoSwitchD */',
+                [
+                    'closure' => false,
+                    'import'  => false,
+                    'trait'   => true,
+                ],
+            ],
+            'parse-error-trait-use-default-no-switch' => [
+                '/* testUseImportPHPCS2DefaultNoSwitchB */',
+                [
+                    'closure' => false,
+                    'import'  => false,
+                    'trait'   => true,
+                ],
+            ],
+
             'live-coding' => [
                 '/* testLiveCoding */',
                 [


### PR DESCRIPTION
In PHPCS 2.x, the `case` and `default` keywords are assigned as conditions, even when they are not within a `switch` statement.

The code in question is a parse error, but it also prevents the `getType()` method from correctly resolving the type of a `use` statement, while it is relatively simple to work-around the issue.

So, adding the work-around.

Includes unit tests.