### PR TITLE
BCTokens: add `magicConstants()` method

### DIFF
--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -11,6 +11,7 @@
 namespace PHPCSUtils\BackCompat;
 
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
 
 /**
  * Token arrays related utility methods.
@@ -394,5 +395,31 @@ class BCTokens
         }
 
         return self::$ooScopeTokens;
+    }
+
+    /**
+     * Tokens representing PHP magic constants.
+     *
+     * Retrieve the PHP magic constants tokens array in a cross-version compatible manner.
+     *
+     * Changelog for the PHPCS native array:
+     * - Introduced in PHPCS 3.5.6.
+     *
+     * @see \PHP_CodeSniffer\Util\Tokens::$magicConstants   Original array.
+     * @see \PHPCSUtils\Tokens\Collections::$magicConstants Same array, pre-dating the PHPCS change.
+     *
+     * @link https://www.php.net/language.constants.predefined PHP Manual on magic constants
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function magicConstants()
+    {
+        if (isset(Tokens::$magicConstants)) {
+            return Tokens::$magicConstants;
+        }
+
+        return Collections::$magicConstants;
     }
 }

--- a/Tests/BackCompat/BCTokens/MagicConstantsTest.php
+++ b/Tests/BackCompat/BCTokens/MagicConstantsTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCTokens;
+
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCTokens::magicConstants
+ *
+ * @group tokens
+ *
+ * @since 1.0.0
+ */
+class MagicConstantsTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testMagicConstants()
+    {
+        $expected = [
+            \T_CLASS_C  => \T_CLASS_C,
+            \T_DIR      => \T_DIR,
+            \T_FILE     => \T_FILE,
+            \T_FUNC_C   => \T_FUNC_C,
+            \T_LINE     => \T_LINE,
+            \T_METHOD_C => \T_METHOD_C,
+            \T_NS_C     => \T_NS_C,
+            \T_TRAIT_C  => \T_TRAIT_C,
+        ];
+
+        $this->assertSame($expected, BCTokens::magicConstants());
+    }
+}


### PR DESCRIPTION
Upstream PR squizlabs/PHP_CodeSniffer#3013 introduces a new `$magicConstants` tokens array to PHPCS, same as already existed in PHPCSUtils as `Collections::$magicConstants` since #106.

This PR backfills the PHPCS native array in the `BCTokens` class.

Includes unit test.