### PR TITLE
Arrays::isShortArray(): work round incorrect tokenization of PHP8 magic constant dereferencing

### DIFF
--- a/Tests/Utils/Arrays/IsShortArrayTokenizerBC1Test.php
+++ b/Tests/Utils/Arrays/IsShortArrayTokenizerBC1Test.php
@@ -124,6 +124,10 @@ class IsShortArrayTokenizerBC1Test extends UtilityMethodTestCase
                 '/* testTokenizerIssue1284PHPCSlt280D */',
                 false,
             ],
+            'issue-3013-magic-constant-dereferencing' => [
+                '/* testTokenizerIssue3013PHPCSlt3xx */',
+                false,
+            ],
         ];
     }
 }

--- a/Tests/Utils/Lists/IsShortListTokenizerBC1Test.inc
+++ b/Tests/Utils/Lists/IsShortListTokenizerBC1Test.inc
@@ -29,3 +29,6 @@ $foo = ${$bar}['key'];
 
 /* testTokenizerIssue1284PHPCSlt280D */
 $c->{$var}[ ] = 2;
+
+/* testTokenizerIssue3013PHPCSlt3xx */
+$var = __FILE__[0];

--- a/Tests/Utils/Lists/IsShortListTokenizerBC1Test.php
+++ b/Tests/Utils/Lists/IsShortListTokenizerBC1Test.php
@@ -102,6 +102,10 @@ class IsShortListTokenizerBC1Test extends UtilityMethodTestCase
                 '/* testTokenizerIssue1284PHPCSlt280D */',
                 false,
             ],
+            'issue-3013-magic-constant-dereferencing' => [
+                '/* testTokenizerIssue3013PHPCSlt3xx */',
+                false,
+            ],
         ];
     }
 }


### PR DESCRIPTION
As of PHP 8, magic constants can be dereferenced, however, the square brackets in `__FILE__[0]` are incorrectly tokenized as _short array_ brackets instead of as "normal" square brackets.

A fix for the PHPCS Tokenizer has been pulled upstream.

Fingers crossed, the fix will be merged soon.

In the mean time, this commit fixes the issue for PHPCS 2.6.0 - current.

Once the upstream PR has been merged, the version numbers in the inline documentation and test marker will need to be updated.

Includes unit test.

Refs:
* https://wiki.php.net/rfc/variable_syntax_tweaks#constants_and_magic_constants
* squizlabs/PHP_CodeSniffer#3013