### PR TITLE
New `Utils\Context` class

### DIFF
--- a/PHPCSUtils/Utils/Context.php
+++ b/PHPCSUtils/Utils/Context.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Utils;
+
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\Parentheses;
+
+/**
+ * Utility functions for examining in which context a certain token is used.
+ *
+ * Example use-cases:
+ * - A sniff looking for the use of certain variables may want to disregard the "use"
+ *   of these variables within a call to `isset()` or `empty()`.
+ * - A sniff looking for incrementor/decrementors may want to disregard these when used
+ *   as the third expression in a `for()` condition.
+ *
+ * @since 1.0.0
+ */
+class Context
+{
+
+    /**
+     * Check whether an arbitrary token is within a call to empty().
+     *
+     * _This method is a thin, descriptive wrapper around the {@see Parentheses::getLastOwner()} method.
+     * For more complex/combined queries, it is recommended to call the {@see Parentheses::getLastOwner()}
+     * method directly._
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the token we are checking.
+     *
+     * @return bool
+     */
+    public static function inEmpty(File $phpcsFile, $stackPtr)
+    {
+        return (Parentheses::getLastOwner($phpcsFile, $stackPtr, \T_EMPTY) !== false);
+    }
+
+    /**
+     * Check whether an arbitrary token is within a call to isset().
+     *
+     * _This method is a thin, descriptive wrapper around the {@see Parentheses::getLastOwner()} method.
+     * For more complex/combined queries, it is recommended to call the {@see Parentheses::getLastOwner()}
+     * method directly._
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the token we are checking.
+     *
+     * @return bool
+     */
+    public static function inIsset(File $phpcsFile, $stackPtr)
+    {
+        return (Parentheses::getLastOwner($phpcsFile, $stackPtr, \T_ISSET) !== false);
+    }
+
+    /**
+     * Check whether an arbitrary token is within a call to unset().
+     *
+     * _This method is a thin, descriptive wrapper around the {@see Parentheses::getLastOwner()} method.
+     * For more complex/combined queries, it is recommended to call the {@see Parentheses::getLastOwner()}
+     * method directly._
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the token we are checking.
+     *
+     * @return bool
+     */
+    public static function inUnset(File $phpcsFile, $stackPtr)
+    {
+        return (Parentheses::getLastOwner($phpcsFile, $stackPtr, \T_UNSET) !== false);
+    }
+
+    /**
+     * Check whether an arbitrary token is in a foreach condition and if so, in which part:
+     * before or after the "as".
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the token we are checking.
+     *
+     * @return string|false String `'beforeAs'`, `'as'` or `'afterAs'` when the token is within
+     *                      a foreach condition.
+     *                      `FALSE` in all other cases, including for parse errors.
+     */
+    public static function inForeachCondition(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Check for the existence of the token.
+        if (isset($tokens[$stackPtr]) === false) {
+            return false;
+        }
+
+        $foreach = Parentheses::getLastOwner($phpcsFile, $stackPtr, \T_FOREACH);
+        if ($foreach === false) {
+            return false;
+        }
+
+        if ($tokens[$stackPtr]['code'] === \T_AS) {
+            return 'as';
+        }
+
+        $asPtr = $phpcsFile->findNext(
+            \T_AS,
+            ($tokens[$foreach]['parenthesis_opener'] + 1),
+            $tokens[$foreach]['parenthesis_closer']
+        );
+
+        if ($asPtr === false) {
+            // Parse error or live coding.
+            return false;
+        }
+
+        if ($stackPtr < $asPtr) {
+            return 'beforeAs';
+        }
+
+        return 'afterAs';
+    }
+
+    /**
+     * Check whether an arbitrary token is in a for condition and if so, in which part:
+     * the first, second or third expression.
+     *
+     * Note: the semicolons separating the conditions are regarded as belonging with the
+     * expression before it.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the token we are checking.
+     *
+     * @return string|false String `'expr1'`, `'expr2'` or `'expr3'` when the token is within
+     *                      a for condition.
+     *                      `FALSE` in all other cases, including for parse errors.
+     */
+    public static function inForCondition(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Check for the existence of the token.
+        if (isset($tokens[$stackPtr]) === false) {
+            return false;
+        }
+
+        $for = Parentheses::getLastOwner($phpcsFile, $stackPtr, \T_FOR);
+        if ($for === false) {
+            return false;
+        }
+
+        $semicolons = [];
+        $count      = 0;
+        $opener     = $tokens[$for]['parenthesis_opener'];
+        $closer     = $tokens[$for]['parenthesis_closer'];
+        $level      = $tokens[$for]['level'];
+        $parens     = 1;
+
+        if (isset($tokens[$for]['nested_parenthesis'])) {
+            $parens = (\count($tokens[$for]['nested_parenthesis']) + 1);
+        }
+
+        for ($i = ($opener + 1); $i < $closer; $i++) {
+            if ($tokens[$i]['code'] !== \T_SEMICOLON) {
+                continue;
+            }
+
+            if ($tokens[$i]['level'] !== $level
+                || \count($tokens[$i]['nested_parenthesis']) !== $parens
+            ) {
+                // Disregard semi-colons at lower nesting/condition levels.
+                continue;
+            }
+
+            ++$count;
+            $semicolons[$count] = $i;
+        }
+
+        if ($count !== 2) {
+            return false;
+        }
+
+        foreach ($semicolons as $key => $ptr) {
+            if ($stackPtr <= $ptr) {
+                return 'expr' .  $key;
+            }
+        }
+
+        return 'expr3';
+    }
+}

--- a/Tests/Utils/Context/InEmptyTest.inc
+++ b/Tests/Utils/Context/InEmptyTest.inc
@@ -1,0 +1,17 @@
+<?php
+
+/* testNotEmptyMethodCall */
+$obj->empty($target);
+
+/* testOwnerNotEmpty */
+if ($target + 1 > 10) {}
+
+/* testInEmpty */
+$a = empty($target);
+
+/* testInEmptynested */
+if ((Empty($obj->methodCall($target->prop)) || $somethingElse)) {}
+
+/* testParseError */
+// This has to be the last test in the file.
+empty($target

--- a/Tests/Utils/Context/InEmptyTest.php
+++ b/Tests/Utils/Context/InEmptyTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Context;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Context;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Context::inEmpty() method.
+ *
+ * @covers \PHPCSUtils\Utils\Context::inEmpty
+ *
+ * @group context
+ *
+ * @since 1.0.0
+ */
+class InEmptyTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->assertFalse(Context::inEmpty(self::$phpcsFile, 10000));
+    }
+
+    /**
+     * Test correctly identifying that an arbitrary token is within an empty().
+     *
+     * @dataProvider dataInEmpty
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param bool   $expected   The expected function return value.
+     *
+     * @return void
+     */
+    public function testInEmpty($testMarker, $expected)
+    {
+        $target = $this->getTargetToken($testMarker, \T_VARIABLE, '$target');
+        $this->assertSame($expected, Context::inEmpty(self::$phpcsFile, $target));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testInEmpty()
+     *
+     * @return array
+     */
+    public function dataInEmpty()
+    {
+        return [
+            'method-called-empty' => [
+                '/* testNotEmptyMethodCall */',
+                false,
+            ],
+            'owner-not-empty' => [
+                '/* testOwnerNotEmpty */',
+                false,
+            ],
+            'in-empty' => [
+                '/* testInEmpty */',
+                true,
+            ],
+            'in-empty-nested' => [
+                '/* testInEmptynested */',
+                true,
+            ],
+            'parse-error' => [
+                '/* testParseError */',
+                false,
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/Context/InForConditionTest.inc
+++ b/Tests/Utils/Context/InForConditionTest.inc
@@ -1,0 +1,64 @@
+<?php
+
+/* testNoParentheses */
+echo $target;
+
+/* testNoParenthesisOwner */
+echo ($target + 1);
+
+/* testOwnerNotFor */
+if ($target + 1 > 10) {}
+
+/* testOwnerNotForNestedParentheses */
+foreach (function_call(array($target)) as $value) {}
+
+/* testNotForMethodCall */
+$obj->for ($target) {}
+
+/* testForParseErrorTwoExpressions */
+for ($i = $target; $i < 10) {} // Intentional parse error.
+
+/* testForParseErrorFourExpressions */
+for ($i = $target; $i < 10; $i++; $nonsense) {} // Intentional parse error.
+
+/* testFor */
+for ($i = 0; $i < 10; $target++) :
+    // Do something.
+endfor;
+
+/* testForMultipleStatementsInExpr */
+for ($i = 0, $c = namespace\sizeof($target); $i < $c /* testForSecondSemicolon */ ; $j += $i, print $i, ++$i) {}
+
+/* testForEmptyExpr1 */
+For (; $i < 10; $target + $i) {}
+
+/* testForEmptyExpr2 */
+for ($target = 0; ; ++$i) {}
+
+/* testForEmptyExpr3 */
+for ($i = 0; $target > $i;) {}
+
+/* testForEmptyExpr12 */
+for (;; $next = find($target)) {}
+
+/* testForEmptyExpr13 */
+for (; $target->valid();) {}
+
+/* testForEmptyExpr23 */
+for ($i = $target; ; /* Deliberately empty */) {}
+
+/* testForEmptyExpr123 */
+for (;;) {}
+
+/* testForWithNestedSemiColon */
+for ($closure = function($a, $b) { return $a * $b; }, $i = 10; $closure($a, $b) < 10; $i++) {}
+
+/* testNestedFor */
+add_action('something', function($array) {
+    for($a = call(); $obj->valid($a); $obj->next($a)) {}
+    return;
+});
+
+// Intentional parse error. This has to be the last test in the file.
+/* testParseError */
+for ($i = $target; $i < 10

--- a/Tests/Utils/Context/InForConditionTest.php
+++ b/Tests/Utils/Context/InForConditionTest.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Context;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Context;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Context::inForCondition() method.
+ *
+ * @covers \PHPCSUtils\Utils\Context::inForCondition
+ *
+ * @group context
+ *
+ * @since 1.0.0
+ */
+class InForConditionTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->assertFalse(Context::inForCondition(self::$phpcsFile, 10000));
+    }
+
+    /**
+     * Test receiving `false` when the token passed is not in a for condition.
+     *
+     * @dataProvider dataNotInFor
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     *
+     * @return void
+     */
+    public function testNotInFor($testMarker)
+    {
+        $target = $this->getTargetToken($testMarker, \T_VARIABLE, '$target');
+        $this->assertFalse(Context::inForCondition(self::$phpcsFile, $target));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNotInFor()
+     *
+     * @return array
+     */
+    public function dataNotInFor()
+    {
+        return [
+            'no-parenthesis'                   => ['/* testNoParentheses */'],
+            'no-parenthesis-owner'             => ['/* testNoParenthesisOwner */'],
+            'owner-not-for'                    => ['/* testOwnerNotFor */'],
+            'owner-not-for-nested-parentheses' => ['/* testOwnerNotForNestedParentheses */'],
+            'method-called-for'                => ['/* testNotForMethodCall */'],
+            'for-two-expressions'              => ['/* testForParseErrorTwoExpressions */'],
+            'for-four-expressions'             => ['/* testForParseErrorFourExpressions */'],
+            'parse-error'                      => ['/* testParseError */'],
+        ];
+    }
+
+    /**
+     * Test correctly identifying the position of a token in a for condition.
+     *
+     * @dataProvider dataInForCondition
+     *
+     * @param string           $testMarker    The comment which prefaces the target token in the test file.
+     * @param string           $expected      The expected function return value.
+     * @param int|string|array $targetType    Optional. The token type of the target token.
+     *                                        Defaults to T_VARIABLE.
+     * @param string           $targetContent Optional. The token content of the target token.
+     *                                        Defaults to `$target` for `T_VARIABLE`.
+     *
+     * @return void
+     */
+    public function testInForCondition($testMarker, $expected, $targetType = \T_VARIABLE, $targetContent = null)
+    {
+        if ($targetType === \T_VARIABLE && $targetContent === null) {
+            $targetContent = '$target';
+        }
+
+        $stackPtr = $this->getTargetToken($testMarker, $targetType, $targetContent);
+        $result   = Context::inForCondition(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testInForCondition()
+     *
+     * @return array
+     */
+    public function dataInForCondition()
+    {
+        return [
+            'expr1' => [
+                '/* testFor */',
+                'expr1',
+                \T_EQUAL,
+            ],
+            'expr1-semicolon' => [
+                '/* testFor */',
+                'expr1',
+                \T_SEMICOLON,
+            ],
+            'expr2' => [
+                '/* testFor */',
+                'expr2',
+                \T_LNUMBER,
+                '10',
+            ],
+            'expr3' => [
+                '/* testFor */',
+                'expr3',
+            ],
+            'multi-expression-expr1' => [
+                '/* testForMultipleStatementsInExpr */',
+                'expr1',
+            ],
+            'multi-expression-expr2' => [
+                '/* testForMultipleStatementsInExpr */',
+                'expr2',
+                \T_LESS_THAN,
+            ],
+            'multi-expression-expr2-semicolon' => [
+                '/* testForSecondSemicolon */',
+                'expr2',
+                \T_SEMICOLON,
+            ],
+            'multi-expression-expr3' => [
+                '/* testForSecondSemicolon */',
+                'expr3',
+                \T_PRINT,
+            ],
+            'empty-1-expr2' => [
+                '/* testForEmptyExpr1 */',
+                'expr2',
+                \T_LNUMBER,
+                '10',
+            ],
+            'empty-1-expr3' => [
+                '/* testForEmptyExpr1 */',
+                'expr3',
+            ],
+            'empty-2-expr1' => [
+                '/* testForEmptyExpr2 */',
+                'expr1',
+            ],
+            'empty-2-expr3' => [
+                '/* testForEmptyExpr2 */',
+                'expr3',
+                \T_INC,
+            ],
+            'empty-3-expr1' => [
+                '/* testForEmptyExpr3 */',
+                'expr1',
+                \T_VARIABLE,
+                '$i',
+            ],
+            'empty-3-expr2' => [
+                '/* testForEmptyExpr3 */',
+                'expr2',
+            ],
+            'empty-12-expr3' => [
+                '/* testForEmptyExpr12 */',
+                'expr3',
+            ],
+            'empty-13-expr2' => [
+                '/* testForEmptyExpr13 */',
+                'expr2',
+            ],
+            'empty-23-expr1' => [
+                '/* testForEmptyExpr23 */',
+                'expr1',
+            ],
+            'empty-23-expr3' => [
+                '/* testForEmptyExpr23 */',
+                'expr3',
+                \T_COMMENT,
+            ],
+            'empty-123-expr1' => [
+                '/* testForEmptyExpr123 */',
+                'expr1',
+                \T_SEMICOLON,
+            ],
+            'nested-semicolon-expr1' => [
+                '/* testForWithNestedSemiColon */',
+                'expr1',
+                \T_RETURN,
+            ],
+            'nested-semicolon-expr2' => [
+                '/* testForWithNestedSemiColon */',
+                'expr2',
+                \T_LESS_THAN,
+            ],
+            'nested-semicolon-expr3' => [
+                '/* testForWithNestedSemiColon */',
+                'expr3',
+                \T_INC,
+            ],
+            'nested-for-expr2' => [
+                '/* testNestedFor */',
+                'expr2',
+                \T_STRING,
+                'valid',
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/Context/InForeachConditionTest.inc
+++ b/Tests/Utils/Context/InForeachConditionTest.inc
@@ -1,0 +1,52 @@
+<?php
+
+/* testNoParentheses */
+echo $target;
+
+/* testNoParenthesisOwner */
+echo ($target + 1);
+
+/* testOwnerNotForeach */
+if ($target + 1 > 10) {}
+
+/* testOwnerNotForeachNestedParentheses */
+for ($i = 1; function_call(array($target)) < 10; $i++) {}
+
+/* testNotForeachMethodCall */
+$obj->foreach ($target) {}
+
+/* testForeachWithoutAs */
+foreach ($target) {} // Intentional parse error.
+
+/* testForeachValue */
+foreach ($array as $value) {}
+
+/* testForeachKeyValue */
+foreach ($iterator AS $key => $value) {}
+
+/* testForeachBeforeLongArrayMinimalWhiteSpace */
+foreach (array('a' => 1, 'b' => 2, 3)as$key => $value) {}
+
+/* testForeachBeforeFunctionCall */
+Foreach (callMe(array($target)) As $key => $value) {}
+
+/* testForeachVarAfterAsList */
+foreach($array   as   list($target, $else)) {}
+
+/* testForeachVarAfterAsShortList */
+foreach($array as [$something, $target]) {}
+
+/* testForeachVarAfterAsKeyedList */
+foreach ($array as list('id' => $id, 'name' => $target)):
+    // Do something.
+endforeach;
+
+/* testNestedForeach */
+add_action('something', function($array) {
+    foreach($array as $target) {}
+    return;
+});
+
+// Intentional parse error. This has to be the last test in the file.
+/* testParseError */
+foreach ($array as $target {}

--- a/Tests/Utils/Context/InForeachConditionTest.php
+++ b/Tests/Utils/Context/InForeachConditionTest.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Context;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Context;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Context::inForeachCondition() method.
+ *
+ * @covers \PHPCSUtils\Utils\Context::inForeachCondition
+ *
+ * @group context
+ *
+ * @since 1.0.0
+ */
+class InForeachConditionTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->assertFalse(Context::inForeachCondition(self::$phpcsFile, 10000));
+    }
+
+    /**
+     * Test receiving `false` when the token passed is not in a foreach condition.
+     *
+     * @dataProvider dataNotInForeach
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     *
+     * @return void
+     */
+    public function testNotInForeach($testMarker)
+    {
+        $target = $this->getTargetToken($testMarker, \T_VARIABLE, '$target');
+        $this->assertFalse(Context::inForeachCondition(self::$phpcsFile, $target));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNotInForeach()
+     *
+     * @return array
+     */
+    public function dataNotInForeach()
+    {
+        return [
+            'no-parenthesis'                       => ['/* testNoParentheses */'],
+            'no-parenthesis-owner'                 => ['/* testNoParenthesisOwner */'],
+            'owner-not-foreach'                    => ['/* testOwnerNotForeach */'],
+            'owner-not-foreach-nested-parentheses' => ['/* testOwnerNotForeachNestedParentheses */'],
+            'method-called-foreach'                => ['/* testNotForeachMethodCall */'],
+            'foreach-without-as'                   => ['/* testForeachWithoutAs */'],
+            'parse-error'                          => ['/* testParseError */'],
+        ];
+    }
+
+    /**
+     * Test correctly identifying the position of a token in a foreach condition.
+     *
+     * @dataProvider dataInForeachCondition
+     *
+     * @param string           $testMarker    The comment which prefaces the target token in the test file.
+     * @param string           $expected      The expected function return value.
+     * @param int|string|array $targetType    Optional. The token type of the target token.
+     *                                        Defaults to T_VARIABLE.
+     * @param string           $targetContent Optional. The token content of the target token.
+     *                                        Defaults to `$target` for `T_VARIABLE`.
+     *
+     * @return void
+     */
+    public function testInForeachCondition($testMarker, $expected, $targetType = \T_VARIABLE, $targetContent = null)
+    {
+        if ($targetType === \T_VARIABLE && $targetContent === null) {
+            $targetContent = '$target';
+        }
+
+        $stackPtr = $this->getTargetToken($testMarker, $targetType, $targetContent);
+        $result   = Context::inForeachCondition(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testInForeachCondition()
+     *
+     * @return array
+     */
+    public function dataInForeachCondition()
+    {
+        return [
+            'before' => [
+                '/* testForeachValue */',
+                'beforeAs',
+                \T_VARIABLE,
+                '$array',
+            ],
+            'as' => [
+                '/* testForeachValue */',
+                'as',
+                \T_AS,
+            ],
+            'after' => [
+                '/* testForeachValue */',
+                'afterAs',
+                \T_VARIABLE,
+                '$value',
+            ],
+            'as-caps' => [
+                '/* testForeachKeyValue */',
+                'as',
+                \T_AS,
+            ],
+            'after-key' => [
+                '/* testForeachKeyValue */',
+                'afterAs',
+                \T_VARIABLE,
+                '$key',
+            ],
+            'before-in-long-array' => [
+                '/* testForeachBeforeLongArrayMinimalWhiteSpace */',
+                'beforeAs',
+                \T_LNUMBER,
+                '2',
+            ],
+            'before-function-call' => [
+                '/* testForeachBeforeFunctionCall */',
+                'beforeAs',
+                \T_STRING,
+            ],
+            'before-array-nested-in-function-call' => [
+                '/* testForeachBeforeFunctionCall */',
+                'beforeAs',
+                \T_ARRAY,
+            ],
+            'before-var-nested-in-array-nested-in-function-call' => [
+                '/* testForeachBeforeFunctionCall */',
+                'beforeAs',
+            ],
+            'after-list' => [
+                '/* testForeachVarAfterAsList */',
+                'afterAs',
+                \T_LIST,
+            ],
+            'after-variable-in-list' => [
+                '/* testForeachVarAfterAsList */',
+                'afterAs',
+            ],
+            'after-variable-in-short-list' => [
+                '/* testForeachVarAfterAsList */',
+                'afterAs',
+            ],
+            'after-variable-in-list-value' => [
+                '/* testForeachVarAfterAsKeyedList */',
+                'afterAs',
+            ],
+            'after-variable-in-list-key' => [
+                '/* testForeachVarAfterAsKeyedList */',
+                'afterAs',
+                \T_CONSTANT_ENCAPSED_STRING,
+                "'name'",
+            ],
+            'after-foreach-nested-in-closure' => [
+                '/* testNestedForeach */',
+                'afterAs',
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/Context/InIssetTest.inc
+++ b/Tests/Utils/Context/InIssetTest.inc
@@ -1,0 +1,17 @@
+<?php
+
+/* testNotIssetMethodCall */
+$obj->isset($target);
+
+/* testOwnerNotIsset */
+if ($target + 1 > 10) {}
+
+/* testInIsset */
+$a = isset($target);
+
+/* testInIssetnested */
+if ((Isset($something, $target, $else) || $somethingElse)) {}
+
+/* testParseError */
+// This has to be the last test in the file.
+isset($target

--- a/Tests/Utils/Context/InIssetTest.php
+++ b/Tests/Utils/Context/InIssetTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Context;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Context;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Context::inIsset() method.
+ *
+ * @covers \PHPCSUtils\Utils\Context::inIsset
+ *
+ * @group context
+ *
+ * @since 1.0.0
+ */
+class InIssetTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->assertFalse(Context::inIsset(self::$phpcsFile, 10000));
+    }
+
+    /**
+     * Test correctly identifying that an arbitrary token is within an isset().
+     *
+     * @dataProvider dataInIsset
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param bool   $expected   The expected function return value.
+     *
+     * @return void
+     */
+    public function testInIsset($testMarker, $expected)
+    {
+        $target = $this->getTargetToken($testMarker, \T_VARIABLE, '$target');
+        $this->assertSame($expected, Context::inIsset(self::$phpcsFile, $target));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testInIsset()
+     *
+     * @return array
+     */
+    public function dataInIsset()
+    {
+        return [
+            'method-called-isset' => [
+                '/* testNotIssetMethodCall */',
+                false,
+            ],
+            'owner-not-isset' => [
+                '/* testOwnerNotIsset */',
+                false,
+            ],
+            'in-isset' => [
+                '/* testInIsset */',
+                true,
+            ],
+            'in-isset-nested' => [
+                '/* testInIssetnested */',
+                true,
+            ],
+            'parse-error' => [
+                '/* testParseError */',
+                false,
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/Context/InUnsetTest.inc
+++ b/Tests/Utils/Context/InUnsetTest.inc
@@ -1,0 +1,16 @@
+<?php
+
+/* testNotUnsetMethodCall */
+$obj->unset($target);
+
+function foo() {
+    /* testOwnerNotUnset */
+    if (isset($target) && $target + 1 > 10) {
+        /* testInUnset */
+        Unset($something['a'], $target->prop, $else);
+    }
+}
+
+/* testParseError */
+// This has to be the last test in the file.
+unset($target

--- a/Tests/Utils/Context/InUnsetTest.php
+++ b/Tests/Utils/Context/InUnsetTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Context;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Context;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Context::inUnset() method.
+ *
+ * @covers \PHPCSUtils\Utils\Context::inUnset
+ *
+ * @group context
+ *
+ * @since 1.0.0
+ */
+class InUnsetTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Test passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->assertFalse(Context::inUnset(self::$phpcsFile, 10000));
+    }
+
+    /**
+     * Test correctly identifying that an arbitrary token is within an unset().
+     *
+     * @dataProvider dataInUnset
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param bool   $expected   The expected function return value.
+     *
+     * @return void
+     */
+    public function testInUnset($testMarker, $expected)
+    {
+        $target = $this->getTargetToken($testMarker, \T_VARIABLE, '$target');
+        $this->assertSame($expected, Context::inUnset(self::$phpcsFile, $target));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testInUnset()
+     *
+     * @return array
+     */
+    public function dataInUnset()
+    {
+        return [
+            'method-called-unset' => [
+                '/* testNotUnsetMethodCall */',
+                false,
+            ],
+            'owner-not-unset' => [
+                '/* testOwnerNotUnset */',
+                false,
+            ],
+            'in-unset' => [
+                '/* testInUnset */',
+                true,
+            ],
+            'parse-error' => [
+                '/* testParseError */',
+                false,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This class introduces five new utility methods to examine the context in which an arbitrary token is used.

The class currently contains the following methods:
* `inEmpty()` - to check whether an arbitrary token is used within the `empty()` language construct. Returns boolean.
* `inIsset()` - to check whether an arbitrary token is used within the `isset()` language construct. Returns boolean.
* `inUnset()` - to check whether an arbitrary token is used within the `unset()` language construct. Returns boolean.
* `inForeachCondition()` - to check whether an arbitrary token is used within the condition of a `foreach()` control structure and if so, in what part. Returns string `beforeAs`, `as` or `afterAs` or `false` when not in a foreach condition or in case of a parse error.
* `inForCondition()` - to check whether an arbitrary token is used within the condition of a `for()` control structure and if so, in what part. Returns string `expr1`, `expr2` or `expr3` or `false` when not in a for condition or in case of a parse error.

Includes dedicated unit tests for each method.