### PR TITLE
ObjectDeclarations::findNames(): allow for use of namespace keyword as operator

### DIFF
--- a/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.inc
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.inc
@@ -6,5 +6,8 @@ class testDeclarationWithComments
     // phpcs:ignore Stnd.Cat.Sniff -- For reasons.
     \Package\SubDir /* comment */ \ /* comment */ SomeClass /* comment */ {}
 
+/* testExtendedClassUsingNamespaceOperator */
+class testWithNSOperator extends namespace\Bar {}
+
 /* testExtendedClassStrayComma */
 class testExtendedClassStrayComma extends , testClass {} // Intentional parse error.

--- a/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.php
@@ -60,6 +60,10 @@ class FindExtendedClassNameDiffTest extends UtilityMethodTestCase
                 '/* testDeclarationWithComments */',
                 '\Package\SubDir\SomeClass',
             ],
+            'namespace-operator' => [
+                '/* testExtendedClassUsingNamespaceOperator */',
+                'namespace\Bar',
+            ],
             'parse-error-stray-comma' => [
                 '/* testExtendedClassStrayComma */',
                 'testClass',

--- a/Tests/Utils/ObjectDeclarations/FindExtendedInterfaceNamesTest.inc
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedInterfaceNamesTest.inc
@@ -28,6 +28,9 @@ interface testMultiExtendedInterfaceWithComments
 {
 }
 
+/* testExtendsUsingNamespaceOperator */
+interface testWithNSOperator extends namespace\BarInterface, namespace\Sub\SomeOther {}
+
 // Intentional parse error. Has to be the last test in the file.
 /* testParseError */
 interface testParseError extends testInterface

--- a/Tests/Utils/ObjectDeclarations/FindExtendedInterfaceNamesTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedInterfaceNamesTest.php
@@ -110,6 +110,13 @@ class FindExtendedInterfaceNamesTest extends UtilityMethodTestCase
                     '\testInterfaceC',
                 ],
             ],
+            'extends-using-namespace-operator' => [
+                '/* testExtendsUsingNamespaceOperator */',
+                [
+                    'namespace\BarInterface',
+                    'namespace\Sub\SomeOther',
+                ],
+            ],
             'parse-error' => [
                 '/* testParseError */',
                 false,

--- a/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.inc
+++ b/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.inc
@@ -13,5 +13,8 @@ class testDeclarationWithComments
         // comment
         InterfaceB {}
 
+/* testDeclarationMultiImplementedNamespaceOperator */
+class testMultiImplementedNSOperator implements namespace\testInterfaceA, namespace\testInterfaceB {}
+
 /* testMultiImplementedStrayComma */
 class testMultiImplementedStrayComma implements testInterfaceA, , testInterfaceB {} // Intentional parse error.

--- a/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.php
@@ -63,6 +63,13 @@ class FindImplementedInterfaceNamesDiffTest extends UtilityMethodTestCase
                     'InterfaceB',
                 ],
             ],
+            'namespace-operator' => [
+                '/* testDeclarationMultiImplementedNamespaceOperator */',
+                [
+                    'namespace\testInterfaceA',
+                    'namespace\testInterfaceB',
+                ],
+            ],
             'parse-error-stray-comma' => [
                 '/* testMultiImplementedStrayComma */',
                 [


### PR DESCRIPTION
So far, using the `namespace` keyword as an operator was not accounted for. This has now been fixed.

This fix works through in the `ObjectDeclarations::findExtendedClassName()`, `ObjectDeclarations::findImplementedInterfaceNames()` and the `ObjectDeclarations::findExtendedInterfaceNames()` methods.

Includes additional unit tests for all three of these.