### PR TITLE
CI: fix coverage builds failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -211,10 +211,10 @@ install:
   # The Composer PHPCS plugin takes care of setting the installed_paths for PHPCS.
   - |
     if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
-      # Temporary fix - PHPUnit 9.3 is supposed to officially support PHP 8.
+      # Temporary fix - PHPUnit 9.3 is buggy when used for code coverage, so not allowed "normally".
+      # As PHP 8 doesn't run code coverage, we can safely install it there though.
       composer require --no-update phpunit/phpunit:"^9.3"
-      # PHPUnit 9.x does not (yet) allow for installation on PHP 8, so ignore platform
-      # requirements to get PHPUnit 9.x to install on nightly.
+      # Not all PHPUnit dependencies have stable releases yet allowing for PHP 8.0.
       composer install --prefer-dist --no-suggest --ignore-platform-reqs
     else
       # Do a normal dev install in all other cases.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev" : {
         "php-parallel-lint/php-parallel-lint": "^1.2.0",
         "php-parallel-lint/php-console-highlighter": "^0.5",
-        "phpunit/phpunit" : "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+        "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || >=9.0 <9.3.0"
     },
     "conflict": {
         "squizlabs/php_codesniffer": "3.5.3"


### PR DESCRIPTION
The code coverage builds on PHP 7.3/7.4 started to fail without clear reason recently.

It has now become clear that the underlying reason is that the [PHP Code Coverage](https://github.com/sebastianbergmann/php-code-coverage) package started to use PHP-Parser as of PHP Code Coverage version 9.0.

The first PHPUnit version which has a dependency on PHP Code Coverage 9.x is PHPUnit 9.3, so if we limit the PHPUnit 9.x range to `9.0 - 9.2`, the code coverage builds will be fine (for now).

We then have the situation that PHPUnit 9.3 is needed to run the tests on PHP 8.0. As we don't run code coverage on PHP 8.0, that is not a really issue though, so we just hard-require PHPUnit 9.3 for PHP `nightly` in the Travis script.

While this solution is not ideal, it, at least, will create a workable situation again until PHP 8.0 comes out. Hopefully a proper solution will be found and implemented before that time, so we can remove this work-around.

See also: https://github.com/sebastianbergmann/php-code-coverage/issues/798