### PR TITLE
Tests: introduce generic dummy file

### DIFF
--- a/Tests/BackCompat/Helper/GetCommandLineDataTest.inc
+++ b/Tests/BackCompat/Helper/GetCommandLineDataTest.inc
@@ -1,3 +1,0 @@
-<?php
-
-// Deliberately left empty. This test just needs PHPCS to be instantiated.

--- a/Tests/BackCompat/Helper/GetCommandLineDataTest.php
+++ b/Tests/BackCompat/Helper/GetCommandLineDataTest.php
@@ -24,6 +24,19 @@ class GetCommandLineDataTest extends UtilityMethodTestCase
 {
 
     /**
+     * Initialize PHPCS & tokenize the test case file.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        self::$caseFile = dirname(dirname(__DIR__)) . '/DummyFile.inc';
+        parent::setUpTestFile();
+    }
+
+    /**
      * Test the getCommandLineData() method.
      *
      * @covers \PHPCSUtils\BackCompat\Helper::getCommandLineData

--- a/Tests/DummyFile.inc
+++ b/Tests/DummyFile.inc
@@ -1,0 +1,4 @@
+<?php
+
+// Deliberately left empty.
+// This is just a dummy test case file to get a PHPCS File object. Nothing more.

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.inc
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.inc
@@ -1,3 +1,0 @@
-<?php
-
-// No PHPCSUtils native test cases.

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
@@ -29,6 +29,19 @@ class GetParametersDiffTest extends UtilityMethodTestCase
 {
 
     /**
+     * Initialize PHPCS & tokenize the test case file.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        self::$caseFile = dirname(dirname(__DIR__)) . '/DummyFile.inc';
+        parent::setUpTestFile();
+    }
+
+    /**
      * Test passing a non-existent token pointer.
      *
      * @return void


### PR DESCRIPTION
... for tests which do need a `$phpcsFile` object, but don't have code snippet based tests.