### PR TITLE
Arrays::isShortArray()/Lists::isShortList(): work round PHP8 interpolated string dereferencing

### DIFF
--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -138,6 +138,18 @@ class Arrays
 
             $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true);
 
+            //if (\version_compare($phpcsVersion, '3.6.0', '<')) {
+            /*
+             * BC: Work around a bug in the tokenizer of PHPCS < 3.6.0 where dereferencing
+             * of interpolated text string (PHP 8+) would be incorrectly tokenized as short array.
+             *
+             * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/3172
+             */
+            if ($tokens[$prevNonEmpty]['code'] === \T_DOUBLE_QUOTED_STRING) {
+                return false;
+            }
+            //}
+
             if (\version_compare($phpcsVersion, '3.5.6', '<')) {
                 /*
                  * BC: Work around a bug in the tokenizer of PHPCS < 3.5.6 where dereferencing

--- a/PHPCSUtils/Utils/Lists.php
+++ b/PHPCSUtils/Utils/Lists.php
@@ -129,6 +129,18 @@ class Lists
 
             $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true);
 
+            //if (\version_compare($phpcsVersion, '3.6.0', '<')) {
+            /*
+             * BC: Work around a bug in the tokenizer of PHPCS < 3.6.0 where dereferencing
+             * of interpolated text string (PHP 8+) would be incorrectly tokenized as short array.
+             *
+             * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/3172
+             */
+            if ($tokens[$prevNonEmpty]['code'] === \T_DOUBLE_QUOTED_STRING) {
+                return false;
+            }
+            //}
+
             if (\version_compare($phpcsVersion, '3.5.6', '<')) {
                 /*
                  * BC: Work around a bug in the tokenizer of PHPCS < 3.5.6 where dereferencing

--- a/Tests/Utils/Lists/IsShortArrayOrListTokenizerBC1Test.inc
+++ b/Tests/Utils/Lists/IsShortArrayOrListTokenizerBC1Test.inc
@@ -38,3 +38,6 @@ __NAMESPACE__[] = 'x';
 
 /* testTokenizerIssuePHPCS28xB */
 __method__[0]/* testTokenizerIssuePHPCS28xC */[1]/* testTokenizerIssuePHPCS28xD */[2] *= 'x';
+
+/* testTokenizerIssue3172PHPCSlt360A */
+$var = "PHP{$rocks}"[1]/* testTokenizerIssue3172PHPCSlt360B */[0];

--- a/Tests/Utils/Lists/IsShortArrayOrListTokenizerBC1Test.php
+++ b/Tests/Utils/Lists/IsShortArrayOrListTokenizerBC1Test.php
@@ -219,6 +219,20 @@ class IsShortArrayOrListTokenizerBC1Test extends UtilityMethodTestCase
                     'list'  => false,
                 ],
             ],
+            'issue-interpolated-string-dereferencing' => [
+                '/* testTokenizerIssue3172PHPCSlt360A */',
+                [
+                    'array' => false,
+                    'list'  => false,
+                ],
+            ],
+            'issue-interpolated-string-dereferencing-nested' => [
+                '/* testTokenizerIssue3172PHPCSlt360B */',
+                [
+                    'array' => false,
+                    'list'  => false,
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
As of PHP 8, text strings containing interpolated variables can be dereferenced, however, the square brackets in `"foo{$bar}"[0]` are incorrectly tokenized as _short array_ brackets instead of as "normal" square brackets.

A fix for the PHPCS Tokenizer has been pulled upstream.

Fingers crossed, the fix will be merged soon.

In the mean time, this commit fixes the issue for PHPCS 2.6.0 - current.

Once the upstream PR has been merged, the version numbers in the inline documentation and test marker will need to be updated.

Includes unit test.

Refs:
* https://wiki.php.net/rfc/variable_syntax_tweaks#interpolated_and_non-interpolated_strings
* squizlabs/PHP_CodeSniffer#3172