### PR TITLE
Collections::propertyTypeTokens[BC](): support the PHP 8 identifier name tokens

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -837,22 +837,24 @@ class Collections
      *
      * @since 1.0.0-alpha4 This method replaces the {@see Collections::$propertyTypeTokens} property.
      * @since 1.0.0-alpha4 Added support for PHP 8.0 union types.
+     * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokens.
      *
      * @return array <int|string> => <int|string>
      */
     public static function propertyTypeTokens()
     {
-        return [
-            \T_CALLABLE     => \T_CALLABLE,
-            \T_SELF         => \T_SELF,
-            \T_PARENT       => \T_PARENT,
-            \T_FALSE        => \T_FALSE,      // Union types only.
-            \T_NULL         => \T_NULL,       // Union types only.
-            \T_STRING       => \T_STRING,
-            \T_NAMESPACE    => \T_NAMESPACE,
-            \T_NS_SEPARATOR => \T_NS_SEPARATOR,
-            \T_BITWISE_OR   => \T_BITWISE_OR, // Union types.
+        $tokens = [
+            \T_CALLABLE   => \T_CALLABLE,
+            \T_SELF       => \T_SELF,
+            \T_PARENT     => \T_PARENT,
+            \T_FALSE      => \T_FALSE,      // Union types only.
+            \T_NULL       => \T_NULL,       // Union types only.
+            \T_BITWISE_OR => \T_BITWISE_OR, // Union types.
         ];
+
+        $tokens += self::namespacedNameTokens();
+
+        return $tokens;
     }
 
     /**
@@ -873,6 +875,7 @@ class Collections
      *
      * @since 1.0.0-alpha3
      * @since 1.0.0-alpha4 Added support for PHP 8.0 union types.
+     * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokens.
      *
      * @return array <int|string> => <int|string>
      */

--- a/PHPCSUtils/Utils/Variables.php
+++ b/PHPCSUtils/Utils/Variables.php
@@ -82,6 +82,7 @@ class Variables
      * - Defensive coding against incorrect calls to this method.
      * - Support for PHP 8.0 union types.
      * - Support for namespace operator in type declarations.
+     * - Support PHP 8.0 identifier name tokens in property types, cross-version PHP & PHPCS.
      *
      * @see \PHP_CodeSniffer\Files\File::getMemberProperties()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getMemberProperties() Cross-version compatible version of the original.

--- a/Tests/Tokens/Collections/PropertyTypeTokensTest.php
+++ b/Tests/Tokens/Collections/PropertyTypeTokensTest.php
@@ -38,11 +38,17 @@ class PropertyTypeTokensTest extends TestCase
             \T_PARENT       => \T_PARENT,
             \T_FALSE        => \T_FALSE,
             \T_NULL         => \T_NULL,
-            \T_STRING       => \T_STRING,
-            \T_NAMESPACE    => \T_NAMESPACE,
-            \T_NS_SEPARATOR => \T_NS_SEPARATOR,
             \T_BITWISE_OR   => \T_BITWISE_OR,
+            \T_NS_SEPARATOR => \T_NS_SEPARATOR,
+            \T_NAMESPACE    => \T_NAMESPACE,
+            \T_STRING       => \T_STRING,
         ];
+
+        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true) {
+            $expected[\T_NAME_QUALIFIED]       = \T_NAME_QUALIFIED;
+            $expected[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;
+            $expected[\T_NAME_RELATIVE]        = \T_NAME_RELATIVE;
+        }
 
         $this->assertSame($expected, Collections::propertyTypeTokens());
     }


### PR DESCRIPTION

Includes adjusted unit test.

This commit implicitly adds support for PHP 8 identifier name tokens to the `Variables::getMemberProperties()` method.

The existing unit tests already cover this.

This commit also _silently_ adds support for PHP 8 identifier name tokens to the `BCFile::getMemberProperties()` method. The PHP 8 identifier name tokens are not supported yet in PHPCS itself and until they are, the fact that the `BCFile::getMemberProperties()` method supports them should be regarded as an artifact and not as official support.