### PR TITLE
PHPCS 4.x | Initial updates to handle T_USE becoming a parentheses owner

### DIFF
--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -124,7 +124,10 @@ class Operators
         if ($lastOpener !== false) {
             $lastOwner = Parentheses::getOwner($phpcsFile, $lastOpener);
 
-            if (isset(Collections::functionDeclarationTokensBC()[$tokens[$lastOwner]['code']]) === true) {
+            if (isset(Collections::functionDeclarationTokensBC()[$tokens[$lastOwner]['code']]) === true
+                // As of PHPCS 4.x, `T_USE` is a parenthesis owner.
+                || $tokens[$lastOwner]['code'] === \T_USE
+            ) {
                 $params = FunctionDeclarations::getParameters($phpcsFile, $lastOwner);
                 foreach ($params as $param) {
                     if ($param['reference_token'] === $stackPtr) {

--- a/Tests/BackCompat/BCTokens/ParenthesisOpenersTest.php
+++ b/Tests/BackCompat/BCTokens/ParenthesisOpenersTest.php
@@ -12,6 +12,7 @@ namespace PHPCSUtils\Tests\BackCompat\BCTokens;
 
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\BackCompat\Helper;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -33,6 +34,7 @@ class ParenthesisOpenersTest extends TestCase
      */
     public function testParenthesisOpeners()
     {
+        $version  = Helper::getVersion();
         $expected = [
             \T_ARRAY      => \T_ARRAY,
             \T_LIST       => \T_LIST,
@@ -48,6 +50,10 @@ class ParenthesisOpenersTest extends TestCase
             \T_CATCH      => \T_CATCH,
             \T_DECLARE    => \T_DECLARE,
         ];
+
+        if (\version_compare($version, '4.0.0', '>=') === true) {
+            $expected[\T_USE] = \T_USE;
+        }
 
         \asort($expected);
 


### PR DESCRIPTION
### PHPCS 4.x | Operators::isReference(): handle closure use as parenthesis owner

`T_USE` tokens used for closure use statements are parentheses owners as of PHPCS 4.x.

This makes a minor code adjustment to handle this in the `Operators::isReference()` method.

The previous code would already handle it correctly, but this adds some forward-compatibility code for when support for PHPCS < 4 would be dropped.

A similar change will be pulled to PHPCS itself once squizlabs/PHP_CodeSniffer#3104, which fixes significant bugs in the current implementation of parenthesis support for `T_USE` tokens, has been merged

### PHPCS 4.x | BCTokens::parenthesisOpeners(): T_USE is now a parenthesis opener

`T_USE` tokens used for closure use statements are parentheses openers as of PHPCS 4.x.

This includes the token having been added to the `Tokens::$parenthesisOpeners` array.

This syncs that change into PHPCSUtils.

The method itself does not need to change as it will automatically pick up on this.
The unit test, however, does need updating.


Refs:
* squizlabs/PHP_CodeSniffer#2593
* squizlabs/PHP_CodeSniffer@08824f3
* squizlabs/PHP_CodeSniffer#3104
