### PR TITLE
New `PHPCSUtils\Exceptions\InvalidTokenArray` Exception

### DIFF
--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -11,6 +11,7 @@
 namespace PHPCSUtils\BackCompat;
 
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Exceptions\InvalidTokenArray;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Tokens\TokenHelper;
 
@@ -140,6 +141,8 @@ class BCTokens
      *                     Unused as none of the methods take arguments.
      *
      * @return array <int|string> => <int|string> Token array
+     *
+     * @throws \PHPCSUtils\Exceptions\InvalidTokenArray When an invalid token array is requested.
      */
     public static function __callStatic($name, $args)
     {
@@ -147,8 +150,8 @@ class BCTokens
             return Tokens::${$name};
         }
 
-        // Default to an empty array.
-        return [];
+        // Unknown token array requested.
+        throw InvalidTokenArray::create($name);
     }
 
     /**

--- a/PHPCSUtils/Exceptions/InvalidTokenArray.php
+++ b/PHPCSUtils/Exceptions/InvalidTokenArray.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Exceptions;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+
+/**
+ * Exception thrown when an non-existent token array is requested.
+ *
+ * @since 1.0.0-alpha4
+ */
+final class InvalidTokenArray extends RuntimeException
+{
+
+    /**
+     * Create a new invalid token array exception with a standardized text.
+     *
+     * @param string $name The name of the token array requested.
+     *
+     * @return \PHPCSUtils\Exceptions\InvalidTokenArray
+     */
+    public static function create($name)
+    {
+        // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+        $stack = \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+
+        return new self(
+            \sprintf(
+                'Call to undefined method %s::%s()',
+                $stack[1]['class'],
+                $name
+            )
+        );
+    }
+}

--- a/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
+++ b/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
@@ -12,7 +12,7 @@ namespace PHPCSUtils\Tests\BackCompat\BCTokens;
 
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCTokens;
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Test class.
@@ -212,7 +212,10 @@ class UnchangedTokenArraysTest extends TestCase
      */
     public function testUndeclaredTokenArray()
     {
-        $this->assertSame([], BCTokens::notATokenArray());
+        $this->expectException('PHPCSUtils\Exceptions\InvalidTokenArray');
+        $this->expectExceptionMessage('Call to undefined method PHPCSUtils\BackCompat\BCTokens::notATokenArray()');
+
+        BCTokens::notATokenArray();
     }
 
     /**

--- a/Tests/Exceptions/InvalidTokenArray/InvalidTokenArrayTest.php
+++ b/Tests/Exceptions/InvalidTokenArray/InvalidTokenArrayTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Exceptions\InvalidTokenArray;
+
+use PHPCSUtils\Exceptions\InvalidTokenArray;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Exceptions\InvalidTokenArray
+ *
+ * @since 1.0.0
+ */
+final class InvalidTokenArrayTest extends TestCase
+{
+
+    /**
+     * Test that the text of the exception is as expected.
+     *
+     * @return void
+     */
+    public function testCreate()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\InvalidTokenArray');
+        $this->expectExceptionMessage(\sprintf('Call to undefined method %s::dummy()', __CLASS__));
+
+        throw InvalidTokenArray::create('dummy');
+    }
+}


### PR DESCRIPTION
This introduces the first PHPCSUtils native exception, which will extend the PHPCS native `PHP_CodeSniffer\Exceptions\RuntimeException`, to throw an informative exception when a non-existent token array is requested.

Includes implementing use of the new Exception in the `BCTokens::__callStatic()` method.

Includes a unit test for the Exception.

Notes:
* While this does constitute a change in behaviour for the `BCTokens` class, it should not be considered a breaking change as this handles a state which was invalid to begin with.
* Also note, that while another "base Exception" to extend, may be semantically more correct, using the PHPCS native `RuntimeException` follows the principle of "least surprise" as that is normally the only exception sniffs will encounter and this new Exception can still be caught by referencing the PHPCS native `RuntimeException` class.