### PR TITLE
Travis: require PHPUnit 9.3 for PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -211,6 +211,8 @@ install:
   # The Composer PHPCS plugin takes care of setting the installed_paths for PHPCS.
   - |
     if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+      # Temporary fix - PHPUnit 9.3 is supposed to officially support PHP 8.
+      composer require --no-update phpunit/phpunit:"^9.3"
       # PHPUnit 9.x does not (yet) allow for installation on PHP 8, so ignore platform
       # requirements to get PHPUnit 9.x to install on nightly.
       composer install --prefer-dist --no-suggest --ignore-platform-reqs


### PR DESCRIPTION
PHPUnit 9.3 is not yet released (expected end of August), but is slated to add official PHP 8 support to PHPUnit.

As some tests are failing due to the new reserved keyword `match` being used in PHPUnit, I'm (temporarily) upping the PHPUnit requirement for PHP 8 explicitly to PHPUnit 9.3 (dev).

Once PHPUnit 9.3 has been released, this condition can be removed in favour of changing the requirements in the `composer.json` file.

Note: for now the `--ignore-platform-reqs` is still needed as the underlying dependencies may still not have tagged a version which officially supports PHP 8 and this would cause a requirement conflict.

Ref: https://github.com/sebastianbergmann/phpunit/issues/4373

---

Note: I've investigated the other unit test failures on PHP 8 and have confirmed that all of them will be fixed once PR https://github.com/squizlabs/PHP_CodeSniffer/pull/3027 has been merged.

I don't think any special accommodation is needed in PHPCSUtils for this for when people run an older PHPCS version on PHP 8, as from the looks of it, the functions work just fine, it's just that the exact expected token pointers and such will be different than the expectations set in the unit tests. They are correct though.

The only time when the output is significantly different is for `getTokensAsString()` and its variants, but that is to be expected.