### PR TITLE
FunctionDeclarations::isArrowFunction(): add test with PHP 8 "static" return type

### DIFF
--- a/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.inc
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.inc
@@ -76,6 +76,9 @@ $fn = fn(callable $a) : callable => $a;
 /* testReturnTypeArray */
 $fn = fn(array $a) : array => $a;
 
+/* testReturnTypeStatic */
+$fn = fn(array $a) : static => $a;
+
 /* testReturnTypeArrayBug2773 */
 $fn = fn(): array => [a($a, $b)];
 

--- a/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
@@ -396,6 +396,18 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
                     ],
                 ],
             ],
+            'arrow-function-with-return-type-static' => [
+                '/* testReturnTypeStatic */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 5,
+                        'scope_opener'       => 11,
+                        'scope_closer'       => 14,
+                    ],
+                ],
+            ],
             'arrow-function-with-return-type-array-bug-2773' => [
                 '/* testReturnTypeArrayBug2773 */',
                 [


### PR DESCRIPTION

Support for static return types was already added in #134. This just adds an extra test for it in relation to arrow functions.

Similar to upstream squizlabs/PHP_CodeSniffer#3019.