### PR TITLE
UtilityMethodTestCase::resetTestFile(): stabilize the resetting

### DIFF
--- a/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+++ b/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
@@ -296,7 +296,7 @@ abstract class UtilityMethodTestCase extends TestCase
     }
 
     /**
-     * Clean up after finished test.
+     * Clean up after finished test by resetting all static properties to their default values.
      *
      * Note: This is a PHPUnit cross-version compatible {@see \PHPUnit\Framework\TestCase::tearDownAfterClass()}
      * method.
@@ -309,7 +309,12 @@ abstract class UtilityMethodTestCase extends TestCase
      */
     public static function resetTestFile()
     {
-        self::$phpcsFile = null;
+        self::$phpcsVersion  = '0';
+        self::$fileExtension = 'inc';
+        self::$caseFile      = '';
+        self::$tabWidth      = 4;
+        self::$phpcsFile     = null;
+        self::$selectedSniff = ['Dummy.Dummy.Dummy'];
     }
 
     /**

--- a/Tests/TestUtils/UtilityMethodTestCase/UtilityMethodTestCaseTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/UtilityMethodTestCaseTest.php
@@ -205,6 +205,11 @@ class UtilityMethodTestCaseTest extends PolyfilledTestCase
     public function testTearDown()
     {
         parent::resetTestFile();
-        $this->assertNull(self::$phpcsFile);
+        $this->assertSame('0', self::$phpcsVersion, 'phpcsVersion was not reset');
+        $this->assertSame('inc', self::$fileExtension, 'fileExtension was not reset');
+        $this->assertSame('', self::$caseFile, 'caseFile was not reset');
+        $this->assertSame(4, self::$tabWidth, 'tabWidth was not reset');
+        $this->assertNull(self::$phpcsFile, 'phpcsFile was not reset');
+        $this->assertSame(['Dummy.Dummy.Dummy'], self::$selectedSniff, 'selectedSniff was not reset');
     }
 }


### PR DESCRIPTION
If a child test class would overload one of these properties without resetting, it could break all the tests (as these are `static` properties), so always resetting these properties from within the `UtilityMethodTestCase::resetTestFile()` class makes the tests more stable.

Includes updated test.