### PR TITLE
PHPCS 4.x | Handle closure use being a parenthesis owner

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -298,7 +298,11 @@ class BCFile
 
         if ($tokens[$stackPtr]['code'] === T_USE) {
             $opener = $phpcsFile->findNext(T_OPEN_PARENTHESIS, ($stackPtr + 1));
-            if ($opener === false || isset($tokens[$opener]['parenthesis_owner']) === true) {
+            if ($opener === false
+                || (isset($tokens[$opener]['parenthesis_owner']) === true
+                // BC: as of PHPCS 4.x, closure use tokens are parentheses owners.
+                && $tokens[$opener]['parenthesis_owner'] !== $stackPtr)
+            ) {
                 throw new RuntimeException('$stackPtr was not a valid T_USE');
             }
         } elseif ($arrowOpenClose !== false) {

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -436,6 +436,7 @@ class FunctionDeclarations
         }
 
         if ($tokens[$stackPtr]['code'] === \T_USE) {
+            // This will work PHPCS 3.x/4.x cross-version without much overhead.
             $opener = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
             if ($opener === false
                 || $tokens[$opener]['code'] !== \T_OPEN_PARENTHESIS

--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -59,6 +59,13 @@ class UseStatements
             return '';
         }
 
+        // More efficient & simpler check for closure use in PHPCS 4.x.
+        if (isset($tokens[$stackPtr]['parenthesis_owner'])
+            && $tokens[$stackPtr]['parenthesis_owner'] === $stackPtr
+        ) {
+            return 'closure';
+        }
+
         $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($prev !== false && $tokens[$prev]['code'] === \T_CLOSE_PARENTHESIS
             && Parentheses::isOwnerIn($phpcsFile, $prev, \T_CLOSURE) === true


### PR DESCRIPTION
### PHPCS 4.x | UseStatements::getType(): efficiency tweak for closure use

`T_USE` tokens used for closure use statements are parentheses owners as of PHPCS 4.x.

So, as of PHPCS 4.x, checking for the `parenthesis_owner` index being set is a simpler and more efficient way to determine if a `use` token is a closure use.

### PHPCS 4.x | BCFile::getMethodParameters(): T_USE is now a parenthesis owner

`T_USE` tokens used for closure use statements are parentheses owners as of PHPCS 4.x.

This fixes compatibility of the `BCFile::getMethodParameters()` method with PHPCS 4.x.

The existing unit tests already cover this.

### PHPCS 4.x | FunctionDeclarations::getParameters(): document T_USE handling

`T_USE` tokens used for closure use statements are parentheses owners as of PHPCS 4.x.

The `FunctionDeclarations::getParameters()` method already handles this correctly cross-version.

This just adds documentation to confirm this has been looked at and no changes are needed for cross-version compatibility.

Refs:
* squizlabs/PHP_CodeSniffer#2593
* squizlabs/PHP_CodeSniffer@08824f3
* squizlabs/PHP_CodeSniffer#3104

