### PR TITLE
PHP 7.4/8.1 | PassedParameters::getParameters(): add tests with array unpacking in array expressions

### DIFF
--- a/Tests/Utils/PassedParameters/GetParametersTest.inc
+++ b/Tests/Utils/PassedParameters/GetParametersTest.inc
@@ -124,3 +124,10 @@ unset( $variable, $object->property, static::$property, $array[$name], );
 $anon = new class( $param1, $param2 ) {
     public function __construct($param1, $param2) {}
 };
+
+/* testPHP74UnpackingInLongArrayExpression */
+$arr4 = array(...$arr1, ...arrGen(), ...new ArrayIterator(['a', 'b', 'c']));
+
+/* testPHP74UnpackingInShortArrayExpression */
+// Also includes code sample for PHP 8.1 unpacking with string keys.
+$fruits = ['banana', ...$parts, 'watermelon', ...["a" => 2],];

--- a/Tests/Utils/PassedParameters/GetParametersTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersTest.php
@@ -538,6 +538,55 @@ class GetParametersTest extends UtilityMethodTestCase
                     ],
                 ],
             ],
+
+            // PHP 7.4 argument unpacking array expressions.
+            'long-array-with-argument-unpacking-via-spread-operator' => [
+                'testMarker' => '/* testPHP74UnpackingInLongArrayExpression */',
+                'targetType' => \T_ARRAY,
+                'expected'   => [
+                    1 => [
+                        'start' => 2,
+                        'end'   => 3,
+                        'raw'   => '...$arr1',
+                    ],
+                    2 => [
+                        'start' => 5,
+                        'end'   => 9,
+                        'raw'   => '...arrGen()',
+                    ],
+                    3 => [
+                        'start' => 11,
+                        'end'   => 26,
+                        'raw'   => "...new ArrayIterator(['a', 'b', 'c'])",
+                    ],
+                ],
+            ],
+            'short-array-with-argument-unpacking-via-spread-operator' => [
+                'testMarker' => '/* testPHP74UnpackingInShortArrayExpression */',
+                'targetType' => \T_OPEN_SHORT_ARRAY,
+                'expected'   => [
+                    1 => [
+                        'start' => 1,
+                        'end'   => 1,
+                        'raw'   => "'banana'",
+                    ],
+                    2 => [
+                        'start' => 3,
+                        'end'   => 5,
+                        'raw'   => '...$parts',
+                    ],
+                    3 => [
+                        'start' => 7,
+                        'end'   => 8,
+                        'raw'   => "'watermelon'",
+                    ],
+                    4 => [
+                        'start' => 10,
+                        'end'   => 18,
+                        'raw'   => '...["a" => 2]',
+                    ],
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
Adds tests to verify compatibility with PHP 7.4 array unpacking in array expressions and PHP 8.1 array unpacking in array expressions with string keys.

Refs;
* https://wiki.php.net/rfc/spread_operator_for_array
* https://wiki.php.net/rfc/array_unpacking_string_keys