### PR TITLE
GH Actions: remove `--no-interaction` from Composer commands

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -41,12 +41,12 @@ jobs:
       - name: 'Composer: adjust dependencies'
         run: |
           # The sniff stage doesn't run the unit tests, so no need for PHPUnit.
-          composer remove --no-update --dev phpunit/phpunit --no-scripts --no-interaction
+          composer remove --no-update --dev phpunit/phpunit --no-scripts
           # Using PHPCS `master` as an early detection system for bugs upstream.
-          composer require --no-update squizlabs/php_codesniffer:"dev-master" --no-interaction
+          composer require --no-update squizlabs/php_codesniffer:"dev-master"
           # Add PHPCSDevCS - this is the CS ruleset we use.
           # This is not in the composer.json as it has different minimum PHPCS reqs and would conflict.
-          composer require --no-update --dev phpcsstandards/phpcsdevcs:"^1.1.3" --no-interaction
+          composer require --no-update --dev phpcsstandards/phpcsdevcs:"^1.1.3"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -63,13 +63,13 @@ jobs:
           coverage: none
 
       - name: 'Composer: set PHPCS version for tests'
-        run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
+        run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
 
       - name: 'Composer: tweak PHPUnit version'
         if: ${{ matrix.php == 'latest' || startsWith( matrix.php, '8' ) }}
         # Temporary fix - PHPUnit 9.3+ is buggy when used for code coverage, so not allowed "normally".
         # For tests which don't run code coverage, we can safely install it for PHP 8 though.
-        run: composer require --no-update phpunit/phpunit:"^9.3" --no-interaction
+        run: composer require --no-update phpunit/phpunit:"^9.3"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,13 +203,13 @@ jobs:
           coverage: none
 
       - name: 'Composer: set PHPCS version for tests'
-        run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
+        run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
 
       - name: 'Composer: conditionally tweak PHPUnit version'
         if: ${{ startsWith( matrix.php, '8' ) }}
         # Temporary fix - PHPUnit 9.3+ is buggy when used for code coverage, so not allowed "normally".
         # For tests which don't run code coverage, we can safely install it for PHP 8 though.
-        run: composer require --no-update phpunit/phpunit:"^9.3" --no-interaction
+        run: composer require --no-update phpunit/phpunit:"^9.3"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
@@ -285,7 +285,7 @@ jobs:
       - name: 'Composer: adjust dependencies'
         run: |
           # Set a specific PHPCS version.
-          composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-scripts --no-interaction
+          composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-scripts
 
       - name: Install Composer dependencies - normal
         uses: "ramsey/composer-install@v2"
@@ -303,7 +303,7 @@ jobs:
 
       - name: Install Coveralls
         if: ${{ success() }}
-        run: composer require php-coveralls/php-coveralls:"^2.4.2" --no-interaction
+        run: composer require php-coveralls/php-coveralls:"^2.4.2"
 
       - name: Upload coverage results to Coveralls
         if: ${{ success() }}


### PR DESCRIPTION
... as since `setup-php` version `2.17.0`, this is no longer needed as this is now the default via an environment variable set by `setup-php`.

Refs:
* https://github.com/shivammathur/setup-php/releases/tag/2.17.0
* https://github.com/shivammathur/setup-php/pull/547