### PR TITLE
UtilityMethodTestCase: new `usesPhp8NameTokens()` method

### DIFF
--- a/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+++ b/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
@@ -312,6 +312,27 @@ abstract class UtilityMethodTestCase extends TestCase
     }
 
     /**
+     * Check whether or not the PHP 8.0 identifier name tokens will be in use.
+     *
+     * The expected token positions/token counts for certain tokens will differ depending
+     * on whether the PHP 8.0 identifier name tokenization is used or the PHP < 8.0
+     * identifier name tokenization.
+     *
+     * Tests can use this method to determine which flavour of tokenization to expect and
+     * to set test expectations accordingly.
+     *
+     * @codeCoverageIgnore Nothing to test.
+     *
+     * @since 1.0.0
+     *
+     * @return bool
+     */
+    public static function usesPhp8NameTokens()
+    {
+        return \version_compare(\PHP_VERSION_ID, '80000', '>=') === true;
+    }
+
+    /**
      * Get the token pointer for a target token based on a specific comment.
      *
      * Note: the test delimiter comment MUST start with `/* test` to allow this function to


### PR DESCRIPTION
In PHP 8.0 identifier name tokenization will change as outline in the [accepted RFC "Treat namespaced names as single token"](https://wiki.php.net/rfc/namespaced_names_as_token).

When the PHP 8.0 identifier name tokenization is used, the target token to find for some tests will need to be a different token - for instance: `T_STRING` vs `T_FULLY_QUALIFIED_NAME` -.
Along the same lines, the expected token positions in the return value of various functions will also be different when the PHP < 8.0 tokenization is used as certain tokens will be "squashed" into one token.

This commit adds a test helper method to allow tests to "know" whether or not to expect the PHP 8.0 identifier name tokenization, so the test setup/expectations can be adjusted based on the expected tokenization.

The method is based on the _current reality_.
At this time the PHP 8 tokenization should be expected on all PHPCS versions when run on PHP 8.

PHP | PHPCS 2.x | PHPCS 3.x | PHPCS 4.x
--- | --- | --- | ---
PHP 5, 7 | :x: | :x: | :x:
PHP >= 8 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:

However, this is expected to change in the near future and the method will be adjusted when it is.

* Based on the proposal outlined in squizlabs/PHP_CodeSniffer#3041, the PHP 8.0 identifier name tokenization will be "undone" for PHPCS 3.x.
    A PR to implement this is currently open: squizlabs/PHP_CodeSniffer#3063 and is expected to be merged in PHPCS 3.5.7.
* A PR to backfill the PHP 8.0 tokenization for all supported PHP versions for the PHPCS 4.x branch is lined up, but not yet pulled as it would conflict with some other changes for which PRs are currently open.

Once the above mentioned PRs have been merged, the matrix of when to expect which tokenization will change to this:

PHP | PHPCS 2.x | PHPCS 3.x < 3.5.7 | PHPCS 3.x >= 3.5.7 | PHPCS 4.x
--- | --- | --- | --- | ---
PHP 5, 7 | :x: | :x: | :x: | :heavy_check_mark:
PHP >= 8 | :heavy_check_mark: | :heavy_check_mark: | :x: | :heavy_check_mark:


Refs:
* https://wiki.php.net/rfc/namespaced_names_as_token
* [Proposal for handling this PHP 8 change in PHPCS](https://github.com/squizlabs/PHP_CodeSniffer/issues/3041)
* [Open PR for the PHPCS 3.x branch to "undo" the PHP 8 tokenization](https://github.com/squizlabs/PHP_CodeSniffer/pull/3063)