### PR TITLE
GH Actions: add Yamllint to QA basics

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -171,3 +171,18 @@ jobs:
           install_deps: false
           level: info
           reporter: github-pr-check
+
+  yamllint:
+    name: 'Lint Yaml'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run Yamllint on all yaml files in repo
+        run: yamllint . --format colored --strict
+
+      - name: Pipe Yamllint results on to GH for inline display
+        if: ${{ failure() }}
+        run: yamllint . --format github --strict

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
         # The GHA matrix works different from Travis.
         # You can define jobs here and then augment them with extra variables in `include`,
         # as well as add extra jobs in `include`.
-        # @link https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
+        # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
         #
         # IMPORTANT: test runs shouldn't fail because of PHPCS being incompatible with a PHP version.
         # - PHPCS will run without errors on PHP 5.4 - 7.2 on any version.
@@ -286,7 +286,9 @@ jobs:
 
       - name: Grab PHPUnit version
         id: phpunit_version
-        run: echo ::set-output name=VERSION::$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')
+        run: >
+          echo ::set-output name=VERSION::
+          $(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')
 
       - name: "DEBUG: Show grabbed version"
         run: echo ${{ steps.phpunit_version.outputs.VERSION }}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,22 @@
+# Details on the default config:
+# https://yamllint.readthedocs.io/en/stable/configuration.html#default-configuration
+extends: default
+
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+
+# Rule documentation: https://yamllint.readthedocs.io/en/stable/rules.html
+rules:
+  colons:
+    max-spaces-after: -1  # Disabled to allow aligning of values.
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: {}
+  document-start:
+    present: false
+  line-length:
+    max: 140
+  truthy:
+    allowed-values: ["true", "false", "on", "off"]

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,19 +8,19 @@ github: [metadata]
 url: "https://phpcsutils.com"
 
 plugins:
-    - jekyll-github-metadata
-    - jemoji
-    - jekyll-mentions
-    - jekyll-seo-tag
-    - jekyll-sitemap
+  - jekyll-github-metadata
+  - jemoji
+  - jekyll-mentions
+  - jekyll-seo-tag
+  - jekyll-sitemap
 
 phpcsutils:
-    packagist: phpcsstandards/phpcsutils
+  packagist: phpcsstandards/phpcsutils
 
 # Theme info.
 title: PHPCSUtils
 description: "A suite of utility functions for use with PHP_CodeSniffer."
-logo: 
+logo:
 show_downloads: false
 google_analytics:
 


### PR DESCRIPTION
### GH Actions: add Yamllint to QA basics

... to loosely safeguard valid and consistent yaml files.

Includes adding a configuration file which loosens up the `default` ruleset to a degree I'm comfortable with.

Ref: https://yamllint.readthedocs.io/

### CS/QA: minor fixes for consistency in Yaml files