### PR TITLE
Tests: improve skip info

### DIFF
--- a/Tests/Utils/Numbers/GetCompleteNumberTest.php
+++ b/Tests/Utils/Numbers/GetCompleteNumberTest.php
@@ -100,7 +100,7 @@ class GetCompleteNumberTest extends UtilityMethodTestCase
     public function testUnsupportedPhpcsException()
     {
         if (\version_compare(static::$phpcsVersion, Numbers::UNSUPPORTED_PHPCS_VERSION, '!=') === true) {
-            $this->markTestSkipped('Test specific to a limited set of PHPCS versions');
+            $this->markTestSkipped('Test only applicable to PHPCS ' . Numbers::UNSUPPORTED_PHPCS_VERSION);
         }
 
         $this->expectPhpcsException(

--- a/Tests/Utils/Operators/IsUnaryPlusMinusTest.php
+++ b/Tests/Utils/Operators/IsUnaryPlusMinusTest.php
@@ -66,13 +66,15 @@ class IsUnaryPlusMinusTest extends UtilityMethodTestCase
              * Skip the test if this is PHP 7.4 or a PHPCS version which backfills the token sequence
              * to one token as in that case, the plus/minus token won't exist
              */
-            $skipMessage = 'Test irrelevant as the target token won\'t exist';
             if (\version_compare(\PHP_VERSION_ID, '70399', '>') === true) {
-                $this->markTestSkipped($skipMessage);
+                $this->markTestSkipped('Test irrelevant as the target token won\'t exist when on PHP >= 7.4');
             }
 
             if (\version_compare(static::$phpcsVersion, Numbers::UNSUPPORTED_PHPCS_VERSION, '>=') === true) {
-                $this->markTestSkipped($skipMessage);
+                $this->markTestSkipped(
+                    'Test irrelevant as the target token won\'t exist when on PHPCS >= '
+                    . Numbers::UNSUPPORTED_PHPCS_VERSION
+                );
             }
         }
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,9 @@
     convertNoticesToExceptions="true"
     convertDeprecationsToExceptions="true"
     colors="true"
-    forceCoversAnnotation="true">
+    forceCoversAnnotation="true"
+    verbose="true"
+    >
 
     <testsuites>
         <testsuite name="PHPCSUtils">


### PR DESCRIPTION
### PHPUnit config: turn on verbosity

... to allow for seeing which tests are being skipped in CI.

### GetCompleteNumberTest::testUnsupportedPhpcsException(): improve skip message

### IsUnaryPlusMinusTest::testIsUnaryPlusMinus(): improve skip message