### PR TITLE
New (internal) Cache and NoFileCache classes + implement use of these

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -74,7 +74,14 @@ jobs:
         if: matrix.phpcs_version == 'dev-master'
         run: composer lint
 
-      - name: Run the unit tests
+      - name: Run the unit tests without caching
         run: vendor/bin/phpunit --no-coverage
         env:
           PHPCS_VERSION: ${{ matrix.phpcs_version }}
+          PHPCSUTILS_USE_CACHE: false
+
+      - name: Run the unit tests with caching
+        run: vendor/bin/phpunit --testsuite PHPCSUtils --no-coverage --repeat 2
+        env:
+          PHPCS_VERSION: ${{ matrix.phpcs_version }}
+          PHPCSUTILS_USE_CACHE: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -189,11 +189,19 @@ jobs:
         with:
           composer-options: --ignore-platform-reqs
 
-      - name: Run the unit tests (non-risky)
+      - name: Run the unit tests without caching (non-risky)
         if: matrix.risky == false
         run: vendor/bin/phpunit --no-coverage
         env:
           PHPCS_VERSION: ${{ matrix.phpcs_version == '4.0.x-dev' && '4.0.0' || matrix.phpcs_version }}
+          PHPCSUTILS_USE_CACHE: false
+
+      - name: Run the unit tests with caching (non-risky)
+        if: matrix.risky == false
+        run: vendor/bin/phpunit --testsuite PHPCSUtils --no-coverage --repeat 2
+        env:
+          PHPCS_VERSION: ${{ matrix.phpcs_version == '4.0.x-dev' && '4.0.0' || matrix.phpcs_version }}
+          PHPCSUTILS_USE_CACHE: true
 
       - name: Run the unit tests (risky)
         if: ${{ matrix.risky }}
@@ -281,17 +289,19 @@ jobs:
         if: ${{ steps.phpunit_version.outputs.VERSION >= '9.3' }}
         run: vendor/bin/phpunit --coverage-cache ./build/phpunit-cache --warm-coverage-cache
 
-      - name: "Run the unit tests with code coverage (PHPUnit < 9.3)"
+      - name: "Run the unit tests without caching with code coverage (PHPUnit < 9.3)"
         if: ${{ steps.phpunit_version.outputs.VERSION < '9.3' }}
         run: vendor/bin/phpunit
         env:
           PHPCS_VERSION: ${{ matrix.phpcs_version }}
+          PHPCSUTILS_USE_CACHE: false
 
-      - name: "Run the unit tests with code coverage (PHPUnit 9.3+)"
+      - name: "Run the unit tests without caching with code coverage (PHPUnit 9.3+)"
         if: ${{ steps.phpunit_version.outputs.VERSION >= '9.3' }}
         run: vendor/bin/phpunit --coverage-cache ./build/phpunit-cache
         env:
           PHPCS_VERSION: ${{ matrix.phpcs_version }}
+          PHPCSUTILS_USE_CACHE: false
 
       # Uploading the results with PHP Coveralls v1 won't work from GH Actions, so switch the PHP version.
       - name: Switch to PHP 7.4

--- a/PHPCSUtils/Internal/Cache.php
+++ b/PHPCSUtils/Internal/Cache.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Internal;
+
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Results cache.
+ *
+ * Allows to cache the return value of utility functions which do a lot of token walking.
+ * Those type of utilities can significantly slow down file scanning, especially
+ * with large files and when multiple sniffs use the same utility function.
+ *
+ * Caching the results can significantly speed things up, though it can also eat memory,
+ * so use with care.
+ *
+ * Typical usage:
+ * ```php
+ * function doSomething()
+ * {
+ *    if (Cache::isCached($phpcsFile, __METHOD__, $stackPtr) === true) {
+ *        return Cache::get($phpcsFile, __METHOD__, $stackPtr);
+ *    }
+ *
+ *    // Do something.
+ *
+ *    Cache::set($phpcsFile, __METHOD__, $stackPtr, $returnValue);
+ *    return $returnValue;
+ * }
+ * ```
+ *
+ * ---------------------------------------------------------------------------------------------
+ * This class is only intended for internal use by PHPCSUtils and is not part of the public API.
+ * This also means that it has no promise of backward compatibility.
+ * ---------------------------------------------------------------------------------------------
+ *
+ * @internal
+ *
+ * @since 1.0.0
+ */
+final class Cache
+{
+
+    /**
+     * Results cache.
+     *
+     * @var array<int, array<string, array>> Format: $cache[$loop][$fileName][$key][$id] = mixed $value;
+     */
+    private static $cache = [];
+
+    /**
+     * Check whether a result has been cached for a certain utility function.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param string                      $key       The key to identify a particular set of results.
+     *                                               It is recommended to pass __METHOD__ to this parameter.
+     * @param int|string                  $id        Unique identifier for these results.
+     *                                               Generally speaking this will be the $stackPtr passed
+     *                                               to the utility function, but it can also something else,
+     *                                               like a serialization of args passed to a function or an
+     *                                               md5 hash of an input.
+     *
+     * @return bool
+     */
+    public static function isCached(File $phpcsFile, $key, $id)
+    {
+        $fileName = $phpcsFile->getFilename();
+        $loop     = $phpcsFile->fixer->enabled === true ? $phpcsFile->fixer->loops : 0;
+
+        return isset(self::$cache[$loop][$fileName][$key])
+            && \array_key_exists($id, self::$cache[$loop][$fileName][$key]);
+    }
+
+    /**
+     * Retrieve a previously cached result for a certain utility function.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param string                      $key       The key to identify a particular set of results.
+     *                                               It is recommended to pass __METHOD__ to this parameter.
+     * @param int|string                  $id        Unique identifier for these results.
+     *                                               Generally speaking this will be the $stackPtr passed
+     *                                               to the utility function, but it can also something else,
+     *                                               like a serialization of args passed to a function or an
+     *                                               md5 hash of an input.
+     *
+     * @return mixed
+     */
+    public static function get(File $phpcsFile, $key, $id)
+    {
+        $fileName = $phpcsFile->getFilename();
+        $loop     = $phpcsFile->fixer->enabled === true ? $phpcsFile->fixer->loops : 0;
+
+        if (isset(self::$cache[$loop][$fileName][$key])
+            && \array_key_exists($id, self::$cache[$loop][$fileName][$key])
+        ) {
+            return self::$cache[$loop][$fileName][$key][$id];
+        }
+
+        return null;
+    }
+
+    /**
+     * Retrieve all previously cached results for a certain utility function and a certain file.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param string                      $key       The key to identify a particular set of results.
+     *                                               It is recommended to pass __METHOD__ to this parameter.
+     *
+     * @return array
+     */
+    public static function getForFile(File $phpcsFile, $key)
+    {
+        $fileName = $phpcsFile->getFilename();
+        $loop     = $phpcsFile->fixer->enabled === true ? $phpcsFile->fixer->loops : 0;
+
+        if (isset(self::$cache[$loop][$fileName])
+            && \array_key_exists($key, self::$cache[$loop][$fileName])
+        ) {
+            return self::$cache[$loop][$fileName][$key];
+        }
+
+        return [];
+    }
+
+    /**
+     * Cache the result for a certain utility function.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param string                      $key       The key to identify a particular set of results.
+     *                                               It is recommended to pass __METHOD__ to this parameter.
+     * @param int|string                  $id        Unique identifier for these results.
+     *                                               Generally speaking this will be the $stackPtr passed
+     *                                               to the utility function, but it can also something else,
+     *                                               like a serialization of args passed to a function or an
+     *                                               md5 hash of an input.
+     * @param mixed                       $value     An arbitrary value to write to the cache.
+     *
+     * @return mixed
+     */
+    public static function set(File $phpcsFile, $key, $id, $value)
+    {
+        $fileName = $phpcsFile->getFilename();
+        $loop     = $phpcsFile->fixer->enabled === true ? $phpcsFile->fixer->loops : 0;
+
+        /*
+         * If this is a phpcbf run and we've reached the next loop, clear the cache
+         * of all previous loops to free up memory.
+         */
+        if (isset(self::$cache[$loop]) === false
+            && empty(self::$cache) === false
+        ) {
+            self::clear();
+        }
+
+        self::$cache[$loop][$fileName][$key][$id] = $value;
+    }
+
+    /**
+     * Clear the cache.
+     *
+     * @return void
+     */
+    public static function clear()
+    {
+        self::$cache = [];
+    }
+}

--- a/PHPCSUtils/Internal/Cache.php
+++ b/PHPCSUtils/Internal/Cache.php
@@ -50,6 +50,18 @@ final class Cache
 {
 
     /**
+     * Whether caching is enabled or not.
+     *
+     * Note: this switch is ONLY intended for use within test suites and should never
+     * be touched in any other circumstances!
+     *
+     * Don't forget to always turn the cache back on in a `tear_down()` method!
+     *
+     * @var bool
+     */
+    public static $enabled = true;
+
+    /**
      * Results cache.
      *
      * @var array<int, array<string, array>> Format: $cache[$loop][$fileName][$key][$id] = mixed $value;
@@ -72,6 +84,10 @@ final class Cache
      */
     public static function isCached(File $phpcsFile, $key, $id)
     {
+        if (self::$enabled === false) {
+            return false;
+        }
+
         $fileName = $phpcsFile->getFilename();
         $loop     = $phpcsFile->fixer->enabled === true ? $phpcsFile->fixer->loops : 0;
 
@@ -95,6 +111,10 @@ final class Cache
      */
     public static function get(File $phpcsFile, $key, $id)
     {
+        if (self::$enabled === false) {
+            return null;
+        }
+
         $fileName = $phpcsFile->getFilename();
         $loop     = $phpcsFile->fixer->enabled === true ? $phpcsFile->fixer->loops : 0;
 
@@ -118,6 +138,10 @@ final class Cache
      */
     public static function getForFile(File $phpcsFile, $key)
     {
+        if (self::$enabled === false) {
+            return [];
+        }
+
         $fileName = $phpcsFile->getFilename();
         $loop     = $phpcsFile->fixer->enabled === true ? $phpcsFile->fixer->loops : 0;
 
@@ -147,6 +171,10 @@ final class Cache
      */
     public static function set(File $phpcsFile, $key, $id, $value)
     {
+        if (self::$enabled === false) {
+            return;
+        }
+
         $fileName = $phpcsFile->getFilename();
         $loop     = $phpcsFile->fixer->enabled === true ? $phpcsFile->fixer->loops : 0;
 

--- a/PHPCSUtils/Internal/NoFileCache.php
+++ b/PHPCSUtils/Internal/NoFileCache.php
@@ -46,6 +46,18 @@ final class NoFileCache
 {
 
     /**
+     * Whether caching is enabled or not.
+     *
+     * Note: this switch is ONLY intended for use within test suites and should never
+     * be touched in any other circumstances!
+     *
+     * Don't forget to always turn the cache back on in a `tear_down()` method!
+     *
+     * @var bool
+     */
+    public static $enabled = true;
+
+    /**
      * Results cache.
      *
      * @var array<string, array<int|string, mixed>> Format: $cache[$key][$id] = mixed $value;
@@ -65,7 +77,7 @@ final class NoFileCache
      */
     public static function isCached($key, $id)
     {
-        return isset(self::$cache[$key]) && \array_key_exists($id, self::$cache[$key]);
+        return self::$enabled === true && isset(self::$cache[$key]) && \array_key_exists($id, self::$cache[$key]);
     }
 
     /**
@@ -81,7 +93,7 @@ final class NoFileCache
      */
     public static function get($key, $id)
     {
-        if (isset(self::$cache[$key]) && \array_key_exists($id, self::$cache[$key])) {
+        if (self::$enabled === true && isset(self::$cache[$key]) && \array_key_exists($id, self::$cache[$key])) {
             return self::$cache[$key][$id];
         }
 
@@ -98,7 +110,7 @@ final class NoFileCache
      */
     public static function getForKey($key)
     {
-        if (\array_key_exists($key, self::$cache)) {
+        if (self::$enabled === true && \array_key_exists($key, self::$cache)) {
             return self::$cache[$key];
         }
 
@@ -119,6 +131,10 @@ final class NoFileCache
      */
     public static function set($key, $id, $value)
     {
+        if (self::$enabled === false) {
+            return;
+        }
+
         self::$cache[$key][$id] = $value;
     }
 

--- a/PHPCSUtils/Internal/NoFileCache.php
+++ b/PHPCSUtils/Internal/NoFileCache.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Internal;
+
+/**
+ * Cache for function results which are not directly related to a $phpcsFile.
+ *
+ * Allows to cache the return value of utility functions which don't use PHPCS File objects.
+ *
+ * Caching the results can significantly speed things up, though it can also eat memory,
+ * so use with care.
+ *
+ * Typical usage:
+ * ```php
+ * function doSomething()
+ * {
+ *    if (NoFileCache::isCached(__METHOD__, $paramHash) === true) {
+ *        return NoFileCache::get(__METHOD__, $paramHash);
+ *    }
+ *
+ *    // Do something.
+ *
+ *    NoFileCache::set(__METHOD__, $paramHash, $returnValue);
+ *    return $returnValue;
+ * }
+ * ```
+ *
+ * ---------------------------------------------------------------------------------------------
+ * This class is only intended for internal use by PHPCSUtils and is not part of the public API.
+ * This also means that it has no promise of backward compatibility.
+ * ---------------------------------------------------------------------------------------------
+ *
+ * @internal
+ *
+ * @since 1.0.0
+ */
+final class NoFileCache
+{
+
+    /**
+     * Results cache.
+     *
+     * @var array<string, array<int|string, mixed>> Format: $cache[$key][$id] = mixed $value;
+     */
+    private static $cache = [];
+
+    /**
+     * Check whether a result has been cached for a certain utility function.
+     *
+     * @param string     $key The key to identify a particular set of results.
+     *                        It is recommended to pass `__METHOD__` to this parameter.
+     * @param int|string $id  Unique identifier for these results.
+     *                        It is recommended for this to be a serialization of arguments passed
+     *                        to the function or an md5 hash of an input.
+     *
+     * @return bool
+     */
+    public static function isCached($key, $id)
+    {
+        return isset(self::$cache[$key]) && \array_key_exists($id, self::$cache[$key]);
+    }
+
+    /**
+     * Retrieve a previously cached result for a certain utility function.
+     *
+     * @param string     $key The key to identify a particular set of results.
+     *                        It is recommended to pass `__METHOD__` to this parameter.
+     * @param int|string $id  Unique identifier for these results.
+     *                        It is recommended for this to be a serialization of arguments passed
+     *                        to the function or an md5 hash of an input.
+     *
+     * @return mixed
+     */
+    public static function get($key, $id)
+    {
+        if (isset(self::$cache[$key]) && \array_key_exists($id, self::$cache[$key])) {
+            return self::$cache[$key][$id];
+        }
+
+        return null;
+    }
+
+    /**
+     * Retrieve all previously cached results for a certain utility function.
+     *
+     * @param string $key The key to identify a particular set of results.
+     *                    It is recommended to pass `__METHOD__` to this parameter.
+     *
+     * @return array
+     */
+    public static function getForKey($key)
+    {
+        if (\array_key_exists($key, self::$cache)) {
+            return self::$cache[$key];
+        }
+
+        return [];
+    }
+
+    /**
+     * Cache the result for a certain utility function.
+     *
+     * @param string     $key   The key to identify a particular set of results.
+     *                          It is recommended to pass `__METHOD__` to this parameter.
+     * @param int|string $id    Unique identifier for these results.
+     *                          It is recommended for this to be a serialization of arguments passed
+     *                          to the function or an md5 hash of an input.
+     * @param mixed      $value An arbitrary value to write to the cache.
+     *
+     * @return mixed
+     */
+    public static function set($key, $id, $value)
+    {
+        self::$cache[$key][$id] = $value;
+    }
+
+    /**
+     * Clear the cache.
+     *
+     * @return void
+     */
+    public static function clear()
+    {
+        self::$cache = [];
+    }
+}

--- a/PHPCSUtils/Utils/Lists.php
+++ b/PHPCSUtils/Utils/Lists.php
@@ -15,6 +15,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Internal\Cache;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\Parentheses;
@@ -385,6 +386,10 @@ class Lists
             throw new RuntimeException('The Lists::getAssignments() method expects a long/short list token.');
         }
 
+        if (Cache::isCached($phpcsFile, __METHOD__, $stackPtr) === true) {
+            return Cache::get($phpcsFile, __METHOD__, $stackPtr);
+        }
+
         $opener = $openClose['opener'];
         $closer = $openClose['closer'];
 
@@ -502,6 +507,7 @@ class Lists
             }
         }
 
+        Cache::set($phpcsFile, __METHOD__, $stackPtr, $vars);
         return $vars;
     }
 }

--- a/PHPCSUtils/Utils/TextStrings.php
+++ b/PHPCSUtils/Utils/TextStrings.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Internal\Cache;
+use PHPCSUtils\Internal\NoFileCache;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\GetTokensAsString;
 
@@ -362,6 +363,11 @@ class TextStrings
             ];
         }
 
+        $textHash = \md5($text);
+        if (NoFileCache::isCached(__METHOD__, $textHash) === true) {
+            return NoFileCache::get(__METHOD__, $textHash);
+        }
+
         $offset    = 0;
         $strLen    = \strlen($text); // Use iconv ?
         $stripped  = '';
@@ -410,9 +416,12 @@ class TextStrings
             $stripped .= \substr($text, $offset);
         }
 
-        return [
+        $returnValue = [
             'embeds'    => $variables,
             'remaining' => $stripped,
         ];
+
+        NoFileCache::set(__METHOD__, $textHash, $returnValue);
+        return $returnValue;
     }
 }

--- a/PHPCSUtils/Utils/TextStrings.php
+++ b/PHPCSUtils/Utils/TextStrings.php
@@ -13,6 +13,7 @@ namespace PHPCSUtils\Utils;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Internal\Cache;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\GetTokensAsString;
 
@@ -140,6 +141,10 @@ class TextStrings
             }
         }
 
+        if (Cache::isCached($phpcsFile, __METHOD__, $stackPtr) === true) {
+            return Cache::get($phpcsFile, __METHOD__, $stackPtr);
+        }
+
         switch ($tokens[$stackPtr]['code']) {
             case \T_START_HEREDOC:
                 $targetType = \T_HEREDOC;
@@ -185,6 +190,7 @@ class TextStrings
             $lastPtr = $end;
         }
 
+        Cache::set($phpcsFile, __METHOD__, $stackPtr, $lastPtr);
         return $lastPtr;
     }
 

--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -15,6 +15,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
 use PHPCSUtils\BackCompat\Helper;
+use PHPCSUtils\Internal\Cache;
 use PHPCSUtils\Utils\Conditions;
 use PHPCSUtils\Utils\Parentheses;
 
@@ -221,6 +222,10 @@ class UseStatements
             return $statements;
         }
 
+        if (Cache::isCached($phpcsFile, __METHOD__, $stackPtr) === true) {
+            return Cache::get($phpcsFile, __METHOD__, $stackPtr);
+        }
+
         ++$endOfStatement;
 
         $start     = true;
@@ -401,6 +406,7 @@ class UseStatements
             }
         }
 
+        Cache::set($phpcsFile, __METHOD__, $stackPtr, $statements);
         return $statements;
     }
 

--- a/Tests/Internal/Cache/GetClearTest.php
+++ b/Tests/Internal/Cache/GetClearTest.php
@@ -1,0 +1,335 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Internal\Cache;
+
+use PHPCSUtils\Internal\Cache;
+use PHPCSUtils\Tests\TypeProviderHelper;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+
+/**
+ * Tests for the cache retrieval and cache clear methods.
+ *
+ * @group cache
+ *
+ * @coversDefaultClass \PHPCSUtils\Internal\Cache
+ *
+ * @since 1.0.0
+ */
+class GetClearTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Initialize PHPCS & tokenize the test case file.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        Cache::clear();
+        self::$caseFile = \dirname(\dirname(__DIR__)) . '/DummyFile.inc';
+        parent::setUpTestFile();
+    }
+
+    /**
+     * Fill the initial cache.
+     *
+     * @before
+     *
+     * @return void
+     */
+    protected function createCache()
+    {
+        $data = TypeProviderHelper::getAll();
+        foreach ($data as $id => $dataset) {
+            Cache::set(self::$phpcsFile, 'Utility1', $id, $dataset['input']);
+            Cache::set(self::$phpcsFile, 'Utility2', $id, $dataset['input']);
+        }
+    }
+
+    /**
+     * Clear the cache between tests and reset the base fixer loop.
+     *
+     * @after
+     *
+     * @return void
+     */
+    protected function clearCacheAndFixer()
+    {
+        Cache::clear();
+        self::$phpcsFile->fixer->enabled = false;
+        self::$phpcsFile->fixer->loops   = 0;
+    }
+
+    /**
+     * Test that a cache for a loop which has not been set is identified correctly as such.
+     *
+     * @covers ::isCached
+     *
+     * @return void
+     */
+    public function testIsCachedWillReturnFalseForUnavailableLoop()
+    {
+        self::$phpcsFile->fixer->enabled = true;
+        self::$phpcsFile->fixer->loops   = 3;
+        $this->assertFalse(Cache::isCached(self::$phpcsFile, 'Utility1', 'numeric string'));
+    }
+
+    /**
+     * Test that a cache key which has not been set is identified correctly as such.
+     *
+     * @covers ::isCached
+     *
+     * @return void
+     */
+    public function testIsCachedWillReturnFalseForUnavailableKey()
+    {
+        $this->assertFalse(Cache::isCached(self::$phpcsFile, 'Utility3', 'numeric string'));
+    }
+
+    /**
+     * Test that a cache id which has not been set is identified correctly as such.
+     *
+     * @covers ::isCached
+     *
+     * @return void
+     */
+    public function testIsCachedWillReturnFalseForUnavailableId()
+    {
+        $this->assertFalse(Cache::isCached(self::$phpcsFile, 'Utility1', 'this ID does not exist'));
+    }
+
+    /**
+     * Test that retrieving a cache key for a loop which has not been set, yields null.
+     *
+     * @covers ::get
+     *
+     * @return void
+     */
+    public function testGetWillReturnNullForUnavailableLoop()
+    {
+        self::$phpcsFile->fixer->enabled = true;
+        self::$phpcsFile->fixer->loops   = 2;
+        $this->assertNull(Cache::get(self::$phpcsFile, 'Utility1', 'numeric string'));
+    }
+
+    /**
+     * Test that retrieving a cache key which has not been set, yields null.
+     *
+     * @covers ::get
+     *
+     * @return void
+     */
+    public function testGetWillReturnNullForUnavailableKey()
+    {
+        $this->assertNull(Cache::get(self::$phpcsFile, 'Utility3', 'numeric string'));
+    }
+
+    /**
+     * Test that retrieving a cache id which has not been set, yields null.
+     *
+     * @covers ::get
+     *
+     * @return void
+     */
+    public function testGetWillReturnNullForUnavailableId()
+    {
+        $this->assertNull(Cache::get(self::$phpcsFile, 'Utility1', 'this ID does not exist'));
+    }
+
+    /**
+     * Test that retrieving a cache set for a loop which has not been set, yields an empty array.
+     *
+     * @covers ::getForFile
+     *
+     * @return void
+     */
+    public function testGetForFileWillReturnEmptyArrayForUnavailableLoop()
+    {
+        self::$phpcsFile->fixer->enabled = true;
+        self::$phpcsFile->fixer->loops   = 15;
+        $this->assertSame([], Cache::getForFile(self::$phpcsFile, 'Utility1'));
+    }
+
+    /**
+     * Test that retrieving a cache set for a cache key which has not been set, yields an empty array.
+     *
+     * @covers ::getForFile
+     *
+     * @return void
+     */
+    public function testGetForFileWillReturnEmptyArrayForUnavailableKey()
+    {
+        $this->assertSame([], Cache::getForFile(self::$phpcsFile, 'Utility3'));
+    }
+
+    /**
+     * Test that previously cached data can be retrieved correctly.
+     *
+     * @dataProvider dataEveryTypeOfInput
+     *
+     * @covers ::get
+     *
+     * @param int|string $id       The ID of the cached value to retrieve.
+     * @param mixed      $expected The expected cached value.
+     *
+     * @return void
+     */
+    public function testGetWillRetrievedPreviouslySetValue($id, $expected)
+    {
+        if (\is_object($expected)) {
+            $this->assertEquals($expected, Cache::get(self::$phpcsFile, 'Utility1', $id));
+        } else {
+            $this->assertSame($expected, Cache::get(self::$phpcsFile, 'Utility1', $id));
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataEveryTypeOfInput()
+    {
+        $allTypes = TypeProviderHelper::getAll();
+        $data     = [];
+        foreach ($allTypes as $key => $dataset) {
+            $data[$key] = [
+                'id'       => $key,
+                'expected' => $dataset['input'],
+            ];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Test that the `getForFile()` method correctly retrieves a subset of the cached data.
+     *
+     * @covers ::getForFile
+     *
+     * @return void
+     */
+    public function testGetForFile()
+    {
+        $dataSet1 = Cache::getForFile(self::$phpcsFile, 'Utility1');
+        $dataSet2 = Cache::getForFile(self::$phpcsFile, 'Utility2');
+        $this->assertSame($dataSet1, $dataSet2);
+    }
+
+    /**
+     * Test that data cached during a previous loop will not be recognized once we're in a different loop.
+     *
+     * @covers ::isCached
+     *
+     * @return void
+     */
+    public function testIsCachedWillNotConfuseDataFromDifferentLoops()
+    {
+        $id = 50;
+
+        // Set an initial cache value and verify it is available.
+        Cache::set(self::$phpcsFile, __METHOD__, $id, 'Test value');
+
+        $this->assertTrue(
+            Cache::isCached(self::$phpcsFile, __METHOD__, $id),
+            'Cache::isCached() could not find the originally cached value'
+        );
+
+        self::$phpcsFile->fixer->enabled = true;
+        self::$phpcsFile->fixer->loops   = 2;
+
+        // Verify that the original cache is disregarded.
+        $this->assertFalse(
+            Cache::isCached(self::$phpcsFile, __METHOD__, $id),
+            'Cache::isCached() still found the originally cached value'
+        );
+    }
+
+    /**
+     * Test that data cached during a previous loop will not be returned once we're in a different loop.
+     *
+     * @covers ::get
+     *
+     * @return void
+     */
+    public function testGetWillNotConfuseDataFromDifferentLoops()
+    {
+        $id = 872;
+
+        // Set an initial cache value and verify it is available.
+        Cache::set(self::$phpcsFile, __METHOD__, $id, 'Test value');
+
+        $this->assertTrue(
+            Cache::isCached(self::$phpcsFile, __METHOD__, $id),
+            'Cache::isCached() could not find the originally cached value'
+        );
+
+        self::$phpcsFile->fixer->enabled = true;
+        self::$phpcsFile->fixer->loops   = 4;
+
+        // Verify that the original cache is disregarded.
+        $this->assertNull(
+            Cache::get(self::$phpcsFile, __METHOD__, $id),
+            'Cache::get() still returned the originally cached value'
+        );
+    }
+
+    /**
+     * Test that data cached during a previous loop will not be returned once we're in a different loop.
+     *
+     * @covers ::getForFile
+     *
+     * @return void
+     */
+    public function testGetForFileWillNotConfuseDataFromDifferentLoops()
+    {
+        $id = 233;
+
+        // Set an initial cache value and verify it is available.
+        Cache::set(self::$phpcsFile, __METHOD__, $id, 'Test value');
+
+        $this->assertTrue(
+            Cache::isCached(self::$phpcsFile, __METHOD__, $id),
+            'Cache::isCached() could not find the originally cached value'
+        );
+
+        self::$phpcsFile->fixer->enabled = true;
+        self::$phpcsFile->fixer->loops   = 1;
+
+        // Verify that the original cache is disregarded.
+        $this->assertSame(
+            [],
+            Cache::getForFile(self::$phpcsFile, __METHOD__),
+            'Cache::getForFile() still returned the originally cached value'
+        );
+    }
+
+    /**
+     * Test that previously cached data is no longer available when the cache has been cleared.
+     *
+     * @dataProvider dataEveryTypeOfInput
+     *
+     * @covers ::clear
+     *
+     * @param int|string $id The ID of the cached value to retrieve.
+     *
+     * @return void
+     */
+    public function testClearCache($id)
+    {
+        Cache::clear();
+
+        $this->assertFalse(Cache::isCached(self::$phpcsFile, 'Utility1', $id));
+        $this->assertFalse(Cache::isCached(self::$phpcsFile, 'Utility2', $id));
+    }
+}

--- a/Tests/Internal/Cache/SetTest.php
+++ b/Tests/Internal/Cache/SetTest.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Internal\Cache;
+
+use PHPCSUtils\Internal\Cache;
+use PHPCSUtils\Tests\TypeProviderHelper;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+
+/**
+ * Tests for the caching functionality.
+ *
+ * @group cache
+ *
+ * @covers \PHPCSUtils\Internal\Cache::isCached
+ * @covers \PHPCSUtils\Internal\Cache::get
+ * @covers \PHPCSUtils\Internal\Cache::set
+ *
+ * @since 1.0.0
+ */
+class SetTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Initialize PHPCS & tokenize the test case file.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        Cache::clear();
+        self::$caseFile = \dirname(\dirname(__DIR__)) . '/DummyFile.inc';
+        parent::setUpTestFile();
+    }
+
+    /**
+     * Clear the cache between tests and reset the base fixer loop.
+     *
+     * @after
+     *
+     * @return void
+     */
+    protected function clearCacheAndFixer()
+    {
+        Cache::clear();
+        self::$phpcsFile->fixer->enabled = false;
+        self::$phpcsFile->fixer->loops   = 0;
+    }
+
+    /**
+     * Test that every data type is accepted as a cachable value, including `null`, that the
+     * `Cache::isCached()` function recognizes a set value correctly and that all values can be retrieved.
+     *
+     * @dataProvider dataEveryTypeOfInput
+     *
+     * @param mixed $input Value to cache.
+     *
+     * @return void
+     */
+    public function testSetAcceptsEveryTypeOfInput($input)
+    {
+        $id = $this->getName();
+        Cache::set(self::$phpcsFile, __METHOD__, $id, $input);
+
+        $this->assertTrue(
+            Cache::isCached(self::$phpcsFile, __METHOD__, $id),
+            'Cache::isCached() could not find the cached value'
+        );
+
+        $this->assertSame(
+            $input,
+            Cache::get(self::$phpcsFile, __METHOD__, $id),
+            'Value retrieved via Cache::get() did not match expectations'
+        );
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataEveryTypeOfInput()
+    {
+        return TypeProviderHelper::getAll();
+    }
+
+    /**
+     * Verify that all supported types of IDs are accepted.
+     *
+     * Note: this doesn't test the unhappy path of passing an unsupported type of key, but
+     * non-int/string keys are not accepted by PHP for arrays anyway, so that should result
+     * in PHP warnings/errors anyway and as this is an internal class, I'm not too concerned
+     * about that kind of mistake being made.
+     *
+     * @dataProvider dataSetAcceptsIntAndStringIdKeys
+     *
+     * @param int|string $id ID for the cache.
+     *
+     * @return void
+     */
+    public function testSetAcceptsIntAndStringIdKeys($id)
+    {
+        $value = 'value' . $id;
+
+        Cache::set(self::$phpcsFile, __METHOD__, $id, $value);
+
+        $this->assertTrue(
+            Cache::isCached(self::$phpcsFile, __METHOD__, $id),
+            'Cache::isCached() could not find the cached value'
+        );
+
+        $this->assertSame(
+            $value,
+            Cache::get(self::$phpcsFile, __METHOD__, $id),
+            'Value retrieved via Cache::get() did not match expectations'
+        );
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataSetAcceptsIntAndStringIdKeys()
+    {
+        return [
+            'ID: int zero' => [
+                'id' => 0,
+            ],
+            'ID: positive int' => [
+                'id' => 12832,
+            ],
+            'ID: negative int' => [
+                'id' => -274,
+            ],
+            'ID: string' => [
+                'id' => 'string ID',
+            ],
+        ];
+    }
+
+    /**
+     * Verify that a previously set cached value will be overwritten when set() is called again
+     * with the same file, ID and key.
+     *
+     * @return void
+     */
+    public function testSetWillOverwriteExistingValue()
+    {
+        $id        = 'my key';
+        $origValue = 'original value';
+
+        Cache::set(self::$phpcsFile, __METHOD__, $id, $origValue);
+
+        // Verify that the original value was set correctly.
+        $this->assertTrue(
+            Cache::isCached(self::$phpcsFile, __METHOD__, $id),
+            'Cache::isCached() could not find the originally cached value'
+        );
+        $this->assertSame(
+            $origValue,
+            Cache::get(self::$phpcsFile, __METHOD__, $id),
+            'Original value retrieved via Cache::get() did not match expectations'
+        );
+
+        $newValue = 'new value';
+        Cache::set(self::$phpcsFile, __METHOD__, $id, $newValue);
+
+        // Verify the overwrite happened.
+        $this->assertTrue(
+            Cache::isCached(self::$phpcsFile, __METHOD__, $id),
+            'Cache::isCached() could not find the newly cached value'
+        );
+        $this->assertSame(
+            $newValue,
+            Cache::get(self::$phpcsFile, __METHOD__, $id),
+            'New value retrieved via Cache::get() did not match expectations'
+        );
+    }
+
+    /**
+     * Test that previously cached data is no longer available if the fixer has moved on to the next loop.
+     *
+     * @return void
+     */
+    public function testSetDoesNotClearCacheWhenFixerDisabled()
+    {
+        $idA = 50;
+        $idB = 52;
+
+        // Set an initial cache value and verify it is available.
+        Cache::set(self::$phpcsFile, __METHOD__, $idA, 'Test value');
+
+        $this->assertTrue(
+            Cache::isCached(self::$phpcsFile, __METHOD__, $idA),
+            'Cache::isCached() could not find the originally cached value'
+        );
+
+        // Changing loops without the fixer being available should have no effect.
+        self::$phpcsFile->fixer->loops = 5;
+        Cache::set(self::$phpcsFile, 'Another method', $idB, 'Test value');
+
+        // Verify the original cache is still available.
+        $this->assertTrue(
+            Cache::isCached(self::$phpcsFile, __METHOD__, $idA),
+            'Cache::isCached() could not find the originally cached value'
+        );
+        // ... as well as the newly cached value
+        $this->assertTrue(
+            Cache::isCached(self::$phpcsFile, 'Another method', $idB),
+            'Cache::isCached() could not find the newly cached value'
+        );
+    }
+
+    /**
+     * Test that previously cached data is no longer available if the fixer has moved on to the next loop.
+     *
+     * @return void
+     */
+    public function testSetClearsCacheOnDifferentLoop()
+    {
+        $idA = 123;
+        $idB = 276;
+
+        // Set an initial cache value and verify it is available.
+        Cache::set(self::$phpcsFile, __METHOD__, $idA, 'Test value');
+
+        $this->assertTrue(
+            Cache::isCached(self::$phpcsFile, __METHOD__, $idA),
+            'Cache::isCached() could not find the originally cached value'
+        );
+
+        // Set a different cache on a different loop, which should clear the original cache.
+        self::$phpcsFile->fixer->enabled = true;
+        self::$phpcsFile->fixer->loops   = 5;
+        Cache::set(self::$phpcsFile, 'Another method', $idB, 'Test value');
+
+        // Verify the original cache is no longer available.
+        $this->assertFalse(
+            Cache::isCached(self::$phpcsFile, __METHOD__, $idA),
+            'Cache::isCached() still found the originally cached value'
+        );
+    }
+}

--- a/Tests/Internal/NoFileCache/GetClearTest.php
+++ b/Tests/Internal/NoFileCache/GetClearTest.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Internal\NoFileCache;
+
+use PHPCSUtils\Internal\NoFileCache;
+use PHPCSUtils\Tests\TypeProviderHelper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the cache retrieval and cache clear methods.
+ *
+ * @group cache
+ *
+ * @coversDefaultClass \PHPCSUtils\Internal\NoFileCache
+ *
+ * @since 1.0.0
+ */
+class GetClearTest extends TestCase
+{
+
+    /**
+     * Fill the initial cache.
+     *
+     * @before
+     *
+     * @return void
+     */
+    protected function createCache()
+    {
+        NoFileCache::clear();
+
+        $data = TypeProviderHelper::getAll();
+        foreach ($data as $id => $dataset) {
+            NoFileCache::set('Utility1', $id, $dataset['input']);
+            NoFileCache::set('Utility2', $id, $dataset['input']);
+        }
+    }
+
+    /**
+     * Clear the cache between tests.
+     *
+     * @after
+     *
+     * @return void
+     */
+    protected function clearCache()
+    {
+        NoFileCache::clear();
+    }
+
+    /**
+     * Test that a cache key which has not been set is identified correctly as such.
+     *
+     * @covers ::isCached
+     *
+     * @return void
+     */
+    public function testIsCachedWillReturnFalseForUnavailableKey()
+    {
+        $this->assertFalse(NoFileCache::isCached('Utility3', 'numeric string'));
+    }
+
+    /**
+     * Test that a cache id which has not been set is identified correctly as such.
+     *
+     * @covers ::isCached
+     *
+     * @return void
+     */
+    public function testIsCachedWillReturnFalseForUnavailableId()
+    {
+        $this->assertFalse(NoFileCache::isCached('Utility1', 'this ID does not exist'));
+    }
+
+    /**
+     * Test that retrieving a cache key which has not been set, yields null.
+     *
+     * @covers ::get
+     *
+     * @return void
+     */
+    public function testGetWillReturnNullForUnavailableKey()
+    {
+        $this->assertNull(NoFileCache::get('Utility3', 'numeric string'));
+    }
+
+    /**
+     * Test that retrieving a cache id which has not been set, yields null.
+     *
+     * @covers ::get
+     *
+     * @return void
+     */
+    public function testGetWillReturnNullForUnavailableId()
+    {
+        $this->assertNull(NoFileCache::get('Utility1', 'this ID does not exist'));
+    }
+
+    /**
+     * Test that retrieving a cache set for a cache key which has not been set, yields an empty array.
+     *
+     * @covers ::getForKey
+     *
+     * @return void
+     */
+    public function testGetForKeyWillReturnEmptyArrayForUnavailableData()
+    {
+        $this->assertSame([], NoFileCache::getForKey('Utility3'));
+    }
+
+    /**
+     * Test that previously cached data can be retrieved correctly.
+     *
+     * @dataProvider dataEveryTypeOfInput
+     *
+     * @covers ::get
+     *
+     * @param int|string $id       The ID of the cached value to retrieve.
+     * @param mixed      $expected The expected cached value.
+     *
+     * @return void
+     */
+    public function testGetWillRetrievedPreviouslySetValue($id, $expected)
+    {
+        if (\is_object($expected)) {
+            $this->assertEquals($expected, NoFileCache::get('Utility1', $id));
+        } else {
+            $this->assertSame($expected, NoFileCache::get('Utility1', $id));
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataEveryTypeOfInput()
+    {
+        $allTypes = TypeProviderHelper::getAll();
+        $data     = [];
+        foreach ($allTypes as $key => $dataset) {
+            $data[$key] = [
+                'id'       => $key,
+                'expected' => $dataset['input'],
+            ];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Test that the `getForKey()` method correctly retrieves a subset of the cached data.
+     *
+     * @covers ::getForKey
+     *
+     * @return void
+     */
+    public function testGetForKey()
+    {
+        $dataSet1 = NoFileCache::getForKey('Utility1');
+        $dataSet2 = NoFileCache::getForKey('Utility2');
+        $this->assertSame($dataSet1, $dataSet2);
+    }
+
+    /**
+     * Test that previously cached data is no longer available when the cache has been cleared.
+     *
+     * @dataProvider dataEveryTypeOfInput
+     *
+     * @covers ::clear
+     *
+     * @param int|string $id The ID of the cached value to retrieve.
+     *
+     * @return void
+     */
+    public function testClearCache($id)
+    {
+        NoFileCache::clear();
+
+        $this->assertFalse(NoFileCache::isCached('Utility1', $id));
+        $this->assertFalse(NoFileCache::isCached('Utility2', $id));
+    }
+}

--- a/Tests/Internal/NoFileCache/SetTest.php
+++ b/Tests/Internal/NoFileCache/SetTest.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Internal\NoFileCache;
+
+use PHPCSUtils\Internal\NoFileCache;
+use PHPCSUtils\Tests\TypeProviderHelper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the file-independent caching functionality.
+ *
+ * @group cache
+ *
+ * @covers \PHPCSUtils\Internal\NoFileCache::isCached
+ * @covers \PHPCSUtils\Internal\NoFileCache::get
+ * @covers \PHPCSUtils\Internal\NoFileCache::set
+ *
+ * @since 1.0.0
+ */
+class SetTest extends TestCase
+{
+
+    /**
+     * Clear the cache between tests.
+     *
+     * @before
+     * @after
+     *
+     * @return void
+     */
+    protected function clearCache()
+    {
+        NoFileCache::clear();
+    }
+
+    /**
+     * Test that every data type is accepted as a cachable value, including `null`, that the
+     * `NoFileCache::isCached()` function recognizes a set value correctly and that all values can be retrieved.
+     *
+     * @dataProvider dataEveryTypeOfInput
+     *
+     * @param mixed $input Value to cache.
+     *
+     * @return void
+     */
+    public function testSetAcceptsEveryTypeOfInput($input)
+    {
+        $id = $this->getName();
+        NoFileCache::set(__METHOD__, $id, $input);
+
+        $this->assertTrue(
+            NoFileCache::isCached(__METHOD__, $id),
+            'NoFileCache::isCached() could not find the cached value'
+        );
+
+        $this->assertSame(
+            $input,
+            NoFileCache::get(__METHOD__, $id),
+            'Value retrieved via NoFileCache::get() did not match expectations'
+        );
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataEveryTypeOfInput()
+    {
+        return TypeProviderHelper::getAll();
+    }
+
+    /**
+     * Verify that all supported types of IDs are accepted.
+     *
+     * Note: this doesn't test the unhappy path of passing an unsupported type of key, but
+     * non-int/string keys are not accepted by PHP for arrays anyway, so that should result
+     * in PHP warnings/errors anyway and as this is an internal class, I'm not too concerned
+     * about that kind of mistake being made.
+     *
+     * @dataProvider dataSetAcceptsIntAndStringIdKeys
+     *
+     * @param int|string $id ID for the cache.
+     *
+     * @return void
+     */
+    public function testSetAcceptsIntAndStringIdKeys($id)
+    {
+        $value = 'value' . $id;
+
+        NoFileCache::set(__METHOD__, $id, $value);
+
+        $this->assertTrue(
+            NoFileCache::isCached(__METHOD__, $id),
+            'NoFileCache::isCached() could not find the cached value'
+        );
+
+        $this->assertSame(
+            $value,
+            NoFileCache::get(__METHOD__, $id),
+            'Value retrieved via NoFileCache::get() did not match expectations'
+        );
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataSetAcceptsIntAndStringIdKeys()
+    {
+        return [
+            'ID: int zero' => [
+                'id' => 0,
+            ],
+            'ID: positive int' => [
+                'id' => 12832,
+            ],
+            'ID: negative int' => [
+                'id' => -274,
+            ],
+            'ID: string' => [
+                'id' => 'string ID',
+            ],
+        ];
+    }
+
+    /**
+     * Verify that a previously set cached value will be overwritten when set() is called again
+     * with the same file, ID and key.
+     *
+     * @return void
+     */
+    public function testSetWillOverwriteExistingValue()
+    {
+        $id        = 'my key';
+        $origValue = 'original value';
+
+        NoFileCache::set(__METHOD__, $id, $origValue);
+
+        // Verify that the original value was set correctly.
+        $this->assertTrue(
+            NoFileCache::isCached(__METHOD__, $id),
+            'NoFileCache::isCached() could not find the originally cached value'
+        );
+        $this->assertSame(
+            $origValue,
+            NoFileCache::get(__METHOD__, $id),
+            'Original value retrieved via NoFileCache::get() did not match expectations'
+        );
+
+        $newValue = 'new value';
+        NoFileCache::set(__METHOD__, $id, $newValue);
+
+        // Verify the overwrite happened.
+        $this->assertTrue(
+            NoFileCache::isCached(__METHOD__, $id),
+            'NoFileCache::isCached() could not find the newly cached value'
+        );
+        $this->assertSame(
+            $newValue,
+            NoFileCache::get(__METHOD__, $id),
+            'New value retrieved via NoFileCache::get() did not match expectations'
+        );
+    }
+}

--- a/Tests/TypeProviderHelper.php
+++ b/Tests/TypeProviderHelper.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests;
+
+use ArrayIterator;
+use EmptyIterator;
+use stdClass;
+
+/**
+ * Helper class to provide an exhaustive list of types to test type safety/type support.
+ *
+ * @phpcs:disable Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned -- If needed, fix once replaced by better sniff.
+ */
+final class TypeProviderHelper
+{
+
+    /**
+     * Retrieve an array in data provider format with all typical PHP data types (with the exception of resources).
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public static function getAll()
+    {
+        return [
+            'null' => [
+                'input' => null,
+            ],
+            'boolean false' => [
+                'input' => false,
+            ],
+            'boolean true' => [
+                'input' => true,
+            ],
+            'integer 0' => [
+                'input' => 0,
+            ],
+            'negative integer' => [
+                'input' => -123,
+            ],
+            'positive integer' => [
+                'input' => 786687,
+            ],
+            'float 0.0' => [
+                'input' => 0.0,
+            ],
+            'negative float' => [
+                'input' => 5.600e-3,
+            ],
+            'positive float' => [
+                'input' => 124.7,
+            ],
+            'empty string' => [
+                'input' => '',
+            ],
+            'numeric string' => [
+                'input' => '123',
+            ],
+            'textual string' => [
+                'input' => 'foobar',
+            ],
+            'textual string starting with numbers' => [
+                'input' => '123 My Street',
+            ],
+            'empty array' => [
+                'input' => [],
+            ],
+            'array with values, no keys' => [
+                'input' => [1, 2, 3],
+            ],
+            'array with values, string keys' => [
+                'input' => ['a' => 1, 'b' => 2],
+            ],
+            'plain object' => [
+                'input' => new stdClass(),
+            ],
+            'ArrayIterator object' => [
+                'input' => new ArrayIterator([1, 2, 3]),
+            ],
+            'Iterator object, no array access' => [
+                'input' => new EmptyIterator(),
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/Lists/IsShortArrayOrListTest.php
+++ b/Tests/Utils/Lists/IsShortArrayOrListTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\Utils\Arrays;
 
+use PHPCSUtils\Internal\Cache;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\Lists;
@@ -437,5 +438,73 @@ class IsShortArrayOrListTest extends UtilityMethodTestCase
                 ],
             ],
         ];
+    }
+
+    /**
+     * Verify that the build-in caching is used when caching is enabled.
+     *
+     * @covers \PHPCSUtils\Utils\Arrays::isShortArray
+     *
+     * @return void
+     */
+    public function testIsShortArrayResultIsCached()
+    {
+        $methodName = 'PHPCSUtils\\Utils\\Arrays::isShortArray';
+        $cases      = $this->dataIsShortArrayOrList();
+        $testMarker = $cases['short-array-in-foreach'][0];
+        $expected   = $cases['short-array-in-foreach'][1]['array'];
+
+        $stackPtr = $this->getTargetToken($testMarker, \T_OPEN_SHORT_ARRAY);
+
+        // Verify the caching works.
+        $origStatus     = Cache::$enabled;
+        Cache::$enabled = true;
+
+        $resultFirstRun  = Arrays::isShortArray(self::$phpcsFile, $stackPtr);
+        $isCached        = Cache::isCached(self::$phpcsFile, $methodName, $stackPtr);
+        $resultSecondRun = Arrays::isShortArray(self::$phpcsFile, $stackPtr);
+
+        if ($origStatus === false) {
+            Cache::clear();
+        }
+        Cache::$enabled = $origStatus;
+
+        $this->assertSame($expected, $resultFirstRun, 'First result did not match expectation');
+        $this->assertTrue($isCached, 'Cache::isCached() could not find the cached value');
+        $this->assertSame($resultFirstRun, $resultSecondRun, 'Second result did not match first');
+    }
+
+    /**
+     * Verify that the build-in caching is used when caching is enabled.
+     *
+     * @covers \PHPCSUtils\Utils\Lists::isShortList
+     *
+     * @return void
+     */
+    public function testIsShortListResultIsCached()
+    {
+        $methodName = 'PHPCSUtils\\Utils\\Lists::isShortList';
+        $cases      = $this->dataIsShortArrayOrList();
+        $testMarker = $cases['short-list-with-nesting-and-keys'][0];
+        $expected   = $cases['short-list-with-nesting-and-keys'][1]['list'];
+
+        $stackPtr = $this->getTargetToken($testMarker, \T_OPEN_SHORT_ARRAY);
+
+        // Verify the caching works.
+        $origStatus     = Cache::$enabled;
+        Cache::$enabled = true;
+
+        $resultFirstRun  = Lists::isShortList(self::$phpcsFile, $stackPtr);
+        $isCached        = Cache::isCached(self::$phpcsFile, $methodName, $stackPtr);
+        $resultSecondRun = Lists::isShortList(self::$phpcsFile, $stackPtr);
+
+        if ($origStatus === false) {
+            Cache::clear();
+        }
+        Cache::$enabled = $origStatus;
+
+        $this->assertSame($expected, $resultFirstRun, 'First result did not match expectation');
+        $this->assertTrue($isCached, 'Cache::isCached() could not find the cached value');
+        $this->assertSame($resultFirstRun, $resultSecondRun, 'Second result did not match first');
     }
 }

--- a/Tests/Utils/PassedParameters/GetParametersWithLimitTest.inc
+++ b/Tests/Utils/PassedParameters/GetParametersWithLimitTest.inc
@@ -25,3 +25,31 @@ $foo = [
     'f' => 6,
     'g' => true,
 ];
+
+/*
+ * NOTE: the below test code is duplicate, but the cache tests need unique $stackPtrs to
+ * prevent the result of earlier tests poluting the results of the caching tests.
+ */
+
+/* testCachedWithLimit */
+$foo = array( 1, 2, 3, 4, 5, 6, true );
+
+/* testCachedWithoutLimitWhenTotalItemsLessThanLimit */
+$foo = array( 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5, 'f' => 6, 'g' => true )
+
+/* testCachedWithoutLimitWhenTotalItemsEqualsLimit */
+$foo = [
+    'a' => 1,
+    'b' => 2,
+    'c' => 3,
+    'd' => 4,
+    'e' => 5,
+    'f' => 6,
+    'g' => true,
+];
+
+/* testRetrievedFromCacheWhenCachePreviouslySetWithoutLimit */
+myfunction( 1, 2, 3, 4, 5, 6, true );
+
+/* testRetrievedFromScratchIfNoSuitableCacheFound */
+myfunction( 1, 2, 3, 4, 5, 6, true );

--- a/Tests/Utils/PassedParameters/GetParametersWithLimitTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersWithLimitTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\Utils\PassedParameters;
 
+use PHPCSUtils\Internal\Cache;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -168,5 +169,202 @@ class GetParametersWithLimitTest extends UtilityMethodTestCase
                 'limit'      => 4,
             ],
         ];
+    }
+
+    /**
+     * Verify that the build-in caching is used when caching is enabled and that the caching keeps track
+     * of the used limit.
+     *
+     * @return void
+     */
+    public function testResultIsCachedWithLimit()
+    {
+        // Can't re-use test cases for these tests, as in that case, the cache _may_ already be set (for 0 limit).
+        $methodName = 'PHPCSUtils\\Utils\\PassedParameters::getParameters';
+        $testMarker = '/* testCachedWithLimit */';
+        $stackPtr   = $this->getTargetToken($testMarker, \T_ARRAY);
+        $limit      = 1;
+        $expected   = [
+            1 => [
+                'start' => 2 + $stackPtr,
+                'end'   => 3 + $stackPtr,
+                'raw'   => '1',
+                'clean' => '1',
+            ],
+        ];
+
+        // Verify the caching works.
+        $origStatus     = Cache::$enabled;
+        Cache::$enabled = true;
+
+        $resultFirstRun  = PassedParameters::getParameters(self::$phpcsFile, $stackPtr, $limit);
+        $isCached        = Cache::isCached(self::$phpcsFile, $methodName, "$stackPtr-$limit");
+        $resultSecondRun = PassedParameters::getParameters(self::$phpcsFile, $stackPtr, $limit);
+
+        if ($origStatus === false) {
+            Cache::clear();
+        }
+        Cache::$enabled = $origStatus;
+
+        $this->assertSame($expected, $resultFirstRun, 'First result did not match expectation');
+        $this->assertTrue($isCached, 'Cache::isCached() could not find the cached value');
+        $this->assertSame($resultFirstRun, $resultSecondRun, 'Second result did not match first');
+    }
+
+    /**
+     * Verify that when a previous query for the same token was made with a limit which was more than
+     * the item count, the result was cached as if no limit was set.
+     *
+     * @return void
+     */
+    public function testResultIsCachedWithoutLimitWhenTotalItemsLessThanLimit()
+    {
+        // Can't re-use test cases for these tests, as in that case, the cache _may_ already be set (for 0 limit).
+        $methodName = 'PHPCSUtils\\Utils\\PassedParameters::getParameters';
+        $testMarker = '/* testCachedWithoutLimitWhenTotalItemsLessThanLimit */';
+        $stackPtr   = $this->getTargetToken($testMarker, \T_ARRAY);
+
+        // Verify the caching works.
+        $origStatus     = Cache::$enabled;
+        Cache::$enabled = true;
+
+        $resultFirstRun       = PassedParameters::getParameters(self::$phpcsFile, $stackPtr, 10);
+        $isCachedWithLimit    = Cache::isCached(self::$phpcsFile, $methodName, "$stackPtr-10");
+        $isCachedWithoutLimit = Cache::isCached(self::$phpcsFile, $methodName, "$stackPtr-0");
+        $resultSecondRun      = PassedParameters::getParameters(self::$phpcsFile, $stackPtr, 10);
+
+        if ($origStatus === false) {
+            Cache::clear();
+        }
+        Cache::$enabled = $origStatus;
+
+        $this->assertCount(7, $resultFirstRun, 'Count of first result did not match expectation');
+        $this->assertFalse($isCachedWithLimit, 'Cache::isCached() found a cached value with key "ptr-10"');
+        $this->assertTrue($isCachedWithoutLimit, 'Cache::isCached() did not find a cached value with key "ptr-0"');
+        $this->assertCount(7, $resultSecondRun, 'Count of second result did not match expectation');
+    }
+
+    /**
+     * Verify that when a previous query for the same token was made with a limit which matched the item count,
+     * the result was cached as if no limit was set.
+     *
+     * @return void
+     */
+    public function testResultIsCachedWithoutLimitWhenTotalItemsEqualsLimit()
+    {
+        // Can't re-use test cases for these tests, as in that case, the cache _may_ already be set (for 0 limit).
+        $methodName = 'PHPCSUtils\\Utils\\PassedParameters::getParameters';
+        $testMarker = '/* testCachedWithoutLimitWhenTotalItemsEqualsLimit */';
+        $stackPtr   = $this->getTargetToken($testMarker, \T_OPEN_SHORT_ARRAY);
+
+        // Verify the caching works.
+        $origStatus     = Cache::$enabled;
+        Cache::$enabled = true;
+
+        $resultFirstRun       = PassedParameters::getParameters(self::$phpcsFile, $stackPtr, 7);
+        $isCachedWithLimit    = Cache::isCached(self::$phpcsFile, $methodName, "$stackPtr-7");
+        $isCachedWithoutLimit = Cache::isCached(self::$phpcsFile, $methodName, "$stackPtr-0");
+        $resultSecondRun      = PassedParameters::getParameters(self::$phpcsFile, $stackPtr, 7);
+
+        if ($origStatus === false) {
+            Cache::clear();
+        }
+        Cache::$enabled = $origStatus;
+
+        $this->assertCount(7, $resultFirstRun, 'Count of first result did not match expectation');
+        $this->assertFalse($isCachedWithLimit, 'Cache::isCached() found a cached value with key "ptr-7"');
+        $this->assertTrue($isCachedWithoutLimit, 'Cache::isCached() did not find a cached value with key "ptr-0"');
+        $this->assertCount(7, $resultSecondRun, 'Count of second result did not match expectation');
+    }
+
+    /**
+     * Verify that when a previous query for the same token without limit was made, the result
+     * cache is used to retrieve the limited result.
+     *
+     * @return void
+     */
+    public function testResultIsRetrievedFromCacheWhenCachePreviouslySetWithoutLimit()
+    {
+        // Can't re-use test cases for these tests, as in that case, the cache _may_ already be set (for 0 limit).
+        $methodName = 'PHPCSUtils\\Utils\\PassedParameters::getParameters';
+        $testMarker = '/* testRetrievedFromCacheWhenCachePreviouslySetWithoutLimit */';
+        $stackPtr   = $this->getTargetToken($testMarker, \T_STRING);
+        $limit      = 2;
+        $expected   = [
+            1 => [
+                'start' => 2 + $stackPtr,
+                'end'   => 3 + $stackPtr,
+                'raw'   => '1',
+                'clean' => '1',
+            ],
+            2 => [
+                'start' => 5 + $stackPtr,
+                'end'   => 6 + $stackPtr,
+                'raw'   => '2',
+                'clean' => '2',
+            ],
+        ];
+
+        // Verify the caching works.
+        $origStatus     = Cache::$enabled;
+        Cache::$enabled = true;
+
+        $resultFirstRun  = PassedParameters::getParameters(self::$phpcsFile, $stackPtr);
+        $isCached        = Cache::isCached(self::$phpcsFile, $methodName, "$stackPtr-0");
+        $resultSecondRun = PassedParameters::getParameters(self::$phpcsFile, $stackPtr, $limit);
+
+        if ($origStatus === false) {
+            Cache::clear();
+        }
+        Cache::$enabled = $origStatus;
+
+        $this->assertCount(7, $resultFirstRun, 'Count of first result did not match expectation');
+        $this->assertTrue($isCached, 'Cache::isCached() did not find a cached value with key "ptr-0"');
+        $this->assertSame($expected, $resultSecondRun, 'Second result did not match the expected result');
+    }
+
+    /**
+     * Verify that when a previous query for the same token was made with a limit which was less than the total
+     * number of items and the current limit does not match, the function will not use the cache.
+     *
+     * @return void
+     */
+    public function testResultIsRetrievedFromScratchIfNoSuitableCacheFound()
+    {
+        static $firstRun = true;
+
+        // Can't re-use test cases for this test, as in that case, the cache _may_ already be set (for 0 limit).
+        $methodName = 'PHPCSUtils\\Utils\\PassedParameters::getParameters';
+        $testMarker = '/* testRetrievedFromScratchIfNoSuitableCacheFound */';
+        $stackPtr   = $this->getTargetToken($testMarker, \T_STRING);
+
+        // Verify the caching works.
+        $origStatus     = Cache::$enabled;
+        Cache::$enabled = true;
+
+        $resultFirstRun         = PassedParameters::getParameters(self::$phpcsFile, $stackPtr, 2);
+        $isCachedWithLimit2     = Cache::isCached(self::$phpcsFile, $methodName, "$stackPtr-2");
+        $isCachedWithLimit4pre  = Cache::isCached(self::$phpcsFile, $methodName, "$stackPtr-4");
+        $isCachedWithoutLimit   = Cache::isCached(self::$phpcsFile, $methodName, "$stackPtr-0");
+        $resultSecondRun        = PassedParameters::getParameters(self::$phpcsFile, $stackPtr, 4);
+        $isCachedWithLimit4post = Cache::isCached(self::$phpcsFile, $methodName, "$stackPtr-4");
+
+        if ($origStatus === false) {
+            Cache::clear();
+        }
+        Cache::$enabled = $origStatus;
+
+        $this->assertCount(2, $resultFirstRun, 'Count of first result did not match expectation');
+        $this->assertTrue($isCachedWithLimit2, 'Cache::isCached() did not find a cached value with key "ptr-2"');
+        if ($firstRun === true) {
+            $this->assertFalse($isCachedWithLimit4pre, 'Cache::isCached() found a cached value with key "ptr-4"');
+        } else {
+            $this->assertTrue($isCachedWithLimit4pre, 'Cache::isCached() did not find a cached value with key "ptr-4"');
+        }
+        $this->assertFalse($isCachedWithoutLimit, 'Cache::isCached() found a cached value with key "ptr-0"');
+        $this->assertCount(4, $resultSecondRun, 'Count of second result did not match expectation');
+        $this->assertTrue($isCachedWithLimit4post, 'Cache::isCached() did not find a cached value with key "ptr-4"');
+
+        $firstRun = false;
     }
 }

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -14,6 +14,9 @@
 
 namespace PHPCSUtils\Tests;
 
+use PHPCSUtils\Internal\Cache;
+use PHPCSUtils\Internal\NoFileCache;
+
 if (\defined('PHP_CODESNIFFER_IN_TESTS') === false) {
     \define('PHP_CODESNIFFER_IN_TESTS', true);
 }
@@ -124,4 +127,24 @@ if (\defined('__PHPUNIT_PHAR__')) {
  */
 require_once \dirname(__DIR__) . '/phpcsutils-autoload.php';
 
-unset($phpcsDir, $vendorDir);
+/*
+ * Determine whether to run the test suite with caching enabled or disabled.
+ *
+ * Use `<php><env name="PHPCSUTILS_USE_CACHE" value="On|Off"/></php>` in a `phpunit.xml` file
+ * or set the ENV variable on an OS-level.
+ *
+ * If the ENV variable has not been set, the tests will run with caching turned OFF.
+ */
+if (\defined('PHPCSUTILS_USE_CACHE') === false) {
+    $useCache = \getenv('PHPCSUTILS_USE_CACHE');
+    if ($useCache === false) {
+        Cache::$enabled       = false;
+        NoFileCache::$enabled = false;
+    } else {
+        $useCache             = \filter_var($useCache, \FILTER_VALIDATE_BOOLEAN);
+        Cache::$enabled       = $useCache;
+        NoFileCache::$enabled = $useCache;
+    }
+}
+
+unset($phpcsDir, $vendorDir, $useCache);

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7"
     },
     "require-dev" : {
+        "ext-filter": "*",
         "php-parallel-lint/php-parallel-lint": "^1.3.2",
         "php-parallel-lint/php-console-highlighter": "^1.0",
         "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,14 @@
     <testsuites>
         <testsuite name="RunFirst">
             <!--
+            Run caching tests separately as they will clear the caches.
+            -->
+            <file>./Tests/Internal/Cache/GetClearTest.php</file>
+            <file>./Tests/Internal/Cache/SetTest.php</file>
+            <file>./Tests/Internal/NoFileCache/GetClearTest.php</file>
+            <file>./Tests/Internal/NoFileCache/SetTest.php</file>
+
+            <!--
             A number of tests need process isolation to allow for recording code coverage on
             the setting of function local static variables.
             However, using process isolation runs into trouble with PHPUnit 4.x/PHPCS 2.6.0.
@@ -31,6 +39,12 @@
         </testsuite>
         <testsuite name="PHPCSUtils">
             <directory suffix="Test.php">./Tests/</directory>
+
+            <exclude>Tests/Internal/Cache/GetClearTest.php</exclude>
+            <exclude>Tests/Internal/Cache/SetTest.php</exclude>
+            <exclude>Tests/Internal/NoFileCache/GetClearTest.php</exclude>
+            <exclude>Tests/Internal/NoFileCache/SetTest.php</exclude>
+
             <exclude>Tests/BackCompat/BCTokens/EmptyTokensTest.php</exclude>
             <exclude>Tests/Utils/Namespaces/NamespaceTypeTest.php</exclude>
             <exclude>Tests/Utils/Numbers/GetCompleteNumberTest.php</exclude>


### PR DESCRIPTION
### Tests: add TypeProviderHelper class

Based on a similar class I wrote for the [Requests library](https://github.com/WordPress/Requests/pull/710/commits/1f94fb8aed52ecb7365a732dd587ad33b9c56b13).

If/when that class get published as a package, this class should be removed in favour of the package.

### ✨ New (internal) Cache and NoFileCache classes

... to allow for caching the results of processing intensive utility methods.

The `Cache` class is intended to be used for utility functions which depend on the `$phpcsFile` object.
The `NoFileCache` class is for file-independent functions.

Use selectively and with care as the memory usage of PHPCS will increase when using these caches!

Includes full set of tests to cover this new functionality.

These new tests have been added to the `RunFirst` test suite to prevent the cache setting and clearing done in these tests from interfering with the rest of the tests.

### [NoFile]Cache: allow for disabling the cache in test situations

Includes:
* Additional tests to cover this change on the off-chance that someone will use this functionality in a non-test situation.
* Making sure that the tests related to the `[NoFile]Cache` classes will always run with caching turned **on** as running the cache functionality tests without caching enabled is a little pointless (and would fail the tests).

### ControlStructures::getDeclareScopeOpenClose(): implement use of the new `Cache` class

As `declare` constructs using alternative syntax can be long, determining the scope opener/closer can involve a lot of token walking, which is why I'm implementing caching for it.

Includes some minor tweaks to the exit routes of the function to ensure that the cache will always be set when the `T_DECLARE` token doesn't natively have a scope opener/closer assigned.

Includes a dedicated test to verify the cache is used and working.

### FunctionDeclarations::getArrowFunctionOpenClose(): implement use of the new `Cache` class

While arrow functions are generally only small snippets of code, as they don't always have a clear "end token", determining whether something is an arrow function and retrieving the relevant open/close tokens can be token-walking intensive, which is why I'm implementing caching for it.

Note: the results will only be cached for the backported functionality. When using a more recent PHPCS version, the cache code will only be reached in the case of parse errors.

Includes a dedicated test to verify the cache is used and working.

### Namespaces::findNamespacePtr(): implement use of the new `Cache` class

This method searches up in a file to try and find an applicable namespace declaration.
As non-scoped namespace declarations are often at the top of the file, this can involve a **_lot_** of token walking, which is why I'm implementing caching for it.

Includes some minor tweaks to the exit routes of the function to ensure that the cache will always be set when the token passed is not in a scoped namespace declaration.

Includes a dedicated test to verify the cache is used and working.

### PassedParameters::getParameters(): implement use of the new `Cache` class

While most function calls only involve a few parameters, splitting out an array into the individual array items can be very processing intense and will slow things down considerably when multiple sniffs each need the break down of the same array.

With this in mind, I'm implementing caching for it.

The saved cache can be quite large for calls to this function, at the same time, the trade off performance-wise is worth it in this case IMO.

Note: as this function can be called with a `$limit`, we need to be able to distinguish between "limited" results and "full" results, but should also take advantage of available "full" results when a consecutive function call tries to retrieve a "limited" result.

The implementation takes this into account, though the situation where a "limited" result was previously retrieved (and cached), and new "limited" call is made with a _lower_ limit currently does not take full advantage of the available cache. This is possibly an improvement which can still be made in the future.

Includes a set of dedicated tests to verify the cache is used and working, including testing specifically how the cache is set and used when the `$limit` parameter has been passed.

### TextStrings::getEndOfCompleteTextString(): implement use of the new `Cache` class

This method finds the end of a potentially multi-line text string.
While most text strings are short and even multi-line ones are often only a few lines, some can be thousands of lines long.
With that in mind, I'm implementing caching for this method.

I've considered also applying caching for the `TextStrings::getCompleteTextString()` method, but as - in the case of thousands of lines long text - that would take a huge chunk of memory, I've decided against it.
Caching the "end token" of a multi-line text string should sufficiently improve performance.

Includes a dedicated test to verify the cache is used and working.

### UseStatements::splitImportUseStatement(): implement use of the new `Cache` class

Depending on whether or not group use or multi-use statements are used, this method can involve sufficient token walking to make caching relevant.
Especially when keeping in mind that this function will likely be used a **_lot_** in the near future as part of the namespace resolution functionality, so retrieving the results via the cache instead of executing the same logic dozens of times for a file, seem prudent.

Includes a dedicated test to verify the cache is used and working.

### Arrays::getDoubleArrowPtr(): implement use of the new `Cache` class

While this function will generally be _fast_ for array entries _with_ a double arrow, it will be _slow_ for array entries without a double arrow, especially if the contents of the array item contains a lot of tokens as the fact that the array item does not have a double arrow can only be determined when the end of the array item has been reached.
With this in mind, I'm implementing caching for it.

Includes some minor tweaks to the exit routes of the function to ensure that the cache will always be set.

Includes a dedicated test to verify the cache is used and working.

### Lists::getAssignments(): implement use of the new `Cache` class

While most list only involve a few assignment, for more complex and nested list structures, splitting the list into the individual assignments can tax performance, which is why I'm implementing caching for it.

Includes a dedicated test to verify the cache is used and working.

### Arrays::isShortArray()/Lists::isShortList(): implement use of the new `Cache` class

These are easily the most used functions as well as the slowest functions (when dealing with large arrays/lists).

While this commit already implements the use of the new `Cache` class, further improvements are still needed and will be pulled in a follow-up PR.

Note: code coverage for these functions _may_ go down a little due to the multiple exit points in the functions. I'm not concerned about that as that - again - will be addressed in the follow-up PR.

Includes a dedicated test to verify the cache is used and working.

### TextStrings::getStripEmbeds(): implement use of the new `NoFileCache` class

Depending on the size of the text string, this function _could_ become pretty slow/performance intense, which is why I'm implementing caching for it.

Includes a dedicated test to verify the cache is used and working.

### Tests/bootstrap: allow for running the tests with/without caching

This commit sets up a mechanism in the test `bootstrap.php` file to turn the cache on/off depending on an environment variable, which can be set from within a `phpunit.xml` file or on the OS-level.

This allows for running the tests both with caching turned on, as well as with caching turned off.

By default, the tests will run with caching turned **off**.

Being able to run the tests with both settings will allow for:
* [Caching off] Making sure that all code paths can be reached (code coverage check). Caching being enabled could prevent some code paths from being tested.
* [Caching on] Making sure that caching does not (negatively) impact the actual results of the functions.

### GH Actions: run the tests twice - once with cache, once without

Adjust the GH actions test workflows to run the complete test suite once with the cache turned on and once with the cache turned off.

The test run with caching turned on will run the tests twice and only run the tests which don't need isolation.
This should safeguard that the cache does not negatively influence sniff results.

The code coverage job will (should) run with caching turned _off_ to prevent tests not reaching all code paths due to cached results from previous tests short-circuiting things.

Note: the effect of caching on the test suite will be minimal as most tests will only execute a function once for a particular input/code snippet. Still good to safeguard/double-check though.