### PR TITLE
PHP 8.0: add support for attributes

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -111,6 +111,7 @@ class BCFile
      *   'name'                => '$var',  // The variable name.
      *   'token'               => integer, // The stack pointer to the variable name.
      *   'content'             => string,  // The full content of the variable definition.
+     *   'has_attributes'      => boolean, // Does the parameter have one or more attributes attached ?
      *   'pass_by_reference'   => boolean, // Is the variable passed by reference?
      *   'reference_token'     => integer, // The stack pointer to the reference operator
      *                                     // or FALSE if the param is not passed by reference.
@@ -206,6 +207,7 @@ class BCFile
         $defaultStart     = null;
         $equalToken       = null;
         $paramCount       = 0;
+        $hasAttributes    = false;
         $passByReference  = false;
         $referenceToken   = false;
         $variableLength   = false;
@@ -236,6 +238,12 @@ class BCFile
             }
 
             switch ($tokens[$i]['code']) {
+                case T_ATTRIBUTE:
+                    $hasAttributes = true;
+
+                    // Skip to the end of the attribute.
+                    $i = $tokens[$i]['attribute_closer'];
+                    break;
                 case T_BITWISE_AND:
                     if ($defaultStart === null) {
                         $passByReference = true;
@@ -356,6 +364,7 @@ class BCFile
                         $vars[$paramCount]['default_equal_token'] = $equalToken;
                     }
 
+                    $vars[$paramCount]['has_attributes']      = $hasAttributes;
                     $vars[$paramCount]['pass_by_reference']   = $passByReference;
                     $vars[$paramCount]['reference_token']     = $referenceToken;
                     $vars[$paramCount]['variable_length']     = $variableLength;
@@ -381,6 +390,7 @@ class BCFile
                     $paramStart       = ($i + 1);
                     $defaultStart     = null;
                     $equalToken       = null;
+                    $hasAttributes    = false;
                     $passByReference  = false;
                     $referenceToken   = false;
                     $variableLength   = false;

--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -41,9 +41,10 @@ class Arrays
         \T_ARRAY            => \T_ARRAY,
         \T_OPEN_SHORT_ARRAY => \T_OPEN_SHORT_ARRAY,
 
-        // Inline function and control structures to skip over.
+        // Inline function, control structures and other things to skip over.
         \T_FN               => \T_FN,
         \T_MATCH            => \T_MATCH,
+        \T_ATTRIBUTE        => \T_ATTRIBUTE,
     ];
 
     /**
@@ -297,6 +298,7 @@ class Arrays
      * @since 1.0.0
      * @since 1.0.0-alpha2 Now allows for arrow functions in arrays.
      * @since 1.0.0-alpha4 Now allows for match expressions in arrays.
+     * @since 1.0.0-alpha4 Now allows for attributes in arrays.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being examined.
      * @param int                         $start     Stack pointer to the start of the array item.
@@ -351,6 +353,14 @@ class Arrays
                 && isset($tokens[$doubleArrow]['scope_closer']) === true
             ) {
                 $doubleArrow = $tokens[$doubleArrow]['scope_closer'];
+                continue;
+            }
+
+            // Skip over attributes which may contain arrays as a passed parameters.
+            if ($tokens[$doubleArrow]['code'] === \T_ATTRIBUTE
+                && isset($tokens[$doubleArrow]['attribute_closer'])
+            ) {
+                $doubleArrow = $tokens[$doubleArrow]['attribute_closer'];
                 continue;
             }
 

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -313,6 +313,7 @@ class FunctionDeclarations
      *   'name'                => '$var',  // The variable name.
      *   'token'               => integer, // The stack pointer to the variable name.
      *   'content'             => string,  // The full content of the variable definition.
+     *   'has_attributes'      => boolean, // Does the parameter have one or more attributes attached ?
      *   'pass_by_reference'   => boolean, // Is the variable passed by reference?
      *   'reference_token'     => integer, // The stack pointer to the reference operator
      *                                     // or FALSE if the param is not passed by reference.
@@ -359,6 +360,7 @@ class FunctionDeclarations
      * @since 1.0.0-alpha4 Added support for PHP 8.0 union types.
      * @since 1.0.0-alpha4 Added support for PHP 8.0 constructor property promotion.
      * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokenization.
+     * @since 1.0.0-alpha4 Added support for PHP 8.0 parameter attributes.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the function token
@@ -414,6 +416,7 @@ class FunctionDeclarations
         $defaultStart     = null;
         $equalToken       = null;
         $paramCount       = 0;
+        $hasAttributes    = false;
         $passByReference  = false;
         $referenceToken   = false;
         $variableLength   = false;
@@ -439,6 +442,13 @@ class FunctionDeclarations
             }
 
             switch ($tokens[$i]['code']) {
+                case \T_ATTRIBUTE:
+                    $hasAttributes = true;
+
+                    // Skip to the end of the attribute.
+                    $i = $tokens[$i]['attribute_closer'];
+                    break;
+
                 case \T_BITWISE_AND:
                     $passByReference = true;
                     $referenceToken  = $i;
@@ -488,6 +498,7 @@ class FunctionDeclarations
                         $vars[$paramCount]['default_equal_token'] = $equalToken;
                     }
 
+                    $vars[$paramCount]['has_attributes']      = $hasAttributes;
                     $vars[$paramCount]['pass_by_reference']   = $passByReference;
                     $vars[$paramCount]['reference_token']     = $referenceToken;
                     $vars[$paramCount]['variable_length']     = $variableLength;
@@ -513,6 +524,7 @@ class FunctionDeclarations
                     $paramStart       = ($i + 1);
                     $defaultStart     = null;
                     $equalToken       = null;
+                    $hasAttributes    = false;
                     $passByReference  = false;
                     $referenceToken   = false;
                     $variableLength   = false;

--- a/PHPCSUtils/Utils/Namespaces.php
+++ b/PHPCSUtils/Utils/Namespaces.php
@@ -285,6 +285,7 @@ class Namespaces
             \T_CLOSE_SHORT_ARRAY,
             \T_CLOSE_SQUARE_BRACKET,
             \T_DOC_COMMENT_CLOSE_TAG,
+            \T_ATTRIBUTE_END,
         ];
         $returnValue = false;
 
@@ -324,6 +325,12 @@ class Namespaces
                 continue;
             } elseif (isset($tokens[$prev]['parenthesis_opener']) === true) {
                 $prev = $tokens[$prev]['parenthesis_opener'];
+                continue;
+            }
+
+            // Skip over potentially large attributes.
+            if (isset($tokens[$prev]['attribute_opener'])) {
+                $prev = $tokens[$prev]['attribute_opener'];
                 continue;
             }
 

--- a/PHPCSUtils/Utils/PassedParameters.php
+++ b/PHPCSUtils/Utils/PassedParameters.php
@@ -43,6 +43,7 @@ class PassedParameters
         \T_OPEN_SQUARE_BRACKET  => \T_OPEN_SQUARE_BRACKET,
         \T_OPEN_PARENTHESIS     => \T_OPEN_PARENTHESIS,
         \T_DOC_COMMENT_OPEN_TAG => \T_DOC_COMMENT_OPEN_TAG,
+        \T_ATTRIBUTE            => \T_ATTRIBUTE,
     ];
 
     /**
@@ -267,6 +268,14 @@ class PassedParameters
                 && isset($tokens[$nextComma]['comment_closer'])
             ) {
                 $nextComma = $tokens[$nextComma]['comment_closer'];
+                continue;
+            }
+
+            // Skip over attributes.
+            if ($tokens[$nextComma]['code'] === \T_ATTRIBUTE
+                && isset($tokens[$nextComma]['attribute_closer'])
+            ) {
+                $nextComma = $tokens[$nextComma]['attribute_closer'];
                 continue;
             }
 

--- a/PHPCSUtils/Utils/Variables.php
+++ b/PHPCSUtils/Utils/Variables.php
@@ -88,6 +88,7 @@ class Variables
      *
      * @since 1.0.0
      * @since 1.0.0-alpha4 Added support for PHP 8.0 union types.
+     * @since 1.0.0-alpha4 No longer gets confused by PHP 8.0 property attributes.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the `T_VARIABLE` token
@@ -138,6 +139,7 @@ class Variables
                 \T_SEMICOLON,
                 \T_OPEN_CURLY_BRACKET,
                 \T_CLOSE_CURLY_BRACKET,
+                \T_ATTRIBUTE_END,
             ],
             ($stackPtr - 1)
         );

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.inc
@@ -243,3 +243,19 @@ $anon = class() {
     // Intentional fatal error - duplicate types are not allowed in union types, but that's not the concern of the method.
     public int |string| /*comment*/ INT $duplicateTypeInUnion;
 };
+
+$anon = class {
+    /* testPHP8PropertySingleAttribute */
+    #[PropertyWithAttribute]
+    public string $foo;
+
+    /* testPHP8PropertyMultipleAttributes */
+    #[PropertyWithAttribute(foo: 'bar'), MyAttribute]
+    protected ?int|float $bar;
+
+    /* testPHP8PropertyMultilineAttribute */
+    #[
+        PropertyWithAttribute(/* comment */ 'baz')
+    ]
+    private mixed $baz;
+};

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -764,6 +764,42 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'nullable_type'   => false,
                 ],
             ],
+            'php8-property-with-single-attribute' => [
+                '/* testPHP8PropertySingleAttribute */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => 'string',
+                    'type_token'      => -2, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'nullable_type'   => false,
+                ],
+            ],
+            'php8-property-with-multiple-attributes' => [
+                '/* testPHP8PropertyMultipleAttributes */',
+                [
+                    'scope'           => 'protected',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => '?int|float',
+                    'type_token'      => -4, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'nullable_type'   => true,
+                ],
+            ],
+            'php8-property-with-multiline-attribute' => [
+                '/* testPHP8PropertyMultilineAttribute */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'type'            => 'mixed',
+                    'type_token'      => -2, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'nullable_type'   => false,
+                ],
+            ],
         ];
     }
 

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
@@ -220,6 +220,20 @@ function commentsInParams(
     ?MyClass /*-*/ & /*-*/.../*-*/ $param /*-*/ = /*-*/ 'default value' . /*-*/ 'second part' // Trailing comment.
 ) {}
 
+/* testParameterAttributesInFunctionDeclaration */
+class ParametersWithAttributes(
+    public function __construct(
+        #[\MyExample\MyAttribute] private string $constructorPropPromTypedParamSingleAttribute,
+        #[MyAttr([1, 2])]
+        Type|false
+        $typedParamSingleAttribute,
+        #[MyAttribute(1234), MyAttribute(5678)] ?int $nullableTypedParamMultiAttribute,
+        #[WithoutArgument] #[SingleArgument(0)] $nonTypedParamTwoAttributes,
+        #[MyAttribute(array("key" => "value"))]
+        &...$otherParam,
+    ) {}
+}
+
 /* testFunctionCallFnPHPCS353-354 */
 $value = $obj->fn(true);
 

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -162,6 +162,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 5, // Offset from the T_FUNCTION token.
             'name'                => '$var',
             'content'             => '&$var',
+            'has_attributes'      => false,
             'pass_by_reference'   => true,
             'reference_token'     => 4, // Offset from the T_FUNCTION token.
             'variable_length'     => false,
@@ -188,6 +189,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 6, // Offset from the T_FUNCTION token.
             'name'                => '$var',
             'content'             => 'array $var',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -214,6 +216,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 4, // Offset from the T_FUNCTION token.
             'name'                => '$var',
             'content'             => '$var',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -243,6 +246,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => 'self::CONSTANT',
             'default_token'       => 6, // Offset from the T_FUNCTION token.
             'default_equal_token' => 5, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -272,6 +276,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => '1',
             'default_token'       => 6, // Offset from the T_FUNCTION token.
             'default_equal_token' => 5, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -289,6 +294,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => "'value'",
             'default_token'       => 11, // Offset from the T_FUNCTION token.
             'default_equal_token' => 10, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -315,6 +321,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 6, // Offset from the T_FUNCTION token.
             'name'                => '$var1',
             'content'             => 'foo $var1',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -330,6 +337,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 11, // Offset from the T_FUNCTION token.
             'name'                => '$var2',
             'content'             => 'bar $var2',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -356,6 +364,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 6, // Offset from the T_FUNCTION token.
             'name'                => '$var',
             'content'             => 'self $var',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -384,6 +393,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 7, // Offset from the T_FUNCTION token.
             'name'                => '$var1',
             'content'             => '?int $var1',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -399,6 +409,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => ($php8Names === true) ? 13 : 14, // Offset from the T_FUNCTION token.
             'name'                => '$var2',
             'content'             => '?\bar $var2',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -428,6 +439,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => '10 & 20',
             'default_token'       => 8, // Offset from the T_FUNCTION token.
             'default_equal_token' => 6, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -454,6 +466,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 4, // Offset from the T_FN token.
             'name'                => '$a',
             'content'             => 'int $a',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -469,6 +482,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 8, // Offset from the T_FN token.
             'name'                => '$b',
             'content'             => '...$b',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => true,
@@ -495,6 +509,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 6, // Offset from the T_FN token.
             'name'                => '$a',
             'content'             => '?string $a',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -524,6 +539,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => '[]',
             'default_token'       => 8, // Offset from the T_FUNCTION token.
             'default_equal_token' => 6, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -541,6 +557,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => 'array(1, 2, 3)',
             'default_token'       => 16, // Offset from the T_FUNCTION token.
             'default_equal_token' => 14, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -567,6 +584,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 4, // Offset from the T_FUNCTION token.
             'name'                => '$var1',
             'content'             => '$var1',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -584,6 +602,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => 'M_PI',
             'default_token'       => 11, // Offset from the T_FUNCTION token.
             'default_equal_token' => 9, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -613,6 +632,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => 'FOO ? \'bar\' : 10',
             'default_token'       => 9, // Offset from the T_FUNCTION token.
             'default_equal_token' => 7, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -627,6 +647,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 24, // Offset from the T_FUNCTION token.
             'name'                => '$b',
             'content'             => '? bool $b',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -653,6 +674,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 9, // Offset from the T_FUNCTION token.
             'name'                => '$a',
             'content'             => 'int ... $a',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => true,
@@ -679,6 +701,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 7, // Offset from the T_FUNCTION token.
             'name'                => '$a',
             'content'             => '&...$a',
+            'has_attributes'      => false,
             'pass_by_reference'   => true,
             'reference_token'     => 5, // Offset from the T_FUNCTION token.
             'variable_length'     => true,
@@ -705,6 +728,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 4, // Offset from the T_FUNCTION token.
             'name'                => '$unit',
             'content'             => '$unit',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -719,6 +743,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 10, // Offset from the T_FUNCTION token.
             'name'                => '$intervals',
             'content'             => 'DateInterval ...$intervals',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => true,
@@ -747,6 +772,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => ($php8Names === true) ? 7 : 12, // Offset from the T_FUNCTION token.
             'name'                => '$a',
             'content'             => '\Package\Sub\ClassName $a',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -761,6 +787,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => ($php8Names === true) ? 13 : 20, // Offset from the T_FUNCTION token.
             'name'                => '$b',
             'content'             => '?Sub\AnotherClass $b',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -787,6 +814,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 9, // Offset from the T_FUNCTION token.
             'name'                => '$a',
             'content'             => '?ClassName $a',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -801,6 +829,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 15, // Offset from the T_FUNCTION token.
             'name'                => '$b',
             'content'             => 'self $b',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -815,6 +844,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 21, // Offset from the T_FUNCTION token.
             'name'                => '$c',
             'content'             => 'parent $c',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -829,6 +859,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 27, // Offset from the T_FUNCTION token.
             'name'                => '$d',
             'content'             => 'object $d',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -843,6 +874,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 34, // Offset from the T_FUNCTION token.
             'name'                => '$e',
             'content'             => '?int $e',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -857,6 +889,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 41, // Offset from the T_FUNCTION token.
             'name'                => '$f',
             'content'             => 'string &$f',
+            'has_attributes'      => false,
             'pass_by_reference'   => true,
             'reference_token'     => 40, // Offset from the T_FUNCTION token.
             'variable_length'     => false,
@@ -871,6 +904,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 47, // Offset from the T_FUNCTION token.
             'name'                => '$g',
             'content'             => 'iterable $g',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -888,6 +922,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => 'true',
             'default_token'       => 57, // Offset from the T_FUNCTION token.
             'default_equal_token' => 55, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -905,6 +940,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => "'is_null'",
             'default_token'       => 67, // Offset from the T_FUNCTION token.
             'default_equal_token' => 65, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -922,6 +958,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => '1.1',
             'default_token'       => 77, // Offset from the T_FUNCTION token.
             'default_equal_token' => 75, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -936,6 +973,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 84, // Offset from the T_FUNCTION token.
             'name'                => '$k',
             'content'             => 'array ...$k',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => true,
@@ -962,6 +1000,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 7, // Offset from the T_FN token.
             'name'                => '$a',
             'content'             => '?ClassName $a',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -976,6 +1015,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 13, // Offset from the T_FN token.
             'name'                => '$b',
             'content'             => 'self $b',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -990,6 +1030,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 19, // Offset from the T_FN token.
             'name'                => '$c',
             'content'             => 'parent $c',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1004,6 +1045,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 25, // Offset from the T_FN token.
             'name'                => '$d',
             'content'             => 'object $d',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1018,6 +1060,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 32, // Offset from the T_FN token.
             'name'                => '$e',
             'content'             => '?int $e',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1032,6 +1075,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 39, // Offset from the T_FN token.
             'name'                => '$f',
             'content'             => 'string &$f',
+            'has_attributes'      => false,
             'pass_by_reference'   => true,
             'reference_token'     => 38, // Offset from the T_FN token.
             'variable_length'     => false,
@@ -1046,6 +1090,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 45, // Offset from the T_FN token.
             'name'                => '$g',
             'content'             => 'iterable $g',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1063,6 +1108,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => 'true',
             'default_token'       => 55, // Offset from the T_FN token.
             'default_equal_token' => 53, // Offset from the T_FN token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1080,6 +1126,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => "'is_null'",
             'default_token'       => 65, // Offset from the T_FN token.
             'default_equal_token' => 63, // Offset from the T_FN token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1097,6 +1144,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => '1.1',
             'default_token'       => 75, // Offset from the T_FN token.
             'default_equal_token' => 73, // Offset from the T_FN token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1111,6 +1159,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 82, // Offset from the T_FN token.
             'name'                => '$k',
             'content'             => 'array ...$k',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => true,
@@ -1142,6 +1191,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     ?\MyNS /* comment */
         \ SubCat // phpcs:ignore Standard.Cat.Sniff -- for reasons.
             \  MyClass $a',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1159,6 +1209,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => "'default' /* test*/",
             'default_token'       => ($php8Names === true) ? 36 : 37, // Offset from the T_FUNCTION token.
             'default_equal_token' => ($php8Names === true) ? 32 : 33, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1176,6 +1227,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     ? /*comment*/
         bool // phpcs:disable Stnd.Cat.Sniff -- For reasons.
         & /*test*/ ... /* phpcs:ignore */ $c',
+            'has_attributes'      => false,
             'pass_by_reference'   => true,
             'reference_token'     => ($php8Names === true) ? 53 : 54, // Offset from the T_FUNCTION token.
             'variable_length'     => true,
@@ -1202,6 +1254,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 8, // Offset from the T_FUNCTION token.
             'name'                => '$var1',
             'content'             => 'mixed &...$var1',
+            'has_attributes'      => false,
             'pass_by_reference'   => true,
             'reference_token'     => 6, // Offset from the T_FUNCTION token.
             'variable_length'     => true,
@@ -1228,6 +1281,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 7, // Offset from the T_FUNCTION token.
             'name'                => '$var1',
             'content'             => '?Mixed $var1',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1256,6 +1310,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => ($php8Names === true) ? 7 : 9, // Offset from the T_FUNCTION token.
             'name'                => '$var1',
             'content'             => '?namespace\Name $var1',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1282,6 +1337,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 8, // Offset from the T_FUNCTION token.
             'name'                => '$number',
             'content'             => 'int|float $number',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1296,6 +1352,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 17, // Offset from the T_FUNCTION token.
             'name'                => '$obj',
             'content'             => 'self|parent &...$obj',
+            'has_attributes'      => false,
             'pass_by_reference'   => true,
             'reference_token'     => 15, // Offset from the T_FUNCTION token.
             'variable_length'     => true,
@@ -1322,6 +1379,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 9, // Offset from the T_FUNCTION token.
             'name'                => '$paramA',
             'content'             => 'float|null &$paramA',
+            'has_attributes'      => false,
             'pass_by_reference'   => true,
             'reference_token'     => 8, // Offset from the T_FUNCTION token.
             'variable_length'     => false,
@@ -1336,6 +1394,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 17, // Offset from the T_FUNCTION token.
             'name'                => '$paramB',
             'content'             => 'string|int ...$paramB',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => true,
@@ -1364,7 +1423,8 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'content'             => 'int|float $var = CONSTANT_A | CONSTANT_B',
             'default'             => 'CONSTANT_A | CONSTANT_B',
             'default_token'       => 10, // Offset from the T_FUNCTION token.
-            'default_equal_token' => 8, // Offset from the T_FUNCTION token.
+            'default_equal_token' => 8,  // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1393,6 +1453,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => ($php8Names === true) ? 8 : 11, // Offset from the T_FUNCTION token.
             'name'                => '$var',
             'content'             => 'MyClassA|\Package\MyClassB $var',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1419,6 +1480,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 20, // Offset from the T_FUNCTION token.
             'name'                => '$var',
             'content'             => 'array|bool|callable|int|float|null|object|string $var',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1447,6 +1509,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 16, // Offset from the T_FUNCTION token.
             'name'                => '$var',
             'content'             => 'false|mixed|self|parent|iterable|Resource $var',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1473,6 +1536,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 8, // Offset from the T_FUNCTION token.
             'name'                => '$number',
             'content'             => '?int|float $number',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1502,6 +1566,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => 'null',
             'default_token'       => 10, // Offset from the T_FUNCTION token.
             'default_equal_token' => 8, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1531,6 +1596,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => 'false',
             'default_token'       => 10, // Offset from the T_FUNCTION token.
             'default_equal_token' => 8, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1560,6 +1626,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => 'false',
             'default_token'       => 12, // Offset from the T_FUNCTION token.
             'default_equal_token' => 10, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1586,6 +1653,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 8, // Offset from the T_FUNCTION token.
             'name'                => '$var',
             'content'             => 'object|ClassName $var',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1612,6 +1680,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 10, // Offset from the T_FUNCTION token.
             'name'                => '$var',
             'content'             => 'iterable|array|Traversable $var',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1638,6 +1707,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 17, // Offset from the T_FUNCTION token.
             'name'                => '$var',
             'content'             => 'int | string /*comment*/ | INT $var',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1667,6 +1737,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => '0.0',
             'default_token'       => 12, // Offset from the T_FUNCTION token.
             'default_equal_token' => 10, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1686,6 +1757,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => "''",
             'default_token'       => 22, // Offset from the T_FUNCTION token.
             'default_equal_token' => 20, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1705,6 +1777,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => 'null',
             'default_token'       => 32, // Offset from the T_FUNCTION token.
             'default_equal_token' => 30, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1733,6 +1806,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 10, // Offset from the T_FUNCTION token.
             'name'                => '$x',
             'content'             => 'protected float|int $x',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1752,6 +1826,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => "'test'",
             'default_token'       => 23, // Offset from the T_FUNCTION token.
             'default_equal_token' => 21, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => true,
             'reference_token'     => 18, // Offset from the T_FUNCTION token.
             'variable_length'     => false,
@@ -1768,6 +1843,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 30, // Offset from the T_FUNCTION token.
             'name'                => '$z',
             'content'             => 'private mixed $z',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1796,6 +1872,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 8, // Offset from the T_FUNCTION token.
             'name'                => '$promotedProp',
             'content'             => 'public int $promotedProp',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1812,6 +1889,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 14, // Offset from the T_FUNCTION token.
             'name'                => '$normalArg',
             'content'             => '?int $normalArg',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1838,6 +1916,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 6, // Offset from the T_FUNCTION token.
             'name'                => '$x',
             'content'             => 'private $x',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1866,6 +1945,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 8, // Offset from the T_FUNCTION token.
             'name'                => '$y',
             'content'             => 'public callable $y',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1882,6 +1962,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 14, // Offset from the T_FUNCTION token.
             'name'                => '$x',
             'content'             => 'private ...$x',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => true,
@@ -1914,6 +1995,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => '\'default value\' . /*-*/ \'second part\' // Trailing comment.',
             'default_token'       => 27, // Offset from the T_FUNCTION token.
             'default_equal_token' => 23, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => true,
             'reference_token'     => 13, // Offset from the T_FUNCTION token.
             'variable_length'     => true,
@@ -1923,6 +2005,101 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'type_hint_end_token' => 9, // Offset from the T_FUNCTION token.
             'nullable_type'       => true,
             'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify behaviour when parameters have attributes attached.
+     *
+     * @return void
+     */
+    public function testParameterAttributesInFunctionDeclaration()
+    {
+        $php8Names = parent::usesPhp8NameTokens();
+
+        $expected    = [];
+        $expected[0] = [
+            'token'               => ($php8Names === true) ? 14 : 17, // Offset from the T_FUNCTION token.
+            'name'                => '$constructorPropPromTypedParamSingleAttribute',
+            'content'             => '#[\MyExample\MyAttribute] private string'
+                . ' $constructorPropPromTypedParamSingleAttribute',
+            'has_attributes'      => true,
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'string',
+            'type_hint_token'     => ($php8Names === true) ? 12 : 15, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => ($php8Names === true) ? 12 : 15, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'property_visibility' => 'private',
+            'visibility_token'    => ($php8Names === true) ? 10 : 13, // Offset from the T_FUNCTION token.
+            'comma_token'         => ($php8Names === true) ? 15 : 18, // Offset from the T_FUNCTION token.
+        ];
+        $expected[1] = [
+            'token'               => ($php8Names === true) ? 36 : 39, // Offset from the T_FUNCTION token.
+            'name'                => '$typedParamSingleAttribute',
+            'content'             => '#[MyAttr([1, 2])]
+        Type|false
+        $typedParamSingleAttribute',
+            'has_attributes'      => true,
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'Type|false',
+            'type_hint_token'     => ($php8Names === true) ? 31 : 34, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => ($php8Names === true) ? 33 : 36, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => ($php8Names === true) ? 37 : 40, // Offset from the T_FUNCTION token.
+        ];
+        $expected[2] = [
+            'token'               => ($php8Names === true) ? 56 : 59, // Offset from the T_FUNCTION token.
+            'name'                => '$nullableTypedParamMultiAttribute',
+            'content'             => '#[MyAttribute(1234), MyAttribute(5678)] ?int $nullableTypedParamMultiAttribute',
+            'has_attributes'      => true,
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '?int',
+            'type_hint_token'     => ($php8Names === true) ? 54 : 57, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => ($php8Names === true) ? 54 : 57, // Offset from the T_FUNCTION token.
+            'nullable_type'       => true,
+            'comma_token'         => ($php8Names === true) ? 57 : 60, // Offset from the T_FUNCTION token.
+        ];
+        $expected[3] = [
+            'token'               => ($php8Names === true) ? 71 : 74, // Offset from the T_FUNCTION token.
+            'name'                => '$nonTypedParamTwoAttributes',
+            'content'             => '#[WithoutArgument] #[SingleArgument(0)] $nonTypedParamTwoAttributes',
+            'has_attributes'      => true,
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => ($php8Names === true) ? 72 : 75, // Offset from the T_FUNCTION token.
+        ];
+        $expected[4] = [
+            'token'               => ($php8Names === true) ? 92 : 95, // Offset from the T_FUNCTION token.
+            'name'                => '$otherParam',
+            'content'             => '#[MyAttribute(array("key" => "value"))]
+        &...$otherParam',
+            'has_attributes'      => true,
+            'pass_by_reference'   => true,
+            'reference_token'     => ($php8Names === true) ? 90 : 93, // Offset from the T_FUNCTION token.
+            'variable_length'     => true,
+            'variadic_token'      => ($php8Names === true) ? 91 : 94, // Offset from the T_FUNCTION token.
+            'type_hint'           => '',
+            'type_hint_token'     => false,
+            'type_hint_end_token' => false,
+            'nullable_type'       => false,
+            'comma_token'         => ($php8Names === true) ? 93 : 96, // Offset from the T_FUNCTION token.
         ];
 
         $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
@@ -1943,6 +2120,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => "'test'",
             'default_token'       => 7, // Offset from the T_FUNCTION token.
             'default_equal_token' => 5, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1969,6 +2147,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 3, // Offset from the T_USE token.
             'name'                => '$foo',
             'content'             => '$foo',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -1983,6 +2162,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 6, // Offset from the T_USE token.
             'name'                => '$bar',
             'content'             => '$bar',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -2009,6 +2189,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 9, // Offset from the T_FUNCTION token.
             'name'                => '$foo',
             'content'             => '?string $foo  /*comment*/',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -2026,6 +2207,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'default'             => '0',
             'default_token'       => 20, // Offset from the T_FUNCTION token.
             'default_equal_token' => 18, // Offset from the T_FUNCTION token.
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -2052,6 +2234,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 4, // Offset from the T_FUNCTION token.
             'name'                => '$foo',
             'content'             => '$foo',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -2066,6 +2249,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 8, // Offset from the T_FUNCTION token.
             'name'                => '$bar',
             'content'             => '$bar',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -2092,6 +2276,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 6, // Offset from the T_FN token.
             'name'                => '$a',
             'content'             => '?int $a',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -2106,6 +2291,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 11, // Offset from the T_FN token.
             'name'                => '$b',
             'content'             => '...$b',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => true,
@@ -2132,6 +2318,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 4, // Offset from the T_USE token.
             'name'                => '$foo',
             'content'             => '$foo  /*comment*/',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,
@@ -2146,6 +2333,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'token'               => 11, // Offset from the T_USE token.
             'name'                => '$bar',
             'content'             => '$bar',
+            'has_attributes'      => false,
             'pass_by_reference'   => false,
             'reference_token'     => false,
             'variable_length'     => false,

--- a/Tests/Utils/Arrays/GetDoubleArrowPtrTest.inc
+++ b/Tests/Utils/Arrays/GetDoubleArrowPtrTest.inc
@@ -105,6 +105,12 @@ $array = [
         default => [0 => 10],
     } => 'value',
 
+    /* testNoArrowValueClosureWithAttribute */
+    #[MyAttribute([0 => 'value'])] function() { /* do something */ }(),
+
+    /* testArrowKeyClosureWithAttribute */
+    #[MyAttribute([0 => 'value'])] function() { /* do something */ }() => 'value',
+
     /* testEmptyArrayItem */
     // Intentional parse error.
     ,

--- a/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
+++ b/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
@@ -234,6 +234,16 @@ class GetDoubleArrowPtrTest extends UtilityMethodTestCase
                 'expected'   => 38,
             ],
 
+            // Safeguard that double arrows in PHP 8.0 attributes are disregarded.
+            'test-no-arrow-value-closure-with-attached-attribute-containing-arrow' => [
+                'testMarker' => '/* testNoArrowValueClosureWithAttribute */',
+                'expected'   => false,
+            ],
+            'test-double-arrow-key-closure-with-attached-attribute-containing-arrow' => [
+                'testMarker' => '/* testArrowKeyClosureWithAttribute */',
+                'expected'   => 31,
+            ],
+
             'test-empty-array-item' => [
                 'testMarker' => '/* testEmptyArrayItem */',
                 'expected'   => false,

--- a/Tests/Utils/Namespaces/DetermineNamespaceTest.inc
+++ b/Tests/Utils/Namespaces/DetermineNamespaceTest.inc
@@ -114,7 +114,12 @@ echo 0;
 /**
  * Docblock to skip over.
  */
+#[
+    AttributeToSkipOver,
+    AnotherAttribute,
+]
 class Foo {
+    #[AttributeToSkipOver()] #[AnotherAttribute]
     function test() {
         /* testNonScopedNamedNamespace2Nested */
         echo 0;

--- a/Tests/Utils/PassedParameters/GetParametersTest.inc
+++ b/Tests/Utils/PassedParameters/GetParametersTest.inc
@@ -131,3 +131,15 @@ $arr4 = array(...$arr1, ...arrGen(), ...new ArrayIterator(['a', 'b', 'c']));
 /* testPHP74UnpackingInShortArrayExpression */
 // Also includes code sample for PHP 8.1 unpacking with string keys.
 $fruits = ['banana', ...$parts, 'watermelon', ...["a" => 2],];
+
+/* testPHP80FunctionCallInAttribute */
+#[AttributeAttachedToClosure([1, 2, 3])]
+$closure = function() {};
+
+/* testPHP80SkippingOverAttributes */
+$result = function_call(
+    $value,
+    #[MyAttribute()]
+    #[AnotherAttribute([1, 2, 3])]
+    function() { /* do something */}
+);

--- a/Tests/Utils/PassedParameters/GetParametersTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersTest.php
@@ -587,6 +587,39 @@ class GetParametersTest extends UtilityMethodTestCase
                     ],
                 ],
             ],
+
+            // PHP 8.0: function calls in attributes.
+            'function-call-within-an-attribute' => [
+                'testMarker' => '/* testPHP80FunctionCallInAttribute */',
+                'targetType' => \T_STRING,
+                'expected'   => [
+                    1 => [
+                        'start' => 2,
+                        'end'   => 10,
+                        'raw'   => '[1, 2, 3]',
+                    ],
+                ],
+            ],
+
+            // PHP 8.0: skipping over attributes.
+            'function-call-with-attributes-attached-to-passed-closure' => [
+                'testMarker' => '/* testPHP80SkippingOverAttributes */',
+                'targetType' => \T_STRING,
+                'expected'   => [
+                    1 => [
+                        'start' => 2,
+                        'end'   => 4,
+                        'raw'   => '$value',
+                    ],
+                    2 => [
+                        'start' => 6,
+                        'end'   => 39,
+                        'raw'   => '#[MyAttribute()]
+    #[AnotherAttribute([1, 2, 3])]
+    function() { /* do something */}',
+                    ],
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
### PHP 8.0 | BCFile/FunctionDeclarations::get[Method]Parameters(): sync with upstream / bug fix for attributes leaking into type hint

> This commit adds handling of parameter attributes to the `File::getMethodParameters()` method as per option [2] discussed in issue squizlabs/PHP_CodeSniffer#3298.
>
> In practice this means that:
> * [New] A new `has_attributes` index is introduced into the returned array which will hold a boolean value indicating whether attributes are attached to the parameter.
> * [Unchanged] The `content` index in the returned array includes the textual representation of any attributes attached to a parameter.
> * [Fixed] The `type_hint` and `type_hint_token` indexes will no longer be polluted (set incorrectly) with information belonging to the attribute(s) instead of to the type declaration.
>
> Includes minor efficiency fix for handling of parenthesis and brackets in default values.
>
> Includes dedicated unit test.

Refs:
* squizlabs/PHP_CodeSniffer#3298
* squizlabs/PHP_CodeSniffer#3320

### PHP 8.0 | Arrays::getDoubleArrowPtr(): handle attributes

As of PHP 8.0, attributes can be attached to functions, closures, arrow functions, classes, interfaces, traits, class constants, properties, methods and method parameters.

Attributes effectively instantiate a new instance of the class being referenced and can pass arguments to the constructor of that class.

As, while uncommon, closures or arrow functions _could_ be used in an array key, there _could_ be an attribute attached to these.

This adjusts the method to skip over attributes to prevent them confusing the double arrow pointer determination.

Includes tests.

Refs:
* https://wiki.php.net/rfc/attributes_v2

### PHP 8.0 | Namespaces::determineNamespace(): skip over attributes

Efficiency tweak: skip over potentially large attribute declarations when walking up to find a namespace declaration.

Includes test.

Refs:
* https://wiki.php.net/rfc/attributes_v2

### PHP 8.0 | PassedParameters::getParameters(): handle attributes

As of PHP 8.0, attributes can be attached to functions, closures, arrow functions, classes, interfaces, traits, class constants, properties, methods and method parameters.

Attributes effectively instantiate a new instance of the class being referenced and can pass arguments to the constructor of that class.

This has two implications for the `PassedParameters::getParameters()` method:
1. The class instantiation function call within an attribute should be handled by the method same as other class instantiation calls.
2. Attributes may, in select circumstances, be encountered _within_ "parameters" and for efficiency and to prevent incorrect parsing, we should skip over them.

This commit adds a test confirming that situation [1] is already handled correctly.

Additionally, this commit adds the code to skip over attributes _within_ parameters and adds a test covering that as well.

Refs:
* https://wiki.php.net/rfc/attributes_v2

### PHP 8.0 | Variables::getMemberProperties(): correctly handle attributes

Sync with upstream PR squizlabs/PHP_CodeSniffer#3203 which ensures that attributes for properties are correctly regarded as "stop points" for gathering property information.

Ref:
* squizlabs/PHP_CodeSniffer#3203