### PR TITLE
Arrays::isShortArray()/Lists::isShortList(): sync with upstream

### DIFF
--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -138,17 +138,17 @@ class Arrays
 
             $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true);
 
-            //if (\version_compare($phpcsVersion, '3.6.0', '<')) {
-            /*
-             * BC: Work around a bug in the tokenizer of PHPCS < 3.6.0 where dereferencing
-             * of interpolated text string (PHP 8+) would be incorrectly tokenized as short array.
-             *
-             * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/3172
-             */
-            if ($tokens[$prevNonEmpty]['code'] === \T_DOUBLE_QUOTED_STRING) {
-                return false;
+            if (\version_compare($phpcsVersion, '3.6.0', '<')) {
+                /*
+                 * BC: Work around a bug in the tokenizer of PHPCS < 3.6.0 where dereferencing
+                 * of interpolated text string (PHP 8+) would be incorrectly tokenized as short array.
+                 *
+                 * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/3172
+                 */
+                if ($tokens[$prevNonEmpty]['code'] === \T_DOUBLE_QUOTED_STRING) {
+                    return false;
+                }
             }
-            //}
 
             if (\version_compare($phpcsVersion, '3.5.6', '<')) {
                 /*

--- a/PHPCSUtils/Utils/Lists.php
+++ b/PHPCSUtils/Utils/Lists.php
@@ -129,17 +129,17 @@ class Lists
 
             $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($opener - 1), null, true);
 
-            //if (\version_compare($phpcsVersion, '3.6.0', '<')) {
-            /*
-             * BC: Work around a bug in the tokenizer of PHPCS < 3.6.0 where dereferencing
-             * of interpolated text string (PHP 8+) would be incorrectly tokenized as short array.
-             *
-             * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/3172
-             */
-            if ($tokens[$prevNonEmpty]['code'] === \T_DOUBLE_QUOTED_STRING) {
-                return false;
+            if (\version_compare($phpcsVersion, '3.6.0', '<')) {
+                /*
+                 * BC: Work around a bug in the tokenizer of PHPCS < 3.6.0 where dereferencing
+                 * of interpolated text string (PHP 8+) would be incorrectly tokenized as short array.
+                 *
+                 * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/3172
+                 */
+                if ($tokens[$prevNonEmpty]['code'] === \T_DOUBLE_QUOTED_STRING) {
+                    return false;
+                }
             }
-            //}
 
             if (\version_compare($phpcsVersion, '3.5.6', '<')) {
                 /*


### PR DESCRIPTION
Upstream PR squizlabs/PHP_CodeSniffer#3172 has been merged. This updates the previously pulled fix in PHPCSUtils to take this into account.

Refs:
* https://wiki.php.net/rfc/variable_syntax_tweaks#interpolated_and_non-interpolated_strings
* squizlabs/PHP_CodeSniffer#3172
* #230 (previously pulled fix)