### PR TITLE
Operators::isReference(): remove some redundant code

### DIFF
--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -130,23 +130,13 @@ class Operators
                         return true;
                     }
                 }
-            } elseif (isset($tokens[$lastOpener]['parenthesis_owner']) === false) {
-                $prev = false;
-                for ($t = ($lastOpener - 1); $t >= 0; $t--) {
-                    if ($tokens[$t]['code'] !== \T_WHITESPACE) {
-                        $prev = $t;
-                        break;
-                    }
-                }
-
-                if ($prev !== false && $tokens[$prev]['code'] === \T_USE) {
-                    // Closure use by reference.
-                    return true;
-                }
             }
         }
 
-        // Pass by reference in function calls and assign by reference in arrays.
+        /*
+         * Pass by reference in function calls, assign by reference in arrays and
+         * closure use by reference in PHPCS 2.x and 3.x.
+         */
         if ($tokens[$tokenBefore]['code'] === \T_OPEN_PARENTHESIS
             || $tokens[$tokenBefore]['code'] === \T_COMMA
             || $tokens[$tokenBefore]['code'] === \T_OPEN_SHORT_ARRAY

--- a/Tests/BackCompat/BCFile/IsReferenceTest.inc
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.inc
@@ -163,6 +163,12 @@ functionCall( $something , &new Foobar() );
 /* testUseByReference */
 $closure = function() use (&$var){};
 
+/* testUseByReferenceWithCommentFirstParam */
+$closure = function() use /*comment*/ (&$this->value){};
+
+/* testUseByReferenceWithCommentSecondParam */
+$closure = function() use /*comment*/ ($varA, &$varB){};
+
 /* testArrowFunctionReturnByReference */
 fn&($x) => $x;
 

--- a/Tests/BackCompat/BCFile/IsReferenceTest.php
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.php
@@ -309,6 +309,14 @@ class IsReferenceTest extends UtilityMethodTestCase
                 true,
             ],
             [
+                '/* testUseByReferenceWithCommentFirstParam */',
+                true,
+            ],
+            [
+                '/* testUseByReferenceWithCommentSecondParam */',
+                true,
+            ],
+            [
                 '/* testArrowFunctionReturnByReference */',
                 true,
             ],


### PR DESCRIPTION
The "closure use by reference" check only skipped over whitespace, not comments, but in effect, that didn't matter anyway as it would be handled correctly by the "function pass by reference" part of the function logic, so we may as well remove the redundant code.

Includes some additional unit tests.

Note: as of PHPCS 4.x,  closure `T_USE` tokens will become parentheses owners, so by then, it should be handled differently.