### PR TITLE
Operators::isTypeUnion(): BC-fix - namespace operator in return type

### DIFF
--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -277,13 +277,29 @@ class Operators
                     return true;
                 }
 
+                $closeParens = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($beforeType - 1), null, true);
+
+                /*
+                 * This may be a return type using the namespace keyword as an operator in
+                 * combination with PHPCS < 3.5.7 in which the scope indexes won't be set.
+                 * {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/3066}
+                 */
+                if ($tokens[$afterType]['code'] === \T_OPEN_CURLY_BRACKET) {
+                    if ($closeParens !== false
+                        && $tokens[$closeParens]['code'] === \T_CLOSE_PARENTHESIS
+                        && isset($tokens[$closeParens]['parenthesis_owner']) === true
+                        && isset($funcDeclTokens[$tokens[$tokens[$closeParens]['parenthesis_owner']]['code']]) === true
+                    ) {
+                        return true;
+                    }
+                }
+
                 /*
                  * This may be an arrow function in combination with PHPCS < 3.5.3.
-                 * Even when on PHP 7.4, the open curly brace won't have the scope condition set yet,
-                 * so the previous condition will fall through to this one.
+                 * Even when on PHP 7.4, the double arrow won't have the scope condition set yet,
+                 * so the previous conditions will fall through to this one.
                  */
                 if ($tokens[$afterType]['code'] === \T_DOUBLE_ARROW) {
-                    $closeParens = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($beforeType - 1), null, true);
                     if ($closeParens !== false
                         && $tokens[$closeParens]['code'] === \T_CLOSE_PARENTHESIS
                         && isset($tokens[$closeParens]['parenthesis_opener'])

--- a/Tests/Utils/Operators/IsTypeUnionTest.inc
+++ b/Tests/Utils/Operators/IsTypeUnionTest.inc
@@ -46,6 +46,9 @@ class TypeUnion
 
     /* testTypeUnionAbstractMethodReturnType1 */
     abstract public function abstractMethod(): object|array /* testTypeUnionAbstractMethodReturnType2 */ |false;
+
+    /* testTypeUnionReturnTypeNamespaceRelative */
+    public function identifierNamesReturnRelative() : namespace\Sub\NameA|namespace\Sub\NameB {}
 }
 
 /* testTypeUnionClosureParamIllegalNullable */

--- a/Tests/Utils/Operators/IsTypeUnionTest.php
+++ b/Tests/Utils/Operators/IsTypeUnionTest.php
@@ -84,6 +84,7 @@ class IsTypeUnionTest extends UtilityMethodTestCase
             'constructor-property-promotion'  => ['/* testTypeUnionConstructorPropertyPromotion */'],
             'return-abstract-method-1'        => ['/* testTypeUnionAbstractMethodReturnType1 */'],
             'return-abstract-method-2'        => ['/* testTypeUnionAbstractMethodReturnType2 */'],
+            'return-namespace-operator'       => ['/* testTypeUnionReturnTypeNamespaceRelative */'],
             'parameter-closure-with-nullable' => ['/* testTypeUnionClosureParamIllegalNullable */'],
             'return-closure'                  => ['/* testTypeUnionClosureReturn */'],
             'parameter-arrow'                 => ['/* testTypeUnionArrowParam */'],


### PR DESCRIPTION
The `Operators::isTypeUnion()` method is subseptible to the Tokenizer bug which will be fixed in [upstream PR #3066](https://github.com/squizlabs/PHP_CodeSniffer/pull/3066) / PHPCS 3.5.7, where the scope opener/closer/condition would not be set for a function declared with a namespace relative return type using the `namespace` keyword as an operator.

A work-around has been added to the method now.

Includes unit test.

Includes minor fix to existing inline documentation.