### PR TITLE
UtilityMethodTestCase::getTargetToken(): add option to throw an exception...

### DIFF
--- a/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+++ b/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
@@ -15,6 +15,7 @@ use PHP_CodeSniffer\Exceptions\TokenizerException;
 use PHPCSUtils\BackCompat\Helper;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use RuntimeException as PHPRuntimeException;
 
 /**
  * Base class for use when testing utility methods for PHP_CodeSniffer.
@@ -354,10 +355,16 @@ abstract class UtilityMethodTestCase extends TestCase
      *                                        This string should include the comment opener and closer.
      * @param int|string|array $tokenType     The type of token(s) to look for.
      * @param string           $tokenContent  Optional. The token content for the target token.
+     * @param bool             $failTest      Optional. Whether the test should be marked as failed when
+     *                                        the target token cannot be found. Defaults to `true`.
+     *                                        When set to `false`, a catchable PHP native `RuntimeException`
+     *                                        will be thrown instead.
      *
      * @return int
+     *
+     * @throws \RuntimeException When the target token cannot be found and `$failTest` has been set to `false`.
      */
-    public function getTargetToken($commentString, $tokenType, $tokenContent = null)
+    public function getTargetToken($commentString, $tokenType, $tokenContent = null, $failTest = true)
     {
         $start   = (self::$phpcsFile->numTokens - 1);
         $comment = self::$phpcsFile->findPrevious(
@@ -395,6 +402,10 @@ abstract class UtilityMethodTestCase extends TestCase
             $msg = 'Failed to find test target token for comment string: ' . $commentString;
             if ($tokenContent !== null) {
                 $msg .= ' With token content: ' . $tokenContent;
+            }
+
+            if ($failTest === false) {
+                throw new PHPRuntimeException($msg);
             }
 
             $this->fail($msg);

--- a/Tests/TestUtils/UtilityMethodTestCase/UtilityMethodTestCaseTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/UtilityMethodTestCaseTest.php
@@ -174,6 +174,28 @@ class UtilityMethodTestCaseTest extends UtilityMethodTestCase
     }
 
     /**
+     * Test the behaviour of the getTargetToken() method when the target is not found.
+     *
+     * @return void
+     */
+    public function testGetTargetTokenNotFoundException()
+    {
+        $msg       = 'Failed to find test target token for comment string: ';
+        $exception = '\RuntimeException';
+
+        if (\method_exists($this, 'expectException')) {
+            // PHPUnit 5+.
+            $this->expectException($exception);
+            $this->expectExceptionMessage($msg);
+        } else {
+            // PHPUnit 4.
+            $this->setExpectedException($exception, $msg);
+        }
+
+        $this->getTargetToken('/* testNotFindingTarget */', [\T_VARIABLE], '$a', false);
+    }
+
+    /**
      * Test that the helper method to handle cross-version testing of exceptions in PHPUnit
      * works correctly.
      *


### PR DESCRIPTION
… instead of failing the test

By default, if the target token cannot be found, the `UtilityMethodTestCase::getTargetToken()` method will automatically fail the test.

In a limited set of circumstances, however, it can be preferred for the method to throw a (catchable) exception instead.

Case in point: finding a token which - depending on the PHPCS version used - may have a slightly different token content which could inhibit finding the target token in one go.

In that case, it would be preferable for the method to throw a catchable exception, allowing the test to catch the exception and then to try finding the target token again with a slightly different content.

To that end, a new `$failTest` parameter has been added which, when set to `false`, will direct the `UtilityMethodTestCase::getTargetToken()` method to throw a PHP native `RuntimeException` instead of marking the test as failed.

Includes a test covering this new functionality.