### PR TITLE
Operators::isUnaryPlusMinus(): bug fix - unary after arrow in arrow function

### DIFF
--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -408,6 +408,7 @@ class Operators
             || isset(BCTokens::assignmentTokens()[$tokens[$prev]['code']]) === true
             || isset(Tokens::$castTokens[$tokens[$prev]['code']]) === true
             || isset(self::$extraUnaryIndicators[$tokens[$prev]['code']]) === true
+            || $tokens[$prev]['type'] === 'T_FN_ARROW'
         ) {
             return true;
         }

--- a/Tests/Utils/Operators/IsUnaryPlusMinusTest.inc
+++ b/Tests/Utils/Operators/IsUnaryPlusMinusTest.inc
@@ -138,6 +138,9 @@ switch ($a) {
         break +1;
 }
 
+/* testUnaryMinusArrowFunction */
+$fn = static fn(DateTime $a, DateTime $b): int => -($a->getTimestamp() <=> $b->getTimestamp());
+
 // Testing `$a = -+-+10`;
 $a =
     /* testSequenceNonUnary1 */

--- a/Tests/Utils/Operators/IsUnaryPlusMinusTest.php
+++ b/Tests/Utils/Operators/IsUnaryPlusMinusTest.php
@@ -268,8 +268,12 @@ class IsUnaryPlusMinusTest extends UtilityMethodTestCase
                 '/* testUnaryMinusCase */',
                 true,
             ],
-            'unary-minus-break' => [
+            'unary-plus-break' => [
                 '/* testUnaryPlusBreak */',
+                true,
+            ],
+            'unary-minus-arrow-function' => [
+                '/* testUnaryMinusArrowFunction */',
                 true,
             ],
             'operator-sequence-non-unary-1' => [


### PR DESCRIPTION
Just like after the `return` keyword, a plus/minus after the `=>` arrow in an arrow function is unary.

Includes unit test.

Refs:
* squizlabs/PHP_CodeSniffer#3043