### PR TITLE
BCTokens: update `scopeOpeners()` and `ooScopeTokens()`

### DIFF
--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -82,6 +82,9 @@ class BCTokens
      * @since 1.0.0
      * @since 1.0.0-alpha3 Visibility changed from `protected` to `private`.
      *
+     * {@internal Note: T_ENUM is missing from this array and will be added dynamically
+     *            in the ooScopeTokens() method when available.}
+     *
      * @var array <int|string> => <int|string>
      */
     private static $ooScopeTokens = [
@@ -304,6 +307,7 @@ class BCTokens
      * Changelog for the PHPCS native array:
      * - Introduced in PHPCS 0.0.5.
      * - PHPCS 3.6.0: `T_MATCH` added to the array.
+     * - PHPCS 3.7.0: `T_ENUM` added to the array.
      *
      * @since 1.0.0-alpha4
      *
@@ -319,6 +323,14 @@ class BCTokens
          */
         if (\defined('T_MATCH')) {
             $tokens[\T_MATCH] = \T_MATCH;
+        }
+
+        /*
+         * The `T_ENUM` token may be available pre-PHPCS 3.7.0 depending on the PHP version
+         * used to run PHPCS.
+         */
+        if (\defined('T_ENUM')) {
+            $tokens[\T_ENUM] = \T_ENUM;
         }
 
         return $tokens;
@@ -419,6 +431,7 @@ class BCTokens
      *
      * Changelog for the PHPCS native array:
      * - Introduced in PHPCS 3.1.0.
+     * - PHPCS 3.7.0: `T_ENUM` added to the array.
      *
      * @see \PHP_CodeSniffer\Util\Tokens::$ooScopeTokens Original array.
      *
@@ -428,11 +441,21 @@ class BCTokens
      */
     public static function ooScopeTokens()
     {
+        $tokens = self::$ooScopeTokens;
+
         if (isset(Tokens::$ooScopeTokens)) {
-            return Tokens::$ooScopeTokens;
+            $tokens = Tokens::$ooScopeTokens;
         }
 
-        return self::$ooScopeTokens;
+        /*
+         * The `T_ENUM` token may be available pre-PHPCS 3.7.0 depending on the PHP version
+         * used to run PHPCS.
+         */
+        if (\defined('T_ENUM')) {
+            $tokens[\T_ENUM] = \T_ENUM;
+        }
+
+        return $tokens;
     }
 
     /**

--- a/Tests/BackCompat/BCTokens/OoScopeTokensTest.php
+++ b/Tests/BackCompat/BCTokens/OoScopeTokensTest.php
@@ -12,6 +12,7 @@ namespace PHPCSUtils\Tests\BackCompat\BCTokens;
 
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\BackCompat\Helper;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -33,6 +34,7 @@ class OoScopeTokensTest extends TestCase
      */
     public function testOoScopeTokens()
     {
+        $version  = Helper::getVersion();
         $expected = [
             \T_CLASS      => \T_CLASS,
             \T_ANON_CLASS => \T_ANON_CLASS,
@@ -40,7 +42,18 @@ class OoScopeTokensTest extends TestCase
             \T_TRAIT      => \T_TRAIT,
         ];
 
-        $this->assertSame($expected, BCTokens::ooScopeTokens());
+        if (\version_compare($version, '3.7.0', '>=') === true
+            || \version_compare(\PHP_VERSION_ID, '80099', '>=') === true
+        ) {
+            $expected[\T_ENUM] = \T_ENUM;
+        }
+
+        \asort($expected);
+
+        $result = BCTokens::ooScopeTokens();
+        \asort($result);
+
+        $this->assertSame($expected, $result);
     }
 
     /**

--- a/Tests/BackCompat/BCTokens/ScopeOpenersTest.php
+++ b/Tests/BackCompat/BCTokens/ScopeOpenersTest.php
@@ -68,6 +68,12 @@ class ScopeOpenersTest extends TestCase
             $expected[\T_MATCH] = \T_MATCH;
         }
 
+        if (\version_compare($version, '3.7.0', '>=') === true
+            || \version_compare(\PHP_VERSION_ID, '80099', '>=') === true
+        ) {
+            $expected[\T_ENUM] = \T_ENUM;
+        }
+
         \asort($expected);
 
         $result = BCTokens::scopeOpeners();


### PR DESCRIPTION
.. to account for the PHP 8.1 `enum` keyword token `T_ENUM`.

These were added to PHPCS as part of the enum PR, which will be accounted for further in follow up PRs.

For now, this (combined with another upcoming PR) should allow the build to pass again.

Ref: squizlabs/PHP_CodeSniffer#3478