### PR TITLE
ObjectDeclarations::getClassProperties(): allow for `abstract final`

### DIFF
--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -157,7 +157,6 @@ class ObjectDeclarations
      * - Bugs fixed:
      *   - Handling of PHPCS annotations.
      *   - Handling of unorthodox docblock placement.
-     *   - A class cannot both be abstract as well as final, so this utility should not allow for that.
      * - Defensive coding against incorrect calls to this method.
      *
      * @see \PHP_CodeSniffer\Files\File::getClassProperties()   Original source.
@@ -203,11 +202,11 @@ class ObjectDeclarations
             switch ($tokens[$i]['code']) {
                 case \T_ABSTRACT:
                     $properties['is_abstract'] = true;
-                    break 2;
+                    break;
 
                 case \T_FINAL:
                     $properties['is_final'] = true;
-                    break 2;
+                    break;
             }
         }
 

--- a/Tests/BackCompat/BCFile/GetClassPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetClassPropertiesTest.inc
@@ -29,3 +29,10 @@ abstract
  * @phpcs:disable Standard.Cat.SniffName -- Just because.
  */
 class ClassWithDocblock {}
+
+/* testParseErrorAbstractFinal */
+final /* comment */
+
+    abstract // Intentional parse error, class cannot both be final and abstract.
+
+        class AbstractFinal {}

--- a/Tests/BackCompat/BCFile/GetClassPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetClassPropertiesTest.php
@@ -138,6 +138,13 @@ class GetClassPropertiesTest extends UtilityMethodTestCase
                     'is_final'    => false,
                 ],
             ],
+            'abstract-final-parse-error' => [
+                '/* testParseErrorAbstractFinal */',
+                [
+                    'is_abstract' => true,
+                    'is_final'    => true,
+                ],
+            ],
         ];
     }
 }

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.inc
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.inc
@@ -16,10 +16,3 @@ final
  * @phpcs:disable Standard.Cat.SniffName -- Just because.
  */
 class ClassWithPropertyBeforeDocblock {}
-
-/* testParseErrorAbstractFinal */
-final /* comment */
-
-    abstract // Intentional parse error, class cannot both be final and abstract.
-
-        class AbstractFinal {}

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
@@ -81,13 +81,6 @@ class GetClassPropertiesDiffTest extends UtilityMethodTestCase
                     'is_final'    => true,
                 ],
             ],
-            'abstract-final-parse-error' => [
-                '/* testParseErrorAbstractFinal */',
-                [
-                    'is_abstract' => true,
-                    'is_final'    => false,
-                ],
-            ],
         ];
     }
 }


### PR DESCRIPTION
Having both `abstract` as well as `final` as a modifier for a class is an oxymoron (and a parse error in PHP), but the utility methods should not have an opinion on that.

The original `BCFile::getClassProperties()` method already handled this correctly.

Now the `ObjectDeclarations::getClassProperties()` method does as well.

Includes moving a test from the "diff" test files to the generic test files.

Note: this does potentially make the method _slower_ as it has to search further before deciding it has found all applicable keywords, but that's just how it is.