### PR TITLE
BCTokens::functionNameTokens(): sync with upstream

### DIFF
--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -425,6 +425,7 @@ class BCTokens
      * Changelog for the PHPCS native array:
      * - Introduced in PHPCS 2.3.3.
      * - PHPCS 3.1.0: `T_SELF` and `T_STATIC` added to the array.
+     * - PHPCS 3.7.2: `T_PARENT` added to the array.
      * - PHPCS 4.0.0: `T_NAME_QUALIFIED`, `T_NAME_FULLY_QUALIFIED` and `T_NAME_RELATIVE` added to the array.
      *
      * @see \PHP_CodeSniffer\Util\Tokens::$functionNameTokens Original array.
@@ -438,6 +439,7 @@ class BCTokens
         $tokens            = Tokens::$functionNameTokens;
         $tokens[\T_SELF]   = \T_SELF;
         $tokens[\T_STATIC] = \T_STATIC;
+        $tokens[\T_PARENT] = \T_PARENT;
         $tokens           += Collections::nameTokens();
 
         return $tokens;

--- a/Tests/BackCompat/BCTokens/FunctionNameTokensTest.php
+++ b/Tests/BackCompat/BCTokens/FunctionNameTokensTest.php
@@ -48,6 +48,7 @@ class FunctionNameTokensTest extends TestCase
             \T_EMPTY        => \T_EMPTY,
             \T_SELF         => \T_SELF,
             \T_STATIC       => \T_STATIC,
+            \T_PARENT       => \T_PARENT,
         ];
 
         if (\version_compare(\PHP_VERSION_ID, '80000', '>=') === true


### PR DESCRIPTION
Upstream PR squizlabs/PHP_CodeSniffer#3546, which is included in PHPCS 3.7.0, changed the tokenization of the `parent` keyword in `new parent()` from `T_STRING` to `T_PARENT`.

Follow-up PR squizlabs/PHP_CodeSniffer#3619, which is expected to be included in PHPCS 3.7.2, adds the `T_PARENT` token to the `Tokens::$functionNameTokens` array.

This syncs the `BCTokens::functionNameTokens()` function with this upstream change.