### PR TITLE
Operators::isReference(): bug fix - arrow function params passed by reference

### DIFF
--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -66,6 +66,7 @@ class Operators
      * Main differences with the PHPCS version:
      * - Defensive coding against incorrect calls to this method.
      * - Improved handling of select tokenizer errors involving short lists/short arrays.
+     * - Parameters passed by reference in arrow functions are recognized correctly.
      *
      * @see \PHP_CodeSniffer\Files\File::isReference()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::isReference() Cross-version compatible version of the original.
@@ -121,8 +122,9 @@ class Operators
 
         $lastOpener = Parentheses::getLastOpener($phpcsFile, $stackPtr);
         if ($lastOpener !== false) {
-            $lastOwner = Parentheses::lastOwnerIn($phpcsFile, $stackPtr, [\T_FUNCTION, \T_CLOSURE]);
-            if ($lastOwner !== false) {
+            $lastOwner = Parentheses::getOwner($phpcsFile, $lastOpener);
+
+            if (isset(Collections::functionDeclarationTokensBC()[$tokens[$lastOwner]['code']]) === true) {
                 $params = FunctionDeclarations::getParameters($phpcsFile, $lastOwner);
                 foreach ($params as $param) {
                     if ($param['reference_token'] === $stackPtr) {

--- a/Tests/Utils/Operators/IsReferenceDiffTest.inc
+++ b/Tests/Utils/Operators/IsReferenceDiffTest.inc
@@ -11,3 +11,12 @@ if ($foo) {}
 /* testTokenizerIssue1284PHPCSlt280C */
 if ($foo) {}
 [&$a, $b];
+
+/* testArrowFunctionPassByReferenceA */
+$fn = fn(array &$one) => 1;
+
+/* testArrowFunctionPassByReferenceB */
+$fn = fn($param, &...$moreParams) => 1;
+
+/* testArrowFunctionNonReferenceInDefault */
+$fn = fn( $one = E_NOTICE & E_STRICT) => 1;

--- a/Tests/Utils/Operators/IsReferenceDiffTest.php
+++ b/Tests/Utils/Operators/IsReferenceDiffTest.php
@@ -85,6 +85,18 @@ class IsReferenceDiffTest extends UtilityMethodTestCase
                 '/* testTokenizerIssue1284PHPCSlt280C */',
                 true,
             ],
+            'issue-3049-arrow-function-pass-by-reference-A' => [
+                '/* testArrowFunctionPassByReferenceA */',
+                true,
+            ],
+            'issue-3049-arrow-function-pass-by-reference-B' => [
+                '/* testArrowFunctionPassByReferenceB */',
+                true,
+            ],
+            'issue-3049-arrow-function-parameter-default' => [
+                '/* testArrowFunctionNonReferenceInDefault */',
+                false,
+            ],
         ];
     }
 }


### PR DESCRIPTION
The bitwise and `&` for parameters passed by reference in an arrow function declaration were incorrectly not recognized as references.

Includes unit test.

Refs:
* Issue: squizlabs/PHP_CodeSniffer#3049
* PR: squizlabs/PHP_CodeSniffer#3103