### PR TITLE
CI: run code coverage on PHPUnit 9.3+

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -65,12 +65,6 @@ jobs:
       - name: 'Composer: set PHPCS version for tests'
         run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
 
-      - name: 'Composer: tweak PHPUnit version'
-        if: ${{ matrix.php == 'latest' || startsWith( matrix.php, '8' ) }}
-        # Temporary fix - PHPUnit 9.3+ is buggy when used for code coverage, so not allowed "normally".
-        # For tests which don't run code coverage, we can safely install it for PHP 8 though.
-        run: composer require --no-update phpunit/phpunit:"^9.3"
-
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,10 +94,6 @@ jobs:
           # Complement the builds run in code coverage to complete the matrix and prevent issues
           # with PHPCS versions incompatible with certain PHP versions.
           - php: '8.1'
-            phpcs_version: 'dev-master'
-            risky: false
-            experimental: false
-          - php: '8.1'
             phpcs_version: '3.6.1'
             risky: false
             experimental: false
@@ -111,6 +107,10 @@ jobs:
             risky: false
             experimental: false
 
+          - php: '7.4'
+            phpcs_version: 'dev-master'
+            risky: false
+            experimental: false
           - php: '7.4'
             phpcs_version: '3.5.0'
             risky: false
@@ -205,12 +205,6 @@ jobs:
       - name: 'Composer: set PHPCS version for tests'
         run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
 
-      - name: 'Composer: conditionally tweak PHPUnit version'
-        if: ${{ startsWith( matrix.php, '8' ) }}
-        # Temporary fix - PHPUnit 9.3+ is buggy when used for code coverage, so not allowed "normally".
-        # For tests which don't run code coverage, we can safely install it for PHP 8 though.
-        run: composer require --no-update phpunit/phpunit:"^9.3"
-
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies - normal
@@ -249,7 +243,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: '7.4' # This should be changed to 8.0 when the tests can run on PHPUnit 9.3+.
+          - php: '8.1'
             phpcs_version: 'dev-master'
           - php: '7.3'
             phpcs_version: '2.9.2'
@@ -287,11 +281,31 @@ jobs:
           # Set a specific PHPCS version.
           composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-scripts
 
-      - name: Install Composer dependencies - normal
+      - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
 
-      - name: Run the unit tests with code coverage
+      - name: Grab PHPUnit version
+        id: phpunit_version
+        run: echo ::set-output name=VERSION::$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')
+
+      - name: "DEBUG: Show grabbed version"
+        run: echo ${{ steps.phpunit_version.outputs.VERSION }}
+
+      # PHPUnit 9.3 started using PHP-Parser for code coverage causing some of our coverage builds to fail.
+      # As of PHPUnit 9.3.4, a cache warming option is available.
+      # Using that option prevents issues with PHP-Parser backfilling PHP tokens when PHPCS does not (yet),
+      # which would otherwise cause tests to fail on tokens being available when they shouldn't be.
+      - name: "Warm the PHPUnit cache (PHPUnit 9.3+)"
+        if: ${{ steps.phpunit_version.outputs.VERSION >= '9.3' }}
+        run: vendor/bin/phpunit --coverage-cache ./build/phpunit-cache --warm-coverage-cache
+
+      - name: "Run the unit tests with code coverage (PHPUnit < 9.3)"
+        if: ${{ steps.phpunit_version.outputs.VERSION < '9.3' }}
         run: vendor/bin/phpunit
+
+      - name: "Run the unit tests with code coverage (PHPUnit 9.3+)"
+        if: ${{ steps.phpunit_version.outputs.VERSION >= '9.3' }}
+        run: vendor/bin/phpunit --coverage-cache ./build/phpunit-cache
 
       # Uploading the results with PHP Coveralls v1 won't work from GH Actions, so switch the PHP version.
       - name: Switch to PHP 7.4

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev" : {
         "php-parallel-lint/php-parallel-lint": "^1.3.2",
         "php-parallel-lint/php-console-highlighter": "^1.0",
-        "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || >=9.0 <9.3.0",
+        "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "yoast/phpunit-polyfills": "^1.0.1"
     },
     "conflict": {


### PR DESCRIPTION
As of PHPUnit 9.3, PHPUnit started using PHP-Parser as a basis to calculate code coverage. Until now, this prevented this repo from using PHPUnit 9.3 (see PR #304 for more details).

Now the issues related to that have been fixed, the PHPUnit version requirements can be widened again.

This then allows to:
* Remove the tweaking of the PHPUnit version in `test` jobs in GH Actions.
* Run code coverage on the latest PHP version (8.1).

Just in case there would still be residual issues, I'm also implementing cache warming in the code coverage workflow as recommended by Sebastian.

Notes regarding cache-warming:
* The `--coverage-cache` and `--warm-coverage-cache` options are available since PHPUnit 9.3.4 and if these are used on older PHPUnit versions, PHPUnit will error out with an "unrecognized CLI argument" error.
* In other words: these options can only be used with PHPUnit 9.3+, which is why the PHPUnit version is checked and remembered and subsequently used in the conditions.
* Also: running PHPUnit with the `--warm-coverage-cache` option _does not run the tests_. It literally only warms the cache, which is why this is implemented as a separate step in the workflow.
* The cache directory can be configured in the `phpunit.xml[.dist]` file, but only when using the PHPUnit 9.3+ `coverage` XML tag.
    As the PHPUnit config used needs to stay cross-version compatible with older PHPUnit versions, the CLI option is used for now.
    If, at some point in the future, two config files would be used (one for PHPUnit < 9.3 and one for PHPUnit >= 9.3), the cache directory could be added to the config instead of passing it on the command-line.

Refs:
* https://github.com/sebastianbergmann/php-code-coverage/issues/798#issuecomment-678922065
* https://github.com/sebastianbergmann/phpunit/compare/9.3.3...9.3.4