### PR TITLE
GH Actions: various updates

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -11,6 +11,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checkcs:
     name: 'Basic CS and QA checks'

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -10,6 +10,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   #### TEST DOCUMENTATION SITE GENERATION ####
   test:

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -52,7 +52,7 @@ jobs:
           if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
             echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
           else
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On'
+            echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On'
           fi
 
       - name: Install PHP

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -12,6 +12,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   #### QUICK TEST STAGE ####
   # This is a much quicker test which only runs the unit tests and linting against the low/high

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,7 @@ jobs:
           if [[ "${{ matrix.phpcs_version }}" != "dev-master" && "${{ matrix.phpcs_version }}" != "4.0.x-dev" ]]; then
             echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
           else
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On'
+            echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On'
           fi
 
       - name: Install PHP
@@ -228,7 +228,7 @@ jobs:
           if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
             echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
           else
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL, display_errors=On'
+            echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On'
           fi
 
       - name: Install PHP

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   #### TEST STAGE ####
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
         # - PHP 7.4 needs PHPCS 3.5.0+ to run without errors.
         #   On PHPCS 2.x our tests won't fail though, but on PHPCS 3.x < 3.5.0 they will.
         # - PHP 8.0 needs PHPCS 3.5.7+ to run without errors.
+        # - PHP 8.1 needs PHPCS 3.6.1+ to run without errors.
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
         php: ['5.5', '5.6', '7.0', '7.1', '7.2']
@@ -52,6 +53,15 @@ jobs:
         include:
           # Complement the builds run in code coverage to complete the matrix and prevent issues
           # with PHPCS versions incompatible with certain PHP versions.
+          - php: '8.1'
+            phpcs_version: 'dev-master'
+            risky: false
+            experimental: false
+          - php: '8.1'
+            phpcs_version: '3.6.1'
+            risky: false
+            experimental: false
+
           - php: '8.0'
             phpcs_version: 'dev-master'
             risky: false
@@ -105,10 +115,7 @@ jobs:
             experimental: false
 
           # Experimental builds. These are allowed to fail.
-
-          # Current lowest PHPCS version which _may_ run on PHP 8 is 3.5.0, so don't even try
-          # to test against older versions.
-          - php: '8.1'
+          - php: '8.2'
             phpcs_version: 'dev-master'
             risky: false
             experimental: true
@@ -167,12 +174,12 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies - normal
-        if: ${{ matrix.php < 8.1 }}
+        if: ${{ matrix.php < 8.2 }}
         uses: "ramsey/composer-install@v1"
 
       # For the PHP "nightly", we need to install with ignore platform reqs as not all dependencies allow it yet.
       - name: Install Composer dependencies - with ignore platform
-        if: ${{ matrix.php >= 8.1 }}
+        if: ${{ matrix.php >= 8.2 }}
         uses: "ramsey/composer-install@v1"
         with:
           composer-options: --ignore-platform-reqs


### PR DESCRIPTION
### GH Actions: auto-cancel previous builds for same branch

Previously, in Travis, when the same branch was pushed again and the "Auto cancellation" option on the "Settings" page had been turned on (as it was for most repos), any still running builds for the same branch would be stopped in favour of starting the build for the newly pushed version of the branch.

To enable this behaviour in GH Actions, a `concurrency` configuration needs to be added to each workflow for which this should applied to.

More than anything, this is a way to be kind to GitHub by not wasting resources which they so kindly provide to us for free.

Refs:
* https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
* https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency

### GH Actions: use error_reporting=-1

### GH Actions: update for the release of PHP 8.1 