### PR TITLE
BCFile/various methods: compatibility with the PHP 8 identifier name tokenization

### DIFF
--- a/Tests/BackCompat/BCFile/IsReferenceTest.inc
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.inc
@@ -154,6 +154,9 @@ functionCall($something, &\SomeNS\SomeClass::$somethingElse);
 /* testPassByReferenceJ */
 functionCall($something, &namespace\SomeClass::$somethingElse);
 
+/* testPassByReferencePartiallyQualifiedName */
+functionCall($something, &Sub\Level\SomeClass::$somethingElse);
+
 /* testNewByReferenceA */
 $foobar2 = &new Foobar();
 

--- a/Tests/BackCompat/BCFile/IsReferenceTest.php
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.php
@@ -297,6 +297,10 @@ class IsReferenceTest extends UtilityMethodTestCase
                 true,
             ],
             [
+                '/* testPassByReferencePartiallyQualifiedName */',
+                true,
+            ],
+            [
                 '/* testNewByReferenceA */',
                 true,
             ],

--- a/Tests/Utils/Operators/IsReferenceDiffTest.inc
+++ b/Tests/Utils/Operators/IsReferenceDiffTest.inc
@@ -20,6 +20,3 @@ $fn = fn($param, &...$moreParams) => 1;
 
 /* testArrowFunctionNonReferenceInDefault */
 $fn = fn( $one = E_NOTICE & E_STRICT) => 1;
-
-/* testPassByReferencePartiallyQualifiedName */
-functionCall($something, &Sub\Level\SomeClass::$somethingElse);

--- a/Tests/Utils/Operators/IsReferenceDiffTest.php
+++ b/Tests/Utils/Operators/IsReferenceDiffTest.php
@@ -97,10 +97,6 @@ class IsReferenceDiffTest extends UtilityMethodTestCase
                 '/* testArrowFunctionNonReferenceInDefault */',
                 false,
             ],
-            'pass-by-ref-partially-qualified-name-param-type' => [
-                '/* testPassByReferencePartiallyQualifiedName */',
-                true,
-            ],
         ];
     }
 }


### PR DESCRIPTION
While PHPCS itself won't backfill, nor start supporting the PHP 8 identifier name tokens until PHPCS 4.x, for compatibility with PHPCS < 3.5.7 in combination with PHP 8, the `BCFile::getMethodParameters()`, `BCFile::isReference()`, `BCFile::findExtendedClassName()` and `BCFile::findImplementedInterfaceNames()` methods still need adjusting to allow for cross-version compatibility.

Relevant unit tests for this were already added for most methods in PR #205.

For the `isReference()` method, select unit tests are now moved from the `Diff` test file to the `BCFile` test files.