### PR TITLE
Travis/Composer: future-proof the CS setup a little more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,19 +47,26 @@ jobs:
     #### SNIFF STAGE ####
     - stage: sniff
       php: 7.4
-      env: PHPCS_VERSION="dev-master"
       addons:
         apt:
           packages:
             - libxml2-utils
-      install: skip
+      install:
+        - export XMLLINT_INDENT="    "
+        # Set up CS check.
+        # - Using PHPCS `master` as an early detection system for bugs upstream.
+        # - COMPOSER_ROOT_VERSION is needed to get round the recursive dependency when using CI.
+        - export COMPOSER_ROOT_VERSION="1.99.99"
+        - travis_retry composer remove --dev phpunit/phpunit --no-update --no-scripts
+        - travis_retry composer require --no-update squizlabs/php_codesniffer:"dev-master"
+        - travis_retry composer install-devcs
       script:
         # Validate the composer.json file.
         # @link https://getcomposer.org/doc/03-cli.md#validate
         - composer validate --no-check-all --strict
 
         # Check the code style of the code base.
-        - composer travis-checkcs
+        - vendor/bin/phpcs
 
         # Validate the xml files.
         # @link http://xmlsoft.org/xmllint.html
@@ -191,8 +198,6 @@ before_install:
       echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     fi
 
-  - export XMLLINT_INDENT="    "
-
 
 install:
   # Set up test environment using Composer.
@@ -200,11 +205,6 @@ install:
   - |
     if [[ "${TRAVIS_BUILD_STAGE_NAME^}" == "Coverage" ]]; then
       travis_retry composer require --dev --no-update --no-suggest --no-scripts php-coveralls/php-coveralls:${COVERALLS_VERSION}
-    fi
-  - |
-    if [[ "${TRAVIS_BUILD_STAGE_NAME^}" == "Sniff" ]]; then
-      # Don't install PHPUnit when it's not needed.
-      travis_retry composer remove --dev phpunit/phpunit --no-update --no-scripts
     fi
 
   # --prefer-dist will allow for optimal use of the travis caching ability.

--- a/composer.json
+++ b/composer.json
@@ -44,15 +44,21 @@
             "PHPCSUtils\\Tests\\": "Tests/"
         }
     },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.x-dev",
+            "dev-develop": "1.x-dev"
+        }
+    },
     "scripts" : {
         "lint": [
             "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
         ],
         "install-devcs": [
-            "composer require phpcsstandards/phpcsdevcs:\"^1.1\" --no-suggest --update-no-dev"
+            "composer require phpcsstandards/phpcsdevcs:\"^1.1\" --no-suggest"
         ],
         "remove-devcs": [
-            "composer remove phpcsstandards/phpcsdevcs --update-no-dev"
+            "composer remove phpcsstandards/phpcsdevcs"
         ],
         "checkcs": [
             "@install-devcs",
@@ -63,10 +69,6 @@
             "@install-devcs",
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf",
             "@remove-devcs"
-        ],
-        "travis-checkcs": [
-            "@install-devcs",
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
         ],
         "test": [
             "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"


### PR DESCRIPTION
* Composer: add branch aliases
* Travis: move CS install steps to the `Sniff` stage.

See PHPCompatibility/PHPCompatibility#1221 for more extensive background information about these changes.