### PR TITLE
Tests: various minor tweaks

### DIFF
--- a/Tests/BackCompat/BCFile/FindEndOfStatementTest.inc
+++ b/Tests/BackCompat/BCFile/FindEndOfStatementTest.inc
@@ -39,6 +39,8 @@ $a = [
 /* testStaticArrowFunction */
 static fn ($a) => $a;
 
+return 0;
+
 /* testArrowFunctionReturnValue */
 fn(): array => [a($a, $b)];
 
@@ -52,4 +54,3 @@ $foo = foo(
     fn() => [$row[0], $row[3]]
 );
 
-return 0;

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
@@ -30,6 +30,15 @@ function passByReference(&$var) {}
 /* testArrayHint */
 function arrayHint(array $var) {}
 
+/* testVariable */
+function variable($var) {}
+
+/* testSingleDefaultValue */
+function defaultValue($var1=self::CONSTANT) {}
+
+/* testDefaultValues */
+function defaultValues($var1=1, $var2='value') {}
+
 /* testTypeHint */
 function typeHint(foo $var1, bar $var2) {}
 
@@ -40,15 +49,6 @@ class MyClass {
 
 /* testNullableTypeHint */
 function nullableTypeHint(?int $var1, ?\bar $var2) {}
-
-/* testVariable */
-function variable($var) {}
-
-/* testSingleDefaultValue */
-function defaultValue($var1=self::CONSTANT) {}
-
-/* testDefaultValues */
-function defaultValues($var1=1, $var2='value') {}
 
 /* testBitwiseAndConstantExpressionDefaultValue */
 function myFunction($a = 10 & 20) {}

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -204,6 +204,107 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     }
 
     /**
+     * Verify variable.
+     *
+     * @return void
+     */
+    public function testVariable()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 4, // Offset from the T_FUNCTION token.
+            'name'                => '$var',
+            'content'             => '$var',
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify default value parsing with a single function param.
+     *
+     * @return void
+     */
+    public function testSingleDefaultValue()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 4, // Offset from the T_FUNCTION token.
+            'name'                => '$var1',
+            'content'             => '$var1=self::CONSTANT',
+            'default'             => 'self::CONSTANT',
+            'default_token'       => 6, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 5, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify default value parsing.
+     *
+     * @return void
+     */
+    public function testDefaultValues()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 4, // Offset from the T_FUNCTION token.
+            'name'                => '$var1',
+            'content'             => '$var1=1',
+            'default'             => '1',
+            'default_token'       => 6, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 5, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => 7, // Offset from the T_FUNCTION token.
+        ];
+        $expected[1] = [
+            'token'               => 9, // Offset from the T_FUNCTION token.
+            'name'                => '$var2',
+            'content'             => "\$var2='value'",
+            'default'             => "'value'",
+            'default_token'       => 11, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 10, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Verify type hint parsing.
      *
      * @return void
@@ -307,107 +408,6 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'type_hint_token'     => 11, // Offset from the T_FUNCTION token.
             'type_hint_end_token' => ($php8Names === true) ? 11 : 12, // Offset from the T_FUNCTION token.
             'nullable_type'       => true,
-            'comma_token'         => false,
-        ];
-
-        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
-    }
-
-    /**
-     * Verify variable.
-     *
-     * @return void
-     */
-    public function testVariable()
-    {
-        $expected    = [];
-        $expected[0] = [
-            'token'               => 4, // Offset from the T_FUNCTION token.
-            'name'                => '$var',
-            'content'             => '$var',
-            'pass_by_reference'   => false,
-            'reference_token'     => false,
-            'variable_length'     => false,
-            'variadic_token'      => false,
-            'type_hint'           => '',
-            'type_hint_token'     => false,
-            'type_hint_end_token' => false,
-            'nullable_type'       => false,
-            'comma_token'         => false,
-        ];
-
-        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
-    }
-
-    /**
-     * Verify default value parsing with a single function param.
-     *
-     * @return void
-     */
-    public function testSingleDefaultValue()
-    {
-        $expected    = [];
-        $expected[0] = [
-            'token'               => 4, // Offset from the T_FUNCTION token.
-            'name'                => '$var1',
-            'content'             => '$var1=self::CONSTANT',
-            'default'             => 'self::CONSTANT',
-            'default_token'       => 6, // Offset from the T_FUNCTION token.
-            'default_equal_token' => 5, // Offset from the T_FUNCTION token.
-            'pass_by_reference'   => false,
-            'reference_token'     => false,
-            'variable_length'     => false,
-            'variadic_token'      => false,
-            'type_hint'           => '',
-            'type_hint_token'     => false,
-            'type_hint_end_token' => false,
-            'nullable_type'       => false,
-            'comma_token'         => false,
-        ];
-
-        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
-    }
-
-    /**
-     * Verify default value parsing.
-     *
-     * @return void
-     */
-    public function testDefaultValues()
-    {
-        $expected    = [];
-        $expected[0] = [
-            'token'               => 4, // Offset from the T_FUNCTION token.
-            'name'                => '$var1',
-            'content'             => '$var1=1',
-            'default'             => '1',
-            'default_token'       => 6, // Offset from the T_FUNCTION token.
-            'default_equal_token' => 5, // Offset from the T_FUNCTION token.
-            'pass_by_reference'   => false,
-            'reference_token'     => false,
-            'variable_length'     => false,
-            'variadic_token'      => false,
-            'type_hint'           => '',
-            'type_hint_token'     => false,
-            'type_hint_end_token' => false,
-            'nullable_type'       => false,
-            'comma_token'         => 7, // Offset from the T_FUNCTION token.
-        ];
-        $expected[1] = [
-            'token'               => 9, // Offset from the T_FUNCTION token.
-            'name'                => '$var2',
-            'content'             => "\$var2='value'",
-            'default'             => "'value'",
-            'default_token'       => 11, // Offset from the T_FUNCTION token.
-            'default_equal_token' => 10, // Offset from the T_FUNCTION token.
-            'pass_by_reference'   => false,
-            'reference_token'     => false,
-            'variable_length'     => false,
-            'variadic_token'      => false,
-            'type_hint'           => '',
-            'type_hint_token'     => false,
-            'type_hint_end_token' => false,
-            'nullable_type'       => false,
             'comma_token'         => false,
         ];
 

--- a/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
+++ b/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
@@ -31,7 +31,7 @@ class UnchangedTokenArraysTest extends TestCase
      *
      * @var array <int|string> => <int|string>
      */
-    protected $equalityTokens = [
+    private $equalityTokens = [
         \T_IS_EQUAL            => \T_IS_EQUAL,
         \T_IS_NOT_EQUAL        => \T_IS_NOT_EQUAL,
         \T_IS_IDENTICAL        => \T_IS_IDENTICAL,
@@ -45,7 +45,7 @@ class UnchangedTokenArraysTest extends TestCase
      *
      * @var array <int|string> => <int|string>
      */
-    protected $booleanOperators = [
+    private $booleanOperators = [
         \T_BOOLEAN_AND => \T_BOOLEAN_AND,
         \T_BOOLEAN_OR  => \T_BOOLEAN_OR,
         \T_LOGICAL_AND => \T_LOGICAL_AND,
@@ -58,7 +58,7 @@ class UnchangedTokenArraysTest extends TestCase
      *
      * @var array <int|string> => <int|string>
      */
-    protected $castTokens = [
+    private $castTokens = [
         \T_INT_CAST    => \T_INT_CAST,
         \T_STRING_CAST => \T_STRING_CAST,
         \T_DOUBLE_CAST => \T_DOUBLE_CAST,
@@ -74,7 +74,7 @@ class UnchangedTokenArraysTest extends TestCase
      *
      * @var array <int|string> => <int|string>
      */
-    protected $scopeModifiers = [
+    private $scopeModifiers = [
         \T_PRIVATE   => \T_PRIVATE,
         \T_PUBLIC    => \T_PUBLIC,
         \T_PROTECTED => \T_PROTECTED,
@@ -85,7 +85,7 @@ class UnchangedTokenArraysTest extends TestCase
      *
      * @var array <int|string> => <int|string>
      */
-    protected $methodPrefixes = [
+    private $methodPrefixes = [
         \T_PRIVATE   => \T_PRIVATE,
         \T_PUBLIC    => \T_PUBLIC,
         \T_PROTECTED => \T_PROTECTED,
@@ -99,7 +99,7 @@ class UnchangedTokenArraysTest extends TestCase
      *
      * @var array <int|string> => <int|string>
      */
-    protected $blockOpeners = [
+    private $blockOpeners = [
         \T_OPEN_CURLY_BRACKET  => \T_OPEN_CURLY_BRACKET,
         \T_OPEN_SQUARE_BRACKET => \T_OPEN_SQUARE_BRACKET,
         \T_OPEN_PARENTHESIS    => \T_OPEN_PARENTHESIS,
@@ -111,7 +111,7 @@ class UnchangedTokenArraysTest extends TestCase
      *
      * @var array <int|string> => <int|string>
      */
-    protected $stringTokens = [
+    private $stringTokens = [
         \T_CONSTANT_ENCAPSED_STRING => \T_CONSTANT_ENCAPSED_STRING,
         \T_DOUBLE_QUOTED_STRING     => \T_DOUBLE_QUOTED_STRING,
     ];
@@ -121,7 +121,7 @@ class UnchangedTokenArraysTest extends TestCase
      *
      * @var array <int|string> => <int|string>
      */
-    protected $bracketTokens = [
+    private $bracketTokens = [
         \T_OPEN_CURLY_BRACKET   => \T_OPEN_CURLY_BRACKET,
         \T_CLOSE_CURLY_BRACKET  => \T_CLOSE_CURLY_BRACKET,
         \T_OPEN_SQUARE_BRACKET  => \T_OPEN_SQUARE_BRACKET,
@@ -135,7 +135,7 @@ class UnchangedTokenArraysTest extends TestCase
      *
      * @var array <int|string> => <int|string>
      */
-    protected $includeTokens = [
+    private $includeTokens = [
         \T_REQUIRE_ONCE => \T_REQUIRE_ONCE,
         \T_REQUIRE      => \T_REQUIRE,
         \T_INCLUDE_ONCE => \T_INCLUDE_ONCE,
@@ -147,7 +147,7 @@ class UnchangedTokenArraysTest extends TestCase
      *
      * @var array <int|string> => <int|string>
      */
-    protected $heredocTokens = [
+    private $heredocTokens = [
         \T_START_HEREDOC => \T_START_HEREDOC,
         \T_END_HEREDOC   => \T_END_HEREDOC,
         \T_HEREDOC       => \T_HEREDOC,

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.inc
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.inc
@@ -5,7 +5,7 @@ final
     // phpcs:ignore Standard.Cat.SniffName -- Just because.
     class PHPCSAnnotation {}
 
-/* testWithDocblockWithWeirdlyPlacedProperty */
+/* testWithDocblockWithWeirdlyPlacedModifier */
 final
 
 /**
@@ -15,4 +15,4 @@ final
  *
  * @phpcs:disable Standard.Cat.SniffName -- Just because.
  */
-class ClassWithPropertyBeforeDocblock {}
+class ClassWithModifierBeforeDocblock {}

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
@@ -75,7 +75,7 @@ class GetClassPropertiesDiffTest extends UtilityMethodTestCase
                 ],
             ],
             'unorthodox-docblock-placement' => [
-                'testMarker' => '/* testWithDocblockWithWeirdlyPlacedProperty */',
+                'testMarker' => '/* testWithDocblockWithWeirdlyPlacedModifier */',
                 'expected'   => [
                     'is_abstract' => false,
                     'is_final'    => true,

--- a/Tests/Utils/PassedParameters/HasParametersTest.inc
+++ b/Tests/Utils/PassedParameters/HasParametersTest.inc
@@ -64,8 +64,8 @@ class HierarchyKeywordsWithParam {
 }
 
 class HierarchyKeywordsAsMethodNames {
-	public function self() {}
-	public function static() {}
+    public function self() {}
+    public function static() {}
     public function parent() {
         /* testHasParamsFunctionCall6 */
         $a = self::self(true);

--- a/Tests/Utils/UseStatements/SplitImportUseStatementTest.inc
+++ b/Tests/Utils/UseStatements/SplitImportUseStatementTest.inc
@@ -29,7 +29,7 @@ use function MyNamespace\myFunction ?>
 use function Vendor\YourNamespace\yourFunction as FunctionAlias;
 
 /* testUseFunctionMultiple */
-use /* comment */ function foo\math\sin, foo\math\cos as FooCos, foo\math\cosh;
+use /* comment */ function foo\math\sin,foo\math\cos as FooCos,foo\math\cosh;
 
 /* testUseConstPlainUppercaseConstKeyword */
 use CONST MyNamespace\MY_CONST;


### PR DESCRIPTION
### HasParametersTest: minor clean up

### UnchangedTokenArraysTest: make properties private

### FindEndOfStatementTest: fix broken test

The `return 0;` statement belongs with the `testStaticArrowFunction` test and was introduced to test a specific bug in squizlabs/PHP_CodeSniffer#2749.

This brings the test back to its correct state.

Ref:
* squizlabs/PHP_CodeSniffer#2749

### GetMethodParametersTest: minor test order tweak

... to make comparison of the test file with the PHPCS native tests more straight forward.

### UseStatements::SplitImportUseStatement: minor test tweak

... to make sure a case where there is no whitespace after the comma separating multiple statements is also tested.

### GetClassPropertiesDiffTest: minor testmarker tweak