### PR TITLE
BCFile::getMethodProperties(): sync with PHPCS / 'return_type_end_token' index

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -532,17 +532,19 @@ class BCFile
      * The format of the return value is:
      * ```php
      * array(
-     *   'scope'                => 'public', // Public, private, or protected
-     *   'scope_specified'      => true,     // TRUE if the scope keyword was found.
-     *   'return_type'          => '',       // The return type of the method.
-     *   'return_type_token'    => integer,  // The stack pointer to the start of the return type
-     *                                       // or FALSE if there is no return type.
-     *   'nullable_return_type' => false,    // TRUE if the return type is preceded by
-     *                                       // the nullability operator.
-     *   'is_abstract'          => false,    // TRUE if the abstract keyword was found.
-     *   'is_final'             => false,    // TRUE if the final keyword was found.
-     *   'is_static'            => false,    // TRUE if the static keyword was found.
-     *   'has_body'             => false,    // TRUE if the method has a body
+     *   'scope'                 => 'public', // Public, private, or protected
+     *   'scope_specified'       => true,     // TRUE if the scope keyword was found.
+     *   'return_type'           => '',       // The return type of the method.
+     *   'return_type_token'     => integer,  // The stack pointer to the start of the return type
+     *                                        // or FALSE if there is no return type.
+     *   'return_type_end_token' => integer,  // The stack pointer to the end of the return type
+     *                                        // or FALSE if there is no return type.
+     *   'nullable_return_type'  => false,    // TRUE if the return type is preceded by
+     *                                        // the nullability operator.
+     *   'is_abstract'           => false,    // TRUE if the abstract keyword was found.
+     *   'is_final'              => false,    // TRUE if the final keyword was found.
+     *   'is_static'             => false,    // TRUE if the static keyword was found.
+     *   'has_body'              => false,    // TRUE if the method has a body
      * );
      * ```
      *
@@ -569,6 +571,7 @@ class BCFile
      * - PHPCS 3.5.3: Added support for PHP 7.4 `T_FN` arrow functions.
      * - PHPCS 3.5.7: Added support for namespace operators in type declarations. PHPCS#3066.
      * - PHPCS 3.6.0: Added support for PHP 8.0 union types. PHPCS#3032.
+     * - PHPCS 3.6.0: Added new `"return_type_end_token"` index. PHPCS#3153.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodProperties()      Original source.
      * @see \PHPCSUtils\Utils\FunctionDeclarations::getProperties() PHPCSUtils native improved version.
@@ -658,6 +661,7 @@ class BCFile
         $returnType         = '';
         $returnTypeToken    = false;
         $nullableReturnType = false;
+        $returnTypeEndToken = false;
         $hasBody            = true;
         $returnTypeTokens   = Collections::returnTypeTokensBC();
 
@@ -711,7 +715,8 @@ class BCFile
                         $returnTypeToken = $i;
                     }
 
-                    $returnType .= $tokens[$i]['content'];
+                    $returnType        .= $tokens[$i]['content'];
+                    $returnTypeEndToken = $i;
                 }
             }
 
@@ -733,15 +738,16 @@ class BCFile
         }
 
         return [
-            'scope'                => $scope,
-            'scope_specified'      => $scopeSpecified,
-            'return_type'          => $returnType,
-            'return_type_token'    => $returnTypeToken,
-            'nullable_return_type' => $nullableReturnType,
-            'is_abstract'          => $isAbstract,
-            'is_final'             => $isFinal,
-            'is_static'            => $isStatic,
-            'has_body'             => $hasBody,
+            'scope'                 => $scope,
+            'scope_specified'       => $scopeSpecified,
+            'return_type'           => $returnType,
+            'return_type_token'     => $returnTypeToken,
+            'return_type_end_token' => $returnTypeEndToken,
+            'nullable_return_type'  => $nullableReturnType,
+            'is_abstract'           => $isAbstract,
+            'is_final'              => $isFinal,
+            'is_static'             => $isStatic,
+            'has_body'              => $hasBody,
         ];
     }
 

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -167,7 +167,6 @@ class FunctionDeclarations
      *      parse errors or live coding.
      * - Defensive coding against incorrect calls to this method.
      * - More efficient checking whether a function has a body.
-     * - New `"return_type_end_token"` (int|false) array index.
      * - To allow for backward compatible handling of arrow functions, this method will also accept
      *   `T_STRING` tokens and examine them to check if these are arrow functions.
      * - Support for PHP 8.0 identifier name tokens in return types, cross-version PHP & PHPCS.

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
@@ -41,6 +41,7 @@ class MyClass {
     function myFunction(): \MyNamespace\MyClass {}
 
     /* testReturnMultilineNamespace */
+    // Parse error in PHP 8.0.
     function myFunction(): \MyNamespace /** comment *\/ comment */
                            \MyClass /* comment */
                            \Foo {}

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -87,15 +87,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testBasicFunction()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '',
-            'return_type_token'    => false,
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '',
+            'return_type_token'     => false,
+            'return_type_end_token' => false,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -109,15 +110,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testReturnFunction()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'array',
-            'return_type_token'    => 11, // Offset from the T_FUNCTION token.
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'array',
+            'return_type_token'     => 11, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 11, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -131,15 +133,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testNestedClosure()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'int',
-            'return_type_token'    => 8, // Offset from the T_FUNCTION token.
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'int',
+            'return_type_token'     => 8, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 8, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -153,15 +156,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testBasicMethod()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '',
-            'return_type_token'    => false,
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '',
+            'return_type_token'     => false,
+            'return_type_end_token' => false,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -175,15 +179,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testPrivateStaticMethod()
     {
         $expected = [
-            'scope'                => 'private',
-            'scope_specified'      => true,
-            'return_type'          => '',
-            'return_type_token'    => false,
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => true,
-            'has_body'             => true,
+            'scope'                 => 'private',
+            'scope_specified'       => true,
+            'return_type'           => '',
+            'return_type_token'     => false,
+            'return_type_end_token' => false,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => true,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -197,15 +202,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testFinalMethod()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => true,
-            'return_type'          => '',
-            'return_type_token'    => false,
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => true,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => true,
+            'return_type'           => '',
+            'return_type_token'     => false,
+            'return_type_end_token' => false,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => true,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -219,15 +225,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testProtectedReturnMethod()
     {
         $expected = [
-            'scope'                => 'protected',
-            'scope_specified'      => true,
-            'return_type'          => 'int',
-            'return_type_token'    => 8, // Offset from the T_FUNCTION token.
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'protected',
+            'scope_specified'       => true,
+            'return_type'           => 'int',
+            'return_type_token'     => 8, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 8, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -241,15 +248,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testPublicReturnMethod()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => true,
-            'return_type'          => 'array',
-            'return_type_token'    => 7, // Offset from the T_FUNCTION token.
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => true,
+            'return_type'           => 'array',
+            'return_type_token'     => 7, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 7, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -263,15 +271,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testNullableReturnMethod()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => true,
-            'return_type'          => '?array',
-            'return_type_token'    => 8, // Offset from the T_FUNCTION token.
-            'nullable_return_type' => true,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => true,
+            'return_type'           => '?array',
+            'return_type_token'     => 8, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 8, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -285,15 +294,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testMessyNullableReturnMethod()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => true,
-            'return_type'          => '?array',
-            'return_type_token'    => 18, // Offset from the T_FUNCTION token.
-            'nullable_return_type' => true,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => true,
+            'return_type'           => '?array',
+            'return_type_token'     => 18, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 18, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -306,16 +316,19 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
      */
     public function testReturnNamespace()
     {
+        $php8Names = parent::usesPhp8NameTokens();
+
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '\MyNamespace\MyClass',
-            'return_type_token'    => 7, // Offset from the T_FUNCTION token.
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '\MyNamespace\MyClass',
+            'return_type_token'     => 7, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => ($php8Names === true) ? 7 : 10, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -329,15 +342,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testReturnMultilineNamespace()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '\MyNamespace\MyClass\Foo',
-            'return_type_token'    => 7, // Offset from the T_FUNCTION token.
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '\MyNamespace\MyClass\Foo',
+            'return_type_token'     => 7, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 23, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -351,15 +365,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testReturnUnqualifiedName()
     {
         $expected = [
-            'scope'                => 'private',
-            'scope_specified'      => true,
-            'return_type'          => '?MyClass',
-            'return_type_token'    => 8, // Offset from the T_FUNCTION token.
-            'nullable_return_type' => true,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'private',
+            'scope_specified'       => true,
+            'return_type'           => '?MyClass',
+            'return_type_token'     => 8, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 8, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -372,16 +387,19 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
      */
     public function testReturnPartiallyQualifiedName()
     {
+        $php8Names = parent::usesPhp8NameTokens();
+
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'Sub\Level\MyClass',
-            'return_type_token'    => 7, // Offset from the T_FUNCTION token.
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'Sub\Level\MyClass',
+            'return_type_token'     => 7, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => ($php8Names === true) ? 7 : 11, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -395,15 +413,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testAbstractMethod()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '',
-            'return_type_token'    => false,
-            'nullable_return_type' => false,
-            'is_abstract'          => true,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => false,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '',
+            'return_type_token'     => false,
+            'return_type_end_token' => false,
+            'nullable_return_type'  => false,
+            'is_abstract'           => true,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => false,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -417,15 +436,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testAbstractReturnMethod()
     {
         $expected = [
-            'scope'                => 'protected',
-            'scope_specified'      => true,
-            'return_type'          => 'bool',
-            'return_type_token'    => 7, // Offset from the T_FUNCTION token.
-            'nullable_return_type' => false,
-            'is_abstract'          => true,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => false,
+            'scope'                 => 'protected',
+            'scope_specified'       => true,
+            'return_type'           => 'bool',
+            'return_type_token'     => 7, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 7, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => false,
+            'is_abstract'           => true,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => false,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -439,15 +459,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testInterfaceMethod()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '',
-            'return_type_token'    => false,
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => false,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '',
+            'return_type_token'     => false,
+            'return_type_end_token' => false,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => false,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -461,15 +482,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testArrowFunction()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'int',
-            'return_type_token'    => 9, // Offset from the T_FN token.
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => true,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'int',
+            'return_type_token'     => 9, // Offset from the T_FN token.
+            'return_type_end_token' => 9, // Offset from the T_FN token.
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => true,
+            'has_body'              => true,
         ];
 
         $arrowTokenTypes = Collections::arrowFunctionTokensBC();
@@ -485,15 +507,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testReturnTypeStatic()
     {
         $expected = [
-            'scope'                => 'private',
-            'scope_specified'      => true,
-            'return_type'          => 'static',
-            'return_type_token'    => 7, // Offset from the T_FUNCTION token.
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'private',
+            'scope_specified'       => true,
+            'return_type'           => 'static',
+            'return_type_token'     => 7, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 7, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -507,15 +530,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testPHP8MixedTypeHint()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'mixed',
-            'return_type_token'    => 7, // Offset from the T_FUNCTION token.
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'mixed',
+            'return_type_token'     => 7, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 7, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -529,15 +553,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testPHP8MixedTypeHintNullable()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '?mixed',
-            'return_type_token'    => 8, // Offset from the T_FUNCTION token.
-            'nullable_return_type' => true,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '?mixed',
+            'return_type_token'     => 8, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 8, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -550,11 +575,14 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
      */
     public function testNamespaceOperatorTypeHint()
     {
+        $php8Names = parent::usesPhp8NameTokens();
+
         $expected = [
             'scope'                 => 'public',
             'scope_specified'       => false,
             'return_type'           => '?namespace\Name',
             'return_type_token'     => 9, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => ($php8Names === true) ? 9 : 11, // Offset from the T_FUNCTION token.
             'nullable_return_type'  => true,
             'is_abstract'           => false,
             'is_final'              => false,
@@ -577,6 +605,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope_specified'       => false,
             'return_type'           => 'int|float',
             'return_type_token'     => 9, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 11, // Offset from the T_FUNCTION token.
             'nullable_return_type'  => false,
             'is_abstract'           => false,
             'is_final'              => false,
@@ -601,6 +630,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope_specified'       => false,
             'return_type'           => 'MyClassA|\Package\MyClassB',
             'return_type_token'     => 6, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => ($php8Names === true) ? 8 : 11, // Offset from the T_FUNCTION token.
             'nullable_return_type'  => false,
             'is_abstract'           => false,
             'is_final'              => false,
@@ -625,6 +655,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope_specified'       => false,
             'return_type'           => 'array|bool|callable|int|float|null|Object|string',
             'return_type_token'     => 8, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 22, // Offset from the T_FUNCTION token.
             'nullable_return_type'  => false,
             'is_abstract'           => false,
             'is_final'              => false,
@@ -649,6 +680,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope_specified'       => false,
             'return_type'           => 'false|MIXED|self|parent|static|iterable|Resource|void',
             'return_type_token'     => 9, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 23, // Offset from the T_FUNCTION token.
             'nullable_return_type'  => false,
             'is_abstract'           => false,
             'is_final'              => false,
@@ -671,6 +703,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope_specified'       => false,
             'return_type'           => '?int|float',
             'return_type_token'     => 12, // Offset from the T_CLOSURE token.
+            'return_type_end_token' => 14, // Offset from the T_CLOSURE token.
             'nullable_return_type'  => true,
             'is_abstract'           => false,
             'is_final'              => false,
@@ -693,6 +726,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope_specified'       => false,
             'return_type'           => 'null',
             'return_type_token'     => 7, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 7, // Offset from the T_FUNCTION token.
             'nullable_return_type'  => false,
             'is_abstract'           => false,
             'is_final'              => false,
@@ -715,6 +749,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope_specified'       => false,
             'return_type'           => 'false',
             'return_type_token'     => 7, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 7, // Offset from the T_FUNCTION token.
             'nullable_return_type'  => false,
             'is_abstract'           => false,
             'is_final'              => false,
@@ -737,6 +772,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope_specified'       => false,
             'return_type'           => 'bool|false',
             'return_type_token'     => 7, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 9, // Offset from the T_FUNCTION token.
             'nullable_return_type'  => false,
             'is_abstract'           => false,
             'is_final'              => false,
@@ -759,6 +795,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope_specified'       => false,
             'return_type'           => 'object|ClassName',
             'return_type_token'     => 7, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 9, // Offset from the T_FUNCTION token.
             'nullable_return_type'  => false,
             'is_abstract'           => false,
             'is_final'              => false,
@@ -781,6 +818,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope_specified'       => true,
             'return_type'           => 'iterable|array|Traversable',
             'return_type_token'     => 7, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 11, // Offset from the T_FUNCTION token.
             'nullable_return_type'  => false,
             'is_abstract'           => false,
             'is_final'              => false,
@@ -803,6 +841,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
             'scope_specified'       => false,
             'return_type'           => 'int|string|INT',
             'return_type_token'     => 7, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 17, // Offset from the T_FUNCTION token.
             'nullable_return_type'  => false,
             'is_abstract'           => false,
             'is_final'              => false,
@@ -823,15 +862,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testPhpcsIssue1264()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'array',
-            'return_type_token'    => 8, // Offset from the T_FUNCTION token.
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'array',
+            'return_type_token'     => 8, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 8, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -848,15 +888,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testArrowFunctionArrayReturnValue()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => 'array',
-            'return_type_token'    => 5, // Offset from the T_FN token.
-            'nullable_return_type' => false,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'array',
+            'return_type_token'     => 5, // Offset from the T_FN token.
+            'return_type_end_token' => 5, // Offset from the T_FN token.
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $arrowTokenTypes = Collections::arrowFunctionTokensBC();
@@ -872,15 +913,16 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     public function testArrowFunctionReturnByRef()
     {
         $expected = [
-            'scope'                => 'public',
-            'scope_specified'      => false,
-            'return_type'          => '?string',
-            'return_type_token'    => 12,
-            'nullable_return_type' => true,
-            'is_abstract'          => false,
-            'is_final'             => false,
-            'is_static'            => false,
-            'has_body'             => true,
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '?string',
+            'return_type_token'     => 12, // Offset from the T_FN token.
+            'return_type_end_token' => 12, // Offset from the T_FN token.
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
         ];
 
         $arrowTokenTypes = Collections::arrowFunctionTokensBC();
@@ -905,6 +947,9 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
 
         if ($expected['return_type_token'] !== false) {
             $expected['return_type_token'] += $function;
+        }
+        if ($expected['return_type_end_token'] !== false) {
+            $expected['return_type_end_token'] += $function;
         }
 
         $this->assertSame($expected, $found);

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.inc
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.inc
@@ -17,8 +17,3 @@ trait FooTrait {
             $func();
     }
 }
-
-/* testReturnTypeEndTokenIndex */
-function myFunction(): ?\MyNamespace /* comment */
-                        \MyClass // comment
-                        \Foo {}

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
@@ -87,31 +87,6 @@ class GetPropertiesDiffTest extends UtilityMethodTestCase
     }
 
     /**
-     * Test that the new "return_type_end_token" index is set correctly.
-     *
-     * @return void
-     */
-    public function testReturnTypeEndTokenIndex()
-    {
-        $php8Names = parent::usesPhp8NameTokens();
-
-        $expected = [
-            'scope'                 => 'public',
-            'scope_specified'       => false,
-            'return_type'           => '?\MyNamespace\MyClass\Foo',
-            'return_type_token'     => 8, // Offset from the T_FUNCTION token.
-            'return_type_end_token' => ($php8Names === true) ? 17 : 20, // Offset from the T_FUNCTION token.
-            'nullable_return_type'  => true,
-            'is_abstract'           => false,
-            'is_final'              => false,
-            'is_static'             => false,
-            'has_body'              => true,
-        ];
-
-        $this->getPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
-    }
-
-    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesTest.php
@@ -83,15 +83,9 @@ class GetPropertiesTest extends BCFile_GetMethodPropertiesTest
         if ($expected['return_type_token'] !== false) {
             $expected['return_type_token'] += $function;
         }
-
-        /*
-         * Test the new `return_type_end_token` key which is not in the original datasets.
-         */
-        $this->assertArrayHasKey('return_type_end_token', $found);
-        $this->assertTrue($found['return_type_end_token'] === false || \is_int($found['return_type_end_token']));
-
-        // Remove the array key before doing the compare against the original dataset.
-        unset($found['return_type_end_token']);
+        if ($expected['return_type_end_token'] !== false) {
+            $expected['return_type_end_token'] += $function;
+        }
 
         $this->assertSame($expected, $found);
     }


### PR DESCRIPTION
The `return_type_end_token` index as a part of the return value for `FunctionDeclarations::getProperties()` has existed in PHPCSUtils since PR #33 / release `1.0.0-alpha1`.

Upstream PR squizlabs/PHP_CodeSniffer#3153 has now added this same key to the `File::getMethodProperties()` method.

As that PR has now been merged, this commit syncs the upstream changes in and updates the unit tests to match.