### PR TITLE
Arrays::isShortArray(): update version numbers for upstream merge tokenizer fix

### DIFF
--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -71,7 +71,7 @@ class Arrays
             return false;
         }
 
-        // All known tokenizer bugs are in PHPCS versions before 3.x.x (?) - PHPCS#3013.
+        // All known tokenizer bugs are in PHPCS versions before 3.5.6.
         $phpcsVersion = Helper::getVersion();
 
         /*
@@ -138,18 +138,18 @@ class Arrays
 
             $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true);
 
-            // if (\version_compare($phpcsVersion, '3.x.x', '<')) {
+            if (\version_compare($phpcsVersion, '3.5.6', '<')) {
                 /*
-                 * BC: Work around a bug in the tokenizer of PHPCS < 3.x.x (?) where dereferencing
+                 * BC: Work around a bug in the tokenizer of PHPCS < 3.5.6 where dereferencing
                  * of magic constants (PHP 8+) would be incorrectly tokenized as short array.
                  * I.e. the square brackets in `__FILE__[0]` would be tokenized as short array.
                  *
                  * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/3013
                  */
-            if (isset(Collections::$magicConstants[$tokens[$prevNonEmpty]['code']]) === true) {
-                return false;
+                if (isset(Collections::$magicConstants[$tokens[$prevNonEmpty]['code']]) === true) {
+                    return false;
+                }
             }
-            // }
 
             if (\version_compare($phpcsVersion, '2.9.0', '<')) {
                 /*

--- a/Tests/Utils/Arrays/IsShortArrayTokenizerBC1Test.php
+++ b/Tests/Utils/Arrays/IsShortArrayTokenizerBC1Test.php
@@ -125,7 +125,7 @@ class IsShortArrayTokenizerBC1Test extends UtilityMethodTestCase
                 false,
             ],
             'issue-3013-magic-constant-dereferencing' => [
-                '/* testTokenizerIssue3013PHPCSlt3xx */',
+                '/* testTokenizerIssue3013PHPCSlt356 */',
                 false,
             ],
         ];

--- a/Tests/Utils/Lists/IsShortListTokenizerBC1Test.inc
+++ b/Tests/Utils/Lists/IsShortListTokenizerBC1Test.inc
@@ -30,5 +30,5 @@ $foo = ${$bar}['key'];
 /* testTokenizerIssue1284PHPCSlt280D */
 $c->{$var}[ ] = 2;
 
-/* testTokenizerIssue3013PHPCSlt3xx */
+/* testTokenizerIssue3013PHPCSlt356 */
 $var = __FILE__[0];

--- a/Tests/Utils/Lists/IsShortListTokenizerBC1Test.php
+++ b/Tests/Utils/Lists/IsShortListTokenizerBC1Test.php
@@ -103,7 +103,7 @@ class IsShortListTokenizerBC1Test extends UtilityMethodTestCase
                 false,
             ],
             'issue-3013-magic-constant-dereferencing' => [
-                '/* testTokenizerIssue3013PHPCSlt3xx */',
+                '/* testTokenizerIssue3013PHPCSlt356 */',
                 false,
             ],
         ];


### PR DESCRIPTION
Upstream PR #3013 has been merged and will be released as part of PHPCS 3.5.6.

This updates the inline documentation referring to this fix and the related PR, as well as enables a version based condition for when the BC layer needs to kick in.