### PR TITLE
Support namespace operator in type declarations

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -723,6 +723,7 @@ class Collections
             \T_FALSE        => \T_FALSE,      // Union types only.
             \T_NULL         => \T_NULL,       // Union types only.
             \T_STRING       => \T_STRING,
+            \T_NAMESPACE    => \T_NAMESPACE,
             \T_NS_SEPARATOR => \T_NS_SEPARATOR,
             \T_BITWISE_OR   => \T_BITWISE_OR, // Union types.
         ];
@@ -792,6 +793,7 @@ class Collections
             \T_FALSE        => \T_FALSE,      // Union types only.
             \T_NULL         => \T_NULL,       // Union types only.
             \T_STRING       => \T_STRING,
+            \T_NAMESPACE    => \T_NAMESPACE,
             \T_NS_SEPARATOR => \T_NS_SEPARATOR,
             \T_BITWISE_OR   => \T_BITWISE_OR, // Union types.
         ];
@@ -863,6 +865,7 @@ class Collections
             \T_FALSE        => \T_FALSE,      // Union types only.
             \T_NULL         => \T_NULL,       // Union types only.
             \T_ARRAY        => \T_ARRAY,      // Arrow functions PHPCS < 3.5.4 + union types.
+            \T_NAMESPACE    => \T_NAMESPACE,
             \T_NS_SEPARATOR => \T_NS_SEPARATOR,
             \T_BITWISE_OR   => \T_BITWISE_OR, // Union types.
         ];

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -171,6 +171,7 @@ class FunctionDeclarations
      * - To allow for backward compatible handling of arrow functions, this method will also accept
      *   `T_STRING` tokens and examine them to check if these are arrow functions.
      * - Support for PHP 8.0 union types.
+     * - Support for namespace operator in type declarations.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodProperties()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getMethodProperties() Cross-version compatible version of the original.
@@ -297,6 +298,16 @@ class FunctionDeclarations
 
                 if ($scopeOpener === null && $tokens[$i]['code'] === \T_SEMICOLON) {
                     // End of abstract/interface function definition.
+                    break;
+                }
+
+                /*
+                 * Work-around for a scope map tokenizer bug in PHPCS.
+                 * {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/3066}
+                 */
+                if ($scopeOpener === null && $tokens[$i]['code'] === \T_OPEN_CURLY_BRACKET) {
+                    // End of function definition for which the scope opener is incorrectly not set.
+                    $hasBody = true;
                     break;
                 }
 

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -402,6 +402,7 @@ class FunctionDeclarations
      *   `T_STRING` tokens and examine them to check if these are arrow functions.
      * - Support for PHP 8.0 union types.
      * - Support for PHP 8.0 constructor property promotion.
+     * - Support for namespace operator in type declarations.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodParameters()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getMethodParameters() Cross-version compatible version of the original.
@@ -505,6 +506,7 @@ class FunctionDeclarations
                 case 'T_FALSE': // Union types.
                 case 'T_NULL': // Union types.
                 case 'T_STRING':
+                case 'T_NAMESPACE':
                 case 'T_NS_SEPARATOR':
                 case 'T_BITWISE_OR': // Union type separator.
                     if ($typeHintToken === false) {

--- a/PHPCSUtils/Utils/Variables.php
+++ b/PHPCSUtils/Utils/Variables.php
@@ -81,6 +81,7 @@ class Variables
      *   other non-property variables passed to the method.
      * - Defensive coding against incorrect calls to this method.
      * - Support for PHP 8.0 union types.
+     * - Support for namespace operator in type declarations.
      *
      * @see \PHP_CodeSniffer\Files\File::getMemberProperties()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getMemberProperties() Cross-version compatible version of the original.

--- a/Tests/Tokens/Collections/ParameterTypeTokensTest.php
+++ b/Tests/Tokens/Collections/ParameterTypeTokensTest.php
@@ -39,6 +39,7 @@ class ParameterTypeTokensTest extends TestCase
             \T_FALSE        => \T_FALSE,
             \T_NULL         => \T_NULL,
             \T_STRING       => \T_STRING,
+            \T_NAMESPACE    => \T_NAMESPACE,
             \T_NS_SEPARATOR => \T_NS_SEPARATOR,
             \T_BITWISE_OR   => \T_BITWISE_OR,
         ];

--- a/Tests/Tokens/Collections/PropertyTypeTokensTest.php
+++ b/Tests/Tokens/Collections/PropertyTypeTokensTest.php
@@ -39,6 +39,7 @@ class PropertyTypeTokensTest extends TestCase
             \T_FALSE        => \T_FALSE,
             \T_NULL         => \T_NULL,
             \T_STRING       => \T_STRING,
+            \T_NAMESPACE    => \T_NAMESPACE,
             \T_NS_SEPARATOR => \T_NS_SEPARATOR,
             \T_BITWISE_OR   => \T_BITWISE_OR,
         ];

--- a/Tests/Tokens/Collections/ReturnTypeTokensTest.php
+++ b/Tests/Tokens/Collections/ReturnTypeTokensTest.php
@@ -41,6 +41,7 @@ class ReturnTypeTokensTest extends TestCase
             \T_FALSE        => \T_FALSE,
             \T_NULL         => \T_NULL,
             \T_ARRAY        => \T_ARRAY,
+            \T_NAMESPACE    => \T_NAMESPACE,
             \T_NS_SEPARATOR => \T_NS_SEPARATOR,
             \T_BITWISE_OR   => \T_BITWISE_OR,
         ];

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.inc
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.inc
@@ -75,3 +75,6 @@ abstract class ConstructorPropertyPromotionAbstractMethod {
     // 3. The callable type is not supported for properties, but that's not the concern of this method.
     abstract public function __construct(public callable $y, private ...$x);
 }
+
+/* testNamespaceOperatorTypeHint */
+function namespaceOperatorTypeHint(?namespace\Name $var1) {}

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
@@ -630,6 +630,32 @@ class GetParametersDiffTest extends UtilityMethodTestCase
     }
 
     /**
+     * Verify recognition of type declarations using the namespace operator.
+     *
+     * @return void
+     */
+    public function testNamespaceOperatorTypeHint()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 9, // Offset from the T_FUNCTION token.
+            'name'                => '$var1',
+            'content'             => '?namespace\Name $var1',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '?namespace\Name',
+            'type_hint_token'     => 5, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 7, // Offset from the T_FUNCTION token.
+            'nullable_type'       => true,
+            'comma_token'         => false,
+        ];
+
+        $this->getParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.inc
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.inc
@@ -65,3 +65,6 @@ interface FooBar {
 /* testPHP8DuplicateTypeInUnionWhitespaceAndComment */
 // Intentional fatal error - duplicate types are not allowed in union types, but that's not the concern of the method.
 function duplicateTypeInUnion(): int | /*comment*/ string | INT {}
+
+/* testNamespaceOperatorTypeHint */
+function namespaceOperatorTypeHint() : ?namespace\Name {}

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
@@ -368,6 +368,29 @@ class GetPropertiesDiffTest extends UtilityMethodTestCase
     }
 
     /**
+     * Test a function with return type using the namespace operator.
+     *
+     * @return void
+     */
+    public function testNamespaceOperatorTypeHint()
+    {
+        $expected = [
+            'scope'                => 'public',
+            'scope_specified'      => false,
+            'return_type'          => '?namespace\Name',
+            'return_type_token'     => 9, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 11, // Offset from the T_FUNCTION token.
+            'nullable_return_type' => true,
+            'is_abstract'          => false,
+            'is_final'             => false,
+            'is_static'            => false,
+            'has_body'             => true,
+        ];
+
+        $this->getPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.

--- a/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.inc
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.inc
@@ -64,6 +64,9 @@ $fn = fn($x) : ?\My\NS\ClassName => $x;
 /* testReturnTypeNullableFQNClass */
 $a = fn(?\DateTime $x) : ?\DateTime => $x;
 
+/* testNamespaceOperatorInTypes */
+$fn = fn(namespace\Foo $a) : ?namespace\Foo => $a;
+
 /* testReturnTypeSelf */
 $fn = fn(self $a) : ?self => $a;
 

--- a/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
@@ -348,6 +348,18 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
                     ],
                 ],
             ],
+            'arrow-function-with-namespace-operator-in-types' => [
+                '/* testNamespaceOperatorInTypes */',
+                [
+                    'is'  => true,
+                    'get' => [
+                        'parenthesis_opener' => 1,
+                        'parenthesis_closer' => 7,
+                        'scope_opener'       => 16,
+                        'scope_closer'       => 19,
+                    ],
+                ],
+            ],
             'arrow-function-with-return-type-nullable-self' => [
                 '/* testReturnTypeSelf */',
                 [

--- a/Tests/Utils/Variables/GetMemberPropertiesDiffTest.inc
+++ b/Tests/Utils/Variables/GetMemberPropertiesDiffTest.inc
@@ -52,3 +52,8 @@ $anon = class() {
     // Intentional fatal error - duplicate types are not allowed in union types, but that's not the concern of the method.
     public int |string| /*comment*/ INT $duplicateTypeInUnion;
 };
+
+class NSOperatorInType {
+    /* testNamespaceOperatorTypeHint */
+    public ?namespace\Name $prop;
+}

--- a/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
@@ -232,6 +232,18 @@ class GetMemberPropertiesDiffTest extends UtilityMethodTestCase
                     'nullable_type'   => false,
                 ],
             ],
+            'namespace-operator-type-declaration' => [
+                '/* testNamespaceOperatorTypeHint */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '?namespace\Name',
+                    'type_token'      => -4, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'nullable_type'   => true,
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
Largely the same changes as pulled upstream in https://github.com/squizlabs/PHP_CodeSniffer/pull/3066

---

### Collections: allow for namespace operator in type declarations

This adds support for the namespace keyword used as an operator in property, parameter and return type declarations.

Includes adjusted unit tests.

### FunctionDeclarations: add test for namespace operator in arrow function type declarations

The commit which added namespace operator support to the `Collections::returnTypeTokens[BC]()` methods implicitly added support for the namespace operator in type declarations for arrow functions, i.e. to the `FunctionDeclarations::isArrowFunction()` and the `FunctionDeclarations::getArrowFunctionOpenClose()` methods.

This commit adds a unit test to safeguard this support.

### FunctionDeclarations::getProperties(): add tests verifying support for namespace operator in types

The commit which added support for the namespace keyword used as an operator to the `Collections::returnTypeTokens[BC]()` methods implicitly added support for this to the `FunctionDeclarations::getProperties()` method.

This commit adds a unit test to safeguard this support.

The same commit also _silently_ added support for the namespace operator to the `BCFile::getMethodProperties()` method. Namespace operators in return types are not supported yet in PHPCS itself and until they are, the fact that the `BCFile::getMethodProperties()` method supports this should be regarded as an artifact and not as official support.

### FunctionDeclarations::getParameters(): add support for namespace operator in types

This commit adds support for the namespace keyword used as an operator to the `FunctionDeclarations::getParameters()` method.

Changes along the same lines as included in this PR will also be pulled upstream to PHPCS itself. Once the upstream PR has been merged, those changes will also be applied to the `BCFile::getMethodParameters()` method.

Includes unit test.

### Variables::getMemberProperties(): add tests verifying support for namespace operator in types

The commit which added support for the namespace keyword used as an operator to the `Collections::propertyTypeTokens[BC]()` methods implicitly added support for this to the `Variables::getMemberProperties()` method.

This commit adds a unit test to safeguard this support.

The same commit also _silently_ added support for the namespace operator to the `BCFile::getMemberProperties()` method. Namespace operators in property types are not supported yet in PHPCS itself and until they are, the fact that the `BCFile::getMemberProperties()` method supports this should be regarded as an artifact and not as official support.

