### PR TITLE
Tests: Xdebug 3 compatibility fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -223,6 +223,11 @@ before_install:
       echo 'error_reporting = E_ALL & ~E_DEPRECATED' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     fi
 
+  # Turn on Xdebug code coverage mode in case Xdebug 3 is being used.
+  - |
+    if [[ "${TRAVIS_BUILD_STAGE_NAME^}" == "Coverage" ]]; then
+      echo 'xdebug.mode = coverage' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    fi
 
 install:
   # Set up test environment using Composer.

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -27,6 +27,22 @@ if (\defined('PHP_CODESNIFFER_VERBOSITY') === false) {
     \define('PHP_CODESNIFFER_VERBOSITY', 0);
 }
 
+/*
+ * PHPUnit 9.3 is the first version which supports Xdebug 3, but we're using PHPUnit 9.2
+ * for code coverage due to PHP_Parser interfering with our tests.
+ *
+ * For now, until a fix is pulled to allow us to use PHPUnit 9.3, this will allow
+ * PHPUnit 9.2 to run with Xdebug 3 for code coverage.
+ */
+if (\extension_loaded('xdebug') && \version_compare(\phpversion('xdebug'), '3', '>=')) {
+    if (defined('XDEBUG_CC_UNUSED') === false) {
+        define('XDEBUG_CC_UNUSED', null);
+    }
+    if (defined('XDEBUG_CC_DEAD_CODE') === false) {
+        define('XDEBUG_CC_DEAD_CODE', null);
+    }
+}
+
 // Get the PHPCS dir from an environment variable.
 $phpcsDir = \getenv('PHPCS_DIR');
 


### PR DESCRIPTION
We are currently limiting the PHPUnit version being used to max PHPUnit 9.2.x due to an issue with the code coverage package having switched over to `PHP_Parser` which defines token constants for constants which the sniffs rely on not to exist unless a PHP_CodeSniffer version is used in which they are backfilled.

However, Xdebug `3.0` was released last week and the Travis images for high PHP versions have been updated to include Xdebug `3.0`, but now it turns out that PHPUnit 9.2.x is not compatible with Xdebug 3....

Declaring the "missing" constants which no longer exist in Xdebug 3, but which PHPUnit 9.2 is relying on to exist, will fix this, combined with enabling the Xdebug code coverage mode from within the Travis config.