### PR TITLE
Collections: add new `$arrayOpenTokensBC`, `functionCallTokens()` and `parameterPassingTokens()`

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -59,6 +59,21 @@ class Collections
     ];
 
     /**
+     * Tokens which can open an array.
+     *
+     * PHPCS cross-version compatible.
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @var array <int|string> => <int|string>
+     */
+    public static $arrayOpenTokensBC = [
+        \T_ARRAY               => \T_ARRAY,
+        \T_OPEN_SHORT_ARRAY    => \T_OPEN_SHORT_ARRAY,
+        \T_OPEN_SQUARE_BRACKET => \T_OPEN_SQUARE_BRACKET,
+    ];
+
+    /**
      * Tokens which are used to create arrays.
      *
      * @see \PHPCSUtils\Tokens\Collections::$shortArrayTokens Related property containing only tokens used
@@ -510,6 +525,28 @@ class Collections
     }
 
     /**
+     * Tokens which can represent function calls and function-call-like language constructs.
+     *
+     * @see \PHPCSUtils\Tokens\Collections::parameterPassingTokens() Related method.
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function functionCallTokens()
+    {
+        // Function calls and class instantiation.
+        $tokens              = self::nameTokens();
+        $tokens[\T_VARIABLE] = \T_VARIABLE;
+
+        // Class instantiation only.
+        $tokens[\T_SELF]   = \T_SELF;
+        $tokens[\T_STATIC] = \T_STATIC;
+
+        return $tokens;
+    }
+
+    /**
      * Tokens which can represent a keyword which starts a function declaration.
      *
      * Note: this is a method, not a property as the `T_FN` token for arrow functions may not exist.
@@ -830,6 +867,30 @@ class Collections
         if (\defined('T_ARRAY_HINT') === true) {
             $tokens[\T_ARRAY_HINT] = \T_ARRAY_HINT;
         }
+
+        return $tokens;
+    }
+
+    /**
+     * Tokens which can be passed to the methods in the PassedParameter class.
+     *
+     * @see \PHPCSUtils\Utils\PassedParameters
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function parameterPassingTokens()
+    {
+        // Function call and class instantiation tokens.
+        $tokens = self::functionCallTokens();
+
+        // Function-look-a-like language constructs which can take multiple "parameters".
+        $tokens[\T_ISSET] = \T_ISSET;
+        $tokens[\T_UNSET] = \T_UNSET;
+
+        // Array tokens.
+        $tokens += self::$arrayOpenTokensBC;
 
         return $tokens;
     }

--- a/PHPCSUtils/Utils/PassedParameters.php
+++ b/PHPCSUtils/Utils/PassedParameters.php
@@ -27,26 +27,6 @@ class PassedParameters
 {
 
     /**
-     * The token types these methods can handle.
-     *
-     * @since 1.0.0
-     *
-     * @var array <int|string> => <irrelevant>
-     */
-    private static $allowedConstructs = [
-        \T_STRING              => true,
-        \T_VARIABLE            => true,
-        \T_SELF                => true,
-        \T_STATIC              => true,
-        \T_ARRAY               => true,
-        \T_OPEN_SHORT_ARRAY    => true,
-        \T_ISSET               => true,
-        \T_UNSET               => true,
-        // BC for various short array tokenizer issues. See the Arrays class for more details.
-        \T_OPEN_SQUARE_BRACKET => true,
-    ];
-
-    /**
      * Tokens which are considered stop point, either because they are the end
      * of the parameter (comma) or because we need to skip over them.
      *
@@ -94,9 +74,7 @@ class PassedParameters
         $tokens = $phpcsFile->getTokens();
 
         if (isset($tokens[$stackPtr]) === false
-            || (isset(self::$allowedConstructs[$tokens[$stackPtr]['code']]) === false
-                // Allow for the PHP 8.0 identifier name tokens.
-                && isset(Collections::nameTokens()[$tokens[$stackPtr]['code']]) === false)
+            || isset(Collections::parameterPassingTokens()[$tokens[$stackPtr]['code']]) === false
         ) {
             throw new RuntimeException(
                 'The hasParameters() method expects a function call, array, isset or unset token to be passed.'

--- a/Tests/Tokens/Collections/FunctionCallTokensTest.php
+++ b/Tests/Tokens/Collections/FunctionCallTokensTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::functionCallTokens
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class FunctionCallTokensTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testFunctionCallTokens()
+    {
+        $version  = Helper::getVersion();
+        $expected = [
+            \T_STRING => \T_STRING,
+        ];
+
+        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
+            || (\version_compare($version, '3.5.7', '>=') === true
+                && \version_compare($version, '4.0.0', '<') === true)
+        ) {
+            $expected[\T_NAME_QUALIFIED]       = \T_NAME_QUALIFIED;
+            $expected[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;
+            $expected[\T_NAME_RELATIVE]        = \T_NAME_RELATIVE;
+        }
+
+        $expected += [
+            \T_VARIABLE => \T_VARIABLE,
+            \T_SELF     => \T_SELF,
+            \T_STATIC   => \T_STATIC,
+        ];
+
+        $this->assertSame($expected, Collections::functionCallTokens());
+    }
+}

--- a/Tests/Tokens/Collections/ParameterPassingTokensTest.php
+++ b/Tests/Tokens/Collections/ParameterPassingTokensTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::parameterPassingTokens
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class ParameterPassingTokensTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testParameterPassingTokens()
+    {
+        $version  = Helper::getVersion();
+        $expected = [
+            \T_STRING => \T_STRING,
+        ];
+
+        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
+            || (\version_compare($version, '3.5.7', '>=') === true
+                && \version_compare($version, '4.0.0', '<') === true)
+        ) {
+            $expected[\T_NAME_QUALIFIED]       = \T_NAME_QUALIFIED;
+            $expected[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;
+            $expected[\T_NAME_RELATIVE]        = \T_NAME_RELATIVE;
+        }
+
+        $expected += [
+            \T_VARIABLE            => \T_VARIABLE,
+            \T_SELF                => \T_SELF,
+            \T_STATIC              => \T_STATIC,
+            \T_ISSET               => \T_ISSET,
+            \T_UNSET               => \T_UNSET,
+            \T_ARRAY               => \T_ARRAY,
+            \T_OPEN_SHORT_ARRAY    => \T_OPEN_SHORT_ARRAY,
+            \T_OPEN_SQUARE_BRACKET => \T_OPEN_SQUARE_BRACKET,
+        ];
+
+        $this->assertSame($expected, Collections::parameterPassingTokens());
+    }
+}


### PR DESCRIPTION
Move the token collection which handles which tokens are supported in the `PassedParameters` class to the `Tokens\Collections` class and split it in logical parts.

This will make it easier for sniffs which use the methods in the `PassedParameters` class to `register()` the right tokens.

Includes unit tests.