### PR TITLE
UseStatements::splitImportUseStatement: improve test consistency

### DIFF
--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -244,8 +244,8 @@ class UseStatements
              *
              * If `function` or `const` is used as the alias, the semi-colon after it would
              * be tokenized as T_STRING.
-             * For `function` this was fixed in PHPCS 2.8.0. For `const` the issue still exists
-             * in PHPCS 3.5.2.
+             * For `function` this was fixed in PHPCS 2.8.0. For `const` the issue was fixed
+             * in PHPCS 3.7.0.
              *
              * Along the same lines, the `}` T_CLOSE_USE_GROUP would also be tokenized as T_STRING.
              */

--- a/Tests/Utils/UseStatements/SplitImportUseStatementTest.inc
+++ b/Tests/Utils/UseStatements/SplitImportUseStatementTest.inc
@@ -91,6 +91,8 @@ use Vendor\{
 // Intentional parse error - use of reserved keyword as alias.
 use Vendor\YourNamespace\ClassName as const;
 
+echo 'foo'; // Needed for consistent handling of the above test.
+
 // Intentional parse error. This has to be the last test in the file.
 /* testParseError */
 use MyNS\Level\{

--- a/Tests/Utils/UseStatements/SplitImportUseStatementTest.php
+++ b/Tests/Utils/UseStatements/SplitImportUseStatementTest.php
@@ -276,7 +276,7 @@ class SplitImportUseStatementTest extends UtilityMethodTestCase
             'parse-error-plain-alias-reserved-keyword-const' => [
                 '/* testUsePlainAliasReservedKeywordConst */',
                 [
-                    'name'     => [],
+                    'name'     => ['const' => 'Vendor\YourNamespace\ClassName'],
                     'function' => [],
                     'const'    => [],
                 ],


### PR DESCRIPTION
The "parse error due to reserved keyword as alias" tests for `use .... as function` and `use ... as class` already showed what the _real_ expected output should be.

The test for `use ... as const` did not, as the code after it did not contain a semi-colon.

As part of the underlying issue for this code sample (the semi-colon being tokenized as `T_STRING`) has been fixed in PHPCS 3.7.0, this now meant that the test would give a different result in PHPCS 3.7.0+ vs PHPCS < 3.7.0.

As use statements are generally at the top of a file, it would be extraordinarily rare for code like that to ever occur in real life. On top of that, this is a parse error.
With both of those things in mind, just fixing the test code to allow the test to return consistent results PHPCS cross-version feels like the appropriate fix.