### PR TITLE
PHP 8.0 | Add utilities to handle the nullsafe object operator

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -633,9 +633,15 @@ class Collections
      * is only used when looking back via `$phpcsFile->findPrevious()` as in that case, a non-backfilled
      * nullsafe object operator will still match the "normal" object operator.
      *
+     * Note: if this method is used, the {@see \PHPCSUtils\Utils\Operators::isNullsafeObjectOperator()}
+     * method needs to be used on potential nullsafe object operator tokens to verify whether it really
+     * is a nullsafe object operator or not.
+     *
      * @see \PHPCSUtils\Tokens\Collections::objectOperators()          Related method (PHP 8.0+).
      * @see \PHPCSUtils\Tokens\Collections::nullsafeObjectOperatorBC() Tokens which can represent a
      *                                                                 nullsafe object operator.
+     * @see \PHPCSUtils\Utils\Operators::isNullsafeObjectOperator()    Nullsafe object operator detection for
+     *                                                                 PHP < 8.0.
      *
      * @since 1.0.0-alpha4
      *
@@ -659,6 +665,13 @@ class Collections
      * This method will return the appropriate tokens based on the PHP/PHPCS version used.
      *
      * Note: this is a method, not a property as the `T_NULLSAFE_OBJECT_OPERATOR` token may not exist.
+     *
+     * Note: if this method is used, the {@see \PHPCSUtils\Utils\Operators::isNullsafeObjectOperator()}
+     * method needs to be used on potential nullsafe object operator tokens to verify whether it really
+     * is a nullsafe object operator or not.
+     *
+     * @see \PHPCSUtils\Utils\Operators::isNullsafeObjectOperator() Nullsafe object operator detection for
+     *                                                              PHP < 8.0.
      *
      * @since 1.0.0-alpha4
      *

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -231,9 +231,12 @@ class Collections
     ];
 
     /**
-     * Object operators.
+     * DEPRECATED: Object operators.
      *
      * @since 1.0.0-alpha3
+     *
+     * @deprecated 1.0.0-alpha4 Use the {@see \PHPCSUtils\Tokens\Collections::objectOperators()}
+     *                          method instead.
      *
      * @var array <int> => <int>
      */
@@ -574,6 +577,21 @@ class Collections
         $tokens += self::arrowFunctionTokensBC();
 
         return $tokens;
+    }
+
+    /**
+     * Object operators.
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function objectOperators()
+    {
+        return [
+            \T_OBJECT_OPERATOR => \T_OBJECT_OPERATOR,
+            \T_DOUBLE_COLON    => \T_DOUBLE_COLON,
+        ];
     }
 
     /**

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -584,6 +584,16 @@ class Collections
      *
      * Note: this is a method, not a property as the `T_NULLSAFE_OBJECT_OPERATOR` token may not exist.
      *
+     * Sister-method to the {@see Collections::objectOperatorsBC()} method.
+     * This method supports PHP 8.0 and up.
+     * The {@see Collections::objectOperatorsBC()} method supports PHP < 8.0.
+     *
+     * This method can also safely be used if the token collection is only used when looking back
+     * via `$phpcsFile->findPrevious()` as in that case, a non-backfilled nullsafe object operator
+     * will still match the "normal" object operator.
+     *
+     * @see \PHPCSUtils\Tokens\Collections::objectOperatorsBC() Related method (PHP < 8.0).
+     *
      * @since 1.0.0-alpha4
      *
      * @return array <int|string> => <int|string>
@@ -598,6 +608,50 @@ class Collections
         if (\defined('T_NULLSAFE_OBJECT_OPERATOR') === true) {
             // PHP 8.0.
             $tokens[\T_NULLSAFE_OBJECT_OPERATOR] = \T_NULLSAFE_OBJECT_OPERATOR;
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * Object operators.
+     *
+     * Note: this is a method, not a property as the `T_NULLSAFE_OBJECT_OPERATOR` token may not exist.
+     *
+     * Sister-method to the {@see Collections::objectOperators()} method.
+     * The {@see Collections::objectOperators()} method supports PHP 8.0 and up.
+     * This method supports PHP < 8.0.
+     *
+     * Notable difference:
+     * - This method accounts for tokens which may be encountered when the `T_NULLSAFE_OBJECT_OPERATOR` token
+     *   doesn't exist.
+     *
+     * It is recommended to use the {@see Collections::objectOperators()} method instead of
+     * this method if a standard does not need to support PHP < 8.0.
+     *
+     * The {@see Collections::objectOperators()} method can also safely be used if the token collection
+     * is only used when looking back via `$phpcsFile->findPrevious()` as in that case, a non-backfilled
+     * nullsafe object operator will still match the "normal" object operator.
+     *
+     * @see \PHPCSUtils\Tokens\Collections::objectOperators() Related method (PHP 8.0+).
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function objectOperatorsBC()
+    {
+        $tokens = [
+            \T_OBJECT_OPERATOR => \T_OBJECT_OPERATOR,
+            \T_DOUBLE_COLON    => \T_DOUBLE_COLON,
+        ];
+
+        if (\defined('T_NULLSAFE_OBJECT_OPERATOR') === true) {
+            // PHP 8.0.
+            $tokens[\T_NULLSAFE_OBJECT_OPERATOR] = \T_NULLSAFE_OBJECT_OPERATOR;
+        } else {
+            // PHP < 8.0.
+            $tokens[\T_INLINE_THEN] = \T_INLINE_THEN;
         }
 
         return $tokens;

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -633,7 +633,9 @@ class Collections
      * is only used when looking back via `$phpcsFile->findPrevious()` as in that case, a non-backfilled
      * nullsafe object operator will still match the "normal" object operator.
      *
-     * @see \PHPCSUtils\Tokens\Collections::objectOperators() Related method (PHP 8.0+).
+     * @see \PHPCSUtils\Tokens\Collections::objectOperators()          Related method (PHP 8.0+).
+     * @see \PHPCSUtils\Tokens\Collections::nullsafeObjectOperatorBC() Tokens which can represent a
+     *                                                                 nullsafe object operator.
      *
      * @since 1.0.0-alpha4
      *
@@ -646,15 +648,35 @@ class Collections
             \T_DOUBLE_COLON    => \T_DOUBLE_COLON,
         ];
 
-        if (\defined('T_NULLSAFE_OBJECT_OPERATOR') === true) {
-            // PHP 8.0.
-            $tokens[\T_NULLSAFE_OBJECT_OPERATOR] = \T_NULLSAFE_OBJECT_OPERATOR;
-        } else {
-            // PHP < 8.0.
-            $tokens[\T_INLINE_THEN] = \T_INLINE_THEN;
-        }
+        $tokens += self::nullsafeObjectOperatorBC();
 
         return $tokens;
+    }
+
+    /**
+     * Tokens which can represent the nullsafe object operator.
+     *
+     * This method will return the appropriate tokens based on the PHP/PHPCS version used.
+     *
+     * Note: this is a method, not a property as the `T_NULLSAFE_OBJECT_OPERATOR` token may not exist.
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function nullsafeObjectOperatorBC()
+    {
+        if (\defined('T_NULLSAFE_OBJECT_OPERATOR') === true) {
+            // PHP 8.0.
+            return [
+                \T_NULLSAFE_OBJECT_OPERATOR => \T_NULLSAFE_OBJECT_OPERATOR,
+            ];
+        }
+
+        return [
+            \T_INLINE_THEN     => \T_INLINE_THEN,
+            \T_OBJECT_OPERATOR => \T_OBJECT_OPERATOR,
+        ];
     }
 
     /**

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -582,16 +582,25 @@ class Collections
     /**
      * Object operators.
      *
+     * Note: this is a method, not a property as the `T_NULLSAFE_OBJECT_OPERATOR` token may not exist.
+     *
      * @since 1.0.0-alpha4
      *
      * @return array <int|string> => <int|string>
      */
     public static function objectOperators()
     {
-        return [
+        $tokens = [
             \T_OBJECT_OPERATOR => \T_OBJECT_OPERATOR,
             \T_DOUBLE_COLON    => \T_DOUBLE_COLON,
         ];
+
+        if (\defined('T_NULLSAFE_OBJECT_OPERATOR') === true) {
+            // PHP 8.0.
+            $tokens[\T_NULLSAFE_OBJECT_OPERATOR] = \T_NULLSAFE_OBJECT_OPERATOR;
+        }
+
+        return $tokens;
     }
 
     /**

--- a/PHPCSUtils/Utils/Namespaces.php
+++ b/PHPCSUtils/Utils/Namespaces.php
@@ -62,7 +62,7 @@ class Namespaces
                 + Tokens::$castTokens
                 + Tokens::$blockOpeners
                 + Collections::$incrementDecrementOperators
-                + Collections::$objectOperators;
+                + Collections::objectOperators();
 
             $findAfter[\T_OPEN_CURLY_BRACKET]  = \T_OPEN_CURLY_BRACKET;
             $findAfter[\T_OPEN_SQUARE_BRACKET] = \T_OPEN_SQUARE_BRACKET;

--- a/Tests/Tokens/Collections/NullsafeObjectOperatorTokensBCTest.php
+++ b/Tests/Tokens/Collections/NullsafeObjectOperatorTokensBCTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::nullsafeObjectOperatorBC
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class NullsafeObjectOperatorBCTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testNullsafeObjectOperatorBC()
+    {
+        $expected = [];
+        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
+        ) {
+            $expected = [
+                \T_NULLSAFE_OBJECT_OPERATOR => \T_NULLSAFE_OBJECT_OPERATOR,
+            ];
+        } else {
+            $expected = [
+                \T_INLINE_THEN     => \T_INLINE_THEN,
+                \T_OBJECT_OPERATOR => \T_OBJECT_OPERATOR,
+            ];
+        }
+
+        $this->assertSame($expected, Collections::nullsafeObjectOperatorBC());
+    }
+}

--- a/Tests/Tokens/Collections/ObjectOperatorsBCTest.php
+++ b/Tests/Tokens/Collections/ObjectOperatorsBCTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::objectOperatorsBC
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class ObjectOperatorsBCTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testObjectOperatorsBC()
+    {
+        $expected = [
+            \T_OBJECT_OPERATOR => \T_OBJECT_OPERATOR,
+            \T_DOUBLE_COLON    => \T_DOUBLE_COLON,
+        ];
+
+        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
+        ) {
+            $expected[\T_NULLSAFE_OBJECT_OPERATOR] = \T_NULLSAFE_OBJECT_OPERATOR;
+        } else {
+            $expected[\T_INLINE_THEN] = \T_INLINE_THEN;
+        }
+
+        $this->assertSame($expected, Collections::objectOperatorsBC());
+    }
+}

--- a/Tests/Tokens/Collections/ObjectOperatorsTest.php
+++ b/Tests/Tokens/Collections/ObjectOperatorsTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::objectOperators
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class ObjectOperatorsTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testObjectOperators()
+    {
+        $expected = [
+            \T_OBJECT_OPERATOR => \T_OBJECT_OPERATOR,
+            \T_DOUBLE_COLON    => \T_DOUBLE_COLON,
+        ];
+
+        $this->assertSame($expected, Collections::objectOperators());
+    }
+}

--- a/Tests/Tokens/Collections/ObjectOperatorsTest.php
+++ b/Tests/Tokens/Collections/ObjectOperatorsTest.php
@@ -37,6 +37,11 @@ class ObjectOperatorsTest extends TestCase
             \T_DOUBLE_COLON    => \T_DOUBLE_COLON,
         ];
 
+        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
+        ) {
+            $expected[\T_NULLSAFE_OBJECT_OPERATOR] = \T_NULLSAFE_OBJECT_OPERATOR;
+        }
+
         $this->assertSame($expected, Collections::objectOperators());
     }
 }

--- a/Tests/Utils/Namespaces/NamespaceTypeTest.inc
+++ b/Tests/Utils/Namespaces/NamespaceTypeTest.inc
@@ -45,6 +45,9 @@ namespace\ClassName::$property++;
 /* testNamespaceOperatorGlobalNamespaceStartOfStatementCombiWithNonConfusingToken3 */
 namespace\CONSTANT['key'];
 
+/* testNamespaceOperatorGlobalNamespaceStartOfStatementCombiWithNonConfusingToken4 */
+namespace\functionReturningObj()?->chained();
+
 
 /* testParseErrorScopedNamespaceDeclaration */
 function testScope() {

--- a/Tests/Utils/Namespaces/NamespaceTypeTest.php
+++ b/Tests/Utils/Namespaces/NamespaceTypeTest.php
@@ -184,6 +184,13 @@ class NamespaceTypeTest extends UtilityMethodTestCase
                     'operator'    => true,
                 ],
             ],
+            'namespace-operator-global-namespace-start-of-statement-with-non-confusing-token-4' => [
+                '/* testNamespaceOperatorGlobalNamespaceStartOfStatementCombiWithNonConfusingToken4 */',
+                [
+                    'declaration' => false,
+                    'operator'    => true,
+                ],
+            ],
             'parse-error-scoped-namespace-declaration' => [
                 '/* testParseErrorScopedNamespaceDeclaration */',
                 [

--- a/Tests/Utils/Operators/IsNullsafeObjectOperatorTest.inc
+++ b/Tests/Utils/Operators/IsNullsafeObjectOperatorTest.inc
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Null safe operator.
+ */
+
+/* testUnsupportedToken */
+echo $obj::foo;
+
+/* testObjectOperator */
+echo $obj->foo;
+
+/* testNullsafeObjectOperator */
+echo $obj?->foo;
+
+/* testNullsafeObjectOperatorWriteContext */
+// Intentional parse error, but not the concern of this method.
+$foo?->bar->baz = 'baz';
+
+/* testTernaryThen */
+echo $obj ? $obj->prop : /* testObjectOperatorInTernary */ $other->prop;
+
+/* testParseErrorWhitespaceNotAllowed */
+echo $obj ?
+    -> foo;
+
+/* testParseErrorCommentNotAllowed */
+echo $obj ?/*comment*/-> foo;
+
+/* testLiveCoding */
+// Intentional parse error. This has to be the last test in the file.
+echo $obj?
+

--- a/Tests/Utils/Operators/IsNullsafeObjectOperatorTest.php
+++ b/Tests/Utils/Operators/IsNullsafeObjectOperatorTest.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Operators;
+
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Operators;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Operators::isNullsafeObjectOperator() method.
+ *
+ * @covers \PHPCSUtils\Utils\Operators::isNullsafeObjectOperator
+ *
+ * @group operators
+ *
+ * @since 1.0.0
+ */
+class IsNullsafeObjectOperatorTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test that false is returned when a non-existent token is passed.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->assertFalse(Operators::isNullsafeObjectOperator(self::$phpcsFile, 10000));
+    }
+
+    /**
+     * Test that false is returned when an unsupported token is passed.
+     *
+     * @return void
+     */
+    public function testUnsupportedToken()
+    {
+        $target = $this->getTargetToken('/* testUnsupportedToken */', \T_DOUBLE_COLON);
+        $this->assertFalse(Operators::isNullsafeObjectOperator(self::$phpcsFile, $target));
+    }
+
+    /**
+     * Test whether a nullsafe object operator is correctly identified as such.
+     *
+     * @dataProvider dataIsNullsafeObjectOperator
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     *
+     * @return void
+     */
+    public function testIsNullsafeObjectOperator($testMarker)
+    {
+        $targetTokenTypes = $this->getTargetTokensTypes();
+        $stackPtr         = $this->getTargetToken($testMarker, $targetTokenTypes);
+
+        $this->assertTrue(
+            Operators::isNullsafeObjectOperator(self::$phpcsFile, $stackPtr),
+            'Failed asserting that (first) token is the nullsafe object operator'
+        );
+
+        // Also test the second token of a non-backfilled nullsafe object operator.
+        $tokens = self::$phpcsFile->getTokens();
+        if ($tokens[$stackPtr]['code'] === \T_INLINE_THEN) {
+            $stackPtr = $this->getTargetToken($testMarker, [\T_OBJECT_OPERATOR]);
+
+            $this->assertTrue(
+                Operators::isNullsafeObjectOperator(self::$phpcsFile, $stackPtr),
+                'Failed asserting that (second) token is the nullsafe object operator'
+            );
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testIsNullsafeObjectOperator()
+     *
+     * @return array
+     */
+    public function dataIsNullsafeObjectOperator()
+    {
+        return [
+            'nullsafe'               => ['/* testNullsafeObjectOperator */'],
+            'nullsafe-write-context' => ['/* testNullsafeObjectOperatorWriteContext */'],
+        ];
+    }
+
+    /**
+     * Test whether tokens which can be confused with a non-nullsafe object operator are
+     * not misidentified as a nullsafe object operator.
+     *
+     * @dataProvider dataNotNullsafeObjectOperator
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param bool   $textNext   Whether to also test the next non-empty token. Defaults to false.
+     *
+     * @return void
+     */
+    public function testNotNullsafeObjectOperator($testMarker, $textNext = false)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, $this->getTargetTokensTypes());
+
+        $this->assertFalse(Operators::isNullsafeObjectOperator(self::$phpcsFile, $stackPtr));
+
+        if ($textNext === true) {
+            $next = self::$phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            $this->assertFalse(Operators::isNullsafeObjectOperator(self::$phpcsFile, $next));
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNotNullsafeObjectOperator()
+     *
+     * @return array
+     */
+    public function dataNotNullsafeObjectOperator()
+    {
+        return [
+            'normal-object-operator'             => ['/* testObjectOperator */'],
+            'ternary-then'                       => ['/* testTernaryThen */'],
+            'object-operator-in-ternary'         => ['/* testObjectOperatorInTernary */'],
+            'parse-error-whitespace-not-allowed' => ['/* testParseErrorWhitespaceNotAllowed */', true],
+            'parse-error-comment-not-allowed'    => ['/* testParseErrorCommentNotAllowed */', true],
+            'live-coding'                        => ['/* testLiveCoding */'],
+        ];
+    }
+
+    /**
+     * Get the target token types to pass to the getTargetToken() method.
+     *
+     * @return array <int|string> => <int|string>
+     */
+    private function getTargetTokensTypes()
+    {
+        $targets = [
+            \T_OBJECT_OPERATOR,
+            \T_INLINE_THEN,
+        ];
+
+        if (defined('T_NULLSAFE_OBJECT_OPERATOR') === true) {
+            $targets[] = \T_NULLSAFE_OBJECT_OPERATOR;
+        }
+
+        return $targets;
+    }
+}


### PR DESCRIPTION
### Collections: deprecate $objectOperators in favour of objectOperators()

Deprecate the `$objectOperators` property in favour of a new `Collections::objectOperators()` method.

PHP 8.0 introduces a new `T_NULLSAFE_OBJECT_OPERATOR` token. As that token will not always be available, a property can't handle this.

In anticipation of the introduction of the new token, I'm deprecating the `Collections::$objectOperators` property straight away to prevent BC breaks at a later point in time.

Includes adding unit tests for the new method.

:warning: **_BC-break: This needs a changelog entry_** :warning: 

### Collections::objectOperators(): support the PHP 8 nullsafe object operator

Includes adjusted unit test.

### Tokens\Collections: add new `objectOperatorsBC() method

Sister-method to the `objectOperators()` method, which returns the tokens which can be encountered as object operators in PHP < 8.0 in combination with a PHPCS version in which the token was not backfilled yet.

The backfill for PHPCS has been pulled and is expected to be included in PHPCS 3.5.6 or 3.6.0, but as it stands, is not available yet in a released version.

Includes unit test.

Related:
* squizlabs/PHP_CodeSniffer#3046

### Tokens\Collections: add new `nullsafeObjectOperatorBC() method

... to retrieve the tokens which can represent the nullsafe object operator.

This method will return the appropriate token(s) based on the PHP/PHPCS version used.

Includes unit test.

### New Operators::isNullsafeObjectOperator() method

... which emulates the backfill as pulled to PHPCS itself.

PHP 8 introduces a new object chaining operator `?->` which short-circuits moving to the next expression if the left-hand side evaluates to `null`.

This operator can not be used in write-context, but that is not the concern of this method.

For PHPCS versions where the backfill is not available yet, this method can be used to determine whether a `?` or `->` token is actually part of the `?->` nullsafe object operator token.

Includes perfunctory unit tests.
Includes mentioning the method in appropriate places in the documentation elsewhere.

Refs:
* squizlabs/PHP_CodeSniffer#3046
* https://wiki.php.net/rfc/nullsafe_operator
* php/php-src@9bf1198

### Namespaces::getType: switch to objectOperators() method

... and add a unit test using the nullsafe object operator.

No additional code is needed for the correct functioning of this method, as when the nullsafe object operator is not yet backfilled, the method will correctly signal on the object operator part of the token.

