### PR TITLE
QA/Tests: various code coverage tweaks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -253,6 +253,9 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: xdebug
 
+      - name: "DEBUG: Show version details"
+        run: php -v
+
       - name: 'Composer: adjust dependencies'
         run: |
           # Set a specific PHPCS version.

--- a/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
+++ b/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
@@ -550,7 +550,7 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
                  * Shouldn't be possible. Either way, if it's not one of the above types,
                  * this is not a key we can handle.
                  */
-                return;
+                return; // @codeCoverageIgnore
         }
     }
 }

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -764,7 +764,8 @@ class FunctionDeclarations
 
         $returnValue['parenthesis_opener'] = $nextNonEmpty;
         if (isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false) {
-            return false;
+            // Shouldn't be possible, but just in case.
+            return false; // @codeCoverageIgnore
         }
 
         $returnValue['parenthesis_closer'] = $tokens[$nextNonEmpty]['parenthesis_closer'];

--- a/PHPCSUtils/Utils/Namespaces.php
+++ b/PHPCSUtils/Utils/Namespaces.php
@@ -307,7 +307,8 @@ class Namespaces
                 if (isset($tokens[$prev]['scope_condition']) === true) {
                     $prev = $tokens[$prev]['scope_condition'];
                 } elseif (isset($tokens[$prev]['scope_opener']) === true) {
-                    $prev = $tokens[$prev]['scope_opener'];
+                    // Shouldn't be possible, but just in case.
+                    $prev = $tokens[$prev]['scope_opener']; // @codeCoverageIgnore
                 }
 
                 continue;

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,8 +15,25 @@
     >
 
     <testsuites>
+        <testsuite name="RunFirst">
+            <!--
+            A number of tests need process isolation to allow for recording code coverage on
+            the setting of function local static variables.
+            However, using process isolation runs into trouble with PHPUnit 4.x/PHPCS 2.6.0.
+            Executing these specific tests in a separate testsuite, which is run
+            before the full test suite, will allow for the code coverage for these methods
+            to be recorded properly, while still allowing the tests to run on all supported
+            PHP/PHPUnit/PHPCS combinations.
+            -->
+            <file>./Tests/BackCompat/BCTokens/EmptyTokensTest.php</file>
+            <file>./Tests/Utils/Namespaces/NamespaceTypeTest.php</file>
+            <file>./Tests/Utils/Numbers/GetCompleteNumberTest.php</file>
+        </testsuite>
         <testsuite name="PHPCSUtils">
             <directory suffix="Test.php">./Tests/</directory>
+            <exclude>Tests/BackCompat/BCTokens/EmptyTokensTest.php</exclude>
+            <exclude>Tests/Utils/Namespaces/NamespaceTypeTest.php</exclude>
+            <exclude>Tests/Utils/Numbers/GetCompleteNumberTest.php</exclude>
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
### GH Actions/coverage: add extra (debug) step

While the feedback shown in the `setup-php` step is awesome, it doesn't show the version of Xdebug used when running code coverage, while, in case of issues, the version number of Xdebug is crucial to know.

This extra step allows for that information to always be available.

I've only added the step to the code coverage job though as that's the only one for which the Xdebug version is relevant.

Also see: https://github.com/shivammathur/setup-php/issues/610

### PHPUnit config: isolate a number of tests from the main test suite

The functions being tested in these three test classes all use function local `static` variables for optimization.

Having the function local `static` variable will often prevent code coverage from being recorded correctly for the code as the code for setting the static will only be run when the function is first called, which may not be in the dedicated test for the function, so it makes code coverage recording highly dependent on the order in which tests are run.

In these three cases, I do believe the function local `static` variable is justified (for the time being, benchmarking should be able to determine for sure at some point in the future).

To still prevent missed lines in the code coverage reports, I'm moving the tests for these three functions into a separate test suite, which will run first.
This should ensure the code which sets the static will be run first when the dedicated tests for these methods are run and should allow the correct registration of code coverage for this code.

Mind: if at some point the `executionOrder` configuration would be added to the config/enabled, it needs to be verified how that behaves in combination with multiple test suites. But that's for later.

Ref: https://github.com/sebastianbergmann/php-code-coverage/issues/913

### Tests: add select @codeCoverageIgnore annotations

... for code which is only in place as defensive coding, but shouldn't be reachable under normal circumstances.