### PR TITLE
Collections::parameterTypeTokens[BC](): support the PHP 8 identifier name tokens

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -767,22 +767,24 @@ class Collections
      *
      * @since 1.0.0-alpha4 This method replaces the {@see Collections::$parameterTypeTokens} property.
      * @since 1.0.0-alpha4 Added support for PHP 8.0 union types.
+     * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokens.
      *
      * @return array <int|string> => <int|string>
      */
     public static function parameterTypeTokens()
     {
-        return [
-            \T_CALLABLE     => \T_CALLABLE,
-            \T_SELF         => \T_SELF,
-            \T_PARENT       => \T_PARENT,
-            \T_FALSE        => \T_FALSE,      // Union types only.
-            \T_NULL         => \T_NULL,       // Union types only.
-            \T_STRING       => \T_STRING,
-            \T_NAMESPACE    => \T_NAMESPACE,
-            \T_NS_SEPARATOR => \T_NS_SEPARATOR,
-            \T_BITWISE_OR   => \T_BITWISE_OR, // Union types.
+        $tokens = [
+            \T_CALLABLE   => \T_CALLABLE,
+            \T_SELF       => \T_SELF,
+            \T_PARENT     => \T_PARENT,
+            \T_FALSE      => \T_FALSE,      // Union types only.
+            \T_NULL       => \T_NULL,       // Union types only.
+            \T_BITWISE_OR => \T_BITWISE_OR, // Union types.
         ];
+
+        $tokens += self::namespacedNameTokens();
+
+        return $tokens;
     }
 
     /**
@@ -803,6 +805,7 @@ class Collections
      *
      * @since 1.0.0-alpha3
      * @since 1.0.0-alpha4 Added support for PHP 8.0 union types.
+     * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokens.
      *
      * @return array <int|string> => <int|string>
      */

--- a/Tests/Tokens/Collections/ParameterTypeTokensTest.php
+++ b/Tests/Tokens/Collections/ParameterTypeTokensTest.php
@@ -38,11 +38,17 @@ class ParameterTypeTokensTest extends TestCase
             \T_PARENT       => \T_PARENT,
             \T_FALSE        => \T_FALSE,
             \T_NULL         => \T_NULL,
-            \T_STRING       => \T_STRING,
-            \T_NAMESPACE    => \T_NAMESPACE,
-            \T_NS_SEPARATOR => \T_NS_SEPARATOR,
             \T_BITWISE_OR   => \T_BITWISE_OR,
+            \T_NS_SEPARATOR => \T_NS_SEPARATOR,
+            \T_NAMESPACE    => \T_NAMESPACE,
+            \T_STRING       => \T_STRING,
         ];
+
+        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true) {
+            $expected[\T_NAME_QUALIFIED]       = \T_NAME_QUALIFIED;
+            $expected[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;
+            $expected[\T_NAME_RELATIVE]        = \T_NAME_RELATIVE;
+        }
 
         $this->assertSame($expected, Collections::parameterTypeTokens());
     }


### PR DESCRIPTION

Includes adjusted unit test.