### PR TITLE
BCFile::isReference(): sync with PHPCS / arrow function params passed by ref

### DIFF
--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -66,7 +66,6 @@ class Operators
      * Main differences with the PHPCS version:
      * - Defensive coding against incorrect calls to this method.
      * - Improved handling of select tokenizer errors involving short lists/short arrays.
-     * - Parameters passed by reference in arrow functions are recognized correctly.
      *
      * @see \PHP_CodeSniffer\Files\File::isReference()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::isReference() Cross-version compatible version of the original.

--- a/Tests/BackCompat/BCFile/IsReferenceTest.inc
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.inc
@@ -188,3 +188,13 @@ $closure = function (
     /* testPassByReferenceExactParameterD */
     $d = E_NOTICE & E_STRICT,
 ) {};
+
+// Issue PHPCS#3049.
+/* testArrowFunctionPassByReferenceA */
+$fn = fn(array &$one) => 1;
+
+/* testArrowFunctionPassByReferenceB */
+$fn = fn($param, &...$moreParams) => 1;
+
+/* testArrowFunctionNonReferenceInDefault */
+$fn = fn( $one = E_NOTICE & E_STRICT) => 1;

--- a/Tests/BackCompat/BCFile/IsReferenceTest.php
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.php
@@ -344,6 +344,18 @@ class IsReferenceTest extends UtilityMethodTestCase
                 '/* testPassByReferenceExactParameterD */',
                 false,
             ],
+            [
+                '/* testArrowFunctionPassByReferenceA */',
+                true,
+            ],
+            [
+                '/* testArrowFunctionPassByReferenceB */',
+                true,
+            ],
+            [
+                '/* testArrowFunctionNonReferenceInDefault */',
+                false,
+            ],
         ];
     }
 }

--- a/Tests/Utils/Operators/IsReferenceDiffTest.inc
+++ b/Tests/Utils/Operators/IsReferenceDiffTest.inc
@@ -11,12 +11,3 @@ if ($foo) {}
 /* testTokenizerIssue1284PHPCSlt280C */
 if ($foo) {}
 [&$a, $b];
-
-/* testArrowFunctionPassByReferenceA */
-$fn = fn(array &$one) => 1;
-
-/* testArrowFunctionPassByReferenceB */
-$fn = fn($param, &...$moreParams) => 1;
-
-/* testArrowFunctionNonReferenceInDefault */
-$fn = fn( $one = E_NOTICE & E_STRICT) => 1;

--- a/Tests/Utils/Operators/IsReferenceDiffTest.php
+++ b/Tests/Utils/Operators/IsReferenceDiffTest.php
@@ -85,18 +85,6 @@ class IsReferenceDiffTest extends UtilityMethodTestCase
                 '/* testTokenizerIssue1284PHPCSlt280C */',
                 true,
             ],
-            'issue-3049-arrow-function-pass-by-reference-A' => [
-                '/* testArrowFunctionPassByReferenceA */',
-                true,
-            ],
-            'issue-3049-arrow-function-pass-by-reference-B' => [
-                '/* testArrowFunctionPassByReferenceB */',
-                true,
-            ],
-            'issue-3049-arrow-function-parameter-default' => [
-                '/* testArrowFunctionNonReferenceInDefault */',
-                false,
-            ],
         ];
     }
 }


### PR DESCRIPTION
PR #192 added support for recognizing the reference operator when used for parameters passed by reference in arrow functions to the `Operators::isReference()` method.

[Upstream PR #3103](https://github.com/squizlabs/PHP_CodeSniffer/pull/3103) added the same to the PHPCS native `File::isReference()` method.

As that PR has now been merged and will be included in PHPCS 3.5.7, this commit syncs the upstream changes in, by moving the unit tests from the "Diff" tests to the BCFile tests and annotating that parameters passed by reference for arrow functions are now officially supported in the `BCFile::isReference()` method.