### PR TITLE
GetTokensAsString: minor tweaks

### DIFF
--- a/PHPCSUtils/Utils/GetTokensAsString.php
+++ b/PHPCSUtils/Utils/GetTokensAsString.php
@@ -33,6 +33,27 @@ class GetTokensAsString
      * Retrieve the tab-replaced content of the tokens from the specified start position in
      * the token stack to the specified end position (inclusive).
      *
+     * Alias for the {@see \PHPCSUtils\Utils\GetTokensAsString::tabReplaced()} method.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $start     The position to start from in the token stack.
+     * @param int                         $end       The position to end at in the token stack (inclusive).
+     *
+     * @return string The token contents.
+     *
+     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified start position does not exist.
+     */
+    public static function normal(File $phpcsFile, $start, $end)
+    {
+        return self::tabReplaced($phpcsFile, $start, $end);
+    }
+
+    /**
+     * Retrieve the tab-replaced content of the tokens from the specified start position in
+     * the token stack to the specified end position (inclusive).
+     *
      * This is the default behaviour for PHPCS.
      *
      * If the `tabWidth` is set, either via a (custom) ruleset, the config file or by passing it
@@ -53,37 +74,16 @@ class GetTokensAsString
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified start position does not exist.
      */
-    public static function normal(File $phpcsFile, $start, $end)
-    {
-        return self::getString($phpcsFile, $start, $end);
-    }
-
-    /**
-     * Retrieve the tab-replaced content of the tokens from the specified start position in
-     * the token stack to the specified end position (inclusive).
-     *
-     * Alias for the {@see \PHPCSUtils\Utils\GetTokensAsString::normal()} method.
-     *
-     * @since 1.0.0
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $start     The position to start from in the token stack.
-     * @param int                         $end       The position to end at in the token stack (inclusive).
-     *
-     * @return string The token contents.
-     *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified start position does not exist.
-     */
     public static function tabReplaced(File $phpcsFile, $start, $end)
     {
-        return self::normal($phpcsFile, $start, $end);
+        return self::getString($phpcsFile, $start, $end);
     }
 
     /**
      * Retrieve the original content of the tokens from the specified start position in
      * the token stack to the specified end position (inclusive).
      *
-     * In contrast to the {@see GetTokensAsString::normal()} method, this method will return
+     * In contrast to the {@see GetTokensAsString::tabReplaced()} method, this method will return
      * the original token content for the specified tokens.
      * That means that if the original content contained tabs, the return value of this function
      * will also contain tabs.
@@ -135,7 +135,7 @@ class GetTokensAsString
      * Retrieve the code-tokens only content of the tokens from the specified start position
      * in the token stack to the specified end position (inclusive) without whitespace or comments.
      *
-     * This is, for instance, useful to retrieve a namespace name without stray whitespace or comments.
+     * This is useful, for instance, to retrieve a namespace name without stray whitespace or comments.
      * Use this function selectively and with care!
      *
      * @see \PHP_CodeSniffer\Files\File::getTokensAsString() Loosely related function.

--- a/Tests/Utils/GetTokensAsString/GetTokensAsStringTest.php
+++ b/Tests/Utils/GetTokensAsString/GetTokensAsStringTest.php
@@ -125,8 +125,8 @@ class GetTokensAsStringTest extends UtilityMethodTestCase
         $start = $this->getTargetToken($testMarker, $startTokenType);
         $end   = $this->getTargetToken($testMarker, \T_SEMICOLON);
 
-        $result = GetTokensAsString::normal(self::$phpcsFile, $start, $end);
-        $this->assertSame($expected['normal'], $result);
+        $result = GetTokensAsString::tabReplaced(self::$phpcsFile, $start, $end);
+        $this->assertSame($expected['tab_replaced'], $result);
     }
 
     /**
@@ -248,81 +248,81 @@ class GetTokensAsStringTest extends UtilityMethodTestCase
                 'marker'   => '/* testNamespace */',
                 'type'     => \T_NAMESPACE,
                 'expected' => [
-                    'normal'      => 'namespace Foo\Bar\Baz;',
-                    'orig'        => 'namespace Foo\Bar\Baz;',
-                    'no_comments' => 'namespace Foo\Bar\Baz;',
-                    'no_empties'  => 'namespaceFoo\Bar\Baz;',
-                    'compact'     => 'namespace Foo\Bar\Baz;',
-                    'compact_nc'  => 'namespace Foo\Bar\Baz;',
+                    'tab_replaced' => 'namespace Foo\Bar\Baz;',
+                    'orig'         => 'namespace Foo\Bar\Baz;',
+                    'no_comments'  => 'namespace Foo\Bar\Baz;',
+                    'no_empties'   => 'namespaceFoo\Bar\Baz;',
+                    'compact'      => 'namespace Foo\Bar\Baz;',
+                    'compact_nc'   => 'namespace Foo\Bar\Baz;',
                 ],
             ],
             'use-with-comments' => [
                 'marker'   => '/* testUseWithComments */',
                 'type'     => \T_STRING,
                 'expected' => [
-                    'normal'      => 'Foo /*comment*/ \ Bar
+                    'tab_replaced' => 'Foo /*comment*/ \ Bar
     // phpcs:ignore Stnd.Cat.Sniff --    For reasons.
     \ Bah;',
-                    'orig'        => 'Foo /*comment*/ \ Bar
+                    'orig'         => 'Foo /*comment*/ \ Bar
 	// phpcs:ignore Stnd.Cat.Sniff --	 For reasons.
 	\ Bah;',
-                    'no_comments' => 'Foo  \ Bar
+                    'no_comments'  => 'Foo  \ Bar
         \ Bah;',
-                    'no_empties'  => 'Foo\Bar\Bah;',
-                    'compact'     => 'Foo /*comment*/ \ Bar // phpcs:ignore Stnd.Cat.Sniff --    For reasons.
+                    'no_empties'   => 'Foo\Bar\Bah;',
+                    'compact'      => 'Foo /*comment*/ \ Bar // phpcs:ignore Stnd.Cat.Sniff --    For reasons.
  \ Bah;',
-                    'compact_nc'  => 'Foo \ Bar \ Bah;',
+                    'compact_nc'   => 'Foo \ Bar \ Bah;',
                 ],
             ],
             'calculation' => [
                 'marker'   => '/* testCalculation */',
                 'type'     => \T_LNUMBER,
                 'expected' => [
-                    'normal'      => '1 + 2 +
+                    'tab_replaced' => '1 + 2 +
         // Comment.
         3 + 4
         + 5 + 6 + 7 > 20;',
-                    'orig'        => '1 + 2 +
+                    'orig'         => '1 + 2 +
         // Comment.
         3 + 4
         + 5 + 6 + 7 > 20;',
-                    'no_comments' => '1 + 2 +
+                    'no_comments'  => '1 + 2 +
                 3 + 4
         + 5 + 6 + 7 > 20;',
-                    'no_empties'  => '1+2+3+4+5+6+7>20;',
-                    'compact'     => '1 + 2 + // Comment.
+                    'no_empties'   => '1+2+3+4+5+6+7>20;',
+                    'compact'      => '1 + 2 + // Comment.
  3 + 4 + 5 + 6 + 7 > 20;',
-                    'compact_nc'  => '1 + 2 + 3 + 4 + 5 + 6 + 7 > 20;',
+                    'compact_nc'   => '1 + 2 + 3 + 4 + 5 + 6 + 7 > 20;',
                 ],
             ],
             'echo-with-tabs' => [
                 'marker'   => '/* testEchoWithTabs */',
                 'type'     => \T_ECHO,
                 'expected' => [
-                    'normal'      => 'echo \'foo\',
+                    'tab_replaced' => 'echo \'foo\',
     \'bar\'   ,
         \'baz\';',
-                    'orig'        => 'echo \'foo\',
+                    'orig'         => 'echo \'foo\',
 	\'bar\'	,
 		\'baz\';',
-                    'no_comments' => 'echo \'foo\',
+                    'no_comments'  => 'echo \'foo\',
     \'bar\'   ,
         \'baz\';',
-                    'no_empties'  => 'echo\'foo\',\'bar\',\'baz\';',
-                    'compact'     => 'echo \'foo\', \'bar\' , \'baz\';',
-                    'compact_nc'  => 'echo \'foo\', \'bar\' , \'baz\';',
+                    'no_empties'   => 'echo\'foo\',\'bar\',\'baz\';',
+                    'compact'      => 'echo \'foo\', \'bar\' , \'baz\';',
+                    'compact_nc'   => 'echo \'foo\', \'bar\' , \'baz\';',
                 ],
             ],
             'end-of-file' => [
                 'marker'   => '/* testEndOfFile */',
                 'type'     => \T_ECHO,
                 'expected' => [
-                    'normal'      => 'echo   $foo;',
-                    'orig'        => 'echo   $foo;',
-                    'no_comments' => 'echo   $foo;',
-                    'no_empties'  => 'echo$foo;',
-                    'compact'     => 'echo $foo;',
-                    'compact_nc'  => 'echo $foo;',
+                    'tab_replaced' => 'echo   $foo;',
+                    'orig'         => 'echo   $foo;',
+                    'no_comments'  => 'echo   $foo;',
+                    'no_empties'   => 'echo$foo;',
+                    'compact'      => 'echo $foo;',
+                    'compact_nc'   => 'echo $foo;',
                 ],
             ],
         ];


### PR DESCRIPTION
* Reversed the alias `normal()` vs the real method `tabReplaced()` as the latter is a more descriptive method name.
* Minor documentation readability tweak.