### PR TITLE
PassedParameters::getParameter(): add one extra test

### DIFF
--- a/Tests/Utils/PassedParameters/GetParametersWithLimitTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersWithLimitTest.php
@@ -29,6 +29,9 @@ class GetParametersWithLimitTest extends UtilityMethodTestCase
     /**
      * Test retrieving the parameter details with a limit from an array without parameters.
      *
+     * @covers \PHPCSUtils\Utils\PassedParameters::getParameters
+     * @covers \PHPCSUtils\Utils\PassedParameters::getParameter
+     *
      * @return void
      */
     public function testGetParametersWithLimitNoParams()
@@ -38,6 +41,10 @@ class GetParametersWithLimitTest extends UtilityMethodTestCase
         $result = PassedParameters::getParameters(self::$phpcsFile, $stackPtr, 3);
         $this->assertSame([], $result);
         $this->assertCount(0, $result);
+
+        // Limit is automatically applied to getParameter().
+        $result = PassedParameters::getParameter(self::$phpcsFile, $stackPtr, 3);
+        $this->assertFalse($result);
     }
 
     /**


### PR DESCRIPTION
... for a non-function call with no parameters (and naturally, no param names) where the limit gets automatically applied, but the return will be `false` due to the construct not having parameters.

This should get test coverage for the class up to 100%.