### PR TITLE
Tests: minor tweaks to allow for running tests on repeat

### DIFF
--- a/Tests/Tokens/TokenHelper/TokenExistsTest.php
+++ b/Tests/Tokens/TokenHelper/TokenExistsTest.php
@@ -33,7 +33,9 @@ class TokenExistsTest extends TestCase
      */
     public static function setUpConstants()
     {
-        \define('T_FAKETOKEN', -5);
+        if (\defined('T_FAKETOKEN') === false) {
+            \define('T_FAKETOKEN', -5);
+        }
     }
 
     /**

--- a/Tests/Utils/FunctionDeclarations/IsArrowFunction2926Test.php
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunction2926Test.php
@@ -95,6 +95,18 @@ class IsArrowFunction2926Test extends UtilityMethodTestCase
     }
 
     /**
+     * Reset static properties to their default value after the tests have finished.
+     *
+     * @afterClass
+     *
+     * @return void
+     */
+    public static function resetProperties()
+    {
+        self::$tokenized = false;
+    }
+
+    /**
      * Test correctly detecting arrow functions.
      *
      * @dataProvider dataArrowFunction


### PR DESCRIPTION
... using the PHPUnit `--repeat` option.

Note: this option was already available in PHPUnit 4.x, so can be safely used for this codebase.

The changes made:
* Prevent "constant already defined notices" on repeated test runs.
* Prevent a file from not being tokenized on repeated test runs.

Ref:
* https://phpunit.readthedocs.io/en/9.5/textui.html