### PR TITLE
QA: remove some unnecessary micro-optimizations

### DIFF
--- a/PHPCSUtils/BackCompat/Helper.php
+++ b/PHPCSUtils/BackCompat/Helper.php
@@ -182,14 +182,10 @@ class Helper
      */
     public static function getEncoding(File $phpcsFile = null)
     {
-        static $default;
-
-        if (isset($default) === false) {
-            $default = 'utf-8';
-            if (\version_compare(self::getVersion(), '2.99.99', '<=') === true) {
-                // In PHPCS 2.x, the default encoding is `iso-8859-1`.
-                $default = 'iso-8859-1';
-            }
+        $default = 'utf-8';
+        if (\version_compare(self::getVersion(), '2.99.99', '<=') === true) {
+            // In PHPCS 2.x, the default encoding is `iso-8859-1`.
+            $default = 'iso-8859-1';
         }
 
         if ($phpcsFile instanceof File) {

--- a/PHPCSUtils/Utils/MessageHelper.php
+++ b/PHPCSUtils/Utils/MessageHelper.php
@@ -120,12 +120,7 @@ class MessageHelper
      */
     public static function hasNewLineSupport()
     {
-        static $supported;
-        if (isset($supported) === false) {
-            $supported = \version_compare(Helper::getVersion(), '3.3.1', '>=');
-        }
-
-        return $supported;
+        return \version_compare(Helper::getVersion(), '3.3.1', '>=');
     }
 
     /**

--- a/PHPCSUtils/Utils/Orthography.php
+++ b/PHPCSUtils/Utils/Orthography.php
@@ -102,13 +102,9 @@ class Orthography
      */
     public static function isLastCharPunctuation($textString, $allowedChars = self::TERMINAL_POINTS)
     {
-        static $encoding;
-
-        if (isset($encoding) === false) {
-            $encoding = Helper::getEncoding();
-        }
-
+        $encoding   = Helper::getEncoding();
         $textString = \rtrim($textString);
+
         if (\function_exists('iconv_substr') === true) {
             $lastChar = \iconv_substr($textString, -1, 1, $encoding);
         } else {


### PR DESCRIPTION
While it is not a bad thing to optimize for performance, some micro-optimizations, like saving information to a function local `static` variable, should only be done when the trade-off is worth it.

Having the function local `static` variable will often prevent code coverage from being recorded correctly for the code as the code for setting the static will only be run when the function is first called, which may not be in the dedicated test for the function, so it makes code coverage recording highly dependant on the order in which tests are run.

In these three cases, I do not think this trade-off is worth it as these are a) not the most popular functions, b) true micro-optimizations which only effectively save one fast PHP native `version_compare()` call.