### PR TITLE
Collections: new nameTokens() method

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -601,6 +601,40 @@ class Collections
     }
 
     /**
+     * The tokens used for "names", be it namespace, OO, function or constant names.
+     *
+     * Includes the tokens introduced in PHP 8.0 for "Namespaced names as single token" when available.
+     *
+     * Note: this is a method, not a property as the PHP 8.0 identifier name tokens may not exist.
+     *
+     * @link https://wiki.php.net/rfc/namespaced_names_as_token
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function nameTokens()
+    {
+        $tokens = [
+            \T_STRING => \T_STRING,
+        ];
+
+        if (\defined('T_NAME_QUALIFIED') === true) {
+            $tokens[\T_NAME_QUALIFIED] = \T_NAME_QUALIFIED;
+        }
+
+        if (\defined('T_NAME_FULLY_QUALIFIED') === true) {
+            $tokens[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;
+        }
+
+        if (\defined('T_NAME_RELATIVE') === true) {
+            $tokens[\T_NAME_RELATIVE] = \T_NAME_RELATIVE;
+        }
+
+        return $tokens;
+    }
+
+    /**
      * Object operators.
      *
      * Note: this is a method, not a property as the `T_NULLSAFE_OBJECT_OPERATOR` token may not exist.

--- a/Tests/Tokens/Collections/NameTokensTest.php
+++ b/Tests/Tokens/Collections/NameTokensTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::nameTokens
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class NameTokensTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testNameTokens()
+    {
+        $expected = [
+            \T_STRING => \T_STRING,
+        ];
+
+        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true) {
+            $expected[\T_NAME_QUALIFIED]       = \T_NAME_QUALIFIED;
+            $expected[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;
+            $expected[\T_NAME_RELATIVE]        = \T_NAME_RELATIVE;
+        }
+
+        $this->assertSame($expected, Collections::nameTokens());
+    }
+}


### PR DESCRIPTION
... containing the tokens used for "names", be it namespace, OO, function or constant names.

Includes the tokens introduced in PHP 8.0 for "Namespaced names as single token" when available.

Includes unit test.