### PR TITLE
Tests: minor cleanup

### DIFF
--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -30,22 +30,6 @@ if (\defined('PHP_CODESNIFFER_VERBOSITY') === false) {
     \define('PHP_CODESNIFFER_VERBOSITY', 0);
 }
 
-/*
- * PHPUnit 9.3 is the first version which supports Xdebug 3, but we're using PHPUnit 9.2
- * for code coverage due to PHP_Parser interfering with our tests.
- *
- * For now, until a fix is pulled to allow us to use PHPUnit 9.3, this will allow
- * PHPUnit 9.2 to run with Xdebug 3 for code coverage.
- */
-if (\extension_loaded('xdebug') && \version_compare(\phpversion('xdebug'), '3', '>=')) {
-    if (\defined('XDEBUG_CC_UNUSED') === false) {
-        \define('XDEBUG_CC_UNUSED', null);
-    }
-    if (\defined('XDEBUG_CC_DEAD_CODE') === false) {
-        \define('XDEBUG_CC_DEAD_CODE', null);
-    }
-}
-
 if (\is_dir(\dirname(__DIR__) . '/vendor') && \file_exists(\dirname(__DIR__) . '/vendor/autoload.php')) {
     $vendorDir = \dirname(__DIR__) . '/vendor';
 } else {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "ext-filter": "*",
         "php-parallel-lint/php-parallel-lint": "^1.3.2",
         "php-parallel-lint/php-console-highlighter": "^1.0",
-        "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3",
         "yoast/phpunit-polyfills": "^1.0.1"
     },
     "conflict": {


### PR DESCRIPTION
Follow up on PR #305. By setting the minimum PHPUnit 9.x version to 9.3, we no longer have to backfill the missing Xdebug constants.