### PR TITLE
QA: various minor code tweaks

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -518,7 +518,7 @@ class BCFile
                     $nullableType     = false;
                     $visibilityToken  = null;
 
-                    $paramCount++;
+                    ++$paramCount;
                     break;
                 case 'T_EQUAL':
                     $defaultStart = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);

--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -436,11 +436,9 @@ class BCTokens
      */
     public static function functionNameTokens()
     {
-        $tokens            = Tokens::$functionNameTokens;
-        $tokens[\T_SELF]   = \T_SELF;
-        $tokens[\T_STATIC] = \T_STATIC;
-        $tokens[\T_PARENT] = \T_PARENT;
-        $tokens           += Collections::nameTokens();
+        $tokens  = Tokens::$functionNameTokens;
+        $tokens += Collections::ooHierarchyKeywords();
+        $tokens += Collections::nameTokens();
 
         return $tokens;
     }

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -851,6 +851,39 @@ class Collections
     }
 
     /**
+     * Tokens which can represent the nullsafe object operator.
+     *
+     * This method will return the appropriate tokens based on the PHP/PHPCS version used.
+     *
+     * Note: this is a method, not a property as the `T_NULLSAFE_OBJECT_OPERATOR` token may not exist.
+     *
+     * Note: if this method is used, the {@see \PHPCSUtils\Utils\Operators::isNullsafeObjectOperator()}
+     * method needs to be used on potential nullsafe object operator tokens to verify whether it really
+     * is a nullsafe object operator or not.
+     *
+     * @see \PHPCSUtils\Utils\Operators::isNullsafeObjectOperator() Nullsafe object operator detection for
+     *                                                              PHPCS < 3.5.7.
+     *
+     * @since 1.0.0-alpha4
+     *
+     * @return array <int|string> => <int|string>
+     */
+    public static function nullsafeObjectOperatorBC()
+    {
+        if (TokenHelper::tokenExists('T_NULLSAFE_OBJECT_OPERATOR') === true) {
+            // PHP >= 8.0 / PHPCS >= 3.5.7.
+            return [
+                \T_NULLSAFE_OBJECT_OPERATOR => \T_NULLSAFE_OBJECT_OPERATOR,
+            ];
+        }
+
+        return [
+            \T_INLINE_THEN     => \T_INLINE_THEN,
+            \T_OBJECT_OPERATOR => \T_OBJECT_OPERATOR,
+        ];
+    }
+
+    /**
      * Object operators.
      *
      * Note: this is a method, not a property as the `T_NULLSAFE_OBJECT_OPERATOR` token may not exist.
@@ -994,39 +1027,6 @@ class Collections
     public static function ooPropertyScopes()
     {
         return self::$OOPropertyScopes;
-    }
-
-    /**
-     * Tokens which can represent the nullsafe object operator.
-     *
-     * This method will return the appropriate tokens based on the PHP/PHPCS version used.
-     *
-     * Note: this is a method, not a property as the `T_NULLSAFE_OBJECT_OPERATOR` token may not exist.
-     *
-     * Note: if this method is used, the {@see \PHPCSUtils\Utils\Operators::isNullsafeObjectOperator()}
-     * method needs to be used on potential nullsafe object operator tokens to verify whether it really
-     * is a nullsafe object operator or not.
-     *
-     * @see \PHPCSUtils\Utils\Operators::isNullsafeObjectOperator() Nullsafe object operator detection for
-     *                                                              PHPCS < 3.5.7.
-     *
-     * @since 1.0.0-alpha4
-     *
-     * @return array <int|string> => <int|string>
-     */
-    public static function nullsafeObjectOperatorBC()
-    {
-        if (TokenHelper::tokenExists('T_NULLSAFE_OBJECT_OPERATOR') === true) {
-            // PHP >= 8.0 / PHPCS >= 3.5.7.
-            return [
-                \T_NULLSAFE_OBJECT_OPERATOR => \T_NULLSAFE_OBJECT_OPERATOR,
-            ];
-        }
-
-        return [
-            \T_INLINE_THEN     => \T_INLINE_THEN,
-            \T_OBJECT_OPERATOR => \T_OBJECT_OPERATOR,
-        ];
     }
 
     /**

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -1272,15 +1272,13 @@ class Collections
     {
         $tokens = [
             \T_CALLABLE   => \T_CALLABLE,
-            \T_SELF       => \T_SELF,
-            \T_PARENT     => \T_PARENT,
-            \T_STATIC     => \T_STATIC,
             \T_FALSE      => \T_FALSE,      // Union types only.
             \T_NULL       => \T_NULL,       // Union types only.
             \T_ARRAY      => \T_ARRAY,      // Arrow functions PHPCS < 3.5.4 + union types.
             \T_BITWISE_OR => \T_BITWISE_OR, // Union types for PHPCS < 3.6.0.
         ];
 
+        $tokens += self::ooHierarchyKeywords();
         $tokens += self::namespacedNameTokens();
 
         // PHPCS > 3.6.0: a new token was introduced for the union type separator.

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -590,7 +590,7 @@ class FunctionDeclarations
                     $nullableType     = false;
                     $visibilityToken  = null;
 
-                    $paramCount++;
+                    ++$paramCount;
                     break;
 
                 case 'T_EQUAL':

--- a/PHPCSUtils/Utils/Numbers.php
+++ b/PHPCSUtils/Utils/Numbers.php
@@ -268,7 +268,7 @@ class Numbers
             && $tokens[($stackPtr + 1)]['code'] === \T_STRING
             && \strtolower($tokens[($stackPtr + 1)]['content'][0]) === 'o'
             && $tokens[($stackPtr + 1)]['content'][1] !== '_'
-            && preg_match('`^(o[0-7]+(?:_[0-7]+)?)[0-9_]*`i', $tokens[($stackPtr + 1)]['content'], $matches) === 1
+            && \preg_match('`^(o[0-7]+(?:_[0-7]+)?)[0-9_]*`i', $tokens[($stackPtr + 1)]['content'], $matches) === 1
         ) {
             $content .= $matches[1];
             $result   = self::updateResult($result, $content, ($stackPtr + 1), true);

--- a/PHPCSUtils/Utils/PassedParameters.php
+++ b/PHPCSUtils/Utils/PassedParameters.php
@@ -333,7 +333,7 @@ class PassedParameters
 
             // Prepare for the next parameter.
             $paramStart = ($nextComma + 1);
-            $cnt++;
+            ++$cnt;
         }
 
         return $parameters;

--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -221,7 +221,7 @@ class UseStatements
             return $statements;
         }
 
-        $endOfStatement++;
+        ++$endOfStatement;
 
         $start     = true;
         $useGroup  = false;

--- a/Tests/BackCompat/Helper/GetCommandLineDataTest.php
+++ b/Tests/BackCompat/Helper/GetCommandLineDataTest.php
@@ -34,7 +34,7 @@ class GetCommandLineDataTest extends UtilityMethodTestCase
      */
     public static function setUpTestFile()
     {
-        self::$caseFile = dirname(dirname(__DIR__)) . '/DummyFile.inc';
+        self::$caseFile = \dirname(\dirname(__DIR__)) . '/DummyFile.inc';
         parent::setUpTestFile();
     }
 

--- a/Tests/TestUtils/UtilityMethodTestCase/UtilityMethodTestCaseTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/UtilityMethodTestCaseTest.php
@@ -10,8 +10,6 @@
 
 namespace PHPCSUtils\Tests\TestUtils\UtilityMethodTestCase;
 
-use PHP_CodeSniffer\Exceptions\RuntimeException;
-use PHP_CodeSniffer\Exceptions\TokenizerException;
 use PHPCSUtils\Tests\PolyfilledTestCase;
 
 /**

--- a/Tests/Tokens/Collections/ReturnTypeTokensTest.php
+++ b/Tests/Tokens/Collections/ReturnTypeTokensTest.php
@@ -36,13 +36,13 @@ class ReturnTypeTokensTest extends TestCase
         $version  = Helper::getVersion();
         $expected = [
             \T_CALLABLE     => \T_CALLABLE,
-            \T_SELF         => \T_SELF,
-            \T_PARENT       => \T_PARENT,
-            \T_STATIC       => \T_STATIC,
             \T_FALSE        => \T_FALSE,
             \T_NULL         => \T_NULL,
             \T_ARRAY        => \T_ARRAY,
             \T_BITWISE_OR   => \T_BITWISE_OR,
+            \T_PARENT       => \T_PARENT,
+            \T_SELF         => \T_SELF,
+            \T_STATIC       => \T_STATIC,
             \T_NS_SEPARATOR => \T_NS_SEPARATOR,
             \T_NAMESPACE    => \T_NAMESPACE,
             \T_STRING       => \T_STRING,

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
@@ -37,7 +37,7 @@ class GetParametersDiffTest extends UtilityMethodTestCase
      */
     public static function setUpTestFile()
     {
-        self::$caseFile = dirname(dirname(__DIR__)) . '/DummyFile.inc';
+        self::$caseFile = \dirname(\dirname(__DIR__)) . '/DummyFile.inc';
         parent::setUpTestFile();
     }
 

--- a/Tests/Utils/FunctionDeclarations/IsArrowFunction2926Test.php
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunction2926Test.php
@@ -132,7 +132,7 @@ class IsArrowFunction2926Test extends UtilityMethodTestCase
         $stackPtr = $this->getTargetToken($testMarker, $targets, $targetContent);
 
         // Change from offsets to absolute token positions.
-        if ($expected['get'] != false) {
+        if ($expected['get'] !== false) {
             foreach ($expected['get'] as $key => $value) {
                 $expected['get'][$key] += $stackPtr;
             }

--- a/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
@@ -128,7 +128,7 @@ class IsArrowFunctionTest extends UtilityMethodTestCase
         $stackPtr = $this->getTargetToken($testMarker, $targets, $targetContent);
 
         // Change from offsets to absolute token positions.
-        if ($expected['get'] != false) {
+        if ($expected['get'] !== false) {
             foreach ($expected['get'] as $key => $value) {
                 $expected['get'][$key] += $stackPtr;
             }


### PR DESCRIPTION
### Tokens\Collections: minor code order tweak

Keep the order of the methods alphabetic.

### CS: use pre-increment instead of post-increment

### QA: use strict comparisons

### QA: remove unused use statements

### CS/QA: use fully qualified function calls

### BCTokens::functionNameTokens(): minor simplification

Follow up to PR #327. This simplifies the code a little.

### Collections::returnTypeTokens(): minor code simplification