### PR TITLE
Composer: tweak the PHPUnit 4.x version used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev" : {
         "php-parallel-lint/php-parallel-lint": "^1.3.0",
         "php-parallel-lint/php-console-highlighter": "^0.5",
-        "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || >=9.0 <9.3.0"
+        "phpunit/phpunit": "^4.8 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || >=9.0 <9.3.0"
     },
     "conflict": {
         "squizlabs/php_codesniffer": "3.5.3"


### PR DESCRIPTION
The PHPUnit 4.x version used was based on a bug [previously encountered in the PHPCompatibility project](https://github.com/PHPCompatibility/PHPCompatibility/pull/511#issuecomment-335676926).

PHPCSUtils however doesn't appear to be susceptible to the same bug, so can use PHPUnit 4.8 safely.