### PR TITLE
Collections::namespacedNameTokens(): support the PHP 8 identifier name tokens

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -594,8 +594,9 @@ class Collections
         $tokens = [
             \T_NS_SEPARATOR => \T_NS_SEPARATOR,
             \T_NAMESPACE    => \T_NAMESPACE,
-            \T_STRING       => \T_STRING,
         ];
+
+        $tokens += self::nameTokens();
 
         return $tokens;
     }

--- a/PHPCSUtils/Utils/ControlStructures.php
+++ b/PHPCSUtils/Utils/ControlStructures.php
@@ -349,6 +349,7 @@ class ControlStructures
      * Retrieve the exception(s) being caught in a CATCH condition.
      *
      * @since 1.0.0-alpha3
+     * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokenization.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the token we are checking.

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -229,6 +229,7 @@ class ObjectDeclarations
      *   - Handling of the namespace keyword used as operator.
      * - Improved handling of parse errors.
      * - The returned name will be clean of superfluous whitespace and/or comments.
+     * - Support for PHP 8.0 tokenization of identifier/namespaced names, cross-version PHP & PHPCS.
      *
      * @see \PHP_CodeSniffer\Files\File::findExtendedClassName()               Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::findExtendedClassName()             Cross-version compatible version of
@@ -264,6 +265,7 @@ class ObjectDeclarations
      *   - Handling of the namespace keyword used as operator.
      * - Improved handling of parse errors.
      * - The returned name(s) will be clean of superfluous whitespace and/or comments.
+     * - Support for PHP 8.0 tokenization of identifier/namespaced names, cross-version PHP & PHPCS.
      *
      * @see \PHP_CodeSniffer\Files\File::findImplementedInterfaceNames()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::findImplementedInterfaceNames() Cross-version compatible version of
@@ -310,6 +312,7 @@ class ObjectDeclarations
      * interfaces that the specific class/interface declaration extends/implements.
      *
      * @since 1.0.0
+     * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokenization.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile  The file where this token was found.
      * @param int                         $stackPtr   The stack position of the

--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -73,6 +73,7 @@ class Operators
      *
      * @since 1.0.0
      * @since 1.0.0-alpha2 Added BC support for PHP 7.4 arrow functions.
+     * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokenization.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the `T_BITWISE_AND` token.

--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.inc
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.inc
@@ -31,6 +31,9 @@ class testFECNNestedExtendedClass {
     }
 }
 
+/* testNamespaceRelativeQualifiedClass */
+class testFECNQualifiedClass extends Core\File\RelativeClass {}
+
 /* testClassThatExtendsAndImplements */
 class testFECNClassThatExtendsAndImplements extends testFECNClass implements InterfaceA, InterfaceB {}
 
@@ -44,7 +47,7 @@ $anon = new class( $a, $b ) extends testFECNExtendedAnonClass {};
 interface Multi extends \Package\FooInterface, \BarInterface {};
 
 /* testMissingExtendsName */
-class testMissingExtendsName extends { /* missing classname */ } // Internal parse error.
+class testMissingExtendsName extends { /* missing classname */ } // Intentional parse error.
 
 // Intentional parse error. Has to be the last test in the file.
 /* testParseError */

--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
@@ -138,6 +138,10 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
                 'testFECNAnonClass',
             ],
             [
+                '/* testNamespaceRelativeQualifiedClass */',
+                'Core\File\RelativeClass',
+            ],
+            [
                 '/* testClassThatExtendsAndImplements */',
                 'testFECNClass',
             ],

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.inc
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.inc
@@ -20,6 +20,9 @@ class testFIINNamespacedClass implements \PHP_CodeSniffer\Tests\Core\File\testFI
 /* testNonImplementedClass */
 class testFIINNonImplementedClass {}
 
+/* testNamespaceRelativeQualifiedClass */
+class testFIINQualifiedClass implements Core\File\RelativeInterface {}
+
 /* testClassThatExtendsAndImplements */
 class testFECNClassThatExtendsAndImplements extends testFECNClass implements InterfaceA, \NameSpaced\Cat\InterfaceB {}
 
@@ -30,7 +33,7 @@ class testFECNClassThatImplementsAndExtends implements \InterfaceA, InterfaceB e
 $anon = class() implements testFIINInterface {}
 
 /* testMissingImplementsName */
-class testMissingExtendsName implements { /* missing interface name */  } // Internal parse error.
+class testMissingExtendsName implements { /* missing interface name */  } // Intentional parse error.
 
 // Intentional parse error. Has to be the last test in the file.
 /* testParseError */

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
@@ -127,6 +127,10 @@ class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
                 false,
             ],
             [
+                '/* testNamespaceRelativeQualifiedClass */',
+                ['Core\File\RelativeInterface'],
+            ],
+            [
                 '/* testClassThatExtendsAndImplements */',
                 [
                     'InterfaceA',

--- a/Tests/Tokens/Collections/NamespacedNameTokensTest.php
+++ b/Tests/Tokens/Collections/NamespacedNameTokensTest.php
@@ -38,6 +38,12 @@ class NamespacedNameTokensTest extends TestCase
             \T_STRING       => \T_STRING,
         ];
 
+        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true) {
+            $expected[\T_NAME_QUALIFIED]       = \T_NAME_QUALIFIED;
+            $expected[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;
+            $expected[\T_NAME_RELATIVE]        = \T_NAME_RELATIVE;
+        }
+
         $this->assertSame($expected, Collections::namespacedNameTokens());
     }
 }

--- a/Tests/Utils/ObjectDeclarations/FindExtendedInterfaceNamesTest.inc
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedInterfaceNamesTest.inc
@@ -28,6 +28,9 @@ interface testMultiExtendedInterfaceWithComments
 {
 }
 
+/* testNamespaceRelativeQualifiedInterface */
+interface testQualifiedInterfaces extends Core\File\RelativeInterface, Another\RelativeInterface {}
+
 /* testExtendsUsingNamespaceOperator */
 interface testWithNSOperator extends namespace\BarInterface, namespace\Sub\SomeOther {}
 

--- a/Tests/Utils/ObjectDeclarations/FindExtendedInterfaceNamesTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedInterfaceNamesTest.php
@@ -110,6 +110,13 @@ class FindExtendedInterfaceNamesTest extends UtilityMethodTestCase
                     '\testInterfaceC',
                 ],
             ],
+            'extends-partially-qualified-names' => [
+                '/* testNamespaceRelativeQualifiedInterface */',
+                [
+                    'Core\File\RelativeInterface',
+                    'Another\RelativeInterface',
+                ],
+            ],
             'extends-using-namespace-operator' => [
                 '/* testExtendsUsingNamespaceOperator */',
                 [

--- a/Tests/Utils/Operators/IsReferenceDiffTest.inc
+++ b/Tests/Utils/Operators/IsReferenceDiffTest.inc
@@ -20,3 +20,6 @@ $fn = fn($param, &...$moreParams) => 1;
 
 /* testArrowFunctionNonReferenceInDefault */
 $fn = fn( $one = E_NOTICE & E_STRICT) => 1;
+
+/* testPassByReferencePartiallyQualifiedName */
+functionCall($something, &Sub\Level\SomeClass::$somethingElse);

--- a/Tests/Utils/Operators/IsReferenceDiffTest.php
+++ b/Tests/Utils/Operators/IsReferenceDiffTest.php
@@ -97,6 +97,10 @@ class IsReferenceDiffTest extends UtilityMethodTestCase
                 '/* testArrowFunctionNonReferenceInDefault */',
                 false,
             ],
+            'pass-by-ref-partially-qualified-name-param-type' => [
+                '/* testPassByReferencePartiallyQualifiedName */',
+                true,
+            ],
         ];
     }
 }


### PR DESCRIPTION
Includes adjusted unit test.

This change automatically adds compatibility with the PHP 8.0 identifier name tokens to the following methods:
* `ControlStructures::getCaughtExceptions()`
* `FunctionDeclarations::isPHPDoubleUnderscoreMethod()` (via `ObjectDeclarations::findExtendedClassName()`)
* `ObjectDeclarations::findNames()`
* `ObjectDeclarations::findExtendedClassName()`
* `ObjectDeclarations::findImplementedInterfaceNames()`
* `ObjectDeclarations::findExtendedInterfaceNames()`
* `Operators::isReference()`

Includes adding additional unit tests for these methods in those cases where any of the identifier name types (fully qualified, partially qualified, namespace relative or unqualified) wasn't covered yet.