### PR TITLE
BCTokens: add `scopeOpeners()` method and update `parenthesisOpeners()`

### DIFF
--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -53,7 +53,6 @@ use PHPCSUtils\Tokens\Collections;
  * @method static array includeTokens()    Tokens that include files.
  * @method static array methodPrefixes()   Tokens that can prefix a method name.
  * @method static array scopeModifiers()   Tokens that represent scope modifiers.
- * @method static array scopeOpeners()     Tokens that are allowed to open scopes.
  * @method static array stringTokens()     Tokens that represent strings.
  *                                         Note that `T_STRINGS` are NOT represented in this list as this list
  *                                         is about _text_ strings.
@@ -263,6 +262,7 @@ class BCTokens
      * Changelog for the PHPCS native array:
      * - Introduced in PHPCS 0.0.5.
      * - PHPCS 3.5.0: `T_LIST` and `T_ANON_CLASS` added to the array.
+     * - PHPCS 3.6.0: `T_MATCH` added to the array.
      *
      * Note: While `T_LIST` and `T_ANON_CLASS` will be included in the return value for this
      * method, the associated parentheses will not have the `'parenthesis_owner'` index set
@@ -284,6 +284,42 @@ class BCTokens
         $tokens                = Tokens::$parenthesisOpeners;
         $tokens[\T_LIST]       = \T_LIST;
         $tokens[\T_ANON_CLASS] = \T_ANON_CLASS;
+
+        /*
+         * The `T_MATCH` token may be available pre-PHPCS 3.6.0 depending on the PHP version
+         * used to run PHPCS.
+         */
+        if (\defined('T_MATCH')) {
+            $tokens[\T_MATCH] = \T_MATCH;
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * Tokens that are allowed to open scopes.
+     *
+     * Retrieve the PHPCS scope openers tokens array in a cross-version compatible manner.
+     *
+     * Changelog for the PHPCS native array:
+     * - Introduced in PHPCS 0.0.5.
+     * - PHPCS 3.6.0: `T_MATCH` added to the array.
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @return array <int|string> => <int|string> Token array.
+     */
+    public static function scopeOpeners()
+    {
+        $tokens = Tokens::$scopeOpeners;
+
+        /*
+         * The `T_MATCH` token may be available pre-PHPCS 3.6.0 depending on the PHP version
+         * used to run PHPCS.
+         */
+        if (\defined('T_MATCH')) {
+            $tokens[\T_MATCH] = \T_MATCH;
+        }
 
         return $tokens;
     }

--- a/Tests/BackCompat/BCTokens/ScopeOpenersTest.php
+++ b/Tests/BackCompat/BCTokens/ScopeOpenersTest.php
@@ -18,13 +18,13 @@ use PHPUnit\Framework\TestCase;
 /**
  * Test class.
  *
- * @covers \PHPCSUtils\BackCompat\BCTokens::parenthesisOpeners
+ * @covers \PHPCSUtils\BackCompat\BCTokens::scopeOpeners
  *
  * @group tokens
  *
  * @since 1.0.0
  */
-class ParenthesisOpenersTest extends TestCase
+class ScopeOpenersTest extends TestCase
 {
 
     /**
@@ -32,23 +32,34 @@ class ParenthesisOpenersTest extends TestCase
      *
      * @return void
      */
-    public function testParenthesisOpeners()
+    public function testScopeOpeners()
     {
         $version  = Helper::getVersion();
         $expected = [
-            \T_ARRAY      => \T_ARRAY,
-            \T_LIST       => \T_LIST,
+            \T_CLASS      => \T_CLASS,
+            \T_ANON_CLASS => \T_ANON_CLASS,
+            \T_INTERFACE  => \T_INTERFACE,
+            \T_TRAIT      => \T_TRAIT,
+            \T_NAMESPACE  => \T_NAMESPACE,
             \T_FUNCTION   => \T_FUNCTION,
             \T_CLOSURE    => \T_CLOSURE,
-            \T_ANON_CLASS => \T_ANON_CLASS,
+            \T_IF         => \T_IF,
+            \T_SWITCH     => \T_SWITCH,
+            \T_CASE       => \T_CASE,
+            \T_DECLARE    => \T_DECLARE,
+            \T_DEFAULT    => \T_DEFAULT,
             \T_WHILE      => \T_WHILE,
+            \T_ELSE       => \T_ELSE,
+            \T_ELSEIF     => \T_ELSEIF,
             \T_FOR        => \T_FOR,
             \T_FOREACH    => \T_FOREACH,
-            \T_SWITCH     => \T_SWITCH,
-            \T_IF         => \T_IF,
-            \T_ELSEIF     => \T_ELSEIF,
+            \T_DO         => \T_DO,
+            \T_TRY        => \T_TRY,
             \T_CATCH      => \T_CATCH,
-            \T_DECLARE    => \T_DECLARE,
+            \T_FINALLY    => \T_FINALLY,
+            \T_PROPERTY   => \T_PROPERTY,
+            \T_OBJECT     => \T_OBJECT,
+            \T_USE        => \T_USE,
         ];
 
         if (\version_compare($version, '3.6.0', '>=') === true
@@ -57,13 +68,9 @@ class ParenthesisOpenersTest extends TestCase
             $expected[\T_MATCH] = \T_MATCH;
         }
 
-        if (\version_compare($version, '4.0.0', '>=') === true) {
-            $expected[\T_USE] = \T_USE;
-        }
-
         \asort($expected);
 
-        $result = BCTokens::parenthesisOpeners();
+        $result = BCTokens::scopeOpeners();
         \asort($result);
 
         $this->assertSame($expected, $result);
@@ -78,8 +85,8 @@ class ParenthesisOpenersTest extends TestCase
      *
      * @return void
      */
-    public function testPHPCSParenthesisOpeners()
+    public function testPHPCSScopeOpeners()
     {
-        $this->assertSame(Tokens::$parenthesisOpeners, BCTokens::parenthesisOpeners());
+        $this->assertSame(Tokens::$scopeOpeners, BCTokens::scopeOpeners());
     }
 }

--- a/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
+++ b/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
@@ -70,38 +70,6 @@ class UnchangedTokenArraysTest extends TestCase
     ];
 
     /**
-     * Tokens that are allowed to open scopes.
-     *
-     * @var array <int|string> => <int|string>
-     */
-    protected $scopeOpeners = [
-        \T_CLASS      => \T_CLASS,
-        \T_ANON_CLASS => \T_ANON_CLASS,
-        \T_INTERFACE  => \T_INTERFACE,
-        \T_TRAIT      => \T_TRAIT,
-        \T_NAMESPACE  => \T_NAMESPACE,
-        \T_FUNCTION   => \T_FUNCTION,
-        \T_CLOSURE    => \T_CLOSURE,
-        \T_IF         => \T_IF,
-        \T_SWITCH     => \T_SWITCH,
-        \T_CASE       => \T_CASE,
-        \T_DECLARE    => \T_DECLARE,
-        \T_DEFAULT    => \T_DEFAULT,
-        \T_WHILE      => \T_WHILE,
-        \T_ELSE       => \T_ELSE,
-        \T_ELSEIF     => \T_ELSEIF,
-        \T_FOR        => \T_FOR,
-        \T_FOREACH    => \T_FOREACH,
-        \T_DO         => \T_DO,
-        \T_TRY        => \T_TRY,
-        \T_CATCH      => \T_CATCH,
-        \T_FINALLY    => \T_FINALLY,
-        \T_PROPERTY   => \T_PROPERTY,
-        \T_OBJECT     => \T_OBJECT,
-        \T_USE        => \T_USE,
-    ];
-
-    /**
      * Tokens that represent scope modifiers.
      *
      * @var array <int|string> => <int|string>


### PR DESCRIPTION
.. to account for the PHP 8.0 `match` keyword token `T_MATCH`.

These were added to PHPCS as part of the match expression PR, which will be accounted for further in follow up PRs.

For now, this should allow the build to pass again.

Ref: squizlabs/PHP_CodeSniffer#3226