### PR TITLE
GH Actions: expand the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,7 @@ jobs:
             phpcs_version: 'dev-master'
             risky: false
             experimental: false
+            extensions: ':iconv' # Run one build with iconv disabled.
           - php: '8.0'
             phpcs_version: '3.5.7'
             risky: false
@@ -199,6 +200,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.extensions }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
@@ -251,6 +253,7 @@ jobs:
             phpcs_version: 'dev-master'
           - php: '7.3'
             phpcs_version: '2.9.2'
+            extensions: ':iconv' # Run one build with iconv disabled.
           - php: '5.4'
             phpcs_version: 'dev-master'
           - php: '5.4'
@@ -277,6 +280,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.extensions }}
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: xdebug
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,81 +77,50 @@ jobs:
         #
         # IMPORTANT: test runs shouldn't fail because of PHPCS being incompatible with a PHP version.
         # - PHPCS will run without errors on PHP 5.4 - 7.2 on any version.
-        # - PHP 7.3 needs PHPCS 2.9.2 and 3.3.1+ to run without errors.
-        #   On PHPCS 2.x our tests won't fail though, but on PHPCS 3.x < 3.3.1 they will.
-        # - PHP 7.4 needs PHPCS 3.5.0+ to run without errors.
-        #   On PHPCS 2.x our tests won't fail though, but on PHPCS 3.x < 3.5.0 they will.
-        # - PHP 8.0 needs PHPCS 3.5.7+ to run without errors.
-        # - PHP 8.1 needs PHPCS 3.6.1+ to run without errors.
+        # - PHP 7.3 needs PHPCS 2.9.2 and 3.3.1+ to run without notices.
+        #   As deprecations are ignored for older PHPCS versions, our tests still shouldn't fail.
+        # - PHP 7.4 needs PHPCS 3.5.0+ to run without notices.
+        #   As deprecations are ignored for older PHPCS versions, our tests still shouldn't fail.
+        # - PHP 8.0 needs PHPCS 3.5.0+ to run without (fatal) errors.
+        #   To run reliably though, PHPCS 3.5.6 is needed, which undoes the PHP 8.0 comment tokenization changes is needed.
+        # - PHP 8.1 needs PHPCS 3.5.0+ to run without (fatal) errors.
+        #   To run reliably though, PHPCS 3.5.6 is needed, which undoes the PHP 8.0 comment tokenization changes is needed.
+        #   Additionally, until the new PHP 8.1 "&" tokenization is accounted for in various functions,
+        #   tests will fail in combination with PHPCS < 3.6.1 (in which the new tokenization was undone).
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
-        php: ['5.5', '5.6', '7.0', '7.1', '7.2']
-        phpcs_version: ['2.6.0', '2.9.2', '3.1.0', 'dev-master']
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+        phpcs_version: ['2.6.0', '2.7.1', '2.8.1', '2.9.2', '3.1.0', '3.2.0', '3.3.1', '3.4.2', '3.5.0', '3.5.6', '3.6.0', 'dev-master']
         risky: [false]
         experimental: [false]
 
+        exclude:
+          # Remove the builds which will already be run via quicktest/code coverage.
+          - php: '5.4'
+            phpcs_version: '2.6.0'
+          - php: '5.4'
+            phpcs_version: 'dev-master'
+          - php: '7.3'
+            phpcs_version: '2.9.2'
+
         include:
-          # Complement the builds run in code coverage to complete the matrix and prevent issues
-          # with PHPCS versions incompatible with certain PHP versions.
-          - php: '8.1'
-            phpcs_version: '3.6.1'
+          # Add builds against PHP 8.0/8.1, but only against PHPCS versions which won't fatal out.
+          - php: '8.0'
+            phpcs_version: '3.5.6'
             risky: false
             experimental: false
-
+          - php: '8.0'
+            phpcs_version: '3.6.0'
+            risky: false
+            experimental: false
           - php: '8.0'
             phpcs_version: 'dev-master'
             risky: false
             experimental: false
             extensions: ':iconv' # Run one build with iconv disabled.
-          - php: '8.0'
-            phpcs_version: '3.5.7'
-            risky: false
-            experimental: false
 
-          - php: '7.4'
-            phpcs_version: 'dev-master'
-            risky: false
-            experimental: false
-          - php: '7.4'
-            phpcs_version: '3.5.0'
-            risky: false
-            experimental: false
-
-          - php: '7.3'
-            phpcs_version: 'dev-master'
-            risky: false
-            experimental: false
-          - php: '7.3'
-            phpcs_version: '3.3.1'
-            risky: false
-            experimental: false
-          - php: '7.3'
-            phpcs_version: '2.6.0'
-            risky: false
-            experimental: false
-
-          - php: '5.4'
-            phpcs_version: '3.1.0'
-            risky: false
-            experimental: false
-          - php: '5.4'
-            phpcs_version: '2.9.2'
-            risky: false
-            experimental: false
-
-          # One extra build to verify issues around PHPCS annotations when they weren't fully accounted for yet.
-          - php: '7.2'
-            phpcs_version: '3.2.0'
-            risky: false
-            experimental: false
-
-          # And a few more to verify various tokenizer issues in older PHPCS versions.
-          - php: '5.6'
-            phpcs_version: '2.8.1'
-            risky: false
-            experimental: false
-          - php: '7.0'
-            phpcs_version: '2.7.1'
+          - php: '8.1'
+            phpcs_version: '3.6.1' # dev-master is run in the code coverage job.
             risky: false
             experimental: false
 


### PR DESCRIPTION
### GH Actions: run at least one test build with iconv disabled

### GH Actions: expand the test matrix

This commit expands the test matrix to test against more PHP/PHPCS combinations, thus extending cross-version support safeguarding.

The tests will now be run for most PHP versions against a wider range of PHPCS versions.
* Builds already run in quick test/code coverage are removed (`exclude`d) as there is no need to run those twice.
* Builds against PHP 8.0+ are explicitly defined via `include`s as most older PHPCS versions cannot be supported due to a fatal error (which was fixed in PHPCS 3.5.0).

Includes updating the documentation for the matrix.

Refs:
* https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs