### PR TITLE
GH Actions: minor clean up

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches-ignore:
       - master
+      - develop
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -270,6 +270,8 @@ jobs:
 
   coveralls-finish:
     needs: coverage
+    if: always() && needs.coverage.result == 'success'
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
* Skip the `quicktest` on `develop` as those are the same builds as for `coverage`, so no need to run those twice, now coverage is being run on merges to `develop`.
* Also make sure that the coveralls-finish will actually run. Should run already, but didn't.

Follow up on #263, #265, #266 and #267