### PR TITLE
BCFile: sync with PHPCS: support namespace operator in type declarations

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -255,6 +255,7 @@ class BCFile
      * - PHPCS 3.5.3: Fixed a bug where the `"type_hint_end_token"` array index for a type hinted
      *                parameter would bleed through to the next (non-type hinted) parameter.
      * - PHPCS 3.5.3: Added support for PHP 7.4 `T_FN` arrow functions.
+     * - PHPCS 3.5.7: Added support for namespace operators in type declarations. PHPCS#3066.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodParameters()      Original source.
      * @see \PHPCSUtils\Utils\FunctionDeclarations::getParameters() PHPCSUtils native improved version.
@@ -418,6 +419,7 @@ class BCFile
                         $typeHintEndToken = $i;
                     }
                     break;
+                case 'T_NAMESPACE':
                 case 'T_NS_SEPARATOR':
                     // Part of a type hint or default value.
                     if ($defaultStart === null) {

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -540,6 +540,7 @@ class BCFile
      * - PHPCS 3.5.0: The Exception thrown changed from a `\PHP_CodeSniffer\Exceptions\TokenizerException`
      *                to `\PHP_CodeSniffer\Exceptions\RuntimeException`.
      * - PHPCS 3.5.3: Added support for PHP 7.4 `T_FN` arrow functions.
+     * - PHPCS 3.5.7: Added support for namespace operators in type declarations. PHPCS#3066.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodProperties()      Original source.
      * @see \PHPCSUtils\Utils\FunctionDeclarations::getProperties() PHPCSUtils native improved version.

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -746,6 +746,7 @@ class BCFile
      *                  and comments in the `"type"` value.
      * - PHPCS 3.5.0: The Exception thrown changed from a `\PHP_CodeSniffer\Exceptions\TokenizerException`
      *                to `\PHP_CodeSniffer\Exceptions\RuntimeException`.
+     * - PHPCS 3.5.7: Added support for namespace operators in type declarations. PHPCS#3066.
      *
      * @see \PHP_CodeSniffer\Files\File::getMemberProperties() Original source.
      * @see \PHPCSUtils\Utils\Variables::getMemberProperties() PHPCSUtils native improved version.

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -403,7 +403,6 @@ class FunctionDeclarations
      *   `T_STRING` tokens and examine them to check if these are arrow functions.
      * - Support for PHP 8.0 union types.
      * - Support for PHP 8.0 constructor property promotion.
-     * - Support for namespace operator in type declarations.
      * - Support for PHP 8.0 identifier name tokens in parameter types, cross-version PHP & PHPCS.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodParameters()   Original source.

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -171,7 +171,6 @@ class FunctionDeclarations
      * - To allow for backward compatible handling of arrow functions, this method will also accept
      *   `T_STRING` tokens and examine them to check if these are arrow functions.
      * - Support for PHP 8.0 union types.
-     * - Support for namespace operator in type declarations.
      * - Support for PHP 8.0 identifier name tokens in return types, cross-version PHP & PHPCS.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodProperties()   Original source.

--- a/PHPCSUtils/Utils/Variables.php
+++ b/PHPCSUtils/Utils/Variables.php
@@ -81,7 +81,6 @@ class Variables
      *   other non-property variables passed to the method.
      * - Defensive coding against incorrect calls to this method.
      * - Support for PHP 8.0 union types.
-     * - Support for namespace operator in type declarations.
      * - Support PHP 8.0 identifier name tokens in property types, cross-version PHP & PHPCS.
      *
      * @see \PHP_CodeSniffer\Files\File::getMemberProperties()   Original source.

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.inc
@@ -191,3 +191,8 @@ class PHP8Mixed {
     // Intentional fatal error - nullability is not allowed with mixed, but that's not the concern of the method.
     private ?mixed $nullableMixed;
 }
+
+class NSOperatorInType {
+    /* testNamespaceOperatorTypeHint */
+    public ?namespace\Name $prop;
+}

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -605,6 +605,18 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'nullable_type'   => true,
                 ],
             ],
+            [
+                '/* testNamespaceOperatorTypeHint */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '?namespace\Name',
+                    'type_token'      => ($php8Names === true) ? -2 : -4, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'nullable_type'   => true,
+                ],
+            ],
         ];
     }
 

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
@@ -132,6 +132,9 @@ function mixedTypeHint(mixed &...$var1) {}
 // Intentional fatal error - nullability is not allowed with mixed, but that's not the concern of the method.
 function mixedTypeHintNullable(?Mixed $var1) {}
 
+/* testNamespaceOperatorTypeHint */
+function namespaceOperatorTypeHint(?namespace\Name $var1) {}
+
 /* testFunctionCallFnPHPCS353-354 */
 $value = $obj->fn(true);
 

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -1250,6 +1250,34 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     }
 
     /**
+     * Verify recognition of type declarations using the namespace operator.
+     *
+     * @return void
+     */
+    public function testNamespaceOperatorTypeHint()
+    {
+        $php8Names = parent::usesPhp8NameTokens();
+
+        $expected    = [];
+        $expected[0] = [
+            'token'               => ($php8Names === true) ? 7 : 9, // Offset from the T_FUNCTION token.
+            'name'                => '$var1',
+            'content'             => '?namespace\Name $var1',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '?namespace\Name',
+            'type_hint_token'     => 5, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => ($php8Names === true) ? 5 : 7, // Offset from the T_FUNCTION token.
+            'nullable_type'       => true,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Verify handling of a closure.
      *
      * @return void

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
@@ -87,6 +87,9 @@ function mixedTypeHint() :mixed {}
 // Intentional fatal error - nullability is not allowed with mixed, but that's not the concern of the method.
 function mixedTypeHintNullable(): ?mixed {}
 
+/* testNamespaceOperatorTypeHint */
+function namespaceOperatorTypeHint() : ?namespace\Name {}
+
 /* testNotAFunction */
 return true;
 

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -544,6 +544,28 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     }
 
     /**
+     * Test a function with return type using the namespace operator.
+     *
+     * @return void
+     */
+    public function testNamespaceOperatorTypeHint()
+    {
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '?namespace\Name',
+            'return_type_token'     => 9, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Test for incorrect tokenization of array return type declarations in PHPCS < 2.8.0.
      *
      * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/1264

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.inc
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.inc
@@ -75,6 +75,3 @@ abstract class ConstructorPropertyPromotionAbstractMethod {
     // 3. The callable type is not supported for properties, but that's not the concern of this method.
     abstract public function __construct(public callable $y, private ...$x);
 }
-
-/* testNamespaceOperatorTypeHint */
-function namespaceOperatorTypeHint(?namespace\Name $var1) {}

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
@@ -632,34 +632,6 @@ class GetParametersDiffTest extends UtilityMethodTestCase
     }
 
     /**
-     * Verify recognition of type declarations using the namespace operator.
-     *
-     * @return void
-     */
-    public function testNamespaceOperatorTypeHint()
-    {
-        $php8Names = parent::usesPhp8NameTokens();
-
-        $expected    = [];
-        $expected[0] = [
-            'token'               => ($php8Names === true) ? 7 : 9, // Offset from the T_FUNCTION token.
-            'name'                => '$var1',
-            'content'             => '?namespace\Name $var1',
-            'pass_by_reference'   => false,
-            'reference_token'     => false,
-            'variable_length'     => false,
-            'variadic_token'      => false,
-            'type_hint'           => '?namespace\Name',
-            'type_hint_token'     => 5, // Offset from the T_FUNCTION token.
-            'type_hint_end_token' => ($php8Names === true) ? 5 : 7, // Offset from the T_FUNCTION token.
-            'nullable_type'       => true,
-            'comma_token'         => false,
-        ];
-
-        $this->getParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
-    }
-
-    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.inc
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.inc
@@ -65,6 +65,3 @@ interface FooBar {
 /* testPHP8DuplicateTypeInUnionWhitespaceAndComment */
 // Intentional fatal error - duplicate types are not allowed in union types, but that's not the concern of the method.
 function duplicateTypeInUnion(): int | /*comment*/ string | INT {}
-
-/* testNamespaceOperatorTypeHint */
-function namespaceOperatorTypeHint() : ?namespace\Name {}

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
@@ -372,31 +372,6 @@ class GetPropertiesDiffTest extends UtilityMethodTestCase
     }
 
     /**
-     * Test a function with return type using the namespace operator.
-     *
-     * @return void
-     */
-    public function testNamespaceOperatorTypeHint()
-    {
-        $php8Names = parent::usesPhp8NameTokens();
-
-        $expected = [
-            'scope'                 => 'public',
-            'scope_specified'       => false,
-            'return_type'           => '?namespace\Name',
-            'return_type_token'     => 9, // Offset from the T_FUNCTION token.
-            'return_type_end_token' => ($php8Names === true) ? 9 : 11, // Offset from the T_FUNCTION token.
-            'nullable_return_type'  => true,
-            'is_abstract'           => false,
-            'is_final'              => false,
-            'is_static'             => false,
-            'has_body'              => true,
-        ];
-
-        $this->getPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
-    }
-
-    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.

--- a/Tests/Utils/Variables/GetMemberPropertiesDiffTest.inc
+++ b/Tests/Utils/Variables/GetMemberPropertiesDiffTest.inc
@@ -52,8 +52,3 @@ $anon = new class() {
     // Intentional fatal error - duplicate types are not allowed in union types, but that's not the concern of the method.
     public int |string| /*comment*/ INT $duplicateTypeInUnion;
 };
-
-class NSOperatorInType {
-    /* testNamespaceOperatorTypeHint */
-    public ?namespace\Name $prop;
-}

--- a/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
@@ -234,18 +234,6 @@ class GetMemberPropertiesDiffTest extends UtilityMethodTestCase
                     'nullable_type'   => false,
                 ],
             ],
-            'namespace-operator-type-declaration' => [
-                '/* testNamespaceOperatorTypeHint */',
-                [
-                    'scope'           => 'public',
-                    'scope_specified' => true,
-                    'is_static'       => false,
-                    'type'            => '?namespace\Name',
-                    'type_token'      => ($php8Names === true) ? -2 : -4, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
-                    'nullable_type'   => true,
-                ],
-            ],
         ];
     }
 }


### PR DESCRIPTION
PR #180 added support for the namespace keyword used as an operator in type declarations to:
* the `FunctionDeclarations::getParameters()` method.
* the `FunctionDeclarations::getProperties()` method and by extension the `BCFile::getMethodProperties()` method, even though PHPCS upstream did not support this yet.
* the `FunctionDeclarations::getMemberProperties()` method and by extension the `BCFile::getMemberProperties()` method, even though PHPCS upstream did not support this yet.

Upstream [PR #3066](https://github.com/squizlabs/PHP_CodeSniffer/pull/3066) added the same to the PHPCS native `File::getMethodParameters()`, `File::getMethodProperties()` and `File::getMemberProperties()` methods.

As that PR has now been merged, this commit syncs the upstream changes into the various PHPCSUtils BackCompat methods.

### BCFile::getMethodParameters(): sync with PHPCS / namespace operator in types

This commit syncs the upstream changes into the `BCFile::getMethodParameters()` method, moves the unit tests to the BCFile test class and updates the documentation for the `FunctionDeclarations::getParameters()` method to support the changes as have been merged upstream.

### BCFile::getMethodProperties(): sync with PHPCS / namespace operator in types

This commit syncs the upstream changes in, by moving the unit tests from the "Diff" tests to the BCFile tests and annotating that namespace operators in type declarations are now officially supported in the `BCFile::getMethodProperties()` method.

### BCFile::getMemberProperties(): sync with PHPCS / namespace operator in types

This commit syncs the upstream changes in, by moving the unit tests from the "Diff" tests to the BCFile tests and annotating that namespace operators in type declarations are now officially supported in the `BCFile::getMemberProperties()` method.

