### PR TITLE
Tests: use PHPUnit Polyfills

### DIFF
--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
@@ -10,8 +10,7 @@
 
 namespace PHPCSUtils\Tests\AbstractSniffs\AbstractArrayDeclaration;
 
-use PHPCSUtils\Tests\AssertAttributeSame;
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 
 /**
  * Tests for the \PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff class.
@@ -22,10 +21,8 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class AbstractArrayDeclarationSniffTest extends UtilityMethodTestCase
+class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
 {
-    // Backfill for the assertAttributeSame() method on PHPUnit 9.x.
-    use AssertAttributeSame;
 
     /**
      * List of methods in the abstract which should be mocked.

--- a/Tests/BackCompat/Helper/ConfigDataTest.php
+++ b/Tests/BackCompat/Helper/ConfigDataTest.php
@@ -13,6 +13,7 @@ namespace PHPCSUtils\Tests\BackCompat\Helper;
 use PHP_CodeSniffer\Config;
 use PHPCSUtils\BackCompat\Helper;
 use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
 
 /**
  * Test class.
@@ -26,6 +27,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ConfigDataTest extends TestCase
 {
+    use ExpectException;
 
     /**
      * Test the getConfigData() and setConfigData() method when used in a cross-version compatible manner.
@@ -87,17 +89,8 @@ class ConfigDataTest extends TestCase
             $this->markTestSkipped('Test only applicable to PHPCS 4.x');
         }
 
-        $msg       = 'Passing the $config parameter is required in PHPCS 4.x';
-        $exception = 'PHP_CodeSniffer\Exceptions\RuntimeException';
-
-        if (\method_exists($this, 'expectException')) {
-            // PHPUnit 5+.
-            $this->expectException($exception);
-            $this->expectExceptionMessage($msg);
-        } else {
-            // PHPUnit 4.
-            $this->setExpectedException($exception, $msg);
-        }
+        $this->expectException('PHP_CodeSniffer\Exceptions\RuntimeException');
+        $this->expectExceptionMessage('Passing the $config parameter is required in PHPCS 4.x');
 
         Helper::setConfigData('arbitrary_name', 'test', true);
     }

--- a/Tests/PolyfilledTestCase.php
+++ b/Tests/PolyfilledTestCase.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests;
+
+use PHPCSUtils\Tests\AssertAttributeSame;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertEqualsSpecializations;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertFileDirectory;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertFileEqualsSpecializations;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertNumericType;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertObjectEquals;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
+use Yoast\PHPUnitPolyfills\Polyfills\EqualToSpecializations;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionObject;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
+
+/**
+ * Abstract utilty method base test case which includes all available polyfills.
+ *
+ * This test case includes all polyfills from the PHPUnit Polyfill library to make them
+ * available to the tests.
+ *
+ * Generally speaking, this testcase only needs to be used when the concrete test class will
+ * use functionality which has changed in PHPUnit cross-version.
+ * In all other cases, the `UtilityMethodTestCase` can be extended directly.
+ *
+ * {@internal The list of included polyfill traits should be reviewed after each new
+ * release of the PHPUnit Polyfill library.}
+ *
+ * @since 1.0.0
+ */
+abstract class PolyfilledTestCase extends UtilityMethodTestCase
+{
+    // PHPCSUtils native helper.
+    use AssertAttributeSame;
+
+    // PHPUnit Polyfills.
+    use AssertClosedResource;
+    use AssertEqualsSpecializations;
+    use AssertFileDirectory;
+    use AssertFileEqualsSpecializations;
+    use AssertionRenames;
+    use AssertIsType;
+    use AssertNumericType;
+    use AssertObjectEquals;
+    use AssertStringContains;
+    use EqualToSpecializations;
+    use ExpectException;
+    use ExpectExceptionMessageMatches;
+    use ExpectExceptionObject;
+    use ExpectPHPException;
+}

--- a/Tests/TestUtils/UtilityMethodTestCase/FailedToTokenizeTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/FailedToTokenizeTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSUtils\Tests\TestUtils\UtilityMethodTestCase;
 
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 
 /**
  * Tests for the \PHPCSUtils\TestUtils\UtilityMethodTestCase class.
@@ -21,7 +21,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class FailedToTokenizeTest extends UtilityMethodTestCase
+class FailedToTokenizeTest extends PolyfilledTestCase
 {
 
     /**
@@ -50,14 +50,8 @@ class FailedToTokenizeTest extends UtilityMethodTestCase
             $exception = 'PHPUnit_Framework_AssertionFailedError';
         }
 
-        if (\method_exists($this, 'expectException')) {
-            // PHPUnit 5+.
-            $this->expectException($exception);
-            $this->expectExceptionMessage($msg);
-        } else {
-            // PHPUnit 4.
-            $this->setExpectedException($exception, $msg);
-        }
+        $this->expectException($exception);
+        $this->expectExceptionMessage($msg);
 
         parent::setUpTestFile();
     }

--- a/Tests/TestUtils/UtilityMethodTestCase/MissingCaseFileTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/MissingCaseFileTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSUtils\Tests\TestUtils\UtilityMethodTestCase;
 
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 
 /**
  * Tests for the \PHPCSUtils\TestUtils\UtilityMethodTestCase class.
@@ -21,7 +21,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class MissingCaseFileTest extends UtilityMethodTestCase
+class MissingCaseFileTest extends PolyfilledTestCase
 {
 
     /**
@@ -50,14 +50,8 @@ class MissingCaseFileTest extends UtilityMethodTestCase
             $exception = 'PHPUnit_Framework_AssertionFailedError';
         }
 
-        if (\method_exists($this, 'expectException')) {
-            // PHPUnit 5+.
-            $this->expectException($exception);
-            $this->expectExceptionMessage($msg);
-        } else {
-            // PHPUnit 4.
-            $this->setExpectedException($exception, $msg);
-        }
+        $this->expectException($exception);
+        $this->expectExceptionMessage($msg);
 
         parent::setUpTestFile();
     }

--- a/Tests/TestUtils/UtilityMethodTestCase/SkipCSJSTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/SkipCSJSTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSUtils\Tests\TestUtils\UtilityMethodTestCase;
 
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 
 /**
  * Tests for the \PHPCSUtils\TestUtils\UtilityMethodTestCase class.
@@ -21,7 +21,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class SkipJSCSSTest extends UtilityMethodTestCase
+class SkipJSCSSTest extends PolyfilledTestCase
 {
 
     /**
@@ -58,14 +58,8 @@ class SkipJSCSSTest extends UtilityMethodTestCase
                 $exception = 'PHPUnit_Framework_SkippedTestError';
             }
 
-            if (\method_exists($this, 'expectException')) {
-                // PHPUnit 5+.
-                $this->expectException($exception);
-                $this->expectExceptionMessage($msg);
-            } else {
-                // PHPUnit 4.
-                $this->setExpectedException($exception, $msg);
-            }
+            $this->expectException($exception);
+            $this->expectExceptionMessage($msg);
         } else {
             // Get rid of the "does not perform assertions" warning when run with PHPCS 3.x.
             $this->assertTrue(true);

--- a/Tests/TestUtils/UtilityMethodTestCase/UtilityMethodTestCaseTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/UtilityMethodTestCaseTest.php
@@ -12,7 +12,7 @@ namespace PHPCSUtils\Tests\TestUtils\UtilityMethodTestCase;
 
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Exceptions\TokenizerException;
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 
 /**
  * Tests for the \PHPCSUtils\TestUtils\UtilityMethodTestCase class.
@@ -23,7 +23,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class UtilityMethodTestCaseTest extends UtilityMethodTestCase
+class UtilityMethodTestCaseTest extends PolyfilledTestCase
 {
 
     /**
@@ -51,13 +51,7 @@ class UtilityMethodTestCaseTest extends UtilityMethodTestCase
         $this->assertSame(57, self::$phpcsFile->numTokens);
 
         $tokens = self::$phpcsFile->getTokens();
-        if (\method_exists($this, 'assertIsArray')) {
-            // PHPUnit 7+.
-            $this->assertIsArray($tokens);
-        } else {
-            // PHPUnit 4/5/6.
-            $this->assertInternalType('array', $tokens);
-        }
+        $this->assertIsArray($tokens);
     }
 
     /**
@@ -161,14 +155,8 @@ class UtilityMethodTestCaseTest extends UtilityMethodTestCase
             $exception = 'PHPUnit_Framework_AssertionFailedError';
         }
 
-        if (\method_exists($this, 'expectException')) {
-            // PHPUnit 5+.
-            $this->expectException($exception);
-            $this->expectExceptionMessage($msg);
-        } else {
-            // PHPUnit 4.
-            $this->setExpectedException($exception, $msg);
-        }
+        $this->expectException($exception);
+        $this->expectExceptionMessage($msg);
 
         $this->getTargetToken('/* testCommentDoesNotExist */', [\T_VARIABLE], '$a');
     }
@@ -187,14 +175,8 @@ class UtilityMethodTestCaseTest extends UtilityMethodTestCase
             $exception = 'PHPUnit_Framework_AssertionFailedError';
         }
 
-        if (\method_exists($this, 'expectException')) {
-            // PHPUnit 5+.
-            $this->expectException($exception);
-            $this->expectExceptionMessage($msg);
-        } else {
-            // PHPUnit 4.
-            $this->setExpectedException($exception, $msg);
-        }
+        $this->expectException($exception);
+        $this->expectExceptionMessage($msg);
 
         $this->getTargetToken('/* testNotFindingTarget */', [\T_VARIABLE], '$a');
     }
@@ -209,14 +191,8 @@ class UtilityMethodTestCaseTest extends UtilityMethodTestCase
         $msg       = 'Failed to find test target token for comment string: ';
         $exception = '\RuntimeException';
 
-        if (\method_exists($this, 'expectException')) {
-            // PHPUnit 5+.
-            $this->expectException($exception);
-            $this->expectExceptionMessage($msg);
-        } else {
-            // PHPUnit 4.
-            $this->setExpectedException($exception, $msg);
-        }
+        $this->expectException($exception);
+        $this->expectExceptionMessage($msg);
 
         $this->getTargetToken('/* testNotFindingTarget */', [\T_VARIABLE], '$a', false);
     }

--- a/Tests/Utils/MessageHelper/HasNewLineSupportTest.php
+++ b/Tests/Utils/MessageHelper/HasNewLineSupportTest.php
@@ -12,7 +12,7 @@ namespace PHPCSUtils\Tests\Utils\MessageHelper;
 
 use PHP_CodeSniffer\Reporter;
 use PHP_CodeSniffer\Reports\Full;
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 use PHPCSUtils\Utils\MessageHelper;
 
 /**
@@ -27,7 +27,7 @@ use PHPCSUtils\Utils\MessageHelper;
  *
  * @since 1.0.0
  */
-class HasNewLineSupportTest extends UtilityMethodTestCase
+class HasNewLineSupportTest extends PolyfilledTestCase
 {
 
     /**
@@ -54,14 +54,7 @@ class HasNewLineSupportTest extends UtilityMethodTestCase
     public function testHasNewLineSupport()
     {
         $result = MessageHelper::hasNewLineSupport();
-
-        if (\method_exists($this, 'assertIsBool') === true) {
-            // PHPUnit >= 7.5.
-            $this->assertIsBool($result);
-        } else {
-            // PHPUnit < 7.5.
-            $this->assertInternalType('bool', $result);
-        }
+        $this->assertIsBool($result);
 
         if ($result === false) {
             return;

--- a/Tests/Utils/PassedParameters/GetParametersSkipShortArrayCheckTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersSkipShortArrayCheckTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSUtils\Tests\Utils\PassedParameters;
 
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 1.0.0
  */
-class GetParametersSkipShortArrayCheckTest extends UtilityMethodTestCase
+class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase
 {
 
     /**
@@ -54,13 +54,7 @@ class GetParametersSkipShortArrayCheckTest extends UtilityMethodTestCase
         $hasParams = PassedParameters::hasParameters(self::$phpcsFile, $target);
 
         if ($expectException === false) {
-            if (\method_exists($this, 'assertIsBool') === true) {
-                // PHPUnit 7.5+.
-                $this->assertIsBool($hasParams);
-            } else {
-                // PHPUnit < 7.5.
-                $this->assertInternalType('bool', $hasParams);
-            }
+            $this->assertIsBool($hasParams);
         }
     }
 
@@ -82,13 +76,7 @@ class GetParametersSkipShortArrayCheckTest extends UtilityMethodTestCase
         $stackPtr = $this->getTargetToken($testMarker, [$targetType]);
         $result   = PassedParameters::getParameters(self::$phpcsFile, $stackPtr, 0, true);
 
-        if (\method_exists($this, 'assertIsArray') === true) {
-            // PHPUnit 7.5+.
-            $this->assertIsArray($result);
-        } else {
-            // PHPUnit < 7.5.
-            $this->assertInternalType('array', $result);
-        }
+        $this->assertIsArray($result);
 
         // Start/end token position values in the expected array are set as offsets
         // in relation to the target token.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "require-dev" : {
         "php-parallel-lint/php-parallel-lint": "^1.3.0",
         "php-parallel-lint/php-console-highlighter": "^0.5",
-        "phpunit/phpunit": "^4.8 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || >=9.0 <9.3.0"
+        "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || >=9.0 <9.3.0",
+        "yoast/phpunit-polyfills": "^1.0.0"
     },
     "conflict": {
         "squizlabs/php_codesniffer": "3.5.3"


### PR DESCRIPTION
### Composer: require-dev the PHPUnit Polyfills

While generally speaking, the `require-dev` for PHPUnit should now be removed, I'm leaving it in place due to the PHPUnit >= 9.3.0 issue with PHP-Parser backfilling tokens.
If/when that issue is resolved in the future, the direct requirement for PHPUnit can be removed.

### Tests: update the bootstrap file

... to always check that a `composer install` has been run and to load the PHPUnit Polyfill autoloader directly when running PHPUnit via a Phar file as the Polyfill library needs to be installed and its autoload file loaded for the tests to work correctly.

### Tests: add abstract PolyfilledTestCase

This test case extends the `UtilityMethodTestCase` from which most test classes extend and makes both the PHPCSUtils native `AssertAttributeSame` polyfill, as well as all polyfills from the PHPUnit Polyfill library available.

For test classes which don't need the set up and tear down methods contained in the `UtilityMethodTestCase` and would therefore normally extend the PHPUnit native `TestCase`, the PHPUnit Polyfill `Yoast\PHPUnitPolyfills\TestCases\XTestCase` can be extended instead.
Alternatively, such a test class can just `use` any of the polyfill traits from the PHPUnit Polyfill library directly.

Test classes which don't need the polyfilled assertion/expectation methods, can - and should - still just extend the PHPUnit native `TestCase` or the PHPCSUtils `UtilityMethodTestCase` directly.

Note: The list of included polyfill traits should be reviewed after each new (major/minor) release of the PHPUnit Polyfill library.

### Tests: remove PHPUnit cross-version work-arounds

... in favour of using the PHPUnit Polyfills.

