### PR TITLE
BCFile/FunctionDeclarations::get[Method]Parameters: sync in new test from upstream

### DIFF
--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
@@ -214,6 +214,12 @@ abstract class ConstructorPropertyPromotionAbstractMethod {
     abstract public function __construct(public callable $y, private ...$x);
 }
 
+/* testCommentsInParameter */
+function commentsInParams(
+    // Leading comment.
+    ?MyClass /*-*/ & /*-*/.../*-*/ $param /*-*/ = /*-*/ 'default value' . /*-*/ 'second part' // Trailing comment.
+) {}
+
 /* testFunctionCallFnPHPCS353-354 */
 $value = $obj->fn(true);
 

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -1899,6 +1899,36 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     }
 
     /**
+     * Verify and document behaviour when there are comments within a parameter declaration.
+     *
+     * @return void
+     */
+    public function testCommentsInParameter()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 19, // Offset from the T_FUNCTION token.
+            'name'                => '$param',
+            'content'             => '// Leading comment.
+    ?MyClass /*-*/ & /*-*/.../*-*/ $param /*-*/ = /*-*/ \'default value\' . /*-*/ \'second part\' // Trailing comment.',
+            'default'             => '\'default value\' . /*-*/ \'second part\' // Trailing comment.',
+            'default_token'       => 27, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 23, // Offset from the T_FUNCTION token.
+            'pass_by_reference'   => true,
+            'reference_token'     => 13, // Offset from the T_FUNCTION token.
+            'variable_length'     => true,
+            'variadic_token'      => 16, // Offset from the T_FUNCTION token.
+            'type_hint'           => '?MyClass',
+            'type_hint_token'     => 9, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 9, // Offset from the T_FUNCTION token.
+            'nullable_type'       => true,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Verify handling of a closure.
      *
      * @return void


### PR DESCRIPTION
Add test documenting behaviour for comments

This test demonstrates and documents the existing behaviour of the method when comments are encountered within a parameter declaration.

Refs:
* https://github.com/squizlabs/PHP_CodeSniffer/commit/e4af9dc436f566c5ae4bb84a5f5500ec7dd5dc84