### PR TITLE
Operators::isUnaryPlusMinus(): allow for exit, break, continue

### DIFF
--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -43,6 +43,9 @@ class Operators
     private static $extraUnaryIndicators = [
         \T_STRING_CONCAT       => true,
         \T_RETURN              => true,
+        \T_EXIT                => true,
+        \T_CONTINUE            => true,
+        \T_BREAK               => true,
         \T_ECHO                => true,
         \T_PRINT               => true,
         \T_YIELD               => true,

--- a/Tests/Utils/Operators/IsUnaryPlusMinusTest.inc
+++ b/Tests/Utils/Operators/IsUnaryPlusMinusTest.inc
@@ -79,6 +79,9 @@ return +1;
 /* testUnaryMinusFloatReturn */
 return -1.1;
 
+/* testUnaryPlusIntExit */
+exit -1;
+
 /* testUnaryPlusPrint */
 print +$b;
 
@@ -126,13 +129,13 @@ declare( ticks = +10 );
 switch ($a) {
     /* testUnaryPlusCase */
     case +20:
-        // Something.
-        break;
+        /* testUnaryPlusContinue */
+        continue +2;
 
     /* testUnaryMinusCase */
     case -1.23:
-        // Something.
-        break;
+        /* testUnaryPlusBreak */
+        break +1;
 }
 
 // Testing `$a = -+-+10`;

--- a/Tests/Utils/Operators/IsUnaryPlusMinusTest.php
+++ b/Tests/Utils/Operators/IsUnaryPlusMinusTest.php
@@ -196,6 +196,10 @@ class IsUnaryPlusMinusTest extends UtilityMethodTestCase
                 '/* testUnaryMinusFloatReturn */',
                 true,
             ],
+            'unary-minus-int-exit' => [
+                '/* testUnaryPlusIntExit */',
+                true,
+            ],
             'unary-plus-print' => [
                 '/* testUnaryPlusPrint */',
                 true,
@@ -256,8 +260,16 @@ class IsUnaryPlusMinusTest extends UtilityMethodTestCase
                 '/* testUnaryPlusCase */',
                 true,
             ],
+            'unary-plus-continue' => [
+                '/* testUnaryPlusContinue */',
+                true,
+            ],
             'unary-minus-switch-case' => [
                 '/* testUnaryMinusCase */',
+                true,
+            ],
+            'unary-minus-break' => [
+                '/* testUnaryPlusBreak */',
                 true,
             ],
             'operator-sequence-non-unary-1' => [


### PR DESCRIPTION
... as indicators that a plus/minus is unary when preceded by it.

Includes unit tests.

Inspired by squizlabs/PHP_CodeSniffer#3098