### PR TITLE
TextStrings::getCompleteTextString(): add BC for incorrectly tokenized double quoted strings

### DIFF
--- a/Tests/Utils/TextStrings/GetCompleteTextString3604Test.inc
+++ b/Tests/Utils/TextStrings/GetCompleteTextString3604Test.inc
@@ -1,0 +1,53 @@
+<?php
+
+// These tests mirror the upstream Core\Tokenizer\DoubleQuotedStringsTest.
+// Test source: https://gist.github.com/iluuu1994/72e2154fc4150f2258316b0255b698f2#file-test-php
+
+/* testSimple1 */
+"$foo";
+/* testSimple2 */
+"{$foo}";
+/* testSimple3 */
+"${foo}";
+
+/* testDIM1 */
+"$foo[bar]";
+/* testDIM2 */
+"{$foo['bar']}";
+/* testDIM3 */
+"${foo['bar']}";
+
+/* testProperty1 */
+"$foo->bar";
+/* testProperty2 */
+"{$foo->bar}";
+
+/* testMethod1 */
+"{$foo->bar()}";
+
+/* testClosure1 */
+"{$foo()}";
+
+/* testChain1 */
+"{$foo['bar']->baz()()}";
+
+/* testVariableVar1 */
+"${$bar}";
+/* testVariableVar2 */
+"${(foo)}";
+/* testVariableVar3 */
+"${foo->bar}";
+
+/* testNested1 */
+"${foo["${bar}"]}";
+/* testNested2 */
+"${foo["${bar['baz']}"]}";
+/* testNested3 */
+"${foo->{$baz}}";
+/* testNested4 */
+"${foo->{${'a'}}}";
+/* testNested5 */
+"${foo->{"${'a'}"}}";
+
+/* testParseError */
+"${foo["${bar

--- a/Tests/Utils/TextStrings/GetCompleteTextString3604Test.php
+++ b/Tests/Utils/TextStrings/GetCompleteTextString3604Test.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\TextStrings;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\TextStrings;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\TextStrings::getCompleteTextString() method covering a specific tokenizer
+ * issue as reported upstream in {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/3604 PHPCS 3604}.
+ *
+ * @covers \PHPCSUtils\Utils\TextStrings::getCompleteTextString
+ *
+ * @group textstrings
+ *
+ * @since 1.0.0
+ */
+class GetCompleteTextString3604Test extends UtilityMethodTestCase
+{
+
+    /**
+     * Test correctly retrieving the contents of a double quoted text string with embedded variables/expressions.
+     *
+     * @dataProvider dataGetCompleteTextString
+     *
+     * @param string $testMarker      The comment which prefaces the target token in the test file.
+     * @param string $expectedContent The expected function return value.
+     *
+     * @return void
+     */
+    public function testGetCompleteTextString($testMarker, $expectedContent)
+    {
+        $stackPtr = $this->getTargetToken($testMarker, \T_DOUBLE_QUOTED_STRING);
+
+        $result = TextStrings::getCompleteTextString(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expectedContent, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetCompleteTextString() For the array format.
+     *
+     * @return array
+     */
+    public function dataGetCompleteTextString()
+    {
+        return [
+            'Simple embedded variable 1' => [
+                'testMarker'      => '/* testSimple1 */',
+                'expectedContent' => '$foo',
+            ],
+            'Simple embedded variable 2' => [
+                'testMarker'      => '/* testSimple2 */',
+                'expectedContent' => '{$foo}',
+            ],
+            'Simple embedded variable 3' => [
+                'testMarker'      => '/* testSimple3 */',
+                'expectedContent' => '${foo}',
+            ],
+            'Embedded array access 1' => [
+                'testMarker'      => '/* testDIM1 */',
+                'expectedContent' => '$foo[bar]',
+            ],
+            'Embedded array access 2' => [
+                'testMarker'      => '/* testDIM2 */',
+                'expectedContent' => '{$foo[\'bar\']}',
+            ],
+            'Embedded array access 3' => [
+                'testMarker'      => '/* testDIM3 */',
+                'expectedContent' => '${foo[\'bar\']}',
+            ],
+            'Embedded property access 1' => [
+                'testMarker'      => '/* testProperty1 */',
+                'expectedContent' => '$foo->bar',
+            ],
+            'Embedded property access 2' => [
+                'testMarker'      => '/* testProperty2 */',
+                'expectedContent' => '{$foo->bar}',
+            ],
+            'Embedded method call 1' => [
+                'testMarker'      => '/* testMethod1 */',
+                'expectedContent' => '{$foo->bar()}',
+            ],
+            'Embedded closure call 1' => [
+                'testMarker'      => '/* testClosure1 */',
+                'expectedContent' => '{$foo()}',
+            ],
+            'Embedded chained array access -> method call -> call' => [
+                'testMarker'      => '/* testChain1 */',
+                'expectedContent' => '{$foo[\'bar\']->baz()()}',
+            ],
+            'Embedded variable variable 1' => [
+                'testMarker'      => '/* testVariableVar1 */',
+                'expectedContent' => '${$bar}',
+            ],
+            'Embedded variable variable 1' => [
+                'testMarker'      => '/* testVariableVar2 */',
+                'expectedContent' => '${(foo)}',
+            ],
+            'Embedded variable variable 2' => [
+                'testMarker'      => '/* testVariableVar3 */',
+                'expectedContent' => '${foo->bar}',
+            ],
+            'Embedded nested variable variable 1' => [
+                'testMarker'      => '/* testNested1 */',
+                'expectedContent' => '${foo["${bar}"]}',
+            ],
+            'Embedded nested variable variable 2' => [
+                'testMarker'      => '/* testNested2 */',
+                'expectedContent' => '${foo["${bar[\'baz\']}"]}',
+            ],
+            'Embedded nested variable variable 3' => [
+                'testMarker'      => '/* testNested3 */',
+                'expectedContent' => '${foo->{$baz}}',
+            ],
+            'Embedded nested variable variable 4' => [
+                'testMarker'      => '/* testNested4 */',
+                'expectedContent' => '${foo->{${\'a\'}}}',
+            ],
+            'Embedded nested variable variable 5' => [
+                'testMarker'      => '/* testNested5 */',
+                'expectedContent' => '${foo->{"${\'a\'}"}}',
+            ],
+            'Parse error at end of file' => [
+                'testMarker'      => '/* testParseError */',
+                'expectedContent' => '"${foo["${bar
+',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
While creating a sniff for PHPCompatibility to detect the PHP 8.2 deprecation of two of the four syntaxes to embed variables/expressions within text strings, I realized that for select examples of the "type 4" syntax - "Variable variables (`“${expr}”`, equivalent to (string) `${expr})`" -, PHPCS did not, and probably never did, tokenize those correctly in PHPCS itself.

A fix for this has been pulled to PHPCS in PR squizlabs/PHP_CodeSniffer#3604.

This commit ensures that the `TextStrings::getCompleteTextString()` method handles double quoted strings affected by this tokenizer bug correctly in all supported PHPCS versions.

Includes dedicated tests specifically for the handling of embedded variables/expressions in double quoted strings.

Refs:
* https://github.com/squizlabs/PHP_CodeSniffer/pull/3604
* https://www.php.net/manual/en/language.types.string.php#language.types.string.parsing
* https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation
* https://gist.github.com/iluuu1994/72e2154fc4150f2258316b0255b698f2