### PR TITLE
UtilityMethodTestCase: fail test on missing test marker comment

### DIFF
--- a/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+++ b/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
@@ -375,6 +375,11 @@ abstract class UtilityMethodTestCase extends TestCase
             $commentString
         );
 
+        if ($comment === false) {
+            $msg = 'Failed to find the test marker: ' . $commentString;
+            $this->fail($msg);
+        }
+
         $tokens = self::$phpcsFile->getTokens();
         $end    = ($start + 1);
 

--- a/Tests/TestUtils/UtilityMethodTestCase/UtilityMethodTestCaseTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/UtilityMethodTestCaseTest.php
@@ -148,6 +148,32 @@ class UtilityMethodTestCaseTest extends UtilityMethodTestCase
     }
 
     /**
+     * Test the behaviour of the getTargetToken() method when the test marker comment is not found.
+     *
+     * @return void
+     */
+    public function testGetTargetTokenCommentNotFound()
+    {
+        $msg       = 'Failed to find the test marker: ';
+        $exception = 'PHPUnit\Framework\AssertionFailedError';
+        if (\class_exists('PHPUnit_Framework_AssertionFailedError')) {
+            // PHPUnit < 6.
+            $exception = 'PHPUnit_Framework_AssertionFailedError';
+        }
+
+        if (\method_exists($this, 'expectException')) {
+            // PHPUnit 5+.
+            $this->expectException($exception);
+            $this->expectExceptionMessage($msg);
+        } else {
+            // PHPUnit 4.
+            $this->setExpectedException($exception, $msg);
+        }
+
+        $this->getTargetToken('/* testCommentDoesNotExist */', [\T_VARIABLE], '$a');
+    }
+
+    /**
      * Test the behaviour of the getTargetToken() method when the target is not found.
      *
      * @return void


### PR DESCRIPTION
When a test marker comment was not found, the `UtilityMethodTestCase::getTargetToken()` would search for the target token between the start of the file and the first test marker it _did_ find.

This could lead to the wrong token being set as the `$stackPtr` for a test.

This improves the `UtilityMethodTestCase::getTargetToken()` method by failing the test when the test marker comment cannot be found.

The `$failTest` parameter to throw an exception instead of failing the test is not taken into account as when the test marker comment cannot be found, the correct test target can never be found, no matter what token types or content is passed.

Includes unit test.