### PR TITLE
BCFile/GetTokensAsString/GetTokensAsStringTest: make tests independent of PHP 8 identifier names

### DIFF
--- a/Tests/BackCompat/BCFile/GetTokensAsStringTest.inc
+++ b/Tests/BackCompat/BCFile/GetTokensAsStringTest.inc
@@ -8,6 +8,14 @@ use Foo /*comment*/ \ Bar
 	// phpcs:ignore Stnd.Cat.Sniff --	 For reasons.
 	\ Bah;
 
+$cl = function() {
+    /* testCalculation */
+    return 1 + 2 +
+        // Comment.
+        3 + 4
+        + 5 + 6 + 7 > 20;
+}
+
 /* testEchoWithTabs */
 echo 'foo',
 	'bar'	,

--- a/Tests/BackCompat/BCFile/GetTokensAsStringTest.php
+++ b/Tests/BackCompat/BCFile/GetTokensAsStringTest.php
@@ -118,67 +118,125 @@ class GetTokensAsStringTest extends UtilityMethodTestCase
      */
     public function dataGetTokensAsString()
     {
+        $php8Names = parent::usesPhp8NameTokens();
+
         return [
             'length-0' => [
-                '/* testNamespace */',
-                \T_NAMESPACE,
+                '/* testCalculation */',
+                \T_LNUMBER,
                 0,
                 '',
             ],
             'length-1' => [
-                '/* testNamespace */',
-                \T_NAMESPACE,
+                '/* testCalculation */',
+                \T_LNUMBER,
                 1,
-                'namespace',
+                '1',
             ],
             'length-2' => [
-                '/* testNamespace */',
-                \T_NAMESPACE,
+                '/* testCalculation */',
+                \T_LNUMBER,
                 2,
-                'namespace ',
+                '1 ',
             ],
             'length-3' => [
-                '/* testNamespace */',
-                \T_NAMESPACE,
+                '/* testCalculation */',
+                \T_LNUMBER,
                 3,
-                'namespace Foo',
+                '1 +',
             ],
             'length-4' => [
-                '/* testNamespace */',
-                \T_NAMESPACE,
+                '/* testCalculation */',
+                \T_LNUMBER,
                 4,
-                'namespace Foo\\',
+                '1 + ',
             ],
             'length-5' => [
-                '/* testNamespace */',
-                \T_NAMESPACE,
+                '/* testCalculation */',
+                \T_LNUMBER,
                 5,
-                'namespace Foo\Bar',
+                '1 + 2',
             ],
             'length-6' => [
-                '/* testNamespace */',
-                \T_NAMESPACE,
+                '/* testCalculation */',
+                \T_LNUMBER,
                 6,
-                'namespace Foo\Bar\\',
+                '1 + 2 ',
             ],
             'length-7' => [
-                '/* testNamespace */',
-                \T_NAMESPACE,
+                '/* testCalculation */',
+                \T_LNUMBER,
                 7,
-                'namespace Foo\Bar\Baz',
+                '1 + 2 +',
             ],
             'length-8' => [
-                '/* testNamespace */',
-                \T_NAMESPACE,
+                '/* testCalculation */',
+                \T_LNUMBER,
                 8,
-                'namespace Foo\Bar\Baz;',
+                '1 + 2 +
+',
             ],
             'length-9' => [
+                '/* testCalculation */',
+                \T_LNUMBER,
+                9,
+                '1 + 2 +
+        ',
+            ],
+            'length-10' => [
+                '/* testCalculation */',
+                \T_LNUMBER,
+                10,
+                '1 + 2 +
+        // Comment.
+',
+            ],
+            'length-11' => [
+                '/* testCalculation */',
+                \T_LNUMBER,
+                11,
+                '1 + 2 +
+        // Comment.
+        ',
+            ],
+            'length-12' => [
+                '/* testCalculation */',
+                \T_LNUMBER,
+                12,
+                '1 + 2 +
+        // Comment.
+        3',
+            ],
+            'length-13' => [
+                '/* testCalculation */',
+                \T_LNUMBER,
+                13,
+                '1 + 2 +
+        // Comment.
+        3 ',
+            ],
+            'length-14' => [
+                '/* testCalculation */',
+                \T_LNUMBER,
+                14,
+                '1 + 2 +
+        // Comment.
+        3 +',
+            ],
+            'length-34' => [
+                '/* testCalculation */',
+                \T_LNUMBER,
+                34,
+                '1 + 2 +
+        // Comment.
+        3 + 4
+        + 5 + 6 + 7 > 20;',
+            ],
+            'namespace' => [
                 '/* testNamespace */',
                 \T_NAMESPACE,
-                9,
-                'namespace Foo\Bar\Baz;
-',
+                ($php8Names === true) ? 4 : 8,
+                'namespace Foo\Bar\Baz;',
             ],
             'use-with-comments' => [
                 '/* testUseWithComments */',

--- a/Tests/Utils/GetTokensAsString/GetTokensAsStringTest.php
+++ b/Tests/Utils/GetTokensAsString/GetTokensAsStringTest.php
@@ -274,6 +274,27 @@ class GetTokensAsStringTest extends UtilityMethodTestCase
                     'compact_nc'  => 'Foo \ Bar \ Bah;',
                 ],
             ],
+            'calculation' => [
+                'marker'   => '/* testCalculation */',
+                'type'     => \T_LNUMBER,
+                'expected' => [
+                    'normal'      => '1 + 2 +
+        // Comment.
+        3 + 4
+        + 5 + 6 + 7 > 20;',
+                    'orig'        => '1 + 2 +
+        // Comment.
+        3 + 4
+        + 5 + 6 + 7 > 20;',
+                    'no_comments' => '1 + 2 +
+                3 + 4
+        + 5 + 6 + 7 > 20;',
+                    'no_empties'  => '1+2+3+4+5+6+7>20;',
+                    'compact'     => '1 + 2 + // Comment.
+ 3 + 4 + 5 + 6 + 7 > 20;',
+                    'compact_nc'  => '1 + 2 + 3 + 4 + 5 + 6 + 7 > 20;',
+                ],
+            ],
             'echo-with-tabs' => [
                 'marker'   => '/* testEchoWithTabs */',
                 'type'     => \T_ECHO,


### PR DESCRIPTION
Related to #201

As the token counts for identifier names are different between PHP < 8 and PHP 8 and depending on which PHPCS version will be used, the test for the `BCFile::getTokensAsString()` method is now unstable.

This commit adds a new test case (calculation) which doesn't suffer from that problem to allow for testing with exact token lengths, the same as was previously done with the namespace declaration test.

Includes:
* In `BCFile/GetTokensAsStringTest`: add an additional test to still cover the namespace declaration test case.
* In `GetTokensAsString/GetTokensAsStringTest`: add a test for the new calculation test case.