### PR TITLE
UseStatements: new `mergeImportUseStatements()` method

### DIFF
--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -376,6 +376,7 @@ class UseStatements
      *
      * @see \PHPCSUtils\AbstractSniffs\AbstractFileContextSniff
      * @see \PHPCSUtils\Utils\UseStatements::splitImportUseStatement()
+     * @see \PHPCSUtils\Utils\UseStatements::mergeImportUseStatements()
      *
      * @since 1.0.0-alpha3
      *
@@ -395,25 +396,57 @@ class UseStatements
     public static function splitAndMergeImportUseStatement(File $phpcsFile, $stackPtr, $previousUseStatements)
     {
         try {
-            $useStatements = self::splitImportUseStatement($phpcsFile, $stackPtr);
-
-            if (isset($previousUseStatements['name']) === false) {
-                $previousUseStatements['name'] = $useStatements['name'];
-            } else {
-                $previousUseStatements['name'] += $useStatements['name'];
-            }
-            if (isset($previousUseStatements['function']) === false) {
-                $previousUseStatements['function'] = $useStatements['function'];
-            } else {
-                $previousUseStatements['function'] += $useStatements['function'];
-            }
-            if (isset($previousUseStatements['const']) === false) {
-                $previousUseStatements['const'] = $useStatements['const'];
-            } else {
-                $previousUseStatements['const'] += $useStatements['const'];
-            }
+            $useStatements         = self::splitImportUseStatement($phpcsFile, $stackPtr);
+            $previousUseStatements = self::mergeImportUseStatements($previousUseStatements, $useStatements);
         } catch (RuntimeException $e) {
             // Not an import use statement.
+        }
+
+        return $previousUseStatements;
+    }
+
+    /**
+     * Merge two import use statement arrays.
+     *
+     * Beware: this method should only be used to combine the import use statements found in *one* file.
+     * Do NOT combine the statements of multiple files as the result will be inaccurate and unreliable.
+     *
+     * @see \PHPCSUtils\Utils\UseStatements::splitImportUseStatement()
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @param array $previousUseStatements The import `use` statements collected so far.
+     *                                     This should be either the output of a
+     *                                     previous call to this method or the output of
+     *                                     an earlier call to the
+     *                                     {@see UseStatements::splitImportUseStatement()}
+     *                                     method.
+     * @param array $currentUseStatement   The parsed import `use` statements to merge with
+     *                                     the previously collected use statements.
+     *                                     This should be the output of a call to the
+     *                                     {@see UseStatements::splitImportUseStatement()}
+     *                                     method.
+     *
+     * @return array A multi-level array containing information about the current `use` statement combined with
+     *               the previously collected `use` statement information.
+     *               See {@see UseStatements::splitImportUseStatement()} for more details about the array format.
+     */
+    public static function mergeImportUseStatements($previousUseStatements, $currentUseStatement)
+    {
+        if (isset($previousUseStatements['name']) === false) {
+            $previousUseStatements['name'] = $currentUseStatement['name'];
+        } else {
+            $previousUseStatements['name'] += $currentUseStatement['name'];
+        }
+        if (isset($previousUseStatements['function']) === false) {
+            $previousUseStatements['function'] = $currentUseStatement['function'];
+        } else {
+            $previousUseStatements['function'] += $currentUseStatement['function'];
+        }
+        if (isset($previousUseStatements['const']) === false) {
+            $previousUseStatements['const'] = $currentUseStatement['const'];
+        } else {
+            $previousUseStatements['const'] += $currentUseStatement['const'];
         }
 
         return $previousUseStatements;

--- a/Tests/Utils/UseStatements/SplitAndMergeImportUseStatementTest.php
+++ b/Tests/Utils/UseStatements/SplitAndMergeImportUseStatementTest.php
@@ -14,9 +14,11 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 use PHPCSUtils\Utils\UseStatements;
 
 /**
- * Tests for the \PHPCSUtils\Utils\UseStatements::splitAndMergeImportUseStatement() method.
+ * Tests for the \PHPCSUtils\Utils\UseStatements::splitAndMergeImportUseStatement()
+ * and the \PHPCSUtils\Utils\UseStatements::mergeImportUseStatements() method.
  *
  * @covers \PHPCSUtils\Utils\UseStatements::splitAndMergeImportUseStatement
+ * @covers \PHPCSUtils\Utils\UseStatements::mergeImportUseStatements
  *
  * @group usestatements
  *


### PR DESCRIPTION
This splits the "merge" functionality off from the `UseStatements::splitAndMergeImportUseStatement()` method.

The unit tests for the `UseStatements::splitAndMergeImportUseStatement()` method already cover this functionality, so this commit does not contain any additional unit tests.