### PR TITLE
QA/CS: update PHPCSDevCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
             "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
         ],
         "install-devcs": [
-            "composer require phpcsstandards/phpcsdevcs:\"^1.0\" --no-suggest --update-no-dev"
+            "composer require phpcsstandards/phpcsdevcs:\"^1.1\" --no-suggest --update-no-dev"
         ],
         "remove-devcs": [
             "composer remove phpcsstandards/phpcsdevcs --update-no-dev"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -47,9 +47,6 @@
     <!-- Set minimum PHP version supported to PHP 5.4. -->
     <config name="testVersion" value="5.4-"/>
 
-    <!-- Enforce short arrays. -->
-    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
-
 
     <!--
     #############################################################################


### PR DESCRIPTION
The new `1.1.x` version already includes a check for short array syntax, so we can remove that from our own ruleset.