### PR TITLE
Operators::isTypeUnion(): account for new T_TYPE_UNION token

### DIFF
--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -176,6 +176,12 @@ class Operators
      * The `T_BITWISE_OR` token is used in PHP as bitwise or, but as of PHP 8.0, also as the
      * separator in union type declarations.
      *
+     * As of PHPCS 3.6.0, the type union separator will be tokenized as `T_TYPE_UNION` in PHPCS.
+     * However, for any standard which needs to support PHPCS < 3.6.0, this method can analyze
+     * whether a T_BITWISE_OR token is a type union separator or an actual bitwise or operator.
+     *
+     * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/3032
+     *
      * @since 1.0.0-alpha4
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
@@ -188,7 +194,16 @@ class Operators
     {
         $tokens = $phpcsFile->getTokens();
 
-        if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== \T_BITWISE_OR) {
+        if (isset($tokens[$stackPtr]) === false) {
+            return false;
+        }
+
+        if ($tokens[$stackPtr]['type'] === 'T_TYPE_UNION') {
+            // Just in case.
+            return true;
+        }
+
+        if ($tokens[$stackPtr]['code'] !== \T_BITWISE_OR) {
             return false;
         }
 

--- a/Tests/Utils/Operators/IsTypeUnionTest.php
+++ b/Tests/Utils/Operators/IsTypeUnionTest.php
@@ -57,7 +57,12 @@ class IsTypeUnionTest extends UtilityMethodTestCase
      */
     public function testIsTypeUnion($testMarker)
     {
-        $stackPtr = $this->getTargetToken($testMarker, [\T_BITWISE_OR]);
+        $targets = [\T_BITWISE_OR];
+        if (\defined('T_TYPE_UNION') === true) {
+            $targets[] = \T_TYPE_UNION;
+        }
+
+        $stackPtr = $this->getTargetToken($testMarker, $targets);
 
         $this->assertTrue(Operators::isTypeUnion(self::$phpcsFile, $stackPtr));
     }
@@ -115,7 +120,12 @@ class IsTypeUnionTest extends UtilityMethodTestCase
      */
     public function testBitwiseOr($testMarker)
     {
-        $stackPtr = $this->getTargetToken($testMarker, [\T_BITWISE_OR]);
+        $targets = [\T_BITWISE_OR];
+        if (\defined('T_TYPE_UNION') === true) {
+            $targets[] = \T_TYPE_UNION;
+        }
+
+        $stackPtr = $this->getTargetToken($testMarker, $targets);
 
         $this->assertFalse(Operators::isTypeUnion(self::$phpcsFile, $stackPtr));
     }


### PR DESCRIPTION
Minor adjustment, mostly to the unit tests to allow for the new `T_TYPE_UNION` token as introduced in PHPCS 3.6.0 via PR squizlabs/PHP_CodeSniffer#3032.