### PR TITLE
Composer: update dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,10 @@
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7"
     },
     "require-dev" : {
-        "php-parallel-lint/php-parallel-lint": "^1.3.0",
+        "php-parallel-lint/php-parallel-lint": "^1.3.1",
         "php-parallel-lint/php-console-highlighter": "^0.5",
         "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || >=9.0 <9.3.0",
-        "yoast/phpunit-polyfills": "^1.0.0"
+        "yoast/phpunit-polyfills": "^1.0.1"
     },
     "conflict": {
         "squizlabs/php_codesniffer": "3.5.3"


### PR DESCRIPTION
Most notably, PHP Parallel Lint 1.3.1 has improved compatibility with PHP 8.1.

Refs:
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.3.1
* https://github.com/Yoast/PHPUnit-Polyfills/releases