### PR TITLE
PHP 8.0 | Tests: set up to work with PHP 8.0 identifier name tokens

### DIFF
--- a/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
@@ -163,7 +163,9 @@ class FindEndOfStatementTest extends UtilityMethodTestCase
         $start = $this->getTargetToken('/* testUseGroup */', T_USE);
         $found = BCFile::findEndOfStatement(self::$phpcsFile, $start);
 
-        $this->assertSame(($start + 23), $found);
+        $expected = parent::usesPhp8NameTokens() ? ($start + 21) : ($start + 23);
+
+        $this->assertSame($expected, $found);
     }
 
     /**

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -82,6 +82,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
      */
     public function dataGetMemberProperties()
     {
+        $php8Names = parent::usesPhp8NameTokens();
+
         return [
             [
                 '/* testVar */',
@@ -498,7 +500,7 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '\MyNamespace\MyClass',
-                    'type_token'      => -5, // Offset from the T_VARIABLE token.
+                    'type_token'      => ($php8Names === true) ? -2 : -5, // Offset from the T_VARIABLE token.
                     'type_end_token'  => -2, // Offset from the T_VARIABLE token.
                     'nullable_type'   => false,
                 ],
@@ -522,7 +524,7 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '?Folder\ClassName',
-                    'type_token'      => -4, // Offset from the T_VARIABLE token.
+                    'type_token'      => ($php8Names === true) ? -2 : -4, // Offset from the T_VARIABLE token.
                     'type_end_token'  => -2, // Offset from the T_VARIABLE token.
                     'nullable_type'   => true,
                 ],
@@ -534,7 +536,7 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '\MyNamespace\MyClass\Foo',
-                    'type_token'      => -18, // Offset from the T_VARIABLE token.
+                    'type_token'      => ($php8Names === true) ? -15 : -18, // Offset from the T_VARIABLE token.
                     'type_end_token'  => -2, // Offset from the T_VARIABLE token.
                     'nullable_type'   => false,
                 ],

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -277,6 +277,8 @@ class GetMethodParametersTest extends UtilityMethodTestCase
      */
     public function testNullableTypeHint()
     {
+        $php8Names = parent::usesPhp8NameTokens();
+
         $expected    = [];
         $expected[0] = [
             'token'               => 7, // Offset from the T_FUNCTION token.
@@ -294,7 +296,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
         ];
 
         $expected[1] = [
-            'token'               => 14, // Offset from the T_FUNCTION token.
+            'token'               => ($php8Names === true) ? 13 : 14, // Offset from the T_FUNCTION token.
             'name'                => '$var2',
             'content'             => '?\bar $var2',
             'pass_by_reference'   => false,
@@ -303,7 +305,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'variadic_token'      => false,
             'type_hint'           => '?\bar',
             'type_hint_token'     => 11, // Offset from the T_FUNCTION token.
-            'type_hint_end_token' => 12, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => ($php8Names === true) ? 11 : 12, // Offset from the T_FUNCTION token.
             'nullable_type'       => true,
             'comma_token'         => false,
         ];
@@ -743,9 +745,11 @@ class GetMethodParametersTest extends UtilityMethodTestCase
      */
     public function testNameSpacedTypeDeclaration()
     {
+        $php8Names = parent::usesPhp8NameTokens();
+
         $expected    = [];
         $expected[0] = [
-            'token'               => 12, // Offset from the T_FUNCTION token.
+            'token'               => ($php8Names === true) ? 7 : 12, // Offset from the T_FUNCTION token.
             'name'                => '$a',
             'content'             => '\Package\Sub\ClassName $a',
             'pass_by_reference'   => false,
@@ -754,12 +758,12 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'variadic_token'      => false,
             'type_hint'           => '\Package\Sub\ClassName',
             'type_hint_token'     => 5, // Offset from the T_FUNCTION token.
-            'type_hint_end_token' => 10, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => ($php8Names === true) ? 5 : 10, // Offset from the T_FUNCTION token.
             'nullable_type'       => false,
-            'comma_token'         => 13, // Offset from the T_FUNCTION token.
+            'comma_token'         => ($php8Names === true) ? 8 : 13, // Offset from the T_FUNCTION token.
         ];
         $expected[1] = [
-            'token'               => 20, // Offset from the T_FUNCTION token.
+            'token'               => ($php8Names === true) ? 13 : 20, // Offset from the T_FUNCTION token.
             'name'                => '$b',
             'content'             => '?Sub\AnotherClass $b',
             'pass_by_reference'   => false,
@@ -767,8 +771,8 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'variable_length'     => false,
             'variadic_token'      => false,
             'type_hint'           => '?Sub\AnotherClass',
-            'type_hint_token'     => 16, // Offset from the T_FUNCTION token.
-            'type_hint_end_token' => 18, // Offset from the T_FUNCTION token.
+            'type_hint_token'     => ($php8Names === true) ? 11 : 16, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => ($php8Names === true) ? 11 : 18, // Offset from the T_FUNCTION token.
             'nullable_type'       => true,
             'comma_token'         => false,
         ];
@@ -1135,9 +1139,11 @@ class GetMethodParametersTest extends UtilityMethodTestCase
      */
     public function testMessyDeclaration()
     {
+        $php8Names = parent::usesPhp8NameTokens();
+
         $expected    = [];
         $expected[0] = [
-            'token'               => 25, // Offset from the T_FUNCTION token.
+            'token'               => ($php8Names === true) ? 24 : 25, // Offset from the T_FUNCTION token.
             'name'                => '$a',
             'content'             => '// comment
     ?\MyNS /* comment */
@@ -1149,17 +1155,17 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'variadic_token'      => false,
             'type_hint'           => '?\MyNS\SubCat\MyClass',
             'type_hint_token'     => 9,
-            'type_hint_end_token' => 23,
+            'type_hint_end_token' => ($php8Names === true) ? 22 : 23,
             'nullable_type'       => true,
-            'comma_token'         => 26, // Offset from the T_FUNCTION token.
+            'comma_token'         => ($php8Names === true) ? 25 : 26, // Offset from the T_FUNCTION token.
         ];
         $expected[1] = [
-            'token'               => 29, // Offset from the T_FUNCTION token.
+            'token'               => ($php8Names === true) ? 28 : 29, // Offset from the T_FUNCTION token.
             'name'                => '$b',
             'content'             => "\$b /* test */ = /* test */ 'default' /* test*/",
             'default'             => "'default' /* test*/",
-            'default_token'       => 37, // Offset from the T_FUNCTION token.
-            'default_equal_token' => 33, // Offset from the T_FUNCTION token.
+            'default_token'       => ($php8Names === true) ? 36 : 37, // Offset from the T_FUNCTION token.
+            'default_equal_token' => ($php8Names === true) ? 32 : 33, // Offset from the T_FUNCTION token.
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1168,22 +1174,22 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'type_hint_token'     => false,
             'type_hint_end_token' => false,
             'nullable_type'       => false,
-            'comma_token'         => 40, // Offset from the T_FUNCTION token.
+            'comma_token'         => ($php8Names === true) ? 39 : 40, // Offset from the T_FUNCTION token.
         ];
         $expected[2] = [
-            'token'               => 62, // Offset from the T_FUNCTION token.
+            'token'               => ($php8Names === true) ? 61 : 62, // Offset from the T_FUNCTION token.
             'name'                => '$c',
             'content'             => '// phpcs:ignore Stnd.Cat.Sniff -- For reasons.
     ? /*comment*/
         bool // phpcs:disable Stnd.Cat.Sniff -- For reasons.
         & /*test*/ ... /* phpcs:ignore */ $c',
             'pass_by_reference'   => true,
-            'reference_token'     => 54, // Offset from the T_FUNCTION token.
+            'reference_token'     => ($php8Names === true) ? 53 : 54, // Offset from the T_FUNCTION token.
             'variable_length'     => true,
-            'variadic_token'      => 58, // Offset from the T_FUNCTION token.
+            'variadic_token'      => ($php8Names === true) ? 57 : 58, // Offset from the T_FUNCTION token.
             'type_hint'           => '?bool',
-            'type_hint_token'     => 50, // Offset from the T_FUNCTION token.
-            'type_hint_end_token' => 50, // Offset from the T_FUNCTION token.
+            'type_hint_token'     => ($php8Names === true) ? 49 : 50, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => ($php8Names === true) ? 49 : 50, // Offset from the T_FUNCTION token.
             'nullable_type'       => true,
             'comma_token'         => false,
         ];

--- a/Tests/Utils/Conditions/GetConditionTest.php
+++ b/Tests/Utils/Conditions/GetConditionTest.php
@@ -103,7 +103,12 @@ class GetConditionTest extends BCFile_GetConditionTest
      */
     public function testNonConditionalTokenGetFirstLast()
     {
-        $stackPtr = $this->getTargetToken('/* testStartPoint */', \T_STRING);
+        $targetType = \T_STRING;
+        if (parent::usesPhp8NameTokens() === true) {
+            $targetType = \T_NAME_QUALIFIED;
+        }
+
+        $stackPtr = $this->getTargetToken('/* testStartPoint */', $targetType);
 
         $result = Conditions::getFirstCondition(self::$phpcsFile, $stackPtr);
         $this->assertFalse($result, 'Failed asserting that getFirstCondition() on non conditional token returns false');

--- a/Tests/Utils/ControlStructures/GetCaughtExceptionsTest.php
+++ b/Tests/Utils/ControlStructures/GetCaughtExceptionsTest.php
@@ -95,6 +95,8 @@ class GetCaughtExceptionsTest extends UtilityMethodTestCase
      */
     public function dataGetCaughtExceptions()
     {
+        $php8Names = parent::usesPhp8NameTokens();
+
         return [
             'single-name-only' => [
                 'target'        => '/* testSingleCatchNameOnly */',
@@ -112,7 +114,7 @@ class GetCaughtExceptionsTest extends UtilityMethodTestCase
                     [
                         'type'           => '\RuntimeException',
                         'type_token'     => 3,
-                        'type_end_token' => 4,
+                        'type_end_token' => ($php8Names === true) ? 3 : 4,
                     ],
                 ],
             ],
@@ -122,7 +124,7 @@ class GetCaughtExceptionsTest extends UtilityMethodTestCase
                     [
                         'type'           => 'MyNS\RuntimeException',
                         'type_token'     => 4,
-                        'type_end_token' => 6,
+                        'type_end_token' => ($php8Names === true) ? 4 : 6,
                     ],
                 ],
             ],
@@ -132,7 +134,7 @@ class GetCaughtExceptionsTest extends UtilityMethodTestCase
                     [
                         'type'           => '\MyNS\RuntimeException',
                         'type_token'     => 4,
-                        'type_end_token' => 7,
+                        'type_end_token' => ($php8Names === true) ? 4 : 7,
                     ],
                 ],
             ],
@@ -142,7 +144,7 @@ class GetCaughtExceptionsTest extends UtilityMethodTestCase
                     [
                         'type'           => 'My\NS\Sub\RuntimeException',
                         'type_token'     => 4,
-                        'type_end_token' => 15,
+                        'type_end_token' => ($php8Names === true) ? 13 : 15,
                     ],
                 ],
             ],
@@ -152,7 +154,7 @@ class GetCaughtExceptionsTest extends UtilityMethodTestCase
                     [
                         'type'           => 'namespace\RuntimeException',
                         'type_token'     => 4,
-                        'type_end_token' => 6,
+                        'type_end_token' => ($php8Names === true) ? 4 : 6,
                     ],
                 ],
             ],
@@ -183,17 +185,17 @@ class GetCaughtExceptionsTest extends UtilityMethodTestCase
                     [
                         'type'           => '\NS\RuntimeException',
                         'type_token'     => 3,
-                        'type_end_token' => 6,
+                        'type_end_token' => ($php8Names === true) ? 3 : 6,
                     ],
                     [
                         'type'           => 'My\ParseErrorException',
-                        'type_token'     => 10,
-                        'type_end_token' => 12,
+                        'type_token'     => ($php8Names === true) ? 7 : 10,
+                        'type_end_token' => ($php8Names === true) ? 7 : 12,
                     ],
                     [
                         'type'           => 'namespace\AnotherException',
-                        'type_token'     => 16,
-                        'type_end_token' => 20,
+                        'type_token'     => ($php8Names === true) ? 11 : 16,
+                        'type_end_token' => ($php8Names === true) ? 15 : 20,
                     ],
                 ],
             ],

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
@@ -119,9 +119,11 @@ class GetParametersDiffTest extends UtilityMethodTestCase
      */
     public function testPHP8UnionTypesTwoClasses()
     {
+        $php8Names = parent::usesPhp8NameTokens();
+
         $expected    = [];
         $expected[0] = [
-            'token'               => 11, // Offset from the T_FUNCTION token.
+            'token'               => ($php8Names === true) ? 8 : 11, // Offset from the T_FUNCTION token.
             'name'                => '$var',
             'content'             => 'MyClassA|\Package\MyClassB $var',
             'pass_by_reference'   => false,
@@ -130,7 +132,7 @@ class GetParametersDiffTest extends UtilityMethodTestCase
             'variadic_token'      => false,
             'type_hint'           => 'MyClassA|\Package\MyClassB',
             'type_hint_token'     => 4, // Offset from the T_FUNCTION token.
-            'type_hint_end_token' => 9, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => ($php8Names === true) ? 6 : 9, // Offset from the T_FUNCTION token.
             'nullable_type'       => false,
             'comma_token'         => false,
         ];
@@ -636,9 +638,11 @@ class GetParametersDiffTest extends UtilityMethodTestCase
      */
     public function testNamespaceOperatorTypeHint()
     {
+        $php8Names = parent::usesPhp8NameTokens();
+
         $expected    = [];
         $expected[0] = [
-            'token'               => 9, // Offset from the T_FUNCTION token.
+            'token'               => ($php8Names === true) ? 7 : 9, // Offset from the T_FUNCTION token.
             'name'                => '$var1',
             'content'             => '?namespace\Name $var1',
             'pass_by_reference'   => false,
@@ -647,7 +651,7 @@ class GetParametersDiffTest extends UtilityMethodTestCase
             'variadic_token'      => false,
             'type_hint'           => '?namespace\Name',
             'type_hint_token'     => 5, // Offset from the T_FUNCTION token.
-            'type_hint_end_token' => 7, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => ($php8Names === true) ? 5 : 7, // Offset from the T_FUNCTION token.
             'nullable_type'       => true,
             'comma_token'         => false,
         ];

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
@@ -94,12 +94,14 @@ class GetPropertiesDiffTest extends UtilityMethodTestCase
      */
     public function testReturnTypeEndTokenIndex()
     {
+        $php8Names = parent::usesPhp8NameTokens();
+
         $expected = [
             'scope'                 => 'public',
             'scope_specified'       => false,
             'return_type'           => '?\MyNamespace\MyClass\Foo',
             'return_type_token'     => 8, // Offset from the T_FUNCTION token.
-            'return_type_end_token' => 20, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => ($php8Names === true) ? 17 : 20, // Offset from the T_FUNCTION token.
             'nullable_return_type'  => true,
             'is_abstract'           => false,
             'is_final'              => false,
@@ -140,12 +142,14 @@ class GetPropertiesDiffTest extends UtilityMethodTestCase
      */
     public function testPHP8UnionTypesTwoClasses()
     {
+        $php8Names = parent::usesPhp8NameTokens();
+
         $expected = [
             'scope'                 => 'public',
             'scope_specified'       => false,
             'return_type'           => 'MyClassA|\Package\MyClassB',
             'return_type_token'     => 6, // Offset from the T_FUNCTION token.
-            'return_type_end_token' => 11, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => ($php8Names === true) ? 8 : 11, // Offset from the T_FUNCTION token.
             'nullable_return_type'  => false,
             'is_abstract'           => false,
             'is_final'              => false,
@@ -374,12 +378,14 @@ class GetPropertiesDiffTest extends UtilityMethodTestCase
      */
     public function testNamespaceOperatorTypeHint()
     {
+        $php8Names = parent::usesPhp8NameTokens();
+
         $expected = [
             'scope'                => 'public',
             'scope_specified'      => false,
             'return_type'          => '?namespace\Name',
             'return_type_token'     => 9, // Offset from the T_FUNCTION token.
-            'return_type_end_token' => 11, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => ($php8Names === true) ? 9 : 11, // Offset from the T_FUNCTION token.
             'nullable_return_type' => true,
             'is_abstract'          => false,
             'is_final'             => false,

--- a/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
@@ -85,11 +85,18 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
      * @param array  $expected      The expected return value for the respective functions.
      * @param array  $targetContent The content for the target token to look for in case there could
      *                              be confusion.
+     * @param bool   $skipOnPHP8    Optional. Whether the test should be skipped when the PHP 8 identifier
+     *                              name tokenization is used (as the target token won't exist).
+     *                              Defaults to `false`.
      *
      * @return void
      */
-    public function testIsArrowFunction($testMarker, $expected, $targetContent = null)
+    public function testIsArrowFunction($testMarker, $expected, $targetContent = null, $skipOnPHP8 = false)
     {
+        if ($skipOnPHP8 === true && parent::usesPhp8NameTokens() === true) {
+            $this->markTestSkipped("PHP 8.0 identifier name tokenization used. Target token won't exist.");
+        }
+
         $targets  = Collections::arrowFunctionTokensBC();
         $stackPtr = $this->getTargetToken($testMarker, $targets, $targetContent);
         $result   = FunctionDeclarations::isArrowFunction(self::$phpcsFile, $stackPtr);
@@ -105,11 +112,18 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
      * @param array  $expected      The expected return value for the respective functions.
      * @param string $targetContent The content for the target token to look for in case there could
      *                              be confusion.
+     * @param bool   $skipOnPHP8    Optional. Whether the test should be skipped when the PHP 8 identifier
+     *                              name tokenization is used (as the target token won't exist).
+     *                              Defaults to `false`.
      *
      * @return void
      */
-    public function testGetArrowFunctionOpenClose($testMarker, $expected, $targetContent = 'fn')
+    public function testGetArrowFunctionOpenClose($testMarker, $expected, $targetContent = 'fn', $skipOnPHP8 = false)
     {
+        if ($skipOnPHP8 === true && parent::usesPhp8NameTokens() === true) {
+            $this->markTestSkipped("PHP 8.0 identifier name tokenization used. Target token won't exist.");
+        }
+
         $targets  = Collections::arrowFunctionTokensBC();
         $stackPtr = $this->getTargetToken($testMarker, $targets, $targetContent);
 
@@ -629,6 +643,7 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
                     'get' => false,
                 ],
                 'Fn',
+                true,
             ],
             'non-arrow-function-call-to-namespaced-function-using-namespace-operator' => [
                 '/* testNonArrowNamespaceOperatorFunctionCall */',
@@ -636,6 +651,8 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
                     'is'  => false,
                     'get' => false,
                 ],
+                'fn',
+                true,
             ],
             'non-arrow-function-declaration-with-union-types' => [
                 '/* testNonArrowFunctionNameWithUnionTypes */',

--- a/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
@@ -134,6 +134,8 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
      */
     public function dataArrowFunction()
     {
+        $php8Names = parent::usesPhp8NameTokens();
+
         return [
             'arrow-function-standard' => [
                 '/* testStandard */',
@@ -331,8 +333,8 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
                     'get' => [
                         'parenthesis_opener' => 1,
                         'parenthesis_closer' => 3,
-                        'scope_opener'       => 15,
-                        'scope_closer'       => 18,
+                        'scope_opener'       => ($php8Names === true) ? 10 : 15,
+                        'scope_closer'       => ($php8Names === true) ? 13 : 18,
                     ],
                 ],
             ],
@@ -342,9 +344,9 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
                     'is'  => true,
                     'get' => [
                         'parenthesis_opener' => 1,
-                        'parenthesis_closer' => 7,
-                        'scope_opener'       => 15,
-                        'scope_closer'       => 18,
+                        'parenthesis_closer' => ($php8Names === true) ? 6 : 7,
+                        'scope_opener'       => ($php8Names === true) ? 13 : 15,
+                        'scope_closer'       => ($php8Names === true) ? 16 : 18,
                     ],
                 ],
             ],
@@ -354,9 +356,9 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
                     'is'  => true,
                     'get' => [
                         'parenthesis_opener' => 1,
-                        'parenthesis_closer' => 7,
-                        'scope_opener'       => 16,
-                        'scope_closer'       => 19,
+                        'parenthesis_closer' => ($php8Names === true) ? 5 : 7,
+                        'scope_opener'       => ($php8Names === true) ? 12 : 16,
+                        'scope_closer'       => ($php8Names === true) ? 15 : 19,
                     ],
                 ],
             ],

--- a/Tests/Utils/Namespaces/DetermineNamespaceTest.php
+++ b/Tests/Utils/Namespaces/DetermineNamespaceTest.php
@@ -200,7 +200,14 @@ class DetermineNamespaceTest extends UtilityMethodTestCase
         $result   = Namespaces::findNamespacePtr(self::$phpcsFile, $stackPtr);
         $this->assertFalse($result, 'Failed checking that namespace declaration token is not regarded as namespaced');
 
-        $stackPtr = $this->getTargetToken('/* Non-scoped named namespace 2 */', \T_STRING, 'Package');
+        $targetType    = \T_STRING;
+        $targetContent = 'Package';
+        if (parent::usesPhp8NameTokens() === true) {
+            $targetType    = \T_NAME_QUALIFIED;
+            $targetContent = 'Vendor\Package\Foz';
+        }
+
+        $stackPtr = $this->getTargetToken('/* Non-scoped named namespace 2 */', $targetType, $targetContent);
         $result   = Namespaces::findNamespacePtr(self::$phpcsFile, $stackPtr);
         $this->assertFalse($result, 'Failed checking that a token in the namespace name is not regarded as namespaced');
     }

--- a/Tests/Utils/Namespaces/GetDeclaredNameTest.php
+++ b/Tests/Utils/Namespaces/GetDeclaredNameTest.php
@@ -46,11 +46,18 @@ class GetDeclaredNameTest extends UtilityMethodTestCase
      *
      * @param string $testMarker The comment which prefaces the target token in the test file.
      * @param array  $expected   The expected output for the function.
+     * @param bool   $skipOnPHP8 Optional. Whether the test should be skipped when the PHP 8 identifier
+     *                           name tokenization is used (as the target token won't exist).
+     *                           Defaults to `false`.
      *
      * @return void
      */
-    public function testGetDeclaredNameClean($testMarker, $expected)
+    public function testGetDeclaredNameClean($testMarker, $expected, $skipOnPHP8 = false)
     {
+        if ($skipOnPHP8 === true && parent::usesPhp8NameTokens() === true) {
+            $this->markTestSkipped("PHP 8.0 identifier name tokenization used. Target token won't exist.");
+        }
+
         $stackPtr = $this->getTargetToken($testMarker, \T_NAMESPACE);
         $result   = Namespaces::getDeclaredName(self::$phpcsFile, $stackPtr, true);
 
@@ -64,11 +71,18 @@ class GetDeclaredNameTest extends UtilityMethodTestCase
      *
      * @param string $testMarker The comment which prefaces the target token in the test file.
      * @param array  $expected   The expected output for the function.
+     * @param bool   $skipOnPHP8 Optional. Whether the test should be skipped when the PHP 8 identifier
+     *                           name tokenization is used (as the target token won't exist).
+     *                           Defaults to `false`.
      *
      * @return void
      */
-    public function testGetDeclaredNameDirty($testMarker, $expected)
+    public function testGetDeclaredNameDirty($testMarker, $expected, $skipOnPHP8 = false)
     {
+        if ($skipOnPHP8 === true && parent::usesPhp8NameTokens() === true) {
+            $this->markTestSkipped("PHP 8.0 identifier name tokenization used. Target token won't exist.");
+        }
+
         $stackPtr = $this->getTargetToken($testMarker, \T_NAMESPACE);
         $result   = Namespaces::getDeclaredName(self::$phpcsFile, $stackPtr, false);
 
@@ -154,6 +168,7 @@ class GetDeclaredNameTest extends UtilityMethodTestCase
                     'clean' => false,
                     'dirty' => false,
                 ],
+                true,
             ],
             'parse-error-reserved-keywords' => [
                 '/* testParseErrorReservedKeywords */',

--- a/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
@@ -87,6 +87,8 @@ class GetMemberPropertiesDiffTest extends UtilityMethodTestCase
      */
     public function dataGetMemberProperties()
     {
+        $php8Names = parent::usesPhp8NameTokens();
+
         return [
             'php8-union-types-simple' => [
                 '/* testPHP8UnionTypesSimple */',
@@ -107,7 +109,7 @@ class GetMemberPropertiesDiffTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => 'MyClassA|\Package\MyClassB',
-                    'type_token'      => -7, // Offset from the T_VARIABLE token.
+                    'type_token'      => ($php8Names === true) ? -4 : -7, // Offset from the T_VARIABLE token.
                     'type_end_token'  => -2, // Offset from the T_VARIABLE token.
                     'nullable_type'   => false,
                 ],
@@ -239,7 +241,7 @@ class GetMemberPropertiesDiffTest extends UtilityMethodTestCase
                     'scope_specified' => true,
                     'is_static'       => false,
                     'type'            => '?namespace\Name',
-                    'type_token'      => -4, // Offset from the T_VARIABLE token.
+                    'type_token'      => ($php8Names === true) ? -2 : -4, // Offset from the T_VARIABLE token.
                     'type_end_token'  => -2, // Offset from the T_VARIABLE token.
                     'nullable_type'   => true,
                 ],


### PR DESCRIPTION
As per PR #200;
* The expected target token type may be different for certain tests depending on whether the PHP 8.0 identifier name tokenization is used.
* The expected token positions in method return values may also be different when the PHP 8.0 identifier name tokenization is used.
* And in some cases, the target token just plainly won't exist when the PHP 8.0 identifier name tokenization is used and the utility method will not be applicable.

This PR adjusts the existing unit tests for PHPCSUtils to allow for the PHP 8.0 identifier name tokenization, using the new `UtilityMethodTestCase::usesPhp8NameTokens` to determine when to set which expectations.