### PR TITLE
Collections: deprecate all properties for methods

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -859,7 +859,7 @@ class BCFile
             }
         }
 
-        $valid  = Collections::$propertyModifierKeywords;
+        $valid  = Collections::propertyModifierKeywords();
         $valid += Tokens::$emptyTokens;
 
         $scope          = 'public';

--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -112,6 +112,24 @@ class BCTokens
     ];
 
     /**
+     * Tokens representing PHP magic constants.
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @var array <int|string> => <int|string>
+     */
+    private static $magicConstants = [
+        \T_CLASS_C  => \T_CLASS_C,
+        \T_DIR      => \T_DIR,
+        \T_FILE     => \T_FILE,
+        \T_FUNC_C   => \T_FUNC_C,
+        \T_LINE     => \T_LINE,
+        \T_METHOD_C => \T_METHOD_C,
+        \T_NS_C     => \T_NS_C,
+        \T_TRAIT_C  => \T_TRAIT_C,
+    ];
+
+    /**
      * Handle calls to (undeclared) methods for token arrays which haven't received any
      * changes since PHPCS 2.6.0.
      *
@@ -467,8 +485,7 @@ class BCTokens
      * Changelog for the PHPCS native array:
      * - Introduced in PHPCS 3.5.6.
      *
-     * @see \PHP_CodeSniffer\Util\Tokens::$magicConstants   Original array.
-     * @see \PHPCSUtils\Tokens\Collections::$magicConstants Same array, pre-dating the PHPCS change.
+     * @see \PHP_CodeSniffer\Util\Tokens::$magicConstants Original array.
      *
      * @link https://www.php.net/language.constants.predefined PHP Manual on magic constants
      *
@@ -482,7 +499,7 @@ class BCTokens
             return Tokens::$magicConstants;
         }
 
-        return Collections::$magicConstants;
+        return self::$magicConstants;
     }
 
     /**

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -278,11 +278,11 @@ class Collections
     ];
 
     /**
-     * OO scopes in which constants can be declared.
+     * DEPRECATED: OO scopes in which constants can be declared.
      *
-     * Note: traits can not declare constants.
+     * @since 1.0.0-alpha1
      *
-     * @since 1.0.0
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::ooConstantScopes()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
@@ -323,11 +323,11 @@ class Collections
     ];
 
     /**
-     * OO scopes in which properties can be declared.
+     * DEPRECATED: OO scopes in which properties can be declared.
      *
-     * Note: interfaces can not declare properties.
+     * @since 1.0.0-alpha1
      *
-     * @since 1.0.0
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::ooPropertyScopes()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
@@ -954,6 +954,34 @@ class Collections
     public static function ooCanImplement()
     {
         return self::$OOCanImplement;
+    }
+
+    /**
+     * OO scopes in which constants can be declared.
+     *
+     * Note: traits can not declare constants.
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$OOConstantScopes} property.
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function ooConstantScopes()
+    {
+        return self::$OOConstantScopes;
+    }
+
+    /**
+     * OO scopes in which properties can be declared.
+     *
+     * Note: interfaces can not declare properties.
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$OOPropertyScopes} property.
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function ooPropertyScopes()
+    {
+        return self::$OOPropertyScopes;
     }
 
     /**

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -167,14 +167,12 @@ class Collections
     ];
 
     /**
-     * Tokens which are used to create lists.
+     * DEPRECATED: Tokens which are used to create lists.
      *
-     * @see \PHPCSUtils\Tokens\Collections::$listTokensBC    Related property containing tokens used
-     *                                                       for lists (PHPCS cross-version).
-     * @see \PHPCSUtils\Tokens\Collections::$shortListTokens Related property containing only tokens used
-     *                                                       for short lists.
+     * @since 1.0.0-alpha1
      *
-     * @since 1.0.0
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::listTokens()} or
+     *                          {@see Collections::listTokensBC()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
@@ -185,15 +183,11 @@ class Collections
     ];
 
     /**
-     * Tokens which are used to create lists.
+     * DEPRECATED: Tokens which are used to create lists.
      *
-     * List which is backward-compatible with PHPCS < 3.3.0.
-     * Should only be used selectively.
+     * @since 1.0.0-alpha1
      *
-     * @see \PHPCSUtils\Tokens\Collections::$shortListTokensBC Related property containing only tokens used
-     *                                                         for short lists (cross-version).
-     *
-     * @since 1.0.0
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::listTokensBC()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
@@ -444,7 +438,7 @@ class Collections
     /**
      * Tokens which are used for short lists.
      *
-     * @see \PHPCSUtils\Tokens\Collections::$listTokens Related property containing all tokens used for lists.
+     * @see \PHPCSUtils\Tokens\Collections::listTokens() Related method to retrieve all tokens used for lists.
      *
      * @since 1.0.0
      *
@@ -461,8 +455,8 @@ class Collections
      * List which is backward-compatible with PHPCS < 3.3.0.
      * Should only be used selectively.
      *
-     * @see \PHPCSUtils\Tokens\Collections::$listTokensBC Related property containing all tokens used for lists
-     *                                                    (cross-version).
+     * @see \PHPCSUtils\Tokens\Collections::listTokensBC() Related method to retrieve all tokens used for lists
+     *                                                     (cross-version).
      *
      * @since 1.0.0
      *
@@ -740,6 +734,41 @@ class Collections
     public static function incrementDecrementOperators()
     {
         return self::$incrementDecrementOperators;
+    }
+
+    /**
+     * Tokens which are used to create lists.
+     *
+     * @see \PHPCSUtils\Tokens\Collections::listTokensBC()    Related method to retrieve tokens used
+     *                                                        for lists (PHPCS cross-version).
+     * @see \PHPCSUtils\Tokens\Collections::$shortListTokens  Related property containing only tokens used
+     *                                                        for short lists.
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$listTokens} property.
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function listTokens()
+    {
+        return self::$listTokens;
+    }
+
+    /**
+     * Tokens which are used to create lists.
+     *
+     * List which is backward-compatible with PHPCS < 3.3.0.
+     * Should only be used selectively.
+     *
+     * @see \PHPCSUtils\Tokens\Collections::$shortListTokensBC Related property containing only tokens used
+     *                                                         for short lists (cross-version).
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$listTokensBC} property.
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function listTokensBC()
+    {
+        return self::$listTokensBC;
     }
 
     /**

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -441,11 +441,12 @@ class Collections
     ];
 
     /**
-     * Tokens which are used for short lists.
+     * DEPRECATED: Tokens which are used for short lists.
      *
-     * @see \PHPCSUtils\Tokens\Collections::listTokens() Related method to retrieve all tokens used for lists.
+     * @since 1.0.0-alpha1
      *
-     * @since 1.0.0
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::shortListTokens()} or
+     *                          {@see Collections::shortListTokensBC()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
@@ -455,15 +456,11 @@ class Collections
     ];
 
     /**
-     * Tokens which are used for short lists.
+     * DEPRECATED: Tokens which are used for short lists.
      *
-     * List which is backward-compatible with PHPCS < 3.3.0.
-     * Should only be used selectively.
+     * @since 1.0.0-alpha1
      *
-     * @see \PHPCSUtils\Tokens\Collections::listTokensBC() Related method to retrieve all tokens used for lists
-     *                                                     (cross-version).
-     *
-     * @since 1.0.0
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::shortListTokensBC()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
@@ -746,7 +743,7 @@ class Collections
      *
      * @see \PHPCSUtils\Tokens\Collections::listTokensBC()    Related method to retrieve tokens used
      *                                                        for lists (PHPCS cross-version).
-     * @see \PHPCSUtils\Tokens\Collections::$shortListTokens  Related property containing only tokens used
+     * @see \PHPCSUtils\Tokens\Collections::shortListTokens() Related method to retrieve only tokens used
      *                                                        for short lists.
      *
      * @since 1.0.0-alpha4 This method replaces the {@see Collections::$listTokens} property.
@@ -764,8 +761,8 @@ class Collections
      * List which is backward-compatible with PHPCS < 3.3.0.
      * Should only be used selectively.
      *
-     * @see \PHPCSUtils\Tokens\Collections::$shortListTokensBC Related property containing only tokens used
-     *                                                         for short lists (cross-version).
+     * @see \PHPCSUtils\Tokens\Collections::shortListTokensBC() Related method to retrieve only tokens used
+     *                                                          for short lists (cross-version).
      *
      * @since 1.0.0-alpha4 This method replaces the {@see Collections::$listTokensBC} property.
      *
@@ -1368,5 +1365,37 @@ class Collections
     public static function shortArrayTokensBC()
     {
         return self::$shortArrayTokensBC;
+    }
+
+    /**
+     * Tokens which are used for short lists.
+     *
+     * @see \PHPCSUtils\Tokens\Collections::listTokens() Related method to retrieve all tokens used for lists.
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$shortListTokens} property.
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function shortListTokens()
+    {
+        return self::$shortListTokens;
+    }
+
+    /**
+     * Tokens which are used for short lists.
+     *
+     * List which is backward-compatible with PHPCS < 3.3.0.
+     * Should only be used selectively.
+     *
+     * @see \PHPCSUtils\Tokens\Collections::listTokensBC() Related method to retrieve all tokens used for lists
+     *                                                     (cross-version).
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$shortListTokensBC} property.
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function shortListTokensBC()
+    {
+        return self::$shortListTokensBC;
     }
 }

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -114,15 +114,11 @@ class Collections
     ];
 
     /**
-     * List of tokens which represent "closed" scopes.
+     * DEPRECATED: List of tokens which represent "closed" scopes.
      *
-     * I.e. anything declared within that scope - except for other closed scopes - is
-     * outside of the global namespace.
+     * @since 1.0.0-alpha1
      *
-     * This list doesn't contain the `T_NAMESPACE` token on purpose as variables declared
-     * within a namespace scope are still global and not limited to that namespace.
-     *
-     * @since 1.0.0
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::closedScopes()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
@@ -607,6 +603,24 @@ class Collections
     public static function classModifierKeywords()
     {
         return self::$classModifierKeywords;
+    }
+
+    /**
+     * List of tokens which represent "closed" scopes.
+     *
+     * I.e. anything declared within that scope - except for other closed scopes - is
+     * outside of the global namespace.
+     *
+     * This list doesn't contain the `T_NAMESPACE` token on purpose as variables declared
+     * within a namespace scope are still global and not limited to that namespace.
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$closedScopes} property.
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function closedScopes()
+    {
+        return self::$closedScopes;
     }
 
     /**

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -100,9 +100,11 @@ class Collections
     ];
 
     /**
-     * Modifier keywords which can be used for a class declaration.
+     * DEPRECATED: Modifier keywords which can be used for a class declaration.
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha1
+     *
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::classModifierKeywords()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
@@ -593,6 +595,18 @@ class Collections
         }
 
         return $tokens;
+    }
+
+    /**
+     * Modifier keywords which can be used for a class declaration.
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$classModifierKeywords} property.
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function classModifierKeywords()
+    {
+        return self::$classModifierKeywords;
     }
 
     /**

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -67,14 +67,12 @@ class Collections
     ];
 
     /**
-     * Tokens which are used to create arrays.
+     * DEPRECATED: Tokens which are used to create arrays.
      *
-     * @see \PHPCSUtils\Tokens\Collections::$arrayTokensBC    Related property containing tokens used
-     *                                                        for arrays (PHPCS cross-version).
-     * @see \PHPCSUtils\Tokens\Collections::$shortArrayTokens Related property containing only tokens used
-     *                                                        for short arrays.
+     * @since 1.0.0-alpha1
      *
-     * @since 1.0.0
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::arrayTokens()} or
+     *                          {@see Collections::arrayTokensBC()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
@@ -85,15 +83,11 @@ class Collections
     ];
 
     /**
-     * Tokens which are used to create arrays.
+     * DEPRECATED: Tokens which are used to create arrays.
      *
-     * List which is backward-compatible with PHPCS < 3.3.0.
-     * Should only be used selectively.
+     * @since 1.0.0-alpha1
      *
-     * @see \PHPCSUtils\Tokens\Collections::$shortArrayTokensBC Related property containing only tokens used
-     *                                                          for short arrays (PHPCS cross-version).
-     *
-     * @since 1.0.0
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::arrayTokensBC()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
@@ -414,7 +408,7 @@ class Collections
     /**
      * Tokens which are used for short arrays.
      *
-     * @see \PHPCSUtils\Tokens\Collections::$arrayTokens Related property containing all tokens used for arrays.
+     * @see \PHPCSUtils\Tokens\Collections::arrayTokens() Related method to retrieve all tokens used for arrays.
      *
      * @since 1.0.0
      *
@@ -431,8 +425,8 @@ class Collections
      * List which is backward-compatible with PHPCS < 3.3.0.
      * Should only be used selectively.
      *
-     * @see \PHPCSUtils\Tokens\Collections::$arrayTokensBC Related property containing all tokens used for arrays
-     *                                                    (cross-version).
+     * @see \PHPCSUtils\Tokens\Collections::arrayTokensBC() Related method to retrieve all tokens used for arrays
+     *                                                     (cross-version).
      *
      * @since 1.0.0
      *
@@ -535,6 +529,41 @@ class Collections
             \T_OPEN_SHORT_ARRAY    => \T_OPEN_SHORT_ARRAY,
             \T_OPEN_SQUARE_BRACKET => \T_OPEN_SQUARE_BRACKET,
         ];
+    }
+
+    /**
+     * Tokens which are used to create arrays.
+     *
+     * @see \PHPCSUtils\Tokens\Collections::arrayTokensBC()   Related method to retrieve tokens used
+     *                                                        for arrays (PHPCS cross-version).
+     * @see \PHPCSUtils\Tokens\Collections::$shortArrayTokens Related property containing only tokens used
+     *                                                        for short arrays.
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$arrayTokens} property.
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function arrayTokens()
+    {
+        return self::$arrayTokens;
+    }
+
+    /**
+     * Tokens which are used to create arrays.
+     *
+     * List which is backward-compatible with PHPCS < 3.3.0.
+     * Should only be used selectively.
+     *
+     * @see \PHPCSUtils\Tokens\Collections::$shortArrayTokensBC Related property containing only tokens used
+     *                                                          for short arrays (PHPCS cross-version).
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$arrayTokensBC} property.
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function arrayTokensBC()
+    {
+        return self::$arrayTokensBC;
     }
 
     /**

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -410,11 +410,12 @@ class Collections
     ];
 
     /**
-     * Tokens which are used for short arrays.
+     * DEPRECATED: Tokens which are used for short arrays.
      *
-     * @see \PHPCSUtils\Tokens\Collections::arrayTokens() Related method to retrieve all tokens used for arrays.
+     * @since 1.0.0-alpha1
      *
-     * @since 1.0.0
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::shortArrayTokens()} or
+     *                          {@see Collections::shortArrayTokensBC()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
@@ -424,15 +425,11 @@ class Collections
     ];
 
     /**
-     * Tokens which are used for short arrays.
+     * DEPRECATED: Tokens which are used for short arrays.
      *
-     * List which is backward-compatible with PHPCS < 3.3.0.
-     * Should only be used selectively.
+     * @since 1.0.0-alpha1
      *
-     * @see \PHPCSUtils\Tokens\Collections::arrayTokensBC() Related method to retrieve all tokens used for arrays
-     *                                                     (cross-version).
-     *
-     * @since 1.0.0
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::shortArrayTokensBC()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
@@ -538,10 +535,10 @@ class Collections
     /**
      * Tokens which are used to create arrays.
      *
-     * @see \PHPCSUtils\Tokens\Collections::arrayTokensBC()   Related method to retrieve tokens used
-     *                                                        for arrays (PHPCS cross-version).
-     * @see \PHPCSUtils\Tokens\Collections::$shortArrayTokens Related property containing only tokens used
-     *                                                        for short arrays.
+     * @see \PHPCSUtils\Tokens\Collections::arrayTokensBC()    Related method to retrieve tokens used
+     *                                                         for arrays (PHPCS cross-version).
+     * @see \PHPCSUtils\Tokens\Collections::shortArrayTokens() Related method to retrieve only tokens used
+     *                                                         for short arrays.
      *
      * @since 1.0.0-alpha4 This method replaces the {@see Collections::$arrayTokens} property.
      *
@@ -558,8 +555,8 @@ class Collections
      * List which is backward-compatible with PHPCS < 3.3.0.
      * Should only be used selectively.
      *
-     * @see \PHPCSUtils\Tokens\Collections::$shortArrayTokensBC Related property containing only tokens used
-     *                                                          for short arrays (PHPCS cross-version).
+     * @see \PHPCSUtils\Tokens\Collections::shortArrayTokensBC() Related method to retrieve only tokens used
+     *                                                           for short arrays (PHPCS cross-version).
      *
      * @since 1.0.0-alpha4 This method replaces the {@see Collections::$arrayTokensBC} property.
      *
@@ -1339,5 +1336,37 @@ class Collections
         }
 
         return $tokens;
+    }
+
+    /**
+     * Tokens which are used for short arrays.
+     *
+     * @see \PHPCSUtils\Tokens\Collections::arrayTokens() Related method to retrieve all tokens used for arrays.
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$shortArrayTokens} property.
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function shortArrayTokens()
+    {
+        return self::$shortArrayTokens;
+    }
+
+    /**
+     * Tokens which are used for short arrays.
+     *
+     * List which is backward-compatible with PHPCS < 3.3.0.
+     * Should only be used selectively.
+     *
+     * @see \PHPCSUtils\Tokens\Collections::arrayTokensBC() Related method to retrieve all tokens used for arrays
+     *                                                      (cross-version).
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$shortArrayTokensBC} property.
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function shortArrayTokensBC()
+    {
+        return self::$shortArrayTokensBC;
     }
 }

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -356,9 +356,11 @@ class Collections
     ];
 
     /**
-     * Modifier keywords which can be used for a property declaration.
+     * DEPRECATED: Modifier keywords which can be used for a property declaration.
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha1
+     *
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::propertyModifierKeywords()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
@@ -1149,6 +1151,18 @@ class Collections
             \T_OPEN_TAG           => \T_OPEN_TAG,
             \T_OPEN_TAG_WITH_ECHO => \T_OPEN_TAG_WITH_ECHO,
         ];
+    }
+
+    /**
+     * Modifier keywords which can be used for a property declaration.
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$propertyModifierKeywords} property.
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function propertyModifierKeywords()
+    {
+        return self::$propertyModifierKeywords;
     }
 
     /**

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -132,9 +132,11 @@ class Collections
     ];
 
     /**
-     * Control structure tokens.
+     * DEPRECATED: Control structure tokens.
      *
      * @since 1.0.0-alpha2
+     *
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::controlStructureTokens()} method instead.
      *
      * @var array <int> => <int>
      */
@@ -621,6 +623,18 @@ class Collections
     public static function closedScopes()
     {
         return self::$closedScopes;
+    }
+
+    /**
+     * Control structure tokens.
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$controlStructureTokens} property.
+     *
+     * @return array <int> => <int>
+     */
+    public static function controlStructureTokens()
+    {
+        return self::$controlStructureTokens;
     }
 
     /**

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -200,11 +200,11 @@ class Collections
     ];
 
     /**
-     * Tokens for the PHP magic constants.
-     *
-     * @link https://www.php.net/language.constants.predefined PHP Manual on magic constants
+     * DEPRECATED: Tokens for the PHP magic constants.
      *
      * @since 1.0.0-alpha3
+     *
+     * @deprecated 1.0.0-alpha4 Use the {@see \PHPCSUtils\BackCompat\BCTokens::magicConstants()} method instead.
      *
      * @var array <int|string> => <int|string>
      */

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -27,9 +27,12 @@ class Collections
 {
 
     /**
-     * Control structures which can use the alternative control structure syntax.
+     * DEPRECATED: Control structures which can use the alternative control structure syntax.
      *
      * @since 1.0.0-alpha2
+     *
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::alternativeControlStructureSyntaxes()}
+     *                          method instead.
      *
      * @var array <int> => <int>
      */
@@ -45,9 +48,12 @@ class Collections
     ];
 
     /**
-     * Alternative control structure syntax closer keyword tokens.
+     * DEPRECATED: Alternative control structure syntax closer keyword tokens.
      *
      * @since 1.0.0-alpha2
+     *
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::alternativeControlStructureSyntaxClosers()}
+     *                          method instead.
      *
      * @var array <int> => <int>
      */
@@ -501,6 +507,32 @@ class Collections
         \T_CONSTANT_ENCAPSED_STRING => \T_CONSTANT_ENCAPSED_STRING,
         \T_DOUBLE_QUOTED_STRING     => \T_DOUBLE_QUOTED_STRING,
     ];
+
+    /**
+     * Tokens for control structures which can use the alternative control structure syntax.
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$alternativeControlStructureSyntaxTokens}
+     *                     property.
+     *
+     * @return array <int> => <int>
+     */
+    public static function alternativeControlStructureSyntaxes()
+    {
+        return self::$alternativeControlStructureSyntaxTokens;
+    }
+
+    /**
+     * Tokens representing alternative control structure syntax closer keywords.
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$alternativeControlStructureSyntaxCloserTokens}
+     *                     property.
+     *
+     * @return array <int> => <int>
+     */
+    public static function alternativeControlStructureSyntaxClosers()
+    {
+        return self::$alternativeControlStructureSyntaxCloserTokens;
+    }
 
     /**
      * Tokens which can represent the arrow function keyword.

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -249,9 +249,11 @@ class Collections
     ];
 
     /**
-     * OO structures which can use the "extends" keyword.
+     * DEPRECATED: OO structures which can use the "extends" keyword.
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha1
+     *
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::ooCanExtend()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
@@ -262,9 +264,11 @@ class Collections
     ];
 
     /**
-     * OO structures which can use the "implements" keyword.
+     * DEPRECATED: OO structures which can use the "implements" keyword.
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha1
+     *
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::ooCanImplement()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
@@ -926,6 +930,30 @@ class Collections
         $tokens += self::nullsafeObjectOperatorBC();
 
         return $tokens;
+    }
+
+    /**
+     * OO structures which can use the "extends" keyword.
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$OOCanExtend} property.
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function ooCanExtend()
+    {
+        return self::$OOCanExtend;
+    }
+
+    /**
+     * OO structures which can use the "implements" keyword.
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$OOCanImplement} property.
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function ooCanImplement()
+    {
+        return self::$OOCanImplement;
     }
 
     /**

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -293,11 +293,11 @@ class Collections
     ];
 
     /**
-     * Tokens types used for "forwarding" calls within OO structures.
-     *
-     * @link https://www.php.net/language.oop5.paamayim-nekudotayim PHP Manual on OO forwarding calls
+     * DEPRECATED: Tokens types used for "forwarding" calls within OO structures.
      *
      * @since 1.0.0-alpha3
+     *
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::ooHierarchyKeywords()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
@@ -968,6 +968,20 @@ class Collections
     public static function ooConstantScopes()
     {
         return self::$OOConstantScopes;
+    }
+
+    /**
+     * Tokens types used for "forwarding" calls within OO structures.
+     *
+     * @link https://www.php.net/language.oop5.paamayim-nekudotayim PHP Manual on OO forwarding calls
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$OOHierarchyKeywords} property.
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function ooHierarchyKeywords()
+    {
+        return self::$OOHierarchyKeywords;
     }
 
     /**

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -472,9 +472,11 @@ class Collections
     ];
 
     /**
-     * Tokens which can start a - potentially multi-line - text string.
+     * DEPRECATED: Tokens which can start a - potentially multi-line - text string.
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha1
+     *
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::textStingStartTokens()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
@@ -1397,5 +1399,17 @@ class Collections
     public static function shortListTokensBC()
     {
         return self::$shortListTokensBC;
+    }
+
+    /**
+     * Tokens which can start a - potentially multi-line - text string.
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$textStingStartTokens} property.
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function textStingStartTokens()
+    {
+        return self::$textStingStartTokens;
     }
 }

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -220,9 +220,11 @@ class Collections
     ];
 
     /**
-     * List of tokens which can end a namespace declaration statement.
+     * DEPRECATED: List of tokens which can end a namespace declaration statement.
      *
-     * @since 1.0.0
+     * @since 1.0.0-alpha1
+     *
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::namespaceDeclarationClosers()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
@@ -769,6 +771,18 @@ class Collections
     public static function listTokensBC()
     {
         return self::$listTokensBC;
+    }
+
+    /**
+     * List of tokens which can end a namespace declaration statement.
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$namespaceDeclarationClosers} property.
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function namespaceDeclarationClosers()
+    {
+        return self::$namespaceDeclarationClosers;
     }
 
     /**

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -67,21 +67,6 @@ class Collections
     ];
 
     /**
-     * Tokens which can open an array.
-     *
-     * PHPCS cross-version compatible.
-     *
-     * @since 1.0.0-alpha4
-     *
-     * @var array <int|string> => <int|string>
-     */
-    public static $arrayOpenTokensBC = [
-        \T_ARRAY               => \T_ARRAY,
-        \T_OPEN_SHORT_ARRAY    => \T_OPEN_SHORT_ARRAY,
-        \T_OPEN_SQUARE_BRACKET => \T_OPEN_SQUARE_BRACKET,
-    ];
-
-    /**
      * Tokens which are used to create arrays.
      *
      * @see \PHPCSUtils\Tokens\Collections::$arrayTokensBC    Related property containing tokens used
@@ -535,6 +520,24 @@ class Collections
     }
 
     /**
+     * Tokens which can open an array.
+     *
+     * PHPCS cross-version compatible.
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function arrayOpenTokensBC()
+    {
+        return [
+            \T_ARRAY               => \T_ARRAY,
+            \T_OPEN_SHORT_ARRAY    => \T_OPEN_SHORT_ARRAY,
+            \T_OPEN_SQUARE_BRACKET => \T_OPEN_SQUARE_BRACKET,
+        ];
+    }
+
+    /**
      * Tokens which can represent the arrow function keyword.
      *
      * Note: this is a method, not a property as the `T_FN` token for arrow functions may not exist.
@@ -849,7 +852,7 @@ class Collections
         $tokens[\T_UNSET] = \T_UNSET;
 
         // Array tokens.
-        $tokens += self::$arrayOpenTokensBC;
+        $tokens += self::arrayOpenTokensBC();
 
         return $tokens;
     }

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -153,9 +153,11 @@ class Collections
     ];
 
     /**
-     * Increment/decrement operator tokens.
+     * DEPRECATED: Increment/decrement operator tokens.
      *
      * @since 1.0.0-alpha3
+     *
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::incrementDecrementOperators()} method instead.
      *
      * @var array <int> => <int>
      */
@@ -726,6 +728,18 @@ class Collections
         $tokens += self::arrowFunctionTokensBC();
 
         return $tokens;
+    }
+
+    /**
+     * Increment/decrement operator tokens.
+     *
+     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$incrementDecrementOperators} property.
+     *
+     * @return array <int> => <int>
+     */
+    public static function incrementDecrementOperators()
+    {
+        return self::$incrementDecrementOperators;
     }
 
     /**

--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -300,7 +300,7 @@ class Arrays
         }
 
         $targets  = self::$doubleArrowTargets;
-        $targets += Collections::$closedScopes;
+        $targets += Collections::closedScopes();
         $targets += Collections::arrowFunctionTokensBC();
 
         $doubleArrow = ($start - 1);
@@ -330,7 +330,7 @@ class Arrays
             }
 
             // Skip over closed scopes which may contain foreach structures or generators.
-            if (isset(Collections::$closedScopes[$tokens[$doubleArrow]['code']]) === true
+            if (isset(Collections::closedScopes()[$tokens[$doubleArrow]['code']]) === true
                 && isset($tokens[$doubleArrow]['scope_closer']) === true
             ) {
                 $doubleArrow = $tokens[$doubleArrow]['scope_closer'];

--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -67,7 +67,7 @@ class Arrays
 
         // Is this one of the tokens this function handles ?
         if (isset($tokens[$stackPtr]) === false
-            || isset(Collections::$shortArrayTokensBC[$tokens[$stackPtr]['code']]) === false
+            || isset(Collections::shortArrayTokensBC()[$tokens[$stackPtr]['code']]) === false
         ) {
             return false;
         }
@@ -78,7 +78,7 @@ class Arrays
         /*
          * Deal with square brackets which may be incorrectly tokenized short arrays.
          */
-        if (isset(Collections::$shortArrayTokens[$tokens[$stackPtr]['code']]) === false) {
+        if (isset(Collections::shortArrayTokens()[$tokens[$stackPtr]['code']]) === false) {
             if (\version_compare($phpcsVersion, '3.3.0', '>=')) {
                 // These will just be properly tokenized, plain square brackets. No need for further checks.
                 return false;

--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -236,7 +236,7 @@ class Arrays
 
         // Is this one of the tokens this function handles ?
         if (isset($tokens[$stackPtr]) === false
-            || isset(Collections::$arrayTokensBC[$tokens[$stackPtr]['code']]) === false
+            || isset(Collections::arrayTokensBC()[$tokens[$stackPtr]['code']]) === false
         ) {
             return false;
         }

--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -13,6 +13,7 @@ namespace PHPCSUtils\Utils;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
@@ -160,7 +161,7 @@ class Arrays
                  *
                  * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/3013
                  */
-                if (isset(Collections::$magicConstants[$tokens[$prevNonEmpty]['code']]) === true) {
+                if (isset(BCTokens::magicConstants()[$tokens[$prevNonEmpty]['code']]) === true) {
                     return false;
                 }
             }

--- a/PHPCSUtils/Utils/ControlStructures.php
+++ b/PHPCSUtils/Utils/ControlStructures.php
@@ -53,7 +53,7 @@ class ControlStructures
 
         // Check for the existence of the token.
         if (isset($tokens[$stackPtr]) === false
-            || isset(Collections::$controlStructureTokens[$tokens[$stackPtr]['code']]) === false
+            || isset(Collections::controlStructureTokens()[$tokens[$stackPtr]['code']]) === false
         ) {
             return false;
         }

--- a/PHPCSUtils/Utils/Lists.php
+++ b/PHPCSUtils/Utils/Lists.php
@@ -70,7 +70,7 @@ class Lists
 
         // Is this one of the tokens this function handles ?
         if (isset($tokens[$stackPtr]) === false
-            || isset(Collections::$shortListTokensBC[$tokens[$stackPtr]['code']]) === false
+            || isset(Collections::shortListTokensBC()[$tokens[$stackPtr]['code']]) === false
         ) {
             return false;
         }

--- a/PHPCSUtils/Utils/Lists.php
+++ b/PHPCSUtils/Utils/Lists.php
@@ -13,6 +13,7 @@ namespace PHPCSUtils\Utils;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\GetTokensAsString;
@@ -150,7 +151,7 @@ class Lists
                  *
                  * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/3013
                  */
-                if (isset(Collections::$magicConstants[$tokens[$prevNonEmpty]['code']]) === true) {
+                if (isset(BCTokens::magicConstants()[$tokens[$prevNonEmpty]['code']]) === true) {
                     return false;
                 }
             }

--- a/PHPCSUtils/Utils/Lists.php
+++ b/PHPCSUtils/Utils/Lists.php
@@ -271,7 +271,7 @@ class Lists
 
         // Is this one of the tokens this function handles ?
         if (isset($tokens[$stackPtr]) === false
-            || isset(Collections::$listTokensBC[$tokens[$stackPtr]['code']]) === false
+            || isset(Collections::listTokensBC()[$tokens[$stackPtr]['code']]) === false
         ) {
             return false;
         }

--- a/PHPCSUtils/Utils/Namespaces.php
+++ b/PHPCSUtils/Utils/Namespaces.php
@@ -62,7 +62,7 @@ class Namespaces
                 + BCTokens::operators()
                 + Tokens::$castTokens
                 + Tokens::$blockOpeners
-                + Collections::$incrementDecrementOperators
+                + Collections::incrementDecrementOperators()
                 + Collections::objectOperators();
 
             $findAfter[\T_OPEN_CURLY_BRACKET]  = \T_OPEN_CURLY_BRACKET;

--- a/PHPCSUtils/Utils/Namespaces.php
+++ b/PHPCSUtils/Utils/Namespaces.php
@@ -188,7 +188,7 @@ class Namespaces
             return false;
         }
 
-        $endOfStatement = $phpcsFile->findNext(Collections::$namespaceDeclarationClosers, ($stackPtr + 1));
+        $endOfStatement = $phpcsFile->findNext(Collections::namespaceDeclarationClosers(), ($stackPtr + 1));
         if ($endOfStatement === false) {
             // Live coding or parse error.
             return false;
@@ -338,7 +338,7 @@ class Namespaces
                 && self::isDeclaration($phpcsFile, $prev) === true
             ) {
                 // Now make sure the token was not part of the declaration.
-                $endOfStatement = $phpcsFile->findNext(Collections::$namespaceDeclarationClosers, ($prev + 1));
+                $endOfStatement = $phpcsFile->findNext(Collections::namespaceDeclarationClosers(), ($prev + 1));
                 if ($endOfStatement > $stackPtr) {
                     return false;
                 }

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -188,7 +188,7 @@ class ObjectDeclarations
             throw new RuntimeException('$stackPtr must be of type T_CLASS');
         }
 
-        $valid      = Collections::$classModifierKeywords + Tokens::$emptyTokens;
+        $valid      = Collections::classModifierKeywords() + Tokens::$emptyTokens;
         $properties = [
             'is_abstract' => false,
             'is_final'    => false,

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -245,7 +245,7 @@ class ObjectDeclarations
      */
     public static function findExtendedClassName(File $phpcsFile, $stackPtr)
     {
-        $names = self::findNames($phpcsFile, $stackPtr, \T_EXTENDS, Collections::$OOCanExtend);
+        $names = self::findNames($phpcsFile, $stackPtr, \T_EXTENDS, Collections::ooCanExtend());
         if ($names === false) {
             return false;
         }
@@ -280,7 +280,7 @@ class ObjectDeclarations
      */
     public static function findImplementedInterfaceNames(File $phpcsFile, $stackPtr)
     {
-        return self::findNames($phpcsFile, $stackPtr, \T_IMPLEMENTS, Collections::$OOCanImplement);
+        return self::findNames($phpcsFile, $stackPtr, \T_IMPLEMENTS, Collections::ooCanImplement());
     }
 
     /**

--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -152,7 +152,7 @@ class Operators
             } else {
                 $skip   = Tokens::$emptyTokens;
                 $skip  += Collections::namespacedNameTokens();
-                $skip  += Collections::$OOHierarchyKeywords;
+                $skip  += Collections::ooHierarchyKeywords();
                 $skip[] = \T_DOUBLE_COLON;
 
                 $nextSignificantAfter = $phpcsFile->findNext(

--- a/PHPCSUtils/Utils/Scopes.php
+++ b/PHPCSUtils/Utils/Scopes.php
@@ -74,7 +74,7 @@ class Scopes
             return false;
         }
 
-        if (self::validDirectScope($phpcsFile, $stackPtr, Collections::$OOConstantScopes) !== false) {
+        if (self::validDirectScope($phpcsFile, $stackPtr, Collections::ooConstantScopes()) !== false) {
             return true;
         }
 
@@ -100,7 +100,7 @@ class Scopes
             return false;
         }
 
-        $scopePtr = self::validDirectScope($phpcsFile, $stackPtr, Collections::$OOPropertyScopes);
+        $scopePtr = self::validDirectScope($phpcsFile, $stackPtr, Collections::ooPropertyScopes());
         if ($scopePtr !== false) {
             // Make sure it's not a method parameter.
             $deepestOpen = Parentheses::getLastOpener($phpcsFile, $stackPtr);

--- a/PHPCSUtils/Utils/TextStrings.php
+++ b/PHPCSUtils/Utils/TextStrings.php
@@ -55,7 +55,7 @@ class TextStrings
         $tokens = $phpcsFile->getTokens();
 
         // Must be the start of a text string token.
-        if (isset($tokens[$stackPtr], Collections::$textStingStartTokens[$tokens[$stackPtr]['code']]) === false) {
+        if (isset($tokens[$stackPtr], Collections::textStingStartTokens()[$tokens[$stackPtr]['code']]) === false) {
             throw new RuntimeException(
                 '$stackPtr must be of type T_START_HEREDOC, T_START_NOWDOC, T_CONSTANT_ENCAPSED_STRING'
                 . ' or T_DOUBLE_QUOTED_STRING'

--- a/PHPCSUtils/Utils/Variables.php
+++ b/PHPCSUtils/Utils/Variables.php
@@ -126,7 +126,7 @@ class Variables
             throw new RuntimeException('$stackPtr is not a class member var');
         }
 
-        $valid = Collections::$propertyModifierKeywords + Tokens::$emptyTokens;
+        $valid = Collections::propertyModifierKeywords() + Tokens::$emptyTokens;
 
         $scope          = 'public';
         $scopeSpecified = false;

--- a/Tests/Tokens/Collections/AlternativeControlStructureSyntaxClosersTest.php
+++ b/Tests/Tokens/Collections/AlternativeControlStructureSyntaxClosersTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::alternativeControlStructureSyntaxClosers
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class AlternativeControlStructureSyntaxClosersTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testAlternativeControlStructureSyntaxClosers()
+    {
+        $this->assertSame(
+            Collections::$alternativeControlStructureSyntaxCloserTokens,
+            Collections::alternativeControlStructureSyntaxClosers()
+        );
+    }
+}

--- a/Tests/Tokens/Collections/AlternativeControlStructureSyntaxesTest.php
+++ b/Tests/Tokens/Collections/AlternativeControlStructureSyntaxesTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::alternativeControlStructureSyntaxes
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class AlternativeControlStructureSyntaxesTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testAlternativeControlStructureSyntaxes()
+    {
+        $this->assertSame(
+            Collections::$alternativeControlStructureSyntaxTokens,
+            Collections::alternativeControlStructureSyntaxes()
+        );
+    }
+}

--- a/Tests/Tokens/Collections/ArrayOpenTokensBCTest.php
+++ b/Tests/Tokens/Collections/ArrayOpenTokensBCTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::arrayOpenTokensBC
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class ArrayOpenTokensBCTest extends TestCase
+{
+    use AssertIsType;
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testArrayOpenTokensBC()
+    {
+        $arrayOpenTokens = Collections::arrayOpenTokensBC();
+        $this->assertIsArray($arrayOpenTokens);
+        $this->assertCount(3, $arrayOpenTokens);
+    }
+}

--- a/Tests/Tokens/Collections/ArrayTokensBCTest.php
+++ b/Tests/Tokens/Collections/ArrayTokensBCTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::arrayTokensBC
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class ArrayTokensBCTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testArrayTokensBC()
+    {
+        $this->assertSame(Collections::$arrayTokensBC, Collections::arrayTokensBC());
+    }
+}

--- a/Tests/Tokens/Collections/ArrayTokensTest.php
+++ b/Tests/Tokens/Collections/ArrayTokensTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::arrayTokens
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class ArrayTokensTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testArrayTokens()
+    {
+        $this->assertSame(Collections::$arrayTokens, Collections::arrayTokens());
+    }
+}

--- a/Tests/Tokens/Collections/ClassModifierKeywordsTest.php
+++ b/Tests/Tokens/Collections/ClassModifierKeywordsTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::classModifierKeywords
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class ClassModifierKeywordsTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testClassModifierKeywords()
+    {
+        $this->assertSame(Collections::$classModifierKeywords, Collections::classModifierKeywords());
+    }
+}

--- a/Tests/Tokens/Collections/ClosedScopesTest.php
+++ b/Tests/Tokens/Collections/ClosedScopesTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::closedScopes
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class ClosedScopesTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testClosedScopes()
+    {
+        $this->assertSame(Collections::$closedScopes, Collections::closedScopes());
+    }
+}

--- a/Tests/Tokens/Collections/ControlStructureTokensTest.php
+++ b/Tests/Tokens/Collections/ControlStructureTokensTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::controlStructureTokens
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class ControlStructureTokensTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testControlStructureTokens()
+    {
+        $this->assertSame(Collections::$controlStructureTokens, Collections::controlStructureTokens());
+    }
+}

--- a/Tests/Tokens/Collections/IncrementDecrementOperatorsTest.php
+++ b/Tests/Tokens/Collections/IncrementDecrementOperatorsTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::incrementDecrementOperators
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class IncrementDecrementOperatorsTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testIncrementDecrementOperators()
+    {
+        $this->assertSame(Collections::$incrementDecrementOperators, Collections::incrementDecrementOperators());
+    }
+}

--- a/Tests/Tokens/Collections/ListTokensBCTest.php
+++ b/Tests/Tokens/Collections/ListTokensBCTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::listTokensBC
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class ListTokensBCTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testListTokensBC()
+    {
+        $this->assertSame(Collections::$listTokensBC, Collections::listTokensBC());
+    }
+}

--- a/Tests/Tokens/Collections/ListTokensTest.php
+++ b/Tests/Tokens/Collections/ListTokensTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::listTokens
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class ListTokensTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testListTokens()
+    {
+        $this->assertSame(Collections::$listTokens, Collections::listTokens());
+    }
+}

--- a/Tests/Tokens/Collections/NamespaceDeclarationClosersTest.php
+++ b/Tests/Tokens/Collections/NamespaceDeclarationClosersTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::namespaceDeclarationClosers
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class NamespaceDeclarationClosersTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testNamespaceDeclarationClosers()
+    {
+        $this->assertSame(Collections::$namespaceDeclarationClosers, Collections::namespaceDeclarationClosers());
+    }
+}

--- a/Tests/Tokens/Collections/OoCanExtendTest.php
+++ b/Tests/Tokens/Collections/OoCanExtendTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::ooCanExtend
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class OoCanExtendTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testOoCanExtend()
+    {
+        $this->assertSame(Collections::$OOCanExtend, Collections::ooCanExtend());
+    }
+}

--- a/Tests/Tokens/Collections/OoCanImplementTest.php
+++ b/Tests/Tokens/Collections/OoCanImplementTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::ooCanImplement
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class OoCanImplementTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testOoCanImplement()
+    {
+        $this->assertSame(Collections::$OOCanImplement, Collections::ooCanImplement());
+    }
+}

--- a/Tests/Tokens/Collections/OoConstantScopesTest.php
+++ b/Tests/Tokens/Collections/OoConstantScopesTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::ooConstantScopes
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class OoConstantScopesTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testOoConstantScopes()
+    {
+        $this->assertSame(Collections::$OOConstantScopes, Collections::ooConstantScopes());
+    }
+}

--- a/Tests/Tokens/Collections/OoHierarchyKeywordsTest.php
+++ b/Tests/Tokens/Collections/OoHierarchyKeywordsTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::ooHierarchyKeywords
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class OoHierarchyKeywordsTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testOoHierarchyKeywords()
+    {
+        $this->assertSame(Collections::$OOHierarchyKeywords, Collections::ooHierarchyKeywords());
+    }
+}

--- a/Tests/Tokens/Collections/OoPropertyScopesTest.php
+++ b/Tests/Tokens/Collections/OoPropertyScopesTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::ooPropertyScopes
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class OoPropertyScopesTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testOoPropertyScopes()
+    {
+        $this->assertSame(Collections::$OOPropertyScopes, Collections::ooPropertyScopes());
+    }
+}

--- a/Tests/Tokens/Collections/PropertyModifierKeywordsTest.php
+++ b/Tests/Tokens/Collections/PropertyModifierKeywordsTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::propertyModifierKeywords
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class PropertyModifierKeywordsTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testPropertyModifierKeywords()
+    {
+        $this->assertSame(Collections::$propertyModifierKeywords, Collections::propertyModifierKeywords());
+    }
+}

--- a/Tests/Tokens/Collections/ShortArrayTokensBCTest.php
+++ b/Tests/Tokens/Collections/ShortArrayTokensBCTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::shortArrayTokensBC
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class ShortArrayTokensBCTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testShortArrayTokensBC()
+    {
+        $this->assertSame(Collections::$shortArrayTokensBC, Collections::shortArrayTokensBC());
+    }
+}

--- a/Tests/Tokens/Collections/ShortArrayTokensTest.php
+++ b/Tests/Tokens/Collections/ShortArrayTokensTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::shortArrayTokens
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class ShortArrayTokensTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testShortArrayTokens()
+    {
+        $this->assertSame(Collections::$shortArrayTokens, Collections::shortArrayTokens());
+    }
+}

--- a/Tests/Tokens/Collections/ShortListTokensBCTest.php
+++ b/Tests/Tokens/Collections/ShortListTokensBCTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::shortListTokensBC
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class ShortListTokensBCTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testShortListTokensBC()
+    {
+        $this->assertSame(Collections::$shortListTokensBC, Collections::shortListTokensBC());
+    }
+}

--- a/Tests/Tokens/Collections/ShortListTokensTest.php
+++ b/Tests/Tokens/Collections/ShortListTokensTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::shortListTokens
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class ShortListTokensTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testShortListTokens()
+    {
+        $this->assertSame(Collections::$shortListTokens, Collections::shortListTokens());
+    }
+}

--- a/Tests/Tokens/Collections/TextStingStartTokensTest.php
+++ b/Tests/Tokens/Collections/TextStingStartTokensTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::textStingStartTokens
+ *
+ * @group collections
+ *
+ * @since 1.0.0
+ */
+class TextStingStartTokensTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testTextStingStartTokens()
+    {
+        $this->assertSame(Collections::$textStingStartTokens, Collections::textStingStartTokens());
+    }
+}

--- a/Tests/Utils/ControlStructures/HasBodyTest.php
+++ b/Tests/Utils/ControlStructures/HasBodyTest.php
@@ -62,7 +62,7 @@ class HasBodyTest extends UtilityMethodTestCase
      */
     public function testHasBody($testMarker, $hasBody, $hasNonEmptyBody)
     {
-        $stackPtr = $this->getTargetToken($testMarker, Collections::$controlStructureTokens);
+        $stackPtr = $this->getTargetToken($testMarker, Collections::controlStructureTokens());
 
         $result = ControlStructures::hasBody(self::$phpcsFile, $stackPtr);
         $this->assertSame($hasBody, $result, 'Failed hasBody check with $allowEmpty = true');


### PR DESCRIPTION
Over the last three PHP versions, PHP has steadily kept on introducing new tokens.

In the context of this class, the introduction of a new token means that a collection can no longer be a property and must be changed to a method with some logic instead.

With this in mind, all properties in the `Collections` class are being deprecated in favour of methods, to prevent the BC-breaks this kind of change would cause if left till later.

The deprecated properties will be removed (or made `private`) before the `1.0.0` version is tagged. The deprecation in the upcoming alpha gives standards which have started to implement the use of PHPCSUtils a little time to switch over though.

👉🏻  **_Note: in **_most_** cases, the method name is 100% the same as the property name, so switching over to the new methods should be a case of removing the `$` sign and adding parentheses `()` after the name._**

### Commit details

**Note:** Unless noted differently, each commit includes only perfunctory unit tests for the new methods, as the methods don't contain any actual logic.
For now, it is just safeguarded that a) the methods are available and can be called and b) that the method is in line with the now deprecated property.

Where applicable, each commit also includes replacing any references to the deprecated properties in the PHPCSUtils codebase to now call the functions instead.

#### Collections: deprecate `$alternativeControlStructureSyntax*` in favour of `alternativeControlStructureSyntax*()`

#### Collections: remove `$arrayOpenTokensBC` in favour of `arrayOpenTokensBC()`

**_Note: as this property has been introduced during the `alpha4` dev cycle, this property is being outright removed instead of being deprecated._**

Includes only a perfunctory unit test for the new method, as the `arrayOpenTokensBC()` method doesn't contain any actual logic.
For now, it is just safeguarded that the method is available, can be called and returns the expected type of return value.

#### Collections: deprecate `$arrayTokens[BC]` in favour of `arrayTokens[BC]()`

#### Collections: deprecate `$classModifierKeywords` in favour of `classModifierKeywords()`

#### Collections: deprecate `$closedScopes` in favour of `closedScopes()`

#### Collections: deprecate `$controlStructureTokens` in favour of `controlStructureTokens()`

#### Collections: deprecate `$incrementDecrementOperators` in favour of `incrementDecrementOperators()`

#### Collections: deprecate `$listTokens[BC]` in favour of `listTokens[BC]()`

#### Collections: deprecate `$magicConstants` in favour of `BCTokens::magicConstants()`

**Note**: As PR #172 already introduced a method for the same in the `BCTokens` class as PHPCS 3.5.6 introduced a `Tokens` property for the same, no replacement has been added to the `Collections` class.

Includes replacing any references to this property in the PHPCSUtils codebase to now call the function in `BCTokens` instead.

#### Collections: deprecate `$namespaceDeclarationClosers` in favour of `namespaceDeclarationClosers()`

#### Collections: deprecate `$OOCan(Implement|Extend)` in favour of `ooCan(Implement|Extend)()`

#### Collections: deprecate `$OO(Constant|Property)Scopes` in favour of `oo(Constant|Property)Scopes()`

#### Collections: deprecate `$OOHierarchyKeywords` in favour of `ooHierarchyKeywords()`

#### Collections: deprecate `$propertyModifierKeywords` in favour of `propertyModifierKeywords()`

#### Collections: deprecate `$shortArrayTokens[BC]` in favour of `shortArrayTokens[BC]()`

#### Collections: deprecate `$shortListTokens[BC]` in favour of `shortListTokens[BC]()`

#### Collections: deprecate `$textStingStartTokens` in favour of `textStingStartTokens()`
