### PR TITLE
PHPCS 4.x | Sync with upstream changes regarding PHP 8 identifier names

### DIFF
--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -358,6 +358,7 @@ class BCTokens
      * Changelog for the PHPCS native array:
      * - Introduced in PHPCS 2.3.3.
      * - PHPCS 3.1.0: `T_SELF` and `T_STATIC` added to the array.
+     * - PHPCS 4.0.0: `T_NAME_QUALIFIED`, `T_NAME_FULLY_QUALIFIED` and `T_NAME_RELATIVE` added to the array.
      *
      * @see \PHP_CodeSniffer\Util\Tokens::$functionNameTokens Original array.
      *
@@ -370,6 +371,7 @@ class BCTokens
         $tokens            = Tokens::$functionNameTokens;
         $tokens[\T_SELF]   = \T_SELF;
         $tokens[\T_STATIC] = \T_STATIC;
+        $tokens           += Collections::nameTokens();
 
         return $tokens;
     }

--- a/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+++ b/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
@@ -330,9 +330,9 @@ abstract class UtilityMethodTestCase extends TestCase
     public static function usesPhp8NameTokens()
     {
         $version = Helper::getVersion();
-        if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
-            && (\version_compare($version, '3.5.7', '<') === true
-                || \version_compare($version, '4.0.0', '>=') === true)
+        if ((\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
+            && \version_compare($version, '3.5.7', '<') === true)
+            || \version_compare($version, '4.0.0', '>=') === true
         ) {
             return true;
         }

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -341,12 +341,14 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
      */
     public function testReturnMultilineNamespace()
     {
+        $php8Names = parent::usesPhp8NameTokens();
+
         $expected = [
             'scope'                 => 'public',
             'scope_specified'       => false,
             'return_type'           => '\MyNamespace\MyClass\Foo',
             'return_type_token'     => 7, // Offset from the T_FUNCTION token.
-            'return_type_end_token' => 23, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => ($php8Names === true) ? 20 : 23, // Offset from the T_FUNCTION token.
             'nullable_return_type'  => false,
             'is_abstract'           => false,
             'is_final'              => false,

--- a/Tests/Tokens/Collections/FunctionCallTokensTest.php
+++ b/Tests/Tokens/Collections/FunctionCallTokensTest.php
@@ -39,8 +39,7 @@ class FunctionCallTokensTest extends TestCase
         ];
 
         if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
-            || (\version_compare($version, '3.5.7', '>=') === true
-                && \version_compare($version, '4.0.0', '<') === true)
+            || \version_compare($version, '3.5.7', '>=') === true
         ) {
             $expected[\T_NAME_QUALIFIED]       = \T_NAME_QUALIFIED;
             $expected[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;

--- a/Tests/Tokens/Collections/NameTokensTest.php
+++ b/Tests/Tokens/Collections/NameTokensTest.php
@@ -39,8 +39,7 @@ class NameTokensTest extends TestCase
         ];
 
         if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
-            || (\version_compare($version, '3.5.7', '>=') === true
-                && \version_compare($version, '4.0.0', '<') === true)
+            || \version_compare($version, '3.5.7', '>=') === true
         ) {
             $expected[\T_NAME_QUALIFIED]       = \T_NAME_QUALIFIED;
             $expected[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;

--- a/Tests/Tokens/Collections/NamespacedNameTokensTest.php
+++ b/Tests/Tokens/Collections/NamespacedNameTokensTest.php
@@ -41,8 +41,7 @@ class NamespacedNameTokensTest extends TestCase
         ];
 
         if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
-            || (\version_compare($version, '3.5.7', '>=') === true
-                && \version_compare($version, '4.0.0', '<') === true)
+            || \version_compare($version, '3.5.7', '>=') === true
         ) {
             $expected[\T_NAME_QUALIFIED]       = \T_NAME_QUALIFIED;
             $expected[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;

--- a/Tests/Tokens/Collections/ParameterPassingTokensTest.php
+++ b/Tests/Tokens/Collections/ParameterPassingTokensTest.php
@@ -39,8 +39,7 @@ class ParameterPassingTokensTest extends TestCase
         ];
 
         if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
-            || (\version_compare($version, '3.5.7', '>=') === true
-                && \version_compare($version, '4.0.0', '<') === true)
+            || \version_compare($version, '3.5.7', '>=') === true
         ) {
             $expected[\T_NAME_QUALIFIED]       = \T_NAME_QUALIFIED;
             $expected[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;

--- a/Tests/Tokens/Collections/ParameterTypeTokensTest.php
+++ b/Tests/Tokens/Collections/ParameterTypeTokensTest.php
@@ -47,8 +47,7 @@ class ParameterTypeTokensTest extends TestCase
         ];
 
         if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
-            || (\version_compare($version, '3.5.7', '>=') === true
-                && \version_compare($version, '4.0.0', '<') === true)
+            || \version_compare($version, '3.5.7', '>=') === true
         ) {
             $expected[\T_NAME_QUALIFIED]       = \T_NAME_QUALIFIED;
             $expected[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;

--- a/Tests/Tokens/Collections/PropertyTypeTokensTest.php
+++ b/Tests/Tokens/Collections/PropertyTypeTokensTest.php
@@ -47,8 +47,7 @@ class PropertyTypeTokensTest extends TestCase
         ];
 
         if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
-            || (\version_compare($version, '3.5.7', '>=') === true
-                && \version_compare($version, '4.0.0', '<') === true)
+            || \version_compare($version, '3.5.7', '>=') === true
         ) {
             $expected[\T_NAME_QUALIFIED]       = \T_NAME_QUALIFIED;
             $expected[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;

--- a/Tests/Tokens/Collections/ReturnTypeTokensTest.php
+++ b/Tests/Tokens/Collections/ReturnTypeTokensTest.php
@@ -49,8 +49,7 @@ class ReturnTypeTokensTest extends TestCase
         ];
 
         if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true
-            || (\version_compare($version, '3.5.7', '>=') === true
-                && \version_compare($version, '4.0.0', '<') === true)
+            || \version_compare($version, '3.5.7', '>=') === true
         ) {
             $expected[\T_NAME_QUALIFIED]       = \T_NAME_QUALIFIED;
             $expected[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;

--- a/Tests/Utils/PassedParameters/GetParametersNamedTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersNamedTest.php
@@ -109,7 +109,7 @@ class GetParametersNamedTest extends UtilityMethodTestCase
                     ],
                     3 => [
                         'start' => ($php8Names === true) ? 7 : 8,
-                        'end'   => ($php8Names === true) ? 7 : 11,
+                        'end'   => ($php8Names === true) ? 8 : 11,
                         'raw'   => 'MyNS\VALUE',
                     ],
                 ],


### PR DESCRIPTION
### PHPCS 4.x | Collections/various methods: sync with PHPCS

Upstream PR squizlabs/PHP_CodeSniffer#3155 for PHPCS 4.x backfills the PHP 8.0 tokenization for identifier names for older PHP versions, including backfilling the PHP 8.0 token constants.

This commit updates the unit tests for various token collections to handle this correctly.

Refs:
* squizlabs/PHP_CodeSniffer#3041
* squizlabs/PHP_CodeSniffer#3155

### UtilityMethodTestCase::usesPhp8NameTokens(): account for PHPCS 4.x backfilling the PHP 8.0 identifier name tokenization

Upstream PR squizlabs/PHP_CodeSniffer#3155 for PHPCS 4.x backfills the PHP 8.0 tokenization for identifier names for older PHP versions.

This updates the `UtilityMethodTestCase::usesPhp8NameTokens()` method to take this upstream change into account.


### BCTokens::functionNameTokens(): account for identifier name tokens as added in PHPCS 4.x

Upstream PR  squizlabs/PHP_CodeSniffer#3155 for PHPCS 4.x adds the PHP 8.0 tokens for identifier names to the `Tokens::$functionNameTokens` property.

This updates the `BCTokens::functionNameTokens()` method to take this upstream change into account.

Includes unit tests.

### Tests: fix two tests for PHP 8 identifier names

* One test didn't yet take PHP 8 identifier names into account.
* The other did, but contained a typo/count error.


---

Note: the remaining two test failures on the PHPCS 4.x branch are related to a bug upstream - see PR  squizlabs/PHP_CodeSniffer#3104
