### PR TITLE
ControlStructures::getDeclareScopeOpenClose(): support closing the declare statement with PHP close tag

### DIFF
--- a/PHPCSUtils/Utils/ControlStructures.php
+++ b/PHPCSUtils/Utils/ControlStructures.php
@@ -326,6 +326,7 @@ class ControlStructures
                         break;
 
                     case \T_SEMICOLON:
+                    case \T_CLOSE_TAG:
                         // Nested single line declare statement.
                         --$declareCount;
                         break;

--- a/Tests/Utils/ControlStructures/GetDeclareScopeOpenCloseTest.inc
+++ b/Tests/Utils/ControlStructures/GetDeclareScopeOpenCloseTest.inc
@@ -48,6 +48,24 @@ declare(ticks=1) :
     }
 enddeclare;
 
+/* testMultiDirectiveFileScope */
+declare(strict_types=1, encoding='UTF-8');
+
+/* testMultiDirectiveBraces */
+declare(strict_types=1, encoding='UTF-8') {
+    // entire script here
+}
+
+/* testMultiDirectiveAltSyntax */
+declare(strict_types=1, encoding='UTF-8'):
+    // entire script here
+enddeclare;
+
+/* testPHPCloseTag */
+?>
+<?php declare(ticks=1) ?>
+<?php
+
 /* testLiveCoding */
 // Intentional parse error.
 declare(ticks=1

--- a/Tests/Utils/ControlStructures/GetDeclareScopeOpenCloseTest.php
+++ b/Tests/Utils/ControlStructures/GetDeclareScopeOpenCloseTest.php
@@ -163,6 +163,30 @@ class GetDeclareScopeOpenCloseTest extends UtilityMethodTestCase
                 'expected'   => false,
             ],
 
+            'multi-directive-file-scoped' => [
+                'testMarker' => '/* testMultiDirectiveFileScope */',
+                'expected'   => false,
+            ],
+            'multi-directive-brace-scoped' => [
+                'testMarker' => '/* testMultiDirectiveBraces */',
+                'expected'   => [
+                    'opener' => 12,
+                    'closer' => 16,
+                ],
+            ],
+            'multi-directive-alt-syntax' => [
+                'testMarker' => '/* testMultiDirectiveAltSyntax */',
+                'expected'   => [
+                    'opener' => 11,
+                    'closer' => 15,
+                ],
+            ],
+
+            'php-close-tag' => [
+                'testMarker' => '/* testPHPCloseTag */',
+                'expected'   => false,
+            ],
+
             'live-coding' => [
                 'testMarker' => '/* testLiveCoding */',
                 'expected'   => false,


### PR DESCRIPTION
... and also add tests to confirm that "multi-directive" statements are handled correctly.

Loosely related to #339 