### PR TITLE
Operators::isUnaryPlusMinus(): allow for match control structures

### DIFF
--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -440,6 +440,7 @@ class Operators
             || isset(Tokens::$castTokens[$tokens[$prev]['code']]) === true
             || isset(self::$extraUnaryIndicators[$tokens[$prev]['code']]) === true
             || $tokens[$prev]['type'] === 'T_FN_ARROW'
+            || $tokens[$prev]['type'] === 'T_MATCH_ARROW'
         ) {
             return true;
         }

--- a/Tests/Utils/Operators/IsUnaryPlusMinusTest.inc
+++ b/Tests/Utils/Operators/IsUnaryPlusMinusTest.inc
@@ -141,6 +141,15 @@ switch ($a) {
 /* testUnaryMinusArrowFunction */
 $fn = static fn(DateTime $a, DateTime $b): int => -($a->getTimestamp() <=> $b->getTimestamp());
 
+$matcher = match ($a) {
+    /* testUnaryPlusMatchArrow */
+    'a' => +1,
+    /* testUnaryMinusMatchArrow */
+    'b', 'c', 'd' => -2,
+    /* testUnaryMinusMatchDefault */
+    default => -3,
+};
+
 // Testing `$a = -+-+10`;
 $a =
     /* testSequenceNonUnary1 */

--- a/Tests/Utils/Operators/IsUnaryPlusMinusTest.php
+++ b/Tests/Utils/Operators/IsUnaryPlusMinusTest.php
@@ -278,6 +278,18 @@ class IsUnaryPlusMinusTest extends UtilityMethodTestCase
                 'testMarker' => '/* testUnaryMinusArrowFunction */',
                 'expected'   => true,
             ],
+            'unary-plus-match-arrow' => [
+                'testMarker' => '/* testUnaryPlusMatchArrow */',
+                'expected'   => true,
+            ],
+            'unary-minus-match-arrow' => [
+                'testMarker' => '/* testUnaryMinusMatchArrow */',
+                'expected'   => true,
+            ],
+            'unary-minus-match-default' => [
+                'testMarker' => '/* testUnaryMinusMatchDefault */',
+                'expected'   => true,
+            ],
             'operator-sequence-non-unary-1' => [
                 'testMarker' => '/* testSequenceNonUnary1 */',
                 'expected'   => false,


### PR DESCRIPTION
Operators::isUnaryPlusMinus(): allow for match control structures

The double arrow in PHP 8.0 match control structures has its own `T_MATCH_ARROW` token.
This token needs to be taken into account when determining if a plus/minus token is unary or arithmetic.

This token was introduced in PHPCS 3.6.0 and will be tokenized as `T_DOUBLE_ARROW` for older PHPCS versions.
The method already looks for `T_DOUBLE_ARROW` before the operator, so checking for `T_MATCH_ARROW` solely based on token type will handle match arrow tokens in a PHPCS-cross-version compatible manner.

Ref: squizlabs/PHP_CodeSniffer#3653