### PR TITLE
GH Actions: pass the PHPCS version to test runs

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -76,3 +76,5 @@ jobs:
 
       - name: Run the unit tests
         run: vendor/bin/phpunit --no-coverage
+        env:
+          PHPCS_VERSION: ${{ matrix.phpcs_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,11 +221,15 @@ jobs:
       - name: Run the unit tests (non-risky)
         if: matrix.risky == false
         run: vendor/bin/phpunit --no-coverage
+        env:
+          PHPCS_VERSION: ${{ matrix.phpcs_version == '4.0.x-dev' && '4.0.0' || matrix.phpcs_version }}
 
       - name: Run the unit tests (risky)
         if: ${{ matrix.risky }}
         # "nothing" is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
         run: vendor/bin/phpunit --no-coverage --group compareWithPHPCS --exclude-group nothing
+        env:
+          PHPCS_VERSION: ${{ matrix.phpcs_version == '4.0.x-dev' && '4.0.0' || matrix.phpcs_version }}
 
 
   #### CODE COVERAGE STAGE ####
@@ -304,10 +308,14 @@ jobs:
       - name: "Run the unit tests with code coverage (PHPUnit < 9.3)"
         if: ${{ steps.phpunit_version.outputs.VERSION < '9.3' }}
         run: vendor/bin/phpunit
+        env:
+          PHPCS_VERSION: ${{ matrix.phpcs_version }}
 
       - name: "Run the unit tests with code coverage (PHPUnit 9.3+)"
         if: ${{ steps.phpunit_version.outputs.VERSION >= '9.3' }}
         run: vendor/bin/phpunit --coverage-cache ./build/phpunit-cache
+        env:
+          PHPCS_VERSION: ${{ matrix.phpcs_version }}
 
       # Uploading the results with PHP Coveralls v1 won't work from GH Actions, so switch the PHP version.
       - name: Switch to PHP 7.4


### PR DESCRIPTION
Only just realized that the test for the `BackCompat\Helper::getVersion()` method wasn't running since the move to GH Actions as it expects the environment variable `PHPCS_VERSION` to be set, which was set automatically from the matrix in Travis, but needs to be explicitly passed in GH Actions.

Fixed now.