### PR TITLE
GH Actions: various updates

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -59,7 +59,7 @@ jobs:
 
       # Show XML violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
-      - uses: korelstar/xmllint-problem-matcher@v1
+      - uses: korelstar/xmllint-problem-matcher@v1.1
 
       # Validate the XML file.
       # @link http://xmlsoft.org/xmllint.html

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -48,9 +48,9 @@ jobs:
         id: set_ini
         run: |
           if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On'
+            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
           fi
 
       - name: Install PHP

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,9 +135,9 @@ jobs:
         id: set_ini
         run: |
           if [[ "${{ matrix.phpcs_version }}" != "dev-master" && "${{ matrix.phpcs_version }}" != "4.0.x-dev" ]]; then
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On'
+            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
           fi
 
       - name: Install PHP
@@ -227,9 +227,9 @@ jobs:
         id: set_ini
         run: |
           if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On'
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On'
+            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
           fi
 
       - name: Install PHP
@@ -253,9 +253,8 @@ jobs:
 
       - name: Grab PHPUnit version
         id: phpunit_version
-        run: >
-          echo ::set-output name=VERSION::
-          $(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')
+        # yamllint disable-line rule:line-length
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
 
       - name: "DEBUG: Show grabbed version"
         run: echo ${{ steps.phpunit_version.outputs.VERSION }}

--- a/.github/workflows/update-phpcs-versionnr.yml
+++ b/.github/workflows/update-phpcs-versionnr.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Grab latest tag name from API response
         id: version
         run: |
-          echo "::set-output name=TAG::${{ fromJson(steps.get_latest_release.outputs.data).tag_name }}"
+          echo "TAG=${{ fromJson(steps.get_latest_release.outputs.data).tag_name }}" >> $GITHUB_OUTPUT
 
       - name: Show tag name found in API response
         run: "echo latest release: ${{ steps.version.outputs.TAG }}"
@@ -48,8 +48,8 @@ jobs:
       - name: Set branches to use
         id: branches
         run: |
-          echo "::set-output name=BASE::develop"
-          echo "::set-output name=PR_BRANCH::feature/getversiontest-update-phpcs-version"
+          echo "BASE=develop" >> $GITHUB_OUTPUT
+          echo "PR_BRANCH=feature/getversiontest-update-phpcs-version" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
### GH Actions: fix use of deprecated set-output

GitHub has deprecated the use of `set-output` (and `set-state`) in favour of new environment files.

This commit updates workflows to use the new methodology.

Refs:
* https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
* https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files

### GH Actions: update the xmllint-problem-matcher

The `xmllint-problem-matcher` action runner has released a new version which updates it to use node 16.
This gets rid of a warning which was shown in the action logs.

Refs:
* https://github.com/korelstar/xmllint-problem-matcher/releases/tag/v1.1