### PR TITLE
Collections::textStringStartTokens(): fix typo in method name

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -476,7 +476,7 @@ class Collections
      *
      * @since 1.0.0-alpha1
      *
-     * @deprecated 1.0.0-alpha4 Use the {@see Collections::textStingStartTokens()} method instead.
+     * @deprecated 1.0.0-alpha4 Use the {@see Collections::textStringStartTokens()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
@@ -1408,7 +1408,7 @@ class Collections
      *
      * @return array <int|string> => <int|string>
      */
-    public static function textStingStartTokens()
+    public static function textStringStartTokens()
     {
         return self::$textStingStartTokens;
     }

--- a/PHPCSUtils/Utils/TextStrings.php
+++ b/PHPCSUtils/Utils/TextStrings.php
@@ -59,7 +59,7 @@ class TextStrings
         $tokens = $phpcsFile->getTokens();
 
         // Must be the start of a text string token.
-        if (isset($tokens[$stackPtr], Collections::textStingStartTokens()[$tokens[$stackPtr]['code']]) === false) {
+        if (isset($tokens[$stackPtr], Collections::textStringStartTokens()[$tokens[$stackPtr]['code']]) === false) {
             throw new RuntimeException(
                 '$stackPtr must be of type T_START_HEREDOC, T_START_NOWDOC, T_CONSTANT_ENCAPSED_STRING'
                 . ' or T_DOUBLE_QUOTED_STRING'

--- a/Tests/Tokens/Collections/TextStringStartTokensTest.php
+++ b/Tests/Tokens/Collections/TextStringStartTokensTest.php
@@ -16,13 +16,13 @@ use PHPUnit\Framework\TestCase;
 /**
  * Test class.
  *
- * @covers \PHPCSUtils\Tokens\Collections::textStingStartTokens
+ * @covers \PHPCSUtils\Tokens\Collections::textStringStartTokens
  *
  * @group collections
  *
  * @since 1.0.0
  */
-class TextStingStartTokensTest extends TestCase
+class TextStringStartTokensTest extends TestCase
 {
 
     /**
@@ -30,8 +30,8 @@ class TextStingStartTokensTest extends TestCase
      *
      * @return void
      */
-    public function testTextStingStartTokens()
+    public function testTextStringStartTokens()
     {
-        $this->assertSame(Collections::$textStingStartTokens, Collections::textStingStartTokens());
+        $this->assertSame(Collections::$textStingStartTokens, Collections::textStringStartTokens());
     }
 }


### PR DESCRIPTION
Includes fixing it up in all uses within PHPCSUtils.

Note: this method was introduced in Alpha-4 so this isn't a breaking change, though it should be safeguarded that the changelog contains the right info.