### PR TITLE
Tests/UtilityMethodTestCase::skipJSCSSTestsOnPHPCS4: get rid of "risky test" warning

### DIFF
--- a/Tests/TestUtils/UtilityMethodTestCase/SkipCSJSTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/SkipCSJSTest.php
@@ -46,8 +46,6 @@ class SkipJSCSSTest extends UtilityMethodTestCase
     /**
      * Test that the skipJSCSSTestsOnPHPCS4() skips JS/CSS file tests on PHPCS 4.x.
      *
-     * @doesNotPerformAssertions
-     *
      * @return void
      */
     public function testSkipJsCss()
@@ -68,6 +66,9 @@ class SkipJSCSSTest extends UtilityMethodTestCase
                 // PHPUnit 4.
                 $this->setExpectedException($exception, $msg);
             }
+        } else {
+            // Get rid of the "does not perform assertions" warning when run with PHPCS 3.x.
+            $this->assertTrue(true);
         }
 
         parent::skipJSCSSTestsOnPHPCS4();


### PR DESCRIPTION
When the `@doesNotPerformAssertions` annotation is used, the test shows as risky when run in combination with PHPCS 4.x as it does perform assertions (expects an exception), but removing the annotation would make the test report as risky when run in combination with PHPCS 3.x as in that case, it didn't perform an assertion.

While a little hackish, this small tweak gets rid of the warnings in all circumstances.