### PR TITLE
PHP 8.1 | Numbers: add support for explicit octal notation

### DIFF
--- a/Tests/Utils/Numbers/GetCompleteNumberTest.inc
+++ b/Tests/Utils/Numbers/GetCompleteNumberTest.inc
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Make sure that number literals are correctly identified.
+ * Make sure that number literals and explicit octals are correctly identified.
  */
 
 /* testNotAnLNumber */
@@ -118,6 +118,20 @@ $a = 1_e2;   // next to e
 /* testPHP74Invalid8 */
 $a = 1e_2;   // next to e
 
+/*
+ * PHP 8.1 explicit octal notation.
+ */
+/* testPHP81ExplicitOctal */
+$octal = 0o137041;
+
+/* testPHP81ExplicitOctalUppercase */
+$octal = 0O137041;
+
+/* testPHP81ExplicitOctalWithSeparator */
+$octal = 0o137_041;
+
+/* testPHP74PHP81InvalidExplicitOctal */
+$invalid = 0o_123; // Underscore next to o.
 
 /* testLiveCoding */
 // Intentional parse error. This has to be the last test in the file (and on the last line) !

--- a/Tests/Utils/Numbers/GetDecimalValueTest.php
+++ b/Tests/Utils/Numbers/GetDecimalValueTest.php
@@ -80,6 +80,11 @@ class GetDecimalValueTest extends TestCase
             'octal-int-10'                                  => ['012', '10'],
             'octal-int-1024'                                => ['02000', '1024'],
             'octal-int-1024-php-7.4'                        => ['020_00', '1024'],
+
+            // Octal PHP 8.1 explicit notation.
+            'explicit-octal-int-10'                         => ['0o12', '10'],
+            'explicit-octal-int-1024'                       => ['0O2000', '1024'],
+            'explicit-octal-int-1024-php-7.4'               => ['0o20_00', '1024'],
         ];
     }
 
@@ -119,6 +124,7 @@ class GetDecimalValueTest extends TestCase
             'invalid-hex'                                   => ['0xZBHI28'],
             'invalid-binary'                                => ['0b121457182'],
             'invalid-octal'                                 => ['0289'],
+            'invalid-octal-explicit-notation'               => ['0o289'],
         ];
     }
 }

--- a/Tests/Utils/Numbers/NumberTypesTest.php
+++ b/Tests/Utils/Numbers/NumberTypesTest.php
@@ -205,6 +205,16 @@ class NumberTypesTest extends TestCase
                     'float'   => false,
                 ],
             ],
+            'invalid-explicit-octal' => [
+                '0o289',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
             'invalid-float-two-decimal-points' => [
                 '1.287.2763',
                 [
@@ -517,6 +527,48 @@ class NumberTypesTest extends TestCase
             ],
             'octal-multi-digit-php-7.4' => [
                 '020_631_542',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => true,
+                    'float'   => false,
+                ],
+            ],
+
+            // Octal numeric strings using PHP 8.1 explicit octal notation.
+            'explicit-octal-single-digit-zero' => [
+                '0o0',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => true,
+                    'float'   => false,
+                ],
+            ],
+            'explicit-octal-single-digit' => [
+                '0O7',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => true,
+                    'float'   => false,
+                ],
+            ],
+            'explicit-octal-multi-digit' => [
+                '0o76543210',
+                [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => true,
+                    'float'   => false,
+                ],
+            ],
+            'explicit-octal-multi-digit-php-7.4' => [
+                '0O20_631_542',
                 [
                     'decimal' => false,
                     'hex'     => false,


### PR DESCRIPTION
This add support for the explicit octal notation using a `0o`/`0O` prefix as supported in PHP as of PHP 8.1.

The only method which needed adjusting was the `Numbers::getCompleteNumber()` method, which now backfills the tokenization when needed.

For the `Numbers::isOctalInt()` method, a small tweak to the regex was all that was needed.

As for the `Numbers::getDecimalValue()` method: this already handled the conversion correctly due to the use of the PHP native `octdec()` function.

From the RFC:
> Surprisingly PHP already has support for this notation when using the `octdec()` and `base_convert()` functions.

Includes adding unit tests to safeguard support in all relevant methods in the class.

Refs:
* https://wiki.php.net/rfc/explicit_octal_notation
* https://github.com/php/php-src/pull/6360
* https://github.com/squizlabs/PHP_CodeSniffer/pull/3481
* https://github.com/squizlabs/PHP_CodeSniffer/pull/3552