### PR TITLE
Operators::isReference(): bug fix - parameters passed by reference

### DIFF
--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -125,7 +125,7 @@ class Operators
             if ($lastOwner !== false) {
                 $params = FunctionDeclarations::getParameters($phpcsFile, $lastOwner);
                 foreach ($params as $param) {
-                    if ($param['pass_by_reference'] === true) {
+                    if ($param['reference_token'] === $stackPtr) {
                         // Function parameter declared to be passed by reference.
                         return true;
                     }

--- a/Tests/BackCompat/BCFile/IsReferenceTest.inc
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.inc
@@ -168,3 +168,14 @@ fn&($x) => $x;
 
 /* testClosureReturnByReference */
 $closure = function &($param) use ($value) {};
+
+$closure = function (
+    /* testPassByReferenceExactParameterA */
+    $a = MY_CONSTANT & parent::OTHER_CONSTANT,
+    /* testPassByReferenceExactParameterB */
+    &$b,
+    /* testPassByReferenceExactParameterC */
+    &...$c,
+    /* testPassByReferenceExactParameterD */
+    $d = E_NOTICE & E_STRICT,
+) {};

--- a/Tests/BackCompat/BCFile/IsReferenceTest.php
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.php
@@ -316,6 +316,22 @@ class IsReferenceTest extends UtilityMethodTestCase
                 '/* testClosureReturnByReference */',
                 true,
             ],
+            [
+                '/* testPassByReferenceExactParameterA */',
+                false,
+            ],
+            [
+                '/* testPassByReferenceExactParameterB */',
+                true,
+            ],
+            [
+                '/* testPassByReferenceExactParameterC */',
+                true,
+            ],
+            [
+                '/* testPassByReferenceExactParameterD */',
+                false,
+            ],
         ];
     }
 }


### PR DESCRIPTION
Somewhere down the line, the key used to look up whether a parameter was passed by reference got mixed up, which caused the "is this a parameter passed by reference ?" part to always return `true` if _one_ of the parameters was passed by reference.

Fixed now.