### PR TITLE
Collections/UtilityMethodTestCase: sync with phpcs 3.x/PHP 8.0 identifier name tokens change

### DIFF
--- a/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+++ b/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
@@ -329,7 +329,15 @@ abstract class UtilityMethodTestCase extends TestCase
      */
     public static function usesPhp8NameTokens()
     {
-        return \version_compare(\PHP_VERSION_ID, '80000', '>=') === true;
+        $version = Helper::getVersion();
+        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
+            && (\version_compare($version, '3.5.7', '<') === true
+                || \version_compare($version, '4.0.0', '>=') === true)
+        ) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -620,6 +620,11 @@ class Collections
             \T_STRING => \T_STRING,
         ];
 
+        /*
+         * PHP >= 8.0 in combination with PHPCS < 3.5.7 and all PHP versions in combination
+         * with PHPCS >= 3.5.7, though when using PHPCS 3.5.7 < 4.0.0, these tokens are
+         * not yet in use, i.e. the PHP 8.0 change is "undone" for PHPCS 3.x.
+         */
         if (\defined('T_NAME_QUALIFIED') === true) {
             $tokens[\T_NAME_QUALIFIED] = \T_NAME_QUALIFIED;
         }

--- a/Tests/Tokens/Collections/NameTokensTest.php
+++ b/Tests/Tokens/Collections/NameTokensTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\Tokens\Collections;
 
+use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tokens\Collections;
 use PHPUnit\Framework\TestCase;
 
@@ -32,11 +33,15 @@ class NameTokensTest extends TestCase
      */
     public function testNameTokens()
     {
+        $version  = Helper::getVersion();
         $expected = [
             \T_STRING => \T_STRING,
         ];
 
-        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true) {
+        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
+            || (\version_compare($version, '3.5.7', '>=') === true
+                && \version_compare($version, '4.0.0', '<') === true)
+        ) {
             $expected[\T_NAME_QUALIFIED]       = \T_NAME_QUALIFIED;
             $expected[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;
             $expected[\T_NAME_RELATIVE]        = \T_NAME_RELATIVE;

--- a/Tests/Tokens/Collections/NamespacedNameTokensTest.php
+++ b/Tests/Tokens/Collections/NamespacedNameTokensTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\Tokens\Collections;
 
+use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tokens\Collections;
 use PHPUnit\Framework\TestCase;
 
@@ -32,13 +33,17 @@ class NamespacedNameTokensTest extends TestCase
      */
     public function testNamespacedNameTokens()
     {
+        $version  = Helper::getVersion();
         $expected = [
             \T_NS_SEPARATOR => \T_NS_SEPARATOR,
             \T_NAMESPACE    => \T_NAMESPACE,
             \T_STRING       => \T_STRING,
         ];
 
-        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true) {
+        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
+            || (\version_compare($version, '3.5.7', '>=') === true
+                && \version_compare($version, '4.0.0', '<') === true)
+        ) {
             $expected[\T_NAME_QUALIFIED]       = \T_NAME_QUALIFIED;
             $expected[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;
             $expected[\T_NAME_RELATIVE]        = \T_NAME_RELATIVE;

--- a/Tests/Tokens/Collections/ParameterTypeTokensTest.php
+++ b/Tests/Tokens/Collections/ParameterTypeTokensTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\Tokens\Collections;
 
+use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tokens\Collections;
 use PHPUnit\Framework\TestCase;
 
@@ -32,6 +33,7 @@ class ParameterTypeTokensTest extends TestCase
      */
     public function testParameterTypeTokens()
     {
+        $version  = Helper::getVersion();
         $expected = [
             \T_CALLABLE     => \T_CALLABLE,
             \T_SELF         => \T_SELF,
@@ -44,7 +46,10 @@ class ParameterTypeTokensTest extends TestCase
             \T_STRING       => \T_STRING,
         ];
 
-        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true) {
+        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
+            || (\version_compare($version, '3.5.7', '>=') === true
+                && \version_compare($version, '4.0.0', '<') === true)
+        ) {
             $expected[\T_NAME_QUALIFIED]       = \T_NAME_QUALIFIED;
             $expected[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;
             $expected[\T_NAME_RELATIVE]        = \T_NAME_RELATIVE;

--- a/Tests/Tokens/Collections/PropertyTypeTokensTest.php
+++ b/Tests/Tokens/Collections/PropertyTypeTokensTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\Tokens\Collections;
 
+use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tokens\Collections;
 use PHPUnit\Framework\TestCase;
 
@@ -32,6 +33,7 @@ class PropertyTypeTokensTest extends TestCase
      */
     public function testPropertyTypeTokens()
     {
+        $version  = Helper::getVersion();
         $expected = [
             \T_CALLABLE     => \T_CALLABLE,
             \T_SELF         => \T_SELF,
@@ -44,7 +46,10 @@ class PropertyTypeTokensTest extends TestCase
             \T_STRING       => \T_STRING,
         ];
 
-        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true) {
+        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
+            || (\version_compare($version, '3.5.7', '>=') === true
+                && \version_compare($version, '4.0.0', '<') === true)
+        ) {
             $expected[\T_NAME_QUALIFIED]       = \T_NAME_QUALIFIED;
             $expected[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;
             $expected[\T_NAME_RELATIVE]        = \T_NAME_RELATIVE;

--- a/Tests/Tokens/Collections/ReturnTypeTokensTest.php
+++ b/Tests/Tokens/Collections/ReturnTypeTokensTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\Tokens\Collections;
 
+use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tokens\Collections;
 use PHPUnit\Framework\TestCase;
 
@@ -32,6 +33,7 @@ class ReturnTypeTokensTest extends TestCase
      */
     public function testReturnTypeTokens()
     {
+        $version  = Helper::getVersion();
         $expected = [
             \T_CALLABLE     => \T_CALLABLE,
             \T_SELF         => \T_SELF,
@@ -46,7 +48,10 @@ class ReturnTypeTokensTest extends TestCase
             \T_STRING       => \T_STRING,
         ];
 
-        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true) {
+        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
+            || (\version_compare($version, '3.5.7', '>=') === true
+                && \version_compare($version, '4.0.0', '<') === true)
+        ) {
             $expected[\T_NAME_QUALIFIED]       = \T_NAME_QUALIFIED;
             $expected[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;
             $expected[\T_NAME_RELATIVE]        = \T_NAME_RELATIVE;


### PR DESCRIPTION
### Collections/various methods: sync with PHPCS

Upstream PR squizlabs/PHP_CodeSniffer#3063 which was merged for PHPCS 3.5.7 effectively "undoes" the PHP 8.0 tokenization for identifier names for PHPCS 3.x, while it also includes backfilling the PHP 8.0 token constants.

In PHPCS 4.x the PHP 8.0 tokenization will be backfilled instead.

This commit annotates this change in the `Collections::nameTokens()` method and updates the unit tests for various token collections to handle this correctly as well.

Refs:
* squizlabs/PHP_CodeSniffer#3041
* squizlabs/PHP_CodeSniffer#3063

### UtilityMethodTestCase::usesPhp8NameTokens(): account for PHPCS 3.x "undoing" the PHP 8.0 identifier name tokenization

Upstream PR #3063 which was merged in PHPCS 3.5.7 effectively "undoes" the PHP 8.0 tokenization for identifier names for PHPCS 3.x.

This updates the `UtilityMethodTestCase::usesPhp8NameTokens()` method to take this upstream change into account.

