### PR TITLE
Update for Composer 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ Notes:
 
 #### Other
 * Composer: PHPCSUtils can now be installed in combination with PHPCS `4.0.x-dev@dev` for testing purposes.
-* Composer: The version requirements for the [DealerDirect Composer PHPCS plugin] have been widened to allow for version 0.7.0 which supports Composer 2.0.0.
+* Composer: The version requirements for the [Composer PHPCS plugin] have been widened to allow for version 0.7.0 which supports Composer 2.0.0.
 * Readme/website homepage: textual improvements. Props [@GaryJones]. [#121](https://github.com/PHPCSStandards/PHPCSUtils/pull/121)
 * Readme/website homepage: added additional FAQ question & answers. [#157](https://github.com/PHPCSStandards/PHPCSUtils/pull/157)
 * The website homepage is now generated using the GitHub Pages gem with Jekyll, making maintenance easier. [#141](https://github.com/PHPCSStandards/PHPCSUtils/pull/141)
@@ -171,7 +171,7 @@ Initial alpha release containing:
 * A `PHPCS23Utils` standard which can be used to allow an external PHPCS standard to be compatible with both PHPCS 2.x as well as 3.x.
 * A `PHPCSUtils` standard which contains generic utilities which can be used when writing sniffs.
     **_This standard does not contain any sniffs!_**
-    To use these utilities in PHPCS 3.x, all that is needed is for this package to be installed and registered with PHPCS using `installed_paths`. If the package is requested via Composer, this will automatically be handled by the [DealerDirect Composer PHPCS plugin].
+    To use these utilities in PHPCS 3.x, all that is needed is for this package to be installed and registered with PHPCS using `installed_paths`. If the package is requested via Composer, this will automatically be handled by the [Composer PHPCS plugin].
     To use these utilities in PHPCS 2.x, make sure the external standard includes the `PHPCS23Utils` standard in the `ruleset.xml` file like so: `<rule ref="PHPCS23Utils"/>`.
 
 All utilities offered are compatible with PHP_CodeSniffer 2.6.0 up to the latest stable release.
@@ -222,7 +222,7 @@ This initial alpha release contains the following utility classes:
 [1.0.0-alpha3]: https://github.com/PHPCSStandards/PHPCSUtils/compare/1.0.0-alpha2...1.0.0-alpha3
 [1.0.0-alpha2]: https://github.com/PHPCSStandards/PHPCSUtils/compare/1.0.0-alpha1...1.0.0-alpha2
 
-[DealerDirect Composer PHPCS plugin]: https://github.com/Dealerdirect/phpcodesniffer-composer-installer/
+[Composer PHPCS plugin]: https://github.com/PHPCSStandards/composer-installer
 
 [`AbstractArrayDeclarationSniff`]: https://phpcsutils.com/phpdoc/classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html
 [`BCFile`]: https://phpcsutils.com/phpdoc/classes/PHPCSUtils-BackCompat-BCFile.html

--- a/README.md
+++ b/README.md
@@ -95,16 +95,23 @@ If your external PHP_CodeSniffer standard only supports Composer-based installs 
 
 Run the following from the root of your external PHPCS standard's project:
 ```bash
+composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
 composer require phpcsstandards/phpcsutils:^1.0
 ```
 
 No further action needed. You can start using all the utility functions, abstract sniff classes and other features of PHPCSUtils straight away.
 
-> :information_source: The PHPCSUtils package includes the [DealerDirect Composer PHPCS plugin](https://github.com/Dealerdirect/phpcodesniffer-composer-installer).
+> :information_source: The PHPCSUtils package includes the [Composer PHPCS plugin](https://github.com/PHPCSStandards/composer-installer).
 >
 > This plugin will automatically register PHPCSUtils (and your own external standard) with PHP_CodeSniffer, so you and your users don't have to worry about this anymore.
 >
 > :warning: Note: if your end-user installation instructions include instructions on adding a Composer PHPCS plugin or on manually registering your standard with PHPCS using the `--config-set installed_paths` command, you can remove those instructions as they are no longer needed.
+>
+> :information_source: As of Composer 2.2, Composer will [ask for permission](https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution) to allow the Composer PHPCS plugin to execute code. For the plugin to be functional, permission needs to be granted.
+> This can be done ahead of time by instructing your users to run the following command before installing your standard:
+> ```bash
+> composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+> ```
 
 #### Running your unit tests
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,11 +79,17 @@ Run the following from the root of your external PHPCS standard's project:
 
 No further action needed. You can start using all the utility functions, abstract sniff classes and other features of PHPCSUtils straight away.
 
-> :information_source: The PHPCSUtils package includes the [DealerDirect Composer PHPCS plugin](https://github.com/Dealerdirect/phpcodesniffer-composer-installer).
+> :information_source: The PHPCSUtils package includes the [Composer PHPCS plugin](https://github.com/PHPCSStandards/composer-installer).
 >
 > This plugin will automatically register PHPCSUtils (and your own external standard) with PHP_CodeSniffer, so you and your users don't have to worry about this anymore.
 >
 > :warning: Note: if your end-user installation instructions include instructions on adding a Composer PHPCS plugin or on manually registering your standard with PHPCS using the `--config-set installed_paths` command, you can remove those instructions as they are no longer needed.
+>
+> :information_source: As of Composer 2.2, Composer will [ask for permission](https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution) to allow the Composer PHPCS plugin to execute code. For the plugin to be functional, permission needs to be granted.
+> This can be done ahead of time by instructing your users to run the following command before installing your standard:
+> ```bash
+> composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+> ```
 
 #### Running your unit tests
 


### PR DESCRIPTION
The `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is a non-dev requirement for PHPCSUtils.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run.

This commit updates the installation instructions to handle this.
It also adds an info block suggesting how to handle this for external standards including PHPCSUtils.

Includes updating the URL references to the plugin to point to the new home of the plugin. (see [upstream issue #146](https://github.com/PHPCSStandards/composer-installer/issues/146))

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution