### PR TITLE
PHP 8.0 | FunctionDeclarations::getParameters(): add support for constructor property promotion

### DIFF
--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.inc
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.inc
@@ -43,3 +43,35 @@ function pseudoTypeIterableAndArray(iterable|array|Traversable $var) {}
 /* testPHP8DuplicateTypeInUnionWhitespaceAndComment */
 // Intentional fatal error - duplicate types are not allowed in union types, but that's not the concern of the method.
 function duplicateTypeInUnion( int | string /*comment*/ | INT $var) {}
+
+class ConstructorPropertyPromotionNoTypes {
+    /* testPHP8ConstructorPropertyPromotionNoTypes */
+    public function __construct(
+        public $x = 0.0,
+        protected $y = '',
+        private $z = null,
+    ) {}
+}
+
+class ConstructorPropertyPromotionWithTypes {
+    /* testPHP8ConstructorPropertyPromotionWithTypes */
+    public function __construct(protected float|int $x, public ?string &$y = 'test', private mixed $z) {}
+}
+
+class ConstructorPropertyPromotionAndNormalParams {
+    /* testPHP8ConstructorPropertyPromotionAndNormalParam */
+    public function __construct(public int $promotedProp, ?int $normalArg) {}
+}
+
+/* testPHP8ConstructorPropertyPromotionGlobalFunction */
+// Intentional fatal error. Property promotion not allowed in non-constructor, but that's not the concern of this method.
+function globalFunction(private $x) {}
+
+abstract class ConstructorPropertyPromotionAbstractMethod {
+    /* testPHP8ConstructorPropertyPromotionAbstractMethod */
+    // Intentional fatal error.
+    // 1. Property promotion not allowed in abstract method, but that's not the concern of this method.
+    // 2. Variadic arguments not allowed in property promotion, but that's not the concern of this method.
+    // 3. The callable type is not supported for properties, but that's not the concern of this method.
+    abstract public function __construct(public callable $y, private ...$x);
+}

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
@@ -384,6 +384,252 @@ class GetParametersDiffTest extends UtilityMethodTestCase
     }
 
     /**
+     * Verify recognition of PHP8 constructor property promotion without type declaration, with defaults.
+     *
+     * @return void
+     */
+    public function testPHP8ConstructorPropertyPromotionNoTypes()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 8, // Offset from the T_FUNCTION token.
+            'name'                => '$x',
+            'content'             => 'public $x = 0.0',
+            'default'             => '0.0',
+            'default_token'       => 12, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 10, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'property_visibility' => 'public',
+            'visibility_token'    => 6, // Offset from the T_FUNCTION token.
+            'comma_token'         => 13,
+        ];
+        $expected[1] = [
+            'token'               => 18, // Offset from the T_FUNCTION token.
+            'name'                => '$y',
+            'content'             => 'protected $y = \'\'',
+            'default'             => "''",
+            'default_token'       => 22, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 20, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'property_visibility' => 'protected',
+            'visibility_token'    => 16, // Offset from the T_FUNCTION token.
+            'comma_token'         => 23,
+        ];
+        $expected[2] = [
+            'token'               => 28, // Offset from the T_FUNCTION token.
+            'name'                => '$z',
+            'content'             => 'private $z = null',
+            'default'             => 'null',
+            'default_token'       => 32, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 30, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'property_visibility' => 'private',
+            'visibility_token'    => 26, // Offset from the T_FUNCTION token.
+            'comma_token'         => 33,
+        ];
+
+        $this->getParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify recognition of PHP8 constructor property promotion with type declarations.
+     *
+     * @return void
+     */
+    public function testPHP8ConstructorPropertyPromotionWithTypes()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 10, // Offset from the T_FUNCTION token.
+            'name'                => '$x',
+            'content'             => 'protected float|int $x',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'float|int',
+            'type_hint_token'     => 6, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 8, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'property_visibility' => 'protected',
+            'visibility_token'    => 4, // Offset from the T_FUNCTION token.
+            'comma_token'         => 11,
+        ];
+        $expected[1] = [
+            'token'               => 19, // Offset from the T_FUNCTION token.
+            'name'                => '$y',
+            'content'             => 'public ?string &$y = \'test\'',
+            'default'             => "'test'",
+            'default_token'       => 23, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 21, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => true,
+            'reference_token'     => 18, // Offset from the T_FUNCTION token.
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '?string',
+            'type_hint_token'     => 16, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 16, // Offset from the T_FUNCTION token.
+            'nullable_type'       => true,
+            'property_visibility' => 'public',
+            'visibility_token'    => 13, // Offset from the T_FUNCTION token.
+            'comma_token'         => 24,
+        ];
+        $expected[2] = [
+            'token'               => 30, // Offset from the T_FUNCTION token.
+            'name'                => '$z',
+            'content'             => 'private mixed $z',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'mixed',
+            'type_hint_token'     => 28, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 28, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'property_visibility' => 'private',
+            'visibility_token'    => 26, // Offset from the T_FUNCTION token.
+            'comma_token'         => false,
+        ];
+
+        $this->getParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify recognition of PHP8 constructor with both property promotion as well as normal parameters.
+     *
+     * @return void
+     */
+    public function testPHP8ConstructorPropertyPromotionAndNormalParam()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 8, // Offset from the T_FUNCTION token.
+            'name'                => '$promotedProp',
+            'content'             => 'public int $promotedProp',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'int',
+            'type_hint_token'     => 6, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 6, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'property_visibility' => 'public',
+            'visibility_token'    => 4, // Offset from the T_FUNCTION token.
+            'comma_token'         => 9,
+        ];
+        $expected[1] = [
+            'token'               => 14, // Offset from the T_FUNCTION token.
+            'name'                => '$normalArg',
+            'content'             => '?int $normalArg',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '?int',
+            'type_hint_token'     => 12, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 12, // Offset from the T_FUNCTION token.
+            'nullable_type'       => true,
+            'comma_token'         => false,
+        ];
+
+        $this->getParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify behaviour when a non-constructor function uses PHP 8 property promotion syntax.
+     *
+     * @return void
+     */
+    public function testPHP8ConstructorPropertyPromotionGlobalFunction()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 6, // Offset from the T_FUNCTION token.
+            'name'                => '$x',
+            'content'             => 'private $x',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'property_visibility' => 'private',
+            'visibility_token'    => 4, // Offset from the T_FUNCTION token.
+            'comma_token'         => false,
+        ];
+
+        $this->getParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify behaviour when an abstract constructor uses PHP 8 property promotion syntax.
+     *
+     * @return void
+     */
+    public function testPHP8ConstructorPropertyPromotionAbstractMethod()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 8, // Offset from the T_FUNCTION token.
+            'name'                => '$y',
+            'content'             => 'public callable $y',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'callable',
+            'type_hint_token'     => 6, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 6, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'property_visibility' => 'public',
+            'visibility_token'    => 4, // Offset from the T_FUNCTION token.
+            'comma_token'         => 9,
+        ];
+        $expected[1] = [
+            'token'               => 14, // Offset from the T_FUNCTION token.
+            'name'                => '$x',
+            'content'             => 'private ...$x',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => true,
+            'variadic_token'      => 13, // Offset from the T_FUNCTION token.
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'property_visibility' => 'private',
+            'visibility_token'    => 11, // Offset from the T_FUNCTION token.
+            'comma_token'         => false,
+        ];
+
+        $this->getParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.
@@ -421,6 +667,9 @@ class GetParametersDiffTest extends UtilityMethodTestCase
             }
             if (isset($param['default_equal_token'])) {
                 $expected[$key]['default_equal_token'] += $target;
+            }
+            if (isset($param['visibility_token'])) {
+                $expected[$key]['visibility_token'] += $target;
             }
         }
 


### PR DESCRIPTION
This commit adds support for constructor property promotion to the `FunctionDeclarations::getParameters()` method.

This change introduces two new keys - `property_visibility` and `visibility_token` - to the return array which will only be included if constructor property promotion is detected.

The method does not check whether property promotion is _valid_ in the function/method in which it is used. That is not the concern of this method.

Changes along the same lines as included in this PR will also be pulled upstream to PHPCS itself. Once the upstream PR has been merged, those changes will also be applied to the `BCFile::getMethodParameters()` method.

Includes unit tests.

Ref: https://wiki.php.net/rfc/constructor_promotion