### PR TITLE
Arrays::isShortArray()/Lists::isShortList(): add extra unit tests + minor fix

### DIFF
--- a/Tests/Utils/Lists/IsShortArrayOrListTokenizerBC1Test.inc
+++ b/Tests/Utils/Lists/IsShortArrayOrListTokenizerBC1Test.inc
@@ -32,3 +32,9 @@ $c->{$var}[ ] = 2;
 
 /* testTokenizerIssue3013PHPCSlt356 */
 $var = __FILE__[0];
+
+/* testTokenizerIssuePHPCS28xA */
+__NAMESPACE__[] = 'x';
+
+/* testTokenizerIssuePHPCS28xB */
+__method__[0]/* testTokenizerIssuePHPCS28xC */[1]/* testTokenizerIssuePHPCS28xD */[2] *= 'x';

--- a/Tests/Utils/Lists/IsShortArrayOrListTokenizerBC1Test.php
+++ b/Tests/Utils/Lists/IsShortArrayOrListTokenizerBC1Test.php
@@ -191,6 +191,34 @@ class IsShortArrayOrListTokenizerBC1Test extends UtilityMethodTestCase
                     'list'  => false,
                 ],
             ],
+            'issue-more-magic-constant-dereferencing-1' => [
+                '/* testTokenizerIssuePHPCS28xA */',
+                [
+                    'array' => false,
+                    'list'  => false,
+                ],
+            ],
+            'issue-nested-magic-constant-dereferencing-2' => [
+                '/* testTokenizerIssuePHPCS28xB */',
+                [
+                    'array' => false,
+                    'list'  => false,
+                ],
+            ],
+            'issue-nested-magic-constant-dereferencing-3' => [
+                '/* testTokenizerIssuePHPCS28xC */',
+                [
+                    'array' => false,
+                    'list'  => false,
+                ],
+            ],
+            'issue-nested-magic-constant-dereferencing-4' => [
+                '/* testTokenizerIssuePHPCS28xD */',
+                [
+                    'array' => false,
+                    'list'  => false,
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
... to safeguard against a PHPCS 2.8.x specific issue, which was already handled correctly in `Arrays::isShortArray()`, but not yet handled in `Lists::isShortList()`.

This now copies over the code used in the `Arrays::isShortArray()` method to the `Lists::isShortList()` method.

At a later point, a refactor to get rid of the duplication would be a good thing.