### PR TITLE
BCTokens: test arrays against PHPCS upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,6 +159,23 @@ jobs:
     - php: 7.4
       env: PHPCS_VERSION="4.0.x-dev@dev"
 
+    # Run risky tests separately.
+    - php: 7.4
+      env: PHPCS_VERSION="4.0.x-dev@dev" TEST_RISKY=1
+      before_script: skip
+      script:
+        # "nothing" is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
+        - composer test -- --group compareWithPHPCS --exclude-group nothing
+      after_success: skip
+
+    - php: 7.4
+      env: PHPCS_VERSION="dev-master" TEST_RISKY=1
+      before_script: skip
+      script:
+        # "nothing" is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
+        - composer test -- --group compareWithPHPCS --exclude-group nothing
+      after_success: skip
+
     #### CODE COVERAGE STAGE ####
     # N.B.: Coverage is only checked on the lowest and highest stable PHP versions for all PHPCS versions.
     # These builds are left out off the "test" stage so as not to duplicate test runs.
@@ -182,6 +199,8 @@ jobs:
     # Allow failures for unstable builds.
     - php: "nightly"
     - env: PHPCS_VERSION="4.0.x-dev@dev"
+    - env: PHPCS_VERSION="4.0.x-dev@dev" TEST_RISKY=1
+    - env: PHPCS_VERSION="dev-master" TEST_RISKY=1
 
 
 before_install:

--- a/Tests/BackCompat/BCTokens/ArithmeticTokensTest.php
+++ b/Tests/BackCompat/BCTokens/ArithmeticTokensTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCTokens;
 
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPUnit\Framework\TestCase;
 
@@ -42,5 +43,19 @@ class ArithmeticTokensTest extends TestCase
         ];
 
         $this->assertSame($expected, BCTokens::arithmeticTokens());
+    }
+
+    /**
+     * Test whether the method in BCTokens is still in sync with the latest version of PHPCS.
+     *
+     * This group is not run by default and has to be specifically requested to be run.
+     *
+     * @group compareWithPHPCS
+     *
+     * @return void
+     */
+    public function testPHPCSArithmeticTokens()
+    {
+        $this->assertSame(Tokens::$arithmeticTokens, BCTokens::arithmeticTokens());
     }
 }

--- a/Tests/BackCompat/BCTokens/AssignmentTokensTest.php
+++ b/Tests/BackCompat/BCTokens/AssignmentTokensTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCTokens;
 
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\BackCompat\Helper;
 use PHPUnit\Framework\TestCase;
@@ -62,5 +63,19 @@ class AssignmentTokensTest extends TestCase
         }
 
         $this->assertSame($expected, BCTokens::assignmentTokens());
+    }
+
+    /**
+     * Test whether the method in BCTokens is still in sync with the latest version of PHPCS.
+     *
+     * This group is not run by default and has to be specifically requested to be run.
+     *
+     * @group compareWithPHPCS
+     *
+     * @return void
+     */
+    public function testPHPCSAssignmentTokens()
+    {
+        $this->assertSame(Tokens::$assignmentTokens, BCTokens::assignmentTokens());
     }
 }

--- a/Tests/BackCompat/BCTokens/ComparisonTokensTest.php
+++ b/Tests/BackCompat/BCTokens/ComparisonTokensTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCTokens;
 
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\BackCompat\Helper;
 use PHPUnit\Framework\TestCase;
@@ -53,5 +54,19 @@ class ComparisonTokensTest extends TestCase
         }
 
         $this->assertSame($expected, BCTokens::comparisonTokens());
+    }
+
+    /**
+     * Test whether the method in BCTokens is still in sync with the latest version of PHPCS.
+     *
+     * This group is not run by default and has to be specifically requested to be run.
+     *
+     * @group compareWithPHPCS
+     *
+     * @return void
+     */
+    public function testPHPCSComparisonTokens()
+    {
+        $this->assertSame(Tokens::$comparisonTokens, BCTokens::comparisonTokens());
     }
 }

--- a/Tests/BackCompat/BCTokens/EmptyTokensTest.php
+++ b/Tests/BackCompat/BCTokens/EmptyTokensTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCTokens;
 
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\BackCompat\Helper;
 use PHPUnit\Framework\TestCase;
@@ -108,5 +109,53 @@ class EmptyTokensTest extends TestCase
         }
 
         $this->assertSame($expected, BCTokens::phpcsCommentTokens());
+    }
+
+    /**
+     * Test whether the method in BCTokens is still in sync with the latest version of PHPCS.
+     *
+     * This group is not run by default and has to be specifically requested to be run.
+     *
+     * @group compareWithPHPCS
+     *
+     * @covers \PHPCSUtils\BackCompat\BCTokens::__callStatic
+     *
+     * @return void
+     */
+    public function testPHPCSEmptyTokens()
+    {
+        $this->assertSame(Tokens::$emptyTokens, BCTokens::emptyTokens());
+    }
+
+    /**
+     * Test whether the method in BCTokens is still in sync with the latest version of PHPCS.
+     *
+     * This group is not run by default and has to be specifically requested to be run.
+     *
+     * @group compareWithPHPCS
+     *
+     * @covers \PHPCSUtils\BackCompat\BCTokens::__callStatic
+     *
+     * @return void
+     */
+    public function testPHPCSUpstreamCommentTokens()
+    {
+        $this->assertSame(Tokens::$commentTokens, BCTokens::commentTokens());
+    }
+
+    /**
+     * Test whether the method in BCTokens is still in sync with the latest version of PHPCS.
+     *
+     * This group is not run by default and has to be specifically requested to be run.
+     *
+     * @group compareWithPHPCS
+     *
+     * @covers \PHPCSUtils\BackCompat\BCTokens::phpcsCommentTokens
+     *
+     * @return void
+     */
+    public function testPHPCSPhpcsCommentTokens()
+    {
+        $this->assertSame(Tokens::$phpcsCommentTokens, BCTokens::phpcsCommentTokens());
     }
 }

--- a/Tests/BackCompat/BCTokens/FunctionNameTokensTest.php
+++ b/Tests/BackCompat/BCTokens/FunctionNameTokensTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCTokens;
 
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPUnit\Framework\TestCase;
 
@@ -48,5 +49,19 @@ class FunctionNameTokensTest extends TestCase
         ];
 
         $this->assertSame($expected, BCTokens::functionNameTokens());
+    }
+
+    /**
+     * Test whether the method in BCTokens is still in sync with the latest version of PHPCS.
+     *
+     * This group is not run by default and has to be specifically requested to be run.
+     *
+     * @group compareWithPHPCS
+     *
+     * @return void
+     */
+    public function testPHPCSFunctionNameTokens()
+    {
+        $this->assertSame(Tokens::$functionNameTokens, BCTokens::functionNameTokens());
     }
 }

--- a/Tests/BackCompat/BCTokens/MagicConstantsTest.php
+++ b/Tests/BackCompat/BCTokens/MagicConstantsTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCTokens;
 
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPUnit\Framework\TestCase;
 
@@ -44,5 +45,19 @@ class MagicConstantsTest extends TestCase
         ];
 
         $this->assertSame($expected, BCTokens::magicConstants());
+    }
+
+    /**
+     * Test whether the method in BCTokens is still in sync with the latest version of PHPCS.
+     *
+     * This group is not run by default and has to be specifically requested to be run.
+     *
+     * @group compareWithPHPCS
+     *
+     * @return void
+     */
+    public function testPHPCSMagicConstants()
+    {
+        $this->assertSame(Tokens::$magicConstants, BCTokens::magicConstants());
     }
 }

--- a/Tests/BackCompat/BCTokens/OoScopeTokensTest.php
+++ b/Tests/BackCompat/BCTokens/OoScopeTokensTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCTokens;
 
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPUnit\Framework\TestCase;
 
@@ -40,5 +41,19 @@ class OoScopeTokensTest extends TestCase
         ];
 
         $this->assertSame($expected, BCTokens::ooScopeTokens());
+    }
+
+    /**
+     * Test whether the method in BCTokens is still in sync with the latest version of PHPCS.
+     *
+     * This group is not run by default and has to be specifically requested to be run.
+     *
+     * @group compareWithPHPCS
+     *
+     * @return void
+     */
+    public function testPHPCSOoScopeTokens()
+    {
+        $this->assertSame(Tokens::$ooScopeTokens, BCTokens::ooScopeTokens());
     }
 }

--- a/Tests/BackCompat/BCTokens/OperatorsTest.php
+++ b/Tests/BackCompat/BCTokens/OperatorsTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCTokens;
 
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\BackCompat\Helper;
 use PHPUnit\Framework\TestCase;
@@ -61,5 +62,19 @@ class OperatorsTest extends TestCase
         \asort($result);
 
         $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Test whether the method in BCTokens is still in sync with the latest version of PHPCS.
+     *
+     * This group is not run by default and has to be specifically requested to be run.
+     *
+     * @group compareWithPHPCS
+     *
+     * @return void
+     */
+    public function testPHPCSOperators()
+    {
+        $this->assertSame(Tokens::$operators, BCTokens::operators());
     }
 }

--- a/Tests/BackCompat/BCTokens/ParenthesisOpenersTest.php
+++ b/Tests/BackCompat/BCTokens/ParenthesisOpenersTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCTokens;
 
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPUnit\Framework\TestCase;
 
@@ -54,5 +55,19 @@ class ParenthesisOpenersTest extends TestCase
         \asort($result);
 
         $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Test whether the method in BCTokens is still in sync with the latest version of PHPCS.
+     *
+     * This group is not run by default and has to be specifically requested to be run.
+     *
+     * @group compareWithPHPCS
+     *
+     * @return void
+     */
+    public function testPHPCSParenthesisOpeners()
+    {
+        $this->assertSame(Tokens::$parenthesisOpeners, BCTokens::parenthesisOpeners());
     }
 }

--- a/Tests/BackCompat/BCTokens/TextStringTokensTest.php
+++ b/Tests/BackCompat/BCTokens/TextStringTokensTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCTokens;
 
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPUnit\Framework\TestCase;
 
@@ -41,5 +42,19 @@ class TextStringTokensTest extends TestCase
         ];
 
         $this->assertSame($expected, BCTokens::textStringTokens());
+    }
+
+    /**
+     * Test whether the method in BCTokens is still in sync with the latest version of PHPCS.
+     *
+     * This group is not run by default and has to be specifically requested to be run.
+     *
+     * @group compareWithPHPCS
+     *
+     * @return void
+     */
+    public function testPHPCSTextStringTokens()
+    {
+        $this->assertSame(Tokens::$textStringTokens, BCTokens::textStringTokens());
     }
 }

--- a/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
+++ b/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCTokens;
 
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPUnit\Framework\TestCase;
 
@@ -241,5 +242,23 @@ class UnchangedTokenArraysTest extends TestCase
     public function testUndeclaredTokenArray()
     {
         $this->assertSame([], BCTokens::notATokenArray());
+    }
+
+    /**
+     * Test whether the method in BCTokens is still in sync with the latest version of PHPCS.
+     *
+     * This group is not run by default and has to be specifically requested to be run.
+     *
+     * @group compareWithPHPCS
+     *
+     * @dataProvider dataUnchangedTokenArrays
+     *
+     * @param string $name The token array name.
+     *
+     * @return void
+     */
+    public function testPHPCSUnchangedTokenArrays($name)
+    {
+        $this->assertSame(Tokens::${$name}, BCTokens::$name());
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,12 @@
         </testsuite>
     </testsuites>
 
+    <groups>
+        <exclude>
+            <group>compareWithPHPCS</group>
+        </exclude>
+    </groups>
+
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
             <!-- Not recording coverage for PHPCS23Utils as there is nothing directly testable. -->


### PR DESCRIPTION
This adds tests for all backfilled token arrays in the `BCTokens` class to verify whether they are still in line with the upstream version.

These tests should be considered _risky_ as they can fail without warning if something upstream would change.
These tests would also fail when run against older PHPCS versions for those token array which have had changes over time.

For that reason, they have been placed in a separate test group `compareWithPHPCS`, which is excluded from being run by default.

In the Travis script two additional runs have been added to specifically and only run these tests against PHPCS `master` and `4.x`. Both of these builds have been added to the `allow_failures` array.

Loosely related to #5