### PR TITLE
GH Actions: try a work-around for weird Coveralls results

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -350,3 +350,16 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
+
+  coveralls-rerun:
+    needs: coveralls-finish
+    if: always() && needs.coverage.result == 'success'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # See: https://github.com/lemurheavy/coveralls-public/issues/1631
+      - name: Rerun coveralls to get more accurate results
+        run: |
+          curl --location --request GET \
+            'https://coveralls.io/rerun_build?repo_token=${{ secrets.COVERALLS_TOKEN }}&build_num=${{ github.run_id }}'


### PR DESCRIPTION
The aggregate coverage results reported back by Coveralls for PRs have been off for quite a while now.

While the Coveralls team has not found the root cause yet, they have put an endpoint in place which _should_ help in working around this.

The short of it is that the initial run results get calculated incorrectly, but that a re-run of the same coveralls build gets the correct results for the calculation, so triggering this calculation re-run from within the build _should_ (theoretically) fix the issue.

I am the first to implement this solution though, so consider this a trial for the time being.

Ref:
* https://github.com/lemurheavy/coveralls-public/issues/1631