### PR TITLE
Operators::isTypeUnion() + BCFile/FunctionDeclarations::get[Method]Parameters(): add some additional tests

### DIFF
--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
@@ -138,6 +138,9 @@ function namespaceOperatorTypeHint(?namespace\Name $var1) {}
 /* testPHP8UnionTypesSimple */
 function unionTypeSimple(int|float $number, self|parent &...$obj) {}
 
+/* testPHP8UnionTypesWithSpreadOperatorAndReference */
+function globalFunctionWithSpreadAndReference(float|null &$paramA, string|int ...$paramB ) {}
+
 /* testPHP8UnionTypesSimpleWithBitwiseOrInDefault */
 $fn = fn(int|float $var = CONSTANT_A | CONSTANT_B) => $var;
 

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -1318,6 +1318,46 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     }
 
     /**
+     * Verify recognition of PHP8 union type declaration when the variable has either a spread operator or a reference.
+     *
+     * @return void
+     */
+    public function testPHP8UnionTypesWithSpreadOperatorAndReference()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 9, // Offset from the T_FUNCTION token.
+            'name'                => '$paramA',
+            'content'             => 'float|null &$paramA',
+            'pass_by_reference'   => true,
+            'reference_token'     => 8, // Offset from the T_FUNCTION token.
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'float|null',
+            'type_hint_token'     => 4, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 6, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => 10,
+        ];
+        $expected[1] = [
+            'token'               => 17, // Offset from the T_FUNCTION token.
+            'name'                => '$paramB',
+            'content'             => 'string|int ...$paramB',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => true,
+            'variadic_token'      => 16, // Offset from the T_FUNCTION token.
+            'type_hint'           => 'string|int',
+            'type_hint_token'     => 12, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 14, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Verify recognition of PHP8 union type declaration with a bitwise or in the default value.
      *
      * @return void

--- a/Tests/Utils/Operators/IsTypeUnionTest.inc
+++ b/Tests/Utils/Operators/IsTypeUnionTest.inc
@@ -78,6 +78,13 @@ class TypeUnion
 /* testTypeUnionClosureParamIllegalNullable */
 $closureWithParamType = function (?string|null $string) {};
 
+function globalFunctionWithSpreadAndReference(
+    /* testTypeUnionWithReference */
+    float|null &$paramB,
+    /* testTypeUnionWithSpreadOperator */
+    string|int ...$paramA
+) {}
+
 /* testBitwiseOrClosureParamDefault */
 $closureWithReturnType = function ($string = NONSENSE | FAKE)/* testTypeUnionClosureReturn */ : \Package\MyA|PackageB {};
 

--- a/Tests/Utils/Operators/IsTypeUnionTest.php
+++ b/Tests/Utils/Operators/IsTypeUnionTest.php
@@ -99,6 +99,8 @@ class IsTypeUnionTest extends UtilityMethodTestCase
             'return-partially-qualified'      => ['/* testTypeUnionReturnPartiallyQualified */'],
             'return-fully-qualified'          => ['/* testTypeUnionReturnFullyQualified */'],
             'parameter-closure-with-nullable' => ['/* testTypeUnionClosureParamIllegalNullable */'],
+            'parameter-with-reference'        => ['/* testTypeUnionWithReference */'],
+            'parameter-with-spread-operator'  => ['/* testTypeUnionWithSpreadOperator */'],
             'return-closure'                  => ['/* testTypeUnionClosureReturn */'],
             'parameter-arrow'                 => ['/* testTypeUnionArrowParam */'],
             'return-arrow'                    => ['/* testTypeUnionArrowReturnType */'],


### PR DESCRIPTION
### Operators::isTypeUnion(): add some additional tests

### BCFile/FunctionDeclarations::get[Method]Parameters(): add some additional tests

Related to upstream issue squizlabs/PHP_CodeSniffer#3267 / PR squizlabs/PHP_CodeSniffer#3268

