### PR TITLE
GH Actions: various tweaks

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           php-version: '7.4'
           coverage: none
+          tools: cs2pr
 
       - name: 'Composer: adjust dependencies'
         run: |
@@ -66,7 +67,11 @@ jobs:
 
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style
-        run: vendor/bin/phpcs
+        continue-on-error: true
+        run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml
+
+      - name: Show PHPCS results in PR
+        run: cs2pr ./phpcs-report.xml
 
       # Validate the composer.json file.
       # @link https://getcomposer.org/doc/03-cli.md#validate

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -8,9 +8,6 @@ on:
       - '**.md'
       - 'docs/**'
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
 
 jobs:
   checkcs:

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -8,6 +8,8 @@ on:
       - '**.md'
       - 'docs/**'
   pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   checkcs:

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     paths:
       - 'docs/**'
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   #### TEST DOCUMENTATION SITE GENERATION ####

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -8,6 +8,8 @@ on:
     paths-ignore:
       - '**.md'
       - 'docs/**'
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   #### QUICK TEST STAGE ####

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,6 @@ on:
       - '**.md'
       - 'docs/**'
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
 
 jobs:
   #### TEST STAGE ####

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
       - '**.md'
       - 'docs/**'
   pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   #### TEST STAGE ####

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -227,6 +227,7 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: xdebug
+          tools: cs2pr
 
       - name: 'Composer: adjust dependencies'
         run: |
@@ -235,6 +236,10 @@ jobs:
 
       - name: Install Composer dependencies - normal
         uses: "ramsey/composer-install@v1"
+
+      - name: Lint against parse errors
+        if: matrix.phpcs_version == 'dev-master'
+        run: composer lint -- --checkstyle | cs2pr
 
       - name: Run the unit tests with code coverage
         run: vendor/bin/phpunit


### PR DESCRIPTION
### GH Actions: don't ignore markdown-only changes

... on pull requests as it doesn't play nice with required statuses.

### GH Actions: allow for manually triggering a workflow

Triggering a workflow for a branch manually is not supported by default in GH Actions, but has to be explicitly allowed.

Ref: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

### GH Actions: report CS violations in the PR

The cs2pr tool will allow to display the results from an action run in checkstyle format in-line in the PR code view, which should improve usability of the workflow results.

Ref: https://github.com/staabm/annotate-pull-request-from-checkstyle

### GH Actions: report linting violations in the PR

The cs2pr tool will allow to display the results from an action run in checkstyle format in-line in the PR code view, which should improve usability of the workflow results.

Ref: https://github.com/staabm/annotate-pull-request-from-checkstyle

