### PR TITLE
PHP 8.0 | QA/CS: don't use reserved keywords as parameter names

### DIFF
--- a/PHPCSUtils/Utils/Numbers.php
+++ b/PHPCSUtils/Utils/Numbers.php
@@ -332,16 +332,18 @@ class Numbers
      *
      * @since 1.0.0
      *
-     * @param string $string Arbitrary token content string.
+     * @param string $textString Arbitrary text string.
+     *                           This text string should be the (combined) token content of
+     *                           one or more tokens which together represent a number in PHP.
      *
      * @return string|false Decimal number as a string or `FALSE` if the passed parameter
      *                      was not a numeric string.
      *                      > Note: floating point numbers with exponent will not be expanded,
      *                      but returned as-is.
      */
-    public static function getDecimalValue($string)
+    public static function getDecimalValue($textString)
     {
-        if (\is_string($string) === false || $string === '') {
+        if (\is_string($textString) === false || $textString === '') {
             return false;
         }
 
@@ -352,26 +354,26 @@ class Numbers
          * here to allow the hexdec(), bindec() functions to work correctly and for
          * the decimal/float to return a cross-version compatible decimal value.}
          */
-        $string = \str_replace('_', '', $string);
+        $textString = \str_replace('_', '', $textString);
 
-        if (self::isDecimalInt($string) === true) {
-            return $string;
+        if (self::isDecimalInt($textString) === true) {
+            return $textString;
         }
 
-        if (self::isHexidecimalInt($string) === true) {
-            return (string) \hexdec($string);
+        if (self::isHexidecimalInt($textString) === true) {
+            return (string) \hexdec($textString);
         }
 
-        if (self::isBinaryInt($string) === true) {
-            return (string) \bindec($string);
+        if (self::isBinaryInt($textString) === true) {
+            return (string) \bindec($textString);
         }
 
-        if (self::isOctalInt($string) === true) {
-            return (string) \octdec($string);
+        if (self::isOctalInt($textString) === true) {
+            return (string) \octdec($textString);
         }
 
-        if (self::isFloat($string) === true) {
-            return $string;
+        if (self::isFloat($textString) === true) {
+            return $textString;
         }
 
         return false;
@@ -384,20 +386,20 @@ class Numbers
      *
      * @since 1.0.0
      *
-     * @param string $string Arbitrary string.
+     * @param string $textString Arbitrary string.
      *
      * @return bool
      */
-    public static function isDecimalInt($string)
+    public static function isDecimalInt($textString)
     {
-        if (\is_string($string) === false || $string === '') {
+        if (\is_string($textString) === false || $textString === '') {
             return false;
         }
 
         // Remove potential PHP 7.4 numeric literal separators.
-        $string = \str_replace('_', '', $string);
+        $textString = \str_replace('_', '', $textString);
 
-        return (\preg_match(self::REGEX_DECIMAL_INT, $string) === 1);
+        return (\preg_match(self::REGEX_DECIMAL_INT, $textString) === 1);
     }
 
     /**
@@ -407,20 +409,20 @@ class Numbers
      *
      * @since 1.0.0
      *
-     * @param string $string Arbitrary string.
+     * @param string $textString Arbitrary string.
      *
      * @return bool
      */
-    public static function isHexidecimalInt($string)
+    public static function isHexidecimalInt($textString)
     {
-        if (\is_string($string) === false || $string === '') {
+        if (\is_string($textString) === false || $textString === '') {
             return false;
         }
 
         // Remove potential PHP 7.4 numeric literal separators.
-        $string = \str_replace('_', '', $string);
+        $textString = \str_replace('_', '', $textString);
 
-        return (\preg_match(self::REGEX_HEX_INT, $string) === 1);
+        return (\preg_match(self::REGEX_HEX_INT, $textString) === 1);
     }
 
     /**
@@ -430,20 +432,20 @@ class Numbers
      *
      * @since 1.0.0
      *
-     * @param string $string Arbitrary string.
+     * @param string $textString Arbitrary string.
      *
      * @return bool
      */
-    public static function isBinaryInt($string)
+    public static function isBinaryInt($textString)
     {
-        if (\is_string($string) === false || $string === '') {
+        if (\is_string($textString) === false || $textString === '') {
             return false;
         }
 
         // Remove potential PHP 7.4 numeric literal separators.
-        $string = \str_replace('_', '', $string);
+        $textString = \str_replace('_', '', $textString);
 
-        return (\preg_match(self::REGEX_BINARY_INT, $string) === 1);
+        return (\preg_match(self::REGEX_BINARY_INT, $textString) === 1);
     }
 
     /**
@@ -453,20 +455,20 @@ class Numbers
      *
      * @since 1.0.0
      *
-     * @param string $string Arbitrary string.
+     * @param string $textString Arbitrary string.
      *
      * @return bool
      */
-    public static function isOctalInt($string)
+    public static function isOctalInt($textString)
     {
-        if (\is_string($string) === false || $string === '') {
+        if (\is_string($textString) === false || $textString === '') {
             return false;
         }
 
         // Remove potential PHP 7.4 numeric literal separators.
-        $string = \str_replace('_', '', $string);
+        $textString = \str_replace('_', '', $textString);
 
-        return (\preg_match(self::REGEX_OCTAL_INT, $string) === 1);
+        return (\preg_match(self::REGEX_OCTAL_INT, $textString) === 1);
     }
 
     /**
@@ -476,19 +478,19 @@ class Numbers
      *
      * @since 1.0.0
      *
-     * @param string $string Arbitrary string.
+     * @param string $textString Arbitrary string.
      *
      * @return bool
      */
-    public static function isFloat($string)
+    public static function isFloat($textString)
     {
-        if (\is_string($string) === false || $string === '') {
+        if (\is_string($textString) === false || $textString === '') {
             return false;
         }
 
         // Remove potential PHP 7.4 numeric literal separators.
-        $string = \str_replace('_', '', $string);
+        $textString = \str_replace('_', '', $textString);
 
-        return (\preg_match(self::REGEX_FLOAT, $string) === 1);
+        return (\preg_match(self::REGEX_FLOAT, $textString) === 1);
     }
 }

--- a/PHPCSUtils/Utils/Orthography.php
+++ b/PHPCSUtils/Utils/Orthography.php
@@ -43,21 +43,21 @@ class Orthography
      *
      * @since 1.0.0
      *
-     * @param string $string The text string to examine.
-     *                       This can be the contents of a text string token,
-     *                       but also, for instance, a comment text.
-     *                       Potential text delimiter quotes should be stripped
-     *                       off a text string before passing it to this method.
-     *                       Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.
+     * @param string $textString The text string to examine.
+     *                           This can be the contents of a text string token,
+     *                           but also, for instance, a comment text.
+     *                           Potential text delimiter quotes should be stripped
+     *                           off a text string before passing it to this method.
+     *                           Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.
      *
      * @return bool `TRUE` when the first character is a capital letter or a letter
      *              which doesn't have a concept of capitalization.
      *              `FALSE` otherwise, including for non-letter characters.
      */
-    public static function isFirstCharCapitalized($string)
+    public static function isFirstCharCapitalized($textString)
     {
-        $string = \ltrim($string);
-        return (\preg_match('`^[\p{Lu}\p{Lt}\p{Lo}]`u', $string) > 0);
+        $textString = \ltrim($textString);
+        return (\preg_match('`^[\p{Lu}\p{Lt}\p{Lo}]`u', $textString) > 0);
     }
 
     /**
@@ -65,21 +65,21 @@ class Orthography
      *
      * @since 1.0.0
      *
-     * @param string $string The text string to examine.
-     *                       This can be the contents of a text string token,
-     *                       but also, for instance, a comment text.
-     *                       Potential text delimiter quotes should be stripped
-     *                       off a text string before passing it to this method.
-     *                       Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.
+     * @param string $textString The text string to examine.
+     *                           This can be the contents of a text string token,
+     *                           but also, for instance, a comment text.
+     *                           Potential text delimiter quotes should be stripped
+     *                           off a text string before passing it to this method.
+     *                           Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.
      *
      * @return bool `TRUE` when the first character is a lowercase letter.
      *              `FALSE` otherwise, including for letters which don't have a concept of
      *              capitalization and for non-letter characters.
      */
-    public static function isFirstCharLowercase($string)
+    public static function isFirstCharLowercase($textString)
     {
-        $string = \ltrim($string);
-        return (\preg_match('`^\p{Ll}`u', $string) > 0);
+        $textString = \ltrim($textString);
+        return (\preg_match('`^\p{Ll}`u', $textString) > 0);
     }
 
     /**
@@ -87,7 +87,7 @@ class Orthography
      *
      * @since 1.0.0
      *
-     * @param string $string       The text string to examine.
+     * @param string $textString   The text string to examine.
      *                             This can be the contents of a text string token,
      *                             but also, for instance, a comment text.
      *                             Potential text delimiter quotes should be stripped
@@ -100,7 +100,7 @@ class Orthography
      *
      * @return bool
      */
-    public static function isLastCharPunctuation($string, $allowedChars = self::TERMINAL_POINTS)
+    public static function isLastCharPunctuation($textString, $allowedChars = self::TERMINAL_POINTS)
     {
         static $encoding;
 
@@ -108,11 +108,11 @@ class Orthography
             $encoding = Helper::getEncoding();
         }
 
-        $string = \rtrim($string);
+        $textString = \rtrim($textString);
         if (\function_exists('iconv_substr') === true) {
-            $lastChar = \iconv_substr($string, -1, 1, $encoding);
+            $lastChar = \iconv_substr($textString, -1, 1, $encoding);
         } else {
-            $lastChar = \substr($string, -1);
+            $lastChar = \substr($textString, -1);
         }
 
         if (\function_exists('iconv_strpos') === true) {

--- a/PHPCSUtils/Utils/TextStrings.php
+++ b/PHPCSUtils/Utils/TextStrings.php
@@ -113,21 +113,21 @@ class TextStrings
     }
 
     /**
-     * Strip text delimiter quotes from an arbitrary string.
+     * Strip text delimiter quotes from an arbitrary text string.
      *
      * Intended for use with the "contents" of a `T_CONSTANT_ENCAPSED_STRING` / `T_DOUBLE_QUOTED_STRING`.
      *
      * - Prevents stripping mis-matched quotes.
-     * - Prevents stripping quotes from the textual content of the string.
+     * - Prevents stripping quotes from the textual content of the text string.
      *
      * @since 1.0.0
      *
-     * @param string $string The raw string.
+     * @param string $textString The raw text string.
      *
-     * @return string String without quotes around it.
+     * @return string Text string without quotes around it.
      */
-    public static function stripQuotes($string)
+    public static function stripQuotes($textString)
     {
-        return \preg_replace('`^([\'"])(.*)\1$`Ds', '$2', $string);
+        return \preg_replace('`^([\'"])(.*)\1$`Ds', '$2', $textString);
     }
 }

--- a/Tests/AssertAttributeSame.php
+++ b/Tests/AssertAttributeSame.php
@@ -58,27 +58,27 @@ trait AssertAttributeSame
      * Retrieve the value of an object's attribute.
      * This also works for attributes that are declared protected or private.
      *
-     * @param object|string $object        The object or class on which to check the property value.
-     * @param string        $attributeName The name of the property to check.
+     * @param object|string $objectUnderTest The object or class on which to check the property value.
+     * @param string        $attributeName   The name of the property to check.
      *
      * @return mixed Property value.
      *
      * @throws \Exception
      */
-    public static function getObjectAttributeValue($object, $attributeName)
+    public static function getObjectAttributeValue($objectUnderTest, $attributeName)
     {
-        $reflector = new ReflectionObject($object);
+        $reflector = new ReflectionObject($objectUnderTest);
 
         do {
             try {
                 $attribute = $reflector->getProperty($attributeName);
 
                 if (!$attribute || $attribute->isPublic()) {
-                    return $object->$attributeName;
+                    return $objectUnderTest->$attributeName;
                 }
 
                 $attribute->setAccessible(true);
-                $value = $attribute->getValue($object);
+                $value = $attribute->getValue($objectUnderTest);
                 $attribute->setAccessible(false);
 
                 return $value;

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -87,15 +87,17 @@ if (isset($vendorDir) && \file_exists($vendorDir . '/autoload.php')) {
      * Fixes issues with PHPUnit not being able to find test classes being extended when running
      * in a non-Composer context.
      */
-    \spl_autoload_register(function ($class) {
+    \spl_autoload_register(function ($fqClassName) {
         // Only try & load our own classes.
-        if (\stripos($class, 'PHPCSUtils\Tests\\') !== 0) {
+        if (\stripos($fqClassName, 'PHPCSUtils\Tests\\') !== 0) {
             return;
         }
 
         // Strip namespace prefix 'PHPCSUtils\Tests\'.
-        $class = \substr($class, 17);
-        $file  = \realpath(__DIR__) . \DIRECTORY_SEPARATOR . \strtr($class, '\\', \DIRECTORY_SEPARATOR) . '.php';
+        $relativeClass = \substr($fqClassName, 17);
+        $file          = \realpath(__DIR__) . \DIRECTORY_SEPARATOR
+            . \strtr($relativeClass, '\\', \DIRECTORY_SEPARATOR) . '.php';
+
         if (\file_exists($file)) {
             include_once $file;
         }

--- a/phpcsutils-autoload.php
+++ b/phpcsutils-autoload.php
@@ -36,13 +36,13 @@ if (defined('PHPCSUTILS_AUTOLOAD') === false) {
      * External PHPCS standards which have their own unit test suite
      * should include this file in their test runner bootstrap.
      */
-    spl_autoload_register(function ($class) {
+    spl_autoload_register(function ($fqClassName) {
         // Only try & load our own classes.
-        if (stripos($class, 'PHPCSUtils') !== 0) {
+        if (stripos($fqClassName, 'PHPCSUtils') !== 0) {
             return;
         }
 
-        $file = realpath(__DIR__) . DIRECTORY_SEPARATOR . strtr($class, '\\', DIRECTORY_SEPARATOR) . '.php';
+        $file = realpath(__DIR__) . DIRECTORY_SEPARATOR . strtr($fqClassName, '\\', DIRECTORY_SEPARATOR) . '.php';
 
         if (file_exists($file)) {
             include_once $file;


### PR DESCRIPTION
... to prevent confusion when PHP 8.0 named parameters in function calls would be used.