### PR TITLE
Operators: new `isTypeUnion()` method

### DIFF
--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -13,9 +13,11 @@ namespace PHPCSUtils\Utils;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\Parentheses;
+use PHPCSUtils\Utils\Scopes;
 
 /**
  * Utility functions for use when working with operators.
@@ -163,6 +165,145 @@ class Operators
                 );
                 if ($tokens[$nextSignificantAfter]['code'] === \T_VARIABLE) {
                     return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if the passed token is a type union separator.
+     *
+     * The `T_BITWISE_OR` token is used in PHP as bitwise or, but as of PHP 8.0, also as the
+     * separator in union type declarations.
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the `T_BITWISE_OR` token.
+     *
+     * @return bool `TRUE` if the specified token position represents a type union separator.
+     *              `FALSE` if the token represents a bitwise operator.
+     */
+    public static function isTypeUnion(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== \T_BITWISE_OR) {
+            return false;
+        }
+
+        /*
+         * Check if it's a union separator in a property or parameter type.
+         */
+        $ignore         = Collections::propertyTypeTokensBC();
+        $ignore        += Collections::parameterTypeTokensBC();
+        $ignore        += Tokens::$emptyTokens;
+        $funcDeclTokens = Collections::functionDeclarationTokensBC();
+
+        $afterType = $phpcsFile->findNext($ignore, ($stackPtr + 1), null, true, null, true);
+        if ($afterType !== false) {
+            if ($tokens[$afterType]['code'] !== \T_VARIABLE) {
+                // Skip past reference and variadic indicators for parameter types.
+                while (($tokens[$afterType]['code'] === \T_BITWISE_AND
+                    || $tokens[$afterType]['code'] === \T_ELLIPSIS
+                    || isset(Tokens::$emptyTokens[$tokens[$afterType]['code']]) === true)
+                    && ($afterType + 1) < $phpcsFile->numTokens
+                ) {
+                    ++$afterType;
+                }
+            }
+
+            if ($tokens[$afterType]['code'] === \T_VARIABLE) {
+                if (Scopes::isOOProperty($phpcsFile, $afterType) === true) {
+                    // Union separator in a property type.
+                    return true;
+                }
+
+                if (Parentheses::lastOwnerIn($phpcsFile, $stackPtr, $funcDeclTokens) !== false) {
+                    // Union separator for a parameter type.
+                    return true;
+                }
+
+                /*
+                 * This may be an arrow function in combination with PHPCS < 3.5.3.
+                 * Even when on PHP 7.4, the parentheses won't have an owner yet, so the previous
+                 * condition will fall through to this one.
+                 */
+                $lastOpen = Parentheses::getLastOpener($phpcsFile, $stackPtr);
+                if ($lastOpen !== false) {
+                    $maybeArrow = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($lastOpen - 1), null, true);
+                    if ($maybeArrow !== false
+                        && FunctionDeclarations::isArrowFunction($phpcsFile, $maybeArrow) === true
+                    ) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        /*
+         * Check if it's a union separator in a return type.
+         */
+        $ignore = Collections::returnTypeTokensBC() + Tokens::$emptyTokens;
+
+        $beforeType = $phpcsFile->findPrevious($ignore, ($stackPtr - 1), null, true);
+
+        // Union types cannot be nullable, but the function should be parse error tolerant.
+        if ($beforeType !== false
+            && ($tokens[$beforeType]['type'] === 'T_NULLABLE'
+            // Handle nullable tokens in PHPCS < 2.8.0 and with arrow functions in PHPCS 2.8.0 - 2.9.0.
+            || (\version_compare(Helper::getVersion(), '2.9.1', '<') === true
+                && $tokens[$beforeType]['code'] === \T_INLINE_THEN))
+        ) {
+            $beforeType = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($beforeType - 1), null, true);
+        }
+
+        if ($beforeType !== false
+            && ($tokens[$beforeType]['code'] === \T_COLON
+            // Handle colon mistokenization in various PHPCS versions < 3.5.3.
+            || $tokens[$beforeType]['code'] === \T_INLINE_ELSE)
+        ) {
+            $afterType = $phpcsFile->findNext($ignore, ($stackPtr + 1), null, true, null, true);
+            if ($afterType !== false) {
+                if ($tokens[$afterType]['code'] === \T_SEMICOLON) {
+                    // Union separator in a return type in an abstract or interface method.
+                    return true;
+                }
+
+                if (isset($tokens[$afterType]['scope_condition']) === true
+                    && isset($funcDeclTokens[$tokens[$tokens[$afterType]['scope_condition']]['code']])
+                ) {
+                    // Union separator in a return type for a function, closure or arrow function.
+                    return true;
+                }
+
+                /*
+                 * This may be an arrow function in combination with PHPCS < 3.5.3.
+                 * Even when on PHP 7.4, the open curly brace won't have the scope condition set yet,
+                 * so the previous condition will fall through to this one.
+                 */
+                if ($tokens[$afterType]['code'] === \T_DOUBLE_ARROW) {
+                    $closeParens = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($beforeType - 1), null, true);
+                    if ($closeParens !== false
+                        && $tokens[$closeParens]['code'] === \T_CLOSE_PARENTHESIS
+                        && isset($tokens[$closeParens]['parenthesis_opener'])
+                    ) {
+                        $beforeOpen = $phpcsFile->findPrevious(
+                            Tokens::$emptyTokens,
+                            ($tokens[$closeParens]['parenthesis_opener'] - 1),
+                            null,
+                            true
+                        );
+
+                        if ($beforeOpen !== false
+                            && FunctionDeclarations::isArrowFunction($phpcsFile, $beforeOpen) === true
+                        ) {
+                            // Union separator in a return type for an arrow function.
+                            return true;
+                        }
+                    }
                 }
             }
         }

--- a/Tests/Utils/Operators/IsTypeUnionTest.inc
+++ b/Tests/Utils/Operators/IsTypeUnionTest.inc
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * Type union or bitwise or.
+ */
+
+/* testNotBitwiseOrToken */
+echo 'foo';
+
+/* testBitwiseOr1 */
+$result = $value | $test /* testBitwiseOr2 */ | $another;
+
+class TypeUnion
+{
+    /* testTypeUnionPropertySimple */
+    public static Foo|Bar $obj;
+
+    /* testTypeUnionPropertyReverseModifierOrder */
+    static protected int|float $number /* testBitwiseOrPropertyDefaultValue */ = E_WARNING | E_NOTICE;
+
+    private
+        /* testTypeUnionPropertyMulti1 */
+        array |
+        /* testTypeUnionPropertyMulti2 */
+        Traversable | // phpcs:ignore Stnd.Cat.Sniff
+        false
+        /* testTypeUnionPropertyMulti3 */
+        | null $arrayOrFalse;
+
+    public function paramTypes(
+        /* testTypeUnionParam1 */
+        int|float $paramA /* testBitwiseOrParamDefaultValue */ = CONSTANT_A | CONSTANT_B,
+
+        /* testTypeUnionParam2 */
+        Foo|\Bar /* testTypeUnionParam3 */ |Baz &...$paramB = null,
+    ) {
+        /* testBitwiseOr3 */
+        return (($a1 ^ $b1) |($a2 ^ $b2)) + $c;
+    }
+
+    /* testTypeUnionReturnType */
+    public function returnType() : int|false {}
+
+    /* testTypeUnionConstructorPropertyPromotion */
+    public function __construct( public bool|null $property) {}
+
+    /* testTypeUnionAbstractMethodReturnType1 */
+    abstract public function abstractMethod(): object|array /* testTypeUnionAbstractMethodReturnType2 */ |false;
+}
+
+/* testTypeUnionClosureParamIllegalNullable */
+$closureWithParamType = function (?string|null $string) {};
+
+/* testBitwiseOrClosureParamDefault */
+$closureWithReturnType = function ($string = NONSENSE | FAKE)/* testTypeUnionClosureReturn */ : \Package\MyA|PackageB {};
+
+/* testTypeUnionArrowParam */
+$arrowWithParamType = fn (object|array $param, /* testBitwiseOrArrowParamDefault */ ?int $int = CONSTA | CONSTB )
+    /* testBitwiseOrArrowExpression */
+    => $param | $int;
+
+/* testTypeUnionArrowReturnType */
+$arrowWithReturnType = fn ($param) : int|null => $param * 10;
+
+/* testBitwiseOrInArrayKey */
+$array = array(
+    A | B => /* testBitwiseOrInArrayValue */ B | C
+);
+
+/* testBitwiseOrInShortArrayKey */
+$array = [
+    A | B => /* testBitwiseOrInShortArrayValue */ B | C
+];
+
+/* testBitwiseOrTryCatch */
+try {
+} catch ( ExceptionA | ExceptionB $e ) {
+}
+
+/* testBitwiseOrNonArrowFnFunctionCall */
+$obj->fn($something | $else);
+
+/* testTypeUnionNonArrowFunctionDeclaration */
+function &fn(int|false $something) {}
+
+/* testBitwiseOrInNestedTernaryPhpcsLt291 */
+echo $a ? $b : CONST_A ? CONST_A | CONST_B : CONST_C;
+
+/* testTypeUnionInTernaryNestedArrowFunction1 */
+$fn = fn($a): int|float => $a ? /* testTypeUnionInTernaryNestedArrowFunction2 */ fn() : string|false => 'a' : /* testTypeUnionInTernaryNestedArrowFunction3 */ fn() : ?bool|null => 'b';
+
+/* testBitwiseOrInTernaryNestedArrowFunction */
+$fn = fn($a) => $a ? fn( $var = CONST_A | CONST_B ) : ?string => 'a' : fn() : string => 'b';
+
+/* testLiveCoding */
+// Intentional parse error. This has to be the last test in the file.
+return function( type|

--- a/Tests/Utils/Operators/IsTypeUnionTest.php
+++ b/Tests/Utils/Operators/IsTypeUnionTest.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Operators;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Operators;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Operators::isTypeUnion() method.
+ *
+ * @covers \PHPCSUtils\Utils\Operators::isTypeUnion
+ *
+ * @group operators
+ *
+ * @since 1.0.0
+ */
+class IsTypeUnionTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test that false is returned when a non-existent token is passed.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->assertFalse(Operators::isTypeUnion(self::$phpcsFile, 10000));
+    }
+
+    /**
+     * Test that false is returned when a non-bitwise or token is passed.
+     *
+     * @return void
+     */
+    public function testNotBitwiseOrToken()
+    {
+        $target = $this->getTargetToken('/* testNotBitwiseOrToken */', \T_ECHO);
+        $this->assertFalse(Operators::isTypeUnion(self::$phpcsFile, $target));
+    }
+
+    /**
+     * Test whether a type union separator is correctly identified as such.
+     *
+     * @dataProvider dataIsTypeUnion
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     *
+     * @return void
+     */
+    public function testIsTypeUnion($testMarker)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, [\T_BITWISE_OR]);
+
+        $this->assertTrue(Operators::isTypeUnion(self::$phpcsFile, $stackPtr));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsTypeUnion()
+     *
+     * @return array
+     */
+    public function dataIsTypeUnion()
+    {
+        return [
+            'property'                        => ['/* testTypeUnionPropertySimple */'],
+            'property-reverse-modifier-order' => ['/* testTypeUnionPropertyReverseModifierOrder */'],
+            'property-multi-type-1'           => ['/* testTypeUnionPropertyMulti1 */'],
+            'property-multi-type-2'           => ['/* testTypeUnionPropertyMulti2 */'],
+            'property-multi-type-3'           => ['/* testTypeUnionPropertyMulti3 */'],
+            'parameter-multi-type-1'          => ['/* testTypeUnionParam1 */'],
+            'parameter-multi-type-2'          => ['/* testTypeUnionParam2 */'],
+            'parameter-multi-type-3'          => ['/* testTypeUnionParam3 */'],
+            'return'                          => ['/* testTypeUnionReturnType */'],
+            'constructor-property-promotion'  => ['/* testTypeUnionConstructorPropertyPromotion */'],
+            'return-abstract-method-1'        => ['/* testTypeUnionAbstractMethodReturnType1 */'],
+            'return-abstract-method-2'        => ['/* testTypeUnionAbstractMethodReturnType2 */'],
+            'parameter-closure-with-nullable' => ['/* testTypeUnionClosureParamIllegalNullable */'],
+            'return-closure'                  => ['/* testTypeUnionClosureReturn */'],
+            'parameter-arrow'                 => ['/* testTypeUnionArrowParam */'],
+            'return-arrow'                    => ['/* testTypeUnionArrowReturnType */'],
+            'parameter-non-arrow-fn-decl'     => ['/* testTypeUnionNonArrowFunctionDeclaration */'],
+            'return-ternary-nested-arrow-1'   => ['/* testTypeUnionInTernaryNestedArrowFunction1 */'],
+            'return-ternary-nested-arrow-2'   => ['/* testTypeUnionInTernaryNestedArrowFunction2 */'],
+            'return-ternary-nested-arrow-3'   => ['/* testTypeUnionInTernaryNestedArrowFunction3 */'],
+        ];
+    }
+
+    /**
+     * Test whether a real "bitwise or" is correctly identified as such.
+     *
+     * @dataProvider dataBitwiseOr
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     *
+     * @return void
+     */
+    public function testBitwiseOr($testMarker)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, [\T_BITWISE_OR]);
+
+        $this->assertFalse(Operators::isTypeUnion(self::$phpcsFile, $stackPtr));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testBitwiseOr()
+     *
+     * @return array
+     */
+    public function dataBitwiseOr()
+    {
+        return [
+            'bitwiseor-1'                     => ['/* testBitwiseOr1 */'],
+            'bitwiseor-2'                     => ['/* testBitwiseOr2 */'],
+            'bitwiseor-property-default'      => ['/* testBitwiseOrPropertyDefaultValue */'],
+            'bitwiseor-param-default'         => ['/* testBitwiseOrParamDefaultValue */'],
+            'bitwiseor-3'                     => ['/* testBitwiseOr3 */'],
+            'bitwiseor-closure-param-default' => ['/* testBitwiseOrClosureParamDefault */'],
+            'bitwiseor-arrow-param-default'   => ['/* testBitwiseOrArrowParamDefault */'],
+            'bitwiseor-arrow-expression'      => ['/* testBitwiseOrArrowExpression */'],
+            'bitwiseor-in-array-key'          => ['/* testBitwiseOrInArrayKey */'],
+            'bitwiseor-in-array-value'        => ['/* testBitwiseOrInArrayValue */'],
+            'bitwiseor-in-short-array-key'    => ['/* testBitwiseOrInShortArrayKey */'],
+            'bitwiseor-in-short-array-value'  => ['/* testBitwiseOrInShortArrayValue */'],
+            'bitwiseor-in-try-catch'          => ['/* testBitwiseOrTryCatch */'],
+            'bitwiseor-in-non-arrow-fn-call'  => ['/* testBitwiseOrNonArrowFnFunctionCall */'],
+            'bitwiseor-in-nested-ternary'     => ['/* testBitwiseOrInNestedTernaryPhpcsLt291 */'],
+            'bitwiseor-in-ternary-arrow-fn'   => ['/* testBitwiseOrInTernaryNestedArrowFunction */'],
+            'live-coding'                     => ['/* testLiveCoding */'],
+        ];
+    }
+}


### PR DESCRIPTION
... to distinguish between a `T_BITWISE_OR` token used as "bitwise or" and the same token when it's used as the type union separator.

Includes extensive unit tests.

This new method emulates the tokenizer change which is expected to be pulled upstream and will allow external standards which need to support older PHPCS versions than the one in which the upstream change will be merged, to still distinguish between the two uses.