### PR TITLE
Namespaces::getType(): compatibility with the PHP 8 identifier name tokenization

### DIFF
--- a/PHPCSUtils/Utils/Namespaces.php
+++ b/PHPCSUtils/Utils/Namespaces.php
@@ -35,6 +35,7 @@ class Namespaces
      * Determine what a T_NAMESPACE token is used for.
      *
      * @since 1.0.0
+     * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokenization.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the `T_NAMESPACE` token.
@@ -98,12 +99,14 @@ class Namespaces
         $start = BCFile::findStartOfStatement($phpcsFile, $stackPtr);
         if ($start === $stackPtr
             && ($tokens[$next]['code'] === \T_STRING
+               || $tokens[$next]['type'] === 'T_NAME_QUALIFIED'
                || $tokens[$next]['code'] === \T_OPEN_CURLY_BRACKET)
         ) {
             return 'declaration';
         }
 
-        if ($tokens[$next]['code'] === \T_NS_SEPARATOR
+        if (($tokens[$next]['code'] === \T_NS_SEPARATOR
+            || $tokens[$next]['type'] === 'T_NAME_FULLY_QUALIFIED') // PHP 8.0 parse error.
             && ($start !== $stackPtr
                 || $phpcsFile->findNext($findAfter, ($stackPtr + 1), null, false, null, true) !== false)
         ) {

--- a/Tests/Utils/Namespaces/NamespaceTypeTest.php
+++ b/Tests/Utils/Namespaces/NamespaceTypeTest.php
@@ -60,11 +60,18 @@ class NamespaceTypeTest extends UtilityMethodTestCase
      *
      * @param string $testMarker The comment which prefaces the target token in the test file.
      * @param array  $expected   The expected output for the functions.
+     * @param bool   $skipOnPHP8 Optional. Whether the test should be skipped when the PHP 8 identifier
+     *                           name tokenization is used (as the target token won't exist).
+     *                           Defaults to `false`.
      *
      * @return void
      */
-    public function testIsDeclaration($testMarker, $expected)
+    public function testIsDeclaration($testMarker, $expected, $skipOnPHP8 = false)
     {
+        if ($skipOnPHP8 === true && parent::usesPhp8NameTokens() === true) {
+            $this->markTestSkipped("PHP 8.0 identifier name tokenization used. Target token won't exist.");
+        }
+
         $stackPtr = $this->getTargetToken($testMarker, \T_NAMESPACE);
         $result   = Namespaces::isDeclaration(self::$phpcsFile, $stackPtr);
 
@@ -78,11 +85,18 @@ class NamespaceTypeTest extends UtilityMethodTestCase
      *
      * @param string $testMarker The comment which prefaces the target token in the test file.
      * @param array  $expected   The expected output for the functions.
+     * @param bool   $skipOnPHP8 Optional. Whether the test should be skipped when the PHP 8 identifier
+     *                           name tokenization is used (as the target token won't exist).
+     *                           Defaults to `false`.
      *
      * @return void
      */
-    public function testIsOperator($testMarker, $expected)
+    public function testIsOperator($testMarker, $expected, $skipOnPHP8 = false)
     {
+        if ($skipOnPHP8 === true && parent::usesPhp8NameTokens() === true) {
+            $this->markTestSkipped("PHP 8.0 identifier name tokenization used. Target token won't exist.");
+        }
+
         $stackPtr = $this->getTargetToken($testMarker, \T_NAMESPACE);
         $result   = Namespaces::isOperator(self::$phpcsFile, $stackPtr);
 
@@ -127,6 +141,7 @@ class NamespaceTypeTest extends UtilityMethodTestCase
                     'declaration' => false,
                     'operator'    => true,
                 ],
+                true,
             ],
             'namespace-operator-with-annotation' => [
                 '/* testNamespaceOperatorWithAnnotation */',
@@ -141,6 +156,7 @@ class NamespaceTypeTest extends UtilityMethodTestCase
                     'declaration' => false,
                     'operator'    => true,
                 ],
+                true,
             ],
             'namespace-operator-in-closed-scope' => [
                 '/* testNamespaceOperatorInClosedScope */',
@@ -148,6 +164,7 @@ class NamespaceTypeTest extends UtilityMethodTestCase
                     'declaration' => false,
                     'operator'    => true,
                 ],
+                true,
             ],
             'namespace-operator-in-parentheses' => [
                 '/* testNamespaceOperatorInParentheses */',
@@ -155,6 +172,7 @@ class NamespaceTypeTest extends UtilityMethodTestCase
                     'declaration' => false,
                     'operator'    => true,
                 ],
+                true,
             ],
             'namespace-operator-global-namespace-start-of-statement-function-call' => [
                 '/* testNamespaceOperatorGlobalNamespaceStartOfStatementFunctionCall */',
@@ -162,6 +180,7 @@ class NamespaceTypeTest extends UtilityMethodTestCase
                     'declaration' => false,
                     'operator'    => true,
                 ],
+                true,
             ],
             'namespace-operator-global-namespace-start-of-statement-with-non-confusing-token-1' => [
                 '/* testNamespaceOperatorGlobalNamespaceStartOfStatementCombiWithNonConfusingToken1 */',
@@ -169,6 +188,7 @@ class NamespaceTypeTest extends UtilityMethodTestCase
                     'declaration' => false,
                     'operator'    => true,
                 ],
+                true,
             ],
             'namespace-operator-global-namespace-start-of-statement-with-non-confusing-token-2' => [
                 '/* testNamespaceOperatorGlobalNamespaceStartOfStatementCombiWithNonConfusingToken2 */',
@@ -176,6 +196,7 @@ class NamespaceTypeTest extends UtilityMethodTestCase
                     'declaration' => false,
                     'operator'    => true,
                 ],
+                true,
             ],
             'namespace-operator-global-namespace-start-of-statement-with-non-confusing-token-3' => [
                 '/* testNamespaceOperatorGlobalNamespaceStartOfStatementCombiWithNonConfusingToken3 */',
@@ -183,6 +204,7 @@ class NamespaceTypeTest extends UtilityMethodTestCase
                     'declaration' => false,
                     'operator'    => true,
                 ],
+                true,
             ],
             'namespace-operator-global-namespace-start-of-statement-with-non-confusing-token-4' => [
                 '/* testNamespaceOperatorGlobalNamespaceStartOfStatementCombiWithNonConfusingToken4 */',
@@ -190,6 +212,7 @@ class NamespaceTypeTest extends UtilityMethodTestCase
                     'declaration' => false,
                     'operator'    => true,
                 ],
+                true,
             ],
             'parse-error-scoped-namespace-declaration' => [
                 '/* testParseErrorScopedNamespaceDeclaration */',


### PR DESCRIPTION
When the PHP 8 identifier name tokenization is used, the `Namespace::getType()` method basically becomes redundant as the `T_NAMESPACE` token when used as an operator will no longer exist, except when there is a PHP 8 parse error.

The `Namespaces::getType()` method has been adjusted to allow for all the situations which were previously already accounted for.

The associated tests have been adjusted to skip the test cases involving namespace keywords used an operator in a non-parse error situation when PHP 8 identifier name tokenization is used, as those tests no longer apply.