### PR TITLE
Tests: various improvements

### DIFF
--- a/Tests/BackCompat/BCFile/GetConditionTest.php
+++ b/Tests/BackCompat/BCFile/GetConditionTest.php
@@ -192,8 +192,13 @@ class GetConditionTest extends UtilityMethodTestCase
      */
     public function testNonConditionalToken()
     {
+        $targetType = \T_STRING;
+        if (parent::usesPhp8NameTokens() === true) {
+            $targetType = \T_NAME_QUALIFIED;
+        }
+
         $testClass = static::TEST_CLASS;
-        $stackPtr  = $this->getTargetToken('/* testStartPoint */', \T_STRING);
+        $stackPtr  = $this->getTargetToken('/* testStartPoint */', $targetType);
 
         $result = $testClass::getCondition(self::$phpcsFile, $stackPtr, \T_IF);
         $this->assertFalse($result);

--- a/Tests/BackCompat/BCTokens/TokenNameTest.php
+++ b/Tests/BackCompat/BCTokens/TokenNameTest.php
@@ -50,13 +50,13 @@ class TokenNameTest extends TestCase
     public function dataTokenName()
     {
         return [
-            'PHP native token: T_COMMA' => [
-                \T_COMMA,
-                'T_COMMA',
+            'PHP native token: T_ECHO' => [
+                \T_ECHO,
+                'T_ECHO',
             ],
-            'PHP native token: T_SELF' => [
-                \T_SELF,
-                'T_SELF',
+            'PHP native token: T_FUNCTION' => [
+                \T_FUNCTION,
+                'T_FUNCTION',
             ],
             'PHPCS native token: T_CLOSURE' => [
                 \T_CLOSURE,

--- a/Tests/TestUtils/UtilityMethodTestCase/ExpectPhpcsExceptionTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/ExpectPhpcsExceptionTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\TestUtils\UtilityMethodTestCase;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Exceptions\TokenizerException;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+
+/**
+ * Tests for the \PHPCSUtils\TestUtils\UtilityMethodTestCase class.
+ *
+ * @covers \PHPCSUtils\TestUtils\UtilityMethodTestCase::expectPhpcsException
+ *
+ * @group testutils
+ *
+ * @since 1.0.0
+ */
+class ExpectPhpcsExceptionTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Overload the "normal" "set up before class" to do nothing.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        // Deliberately left empty.
+    }
+
+    /**
+     * Overload the "normal" "set up" to do nothing.
+     *
+     * @before
+     *
+     * @return void
+     */
+    public function skipJSCSSTestsOnPHPCS4()
+    {
+        // Deliberately left empty.
+    }
+
+    /**
+     * Overload the "normal" "tear down after class" to do nothing.
+     *
+     * @afterClass
+     *
+     * @return void
+     */
+    public static function resetTestFile()
+    {
+        // Deliberately left empty.
+    }
+
+    /**
+     * Test that the helper method to handle cross-version testing of exceptions in PHPUnit
+     * works correctly.
+     *
+     * @return void
+     */
+    public function testExpectPhpcsRuntimeException()
+    {
+        $this->expectPhpcsException('testing-1-2-3');
+        throw new RuntimeException('testing-1-2-3');
+    }
+
+    /**
+     * Test that the helper method to handle cross-version testing of exceptions in PHPUnit
+     * works correctly.
+     *
+     * @return void
+     */
+    public function testExpectPhpcsTokenizerException()
+    {
+        $this->expectPhpcsException('testing-1-2-3', 'tokenizer');
+        throw new TokenizerException('testing-1-2-3');
+    }
+}

--- a/Tests/TestUtils/UtilityMethodTestCase/UtilityMethodTestCaseTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/UtilityMethodTestCaseTest.php
@@ -198,30 +198,6 @@ class UtilityMethodTestCaseTest extends PolyfilledTestCase
     }
 
     /**
-     * Test that the helper method to handle cross-version testing of exceptions in PHPUnit
-     * works correctly.
-     *
-     * @return void
-     */
-    public function testExpectPhpcsRuntimeException()
-    {
-        $this->expectPhpcsException('testing-1-2-3');
-        throw new RuntimeException('testing-1-2-3');
-    }
-
-    /**
-     * Test that the helper method to handle cross-version testing of exceptions in PHPUnit
-     * works correctly.
-     *
-     * @return void
-     */
-    public function testExpectPhpcsTokenizerException()
-    {
-        $this->expectPhpcsException('testing-1-2-3', 'tokenizer');
-        throw new TokenizerException('testing-1-2-3');
-    }
-
-    /**
      * Test that the class is correct reset.
      *
      * @return void

--- a/Tests/Utils/Numbers/GetCompleteNumberTest.inc
+++ b/Tests/Utils/Numbers/GetCompleteNumberTest.inc
@@ -14,6 +14,9 @@ const _100 = null;
 /* testIntDecimal */
 $a = 1000000000;
 
+/* testIntLargerThanIntMaxIsFloat */
+$intMaxPlus3 = 10223372036854775810;
+
 /* testFloat */
 $b = 107925284.88;
 
@@ -38,6 +41,9 @@ $a = 100 'test'; // Intentional parse error, not our concern.
  */
 /* testPHP74IntDecimalMultiUnderscore */
 $threshold = 1_000_000_000;
+
+/* testPHP74IntLargerThanIntMaxIsFloat */
+$intMaxPlus3 = 10_223_372_036_854_775_810;
 
 /* testPHP74Float */
 $testValue = 107_925_284.88;

--- a/Tests/Utils/Numbers/GetCompleteNumberTest.php
+++ b/Tests/Utils/Numbers/GetCompleteNumberTest.php
@@ -18,6 +18,7 @@ use PHPCSUtils\Utils\Numbers;
  * Tests for the \PHPCSUtils\Utils\Numbers::getCompleteNumber() method.
  *
  * @covers \PHPCSUtils\Utils\Numbers::getCompleteNumber
+ * @covers \PHPCSUtils\Utils\Numbers::updateResult
  *
  * @group numbers
  *
@@ -93,7 +94,7 @@ class GetCompleteNumberTest extends UtilityMethodTestCase
     }
 
     /**
-     * Test receiving an exception when PHPCS is run on PHP < 7.4 in combination with PHPCS 3.5.3.
+     * Test receiving an exception when running PHPCS 3.5.3.
      *
      * @return void
      */

--- a/Tests/Utils/Numbers/GetCompleteNumberTest.php
+++ b/Tests/Utils/Numbers/GetCompleteNumberTest.php
@@ -184,6 +184,17 @@ class GetCompleteNumberTest extends UtilityMethodTestCase
                     'last_token'   => 0, // Offset from $stackPtr.
                 ],
             ],
+            'normal-integer-larger-than-intmax-is-float' => [
+                '/* testIntLargerThanIntMaxIsFloat */',
+                [
+                    'orig_content' => '10223372036854775810',
+                    'content'      => '10223372036854775810',
+                    'code'         => \T_DNUMBER,
+                    'type'         => 'T_DNUMBER',
+                    'decimal'      => '10223372036854775810',
+                    'last_token'   => 0, // Offset from $stackPtr.
+                ],
+            ],
             'normal-float' => [
                 '/* testFloat */',
                 [
@@ -262,6 +273,17 @@ class GetCompleteNumberTest extends UtilityMethodTestCase
                     'code'         => \T_LNUMBER,
                     'type'         => 'T_LNUMBER',
                     'decimal'      => '1000000000',
+                    'last_token'   => $multiToken ? 1 : 0, // Offset from $stackPtr.
+                ],
+            ],
+            'php-7.4-integer-larger-than-intmax-is-float' => [
+                '/* testPHP74IntLargerThanIntMaxIsFloat */',
+                [
+                    'orig_content' => '10_223_372_036_854_775_810',
+                    'content'      => '10223372036854775810',
+                    'code'         => \T_DNUMBER,
+                    'type'         => 'T_DNUMBER',
+                    'decimal'      => '10223372036854775810',
                     'last_token'   => $multiToken ? 1 : 0, // Offset from $stackPtr.
                 ],
             ],
@@ -523,6 +545,7 @@ class GetCompleteNumberTest extends UtilityMethodTestCase
                 ],
             ],
 
+            // PHP 8.1 explicit octal notation.
             'php-8.1-explicit-octal-lowercase' => [
                 '/* testPHP81ExplicitOctal */',
                 [


### PR DESCRIPTION
👉🏻 Based on reviewing the code coverage reports.

---

### Numbers: fix incorrect code coverage reporting

PR #293 split some code from the `getCompleteNumber()` method off into a separate `updateResult()` method used only by the `getCompleteNumber()` method, however code coverage was not being recorded for that new method as no `@covers` tag had been added for that method to the `GetCompleteNumberTest` class.

Fixed now.

### TokenNameTest: fix incorrect test cases

Turns out those were still PHPCS native tokens, not PHP native ones 😂

### BCFile\GetConditionTest::testNonConditionalToken() fix target token

With the changes in PHP 8.0, the `T_STRING` (namespace name) target token _may_ not exist as it _may_ be tokenized as `T_NAME_QUALIFIED` instead.

With this change, the correct token should now still be retrieved to allow the test to test what it is supposed to test.

### UtilityMethodTestCaseTest: split off the test for the `expectPhpcsException()` method

The `UtilityMethodTestCase::expectPhpcsException()` method provides a polyfill for changed PHPUnit functionality. To allow for testing this polyfill properly, it should be tested without the PHPUnit Polyfills active as external standards using the `UtilityMethodTestCase` may not implement the PHPUnit Polyfills.

To do so, the tests specific to the `UtilityMethodTestCase::expectPhpcsException()` method have been split off into their own test class which extends the `UtilityMethodTestCase` directly, instead of extending the `PolyfilledTestCase`.

### GetCompleteNumberTest: add test for int max handling

While the value of `PHP_INT_MAX` will differ depending on whether PHP is compiled as 32-bits or 64-bits, this test value should convert to float in both cases.