### PR TITLE
PHP 8.1: add support for enums

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -402,6 +402,7 @@ class Collections
      * Note: traits can not declare constants.
      *
      * @since 1.0.0-alpha1
+     * @since 1.0.0-alpha4 Added the PHP 8.1 T_ENUM token.
      *
      * @deprecated 1.0.0-alpha4 Use the {@see Collections::ooConstantScopes()} method instead.
      *
@@ -411,6 +412,7 @@ class Collections
         \T_CLASS      => \T_CLASS,
         \T_ANON_CLASS => \T_ANON_CLASS,
         \T_INTERFACE  => \T_INTERFACE,
+        \T_ENUM       => \T_ENUM,
     ];
 
     /**
@@ -836,6 +838,7 @@ class Collections
      * Note: traits can not declare constants.
      *
      * @since 1.0.0-alpha4 This method replaces the {@see Collections::$OOConstantScopes} property.
+     * @since 1.0.0-alpha4 Added the PHP 8.1 T_ENUM token.
      *
      * @return array <int|string> => <int|string>
      */

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -184,6 +184,7 @@ class Collections
      * within a namespace scope are still global and not limited to that namespace.
      *
      * @since 1.0.0-alpha1
+     * @since 1.0.0-alpha4 Added the PHP 8.1 T_ENUM token.
      *
      * @deprecated 1.0.0-alpha4 Use the {@see Collections::closedScopes()} method instead.
      *
@@ -194,6 +195,7 @@ class Collections
         \T_ANON_CLASS => \T_ANON_CLASS,
         \T_INTERFACE  => \T_INTERFACE,
         \T_TRAIT      => \T_TRAIT,
+        \T_ENUM       => \T_ENUM,
         \T_FUNCTION   => \T_FUNCTION,
         \T_CLOSURE    => \T_CLOSURE,
     ];

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -386,6 +386,7 @@ class Collections
      * DEPRECATED: OO structures which can use the "implements" keyword.
      *
      * @since 1.0.0-alpha1
+     * @since 1.0.0-alpha4 Added the PHP 8.1 T_ENUM token.
      *
      * @deprecated 1.0.0-alpha4 Use the {@see Collections::ooCanImplement()} method instead.
      *
@@ -394,6 +395,7 @@ class Collections
     public static $OOCanImplement = [
         \T_CLASS      => \T_CLASS,
         \T_ANON_CLASS => \T_ANON_CLASS,
+        \T_ENUM       => \T_ENUM,
     ];
 
     /**
@@ -824,6 +826,7 @@ class Collections
      * OO structures which can use the "implements" keyword.
      *
      * @since 1.0.0-alpha4 This method replaces the {@see Collections::$OOCanImplement} property.
+     * @since 1.0.0-alpha4 Added the PHP 8.1 T_ENUM token.
      *
      * @return array <int|string> => <int|string>
      */

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -31,7 +31,7 @@ class ObjectDeclarations
 {
 
     /**
-     * Retrieves the declaration name for classes, interfaces, traits, and functions.
+     * Retrieves the declaration name for classes, interfaces, traits, enums and functions.
      *
      * Main differences with the PHPCS version:
      * - Defensive coding against incorrect calls to this method.
@@ -48,18 +48,20 @@ class ObjectDeclarations
      * @see \PHPCSUtils\BackCompat\BCFile::getDeclarationName() Cross-version compatible version of the original.
      *
      * @since 1.0.0
+     * @since 1.0.0-alpha4 Added support for PHP 8.1 enums.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the declaration token
      *                                               which declared the class, interface,
-     *                                               trait, or function.
+     *                                               trait, enum or function.
      *
-     * @return string|null The name of the class, interface, trait, or function;
+     * @return string|null The name of the class, interface, trait, enum, or function;
      *                     or `NULL` if the passed token doesn't exist, the function or
      *                     class is anonymous or in case of a parse error/live coding.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified token is not of type
-     *                                                      `T_FUNCTION`, `T_CLASS`, `T_TRAIT`, or `T_INTERFACE`.
+     *                                                      `T_FUNCTION`, `T_CLASS`, `T_ANON_CLASS`,
+     *                                                      `T_CLOSURE`, `T_TRAIT`, `T_ENUM` or `T_INTERFACE`.
      */
     public static function getName(File $phpcsFile, $stackPtr)
     {
@@ -77,9 +79,11 @@ class ObjectDeclarations
             && $tokenCode !== \T_CLASS
             && $tokenCode !== \T_INTERFACE
             && $tokenCode !== \T_TRAIT
+            && $tokenCode !== \T_ENUM
         ) {
             throw new RuntimeException(
-                'Token type "' . $tokens[$stackPtr]['type'] . '" is not T_FUNCTION, T_CLASS, T_INTERFACE or T_TRAIT'
+                'Token type "' . $tokens[$stackPtr]['type']
+                . '" is not T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT or T_ENUM'
             );
         }
 
@@ -108,6 +112,7 @@ class ObjectDeclarations
         $exclude[] = \T_OPEN_PARENTHESIS;
         $exclude[] = \T_OPEN_CURLY_BRACKET;
         $exclude[] = \T_BITWISE_AND;
+        $exclude[] = \T_COLON; // Backed enums.
 
         $nameStart = $phpcsFile->findNext($exclude, ($stackPtr + 1), $stopPoint, true);
         if ($nameStart === false) {

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -235,7 +235,7 @@ class ObjectDeclarations
     }
 
     /**
-     * Retrieves the names of the interfaces that the specified class implements.
+     * Retrieves the names of the interfaces that the specified class or enum implements.
      *
      * Main differences with the PHPCS version:
      * - Bugs fixed:
@@ -251,9 +251,10 @@ class ObjectDeclarations
      *                                                                     the original.
      *
      * @since 1.0.0
+     * @since 1.0.0-alpha4 Added support for PHP 8.1 enums.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The stack position of the class.
+     * @param int                         $stackPtr  The stack position of the class or enum token.
      *
      * @return array|false Array with names of the implemented interfaces or `FALSE` on
      *                     error or if there are no implemented interface names.

--- a/PHPCSUtils/Utils/Scopes.php
+++ b/PHPCSUtils/Utils/Scopes.php
@@ -117,9 +117,10 @@ class Scopes
     }
 
     /**
-     * Check whether a T_FUNCTION token is a class/interface/trait method declaration.
+     * Check whether a T_FUNCTION token is a class/interface/trait/enum method declaration.
      *
      * @since 1.0.0
+     * @since 1.0.0-alpha4 Added support for PHP 8.1 enums.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
      * @param int                         $stackPtr  The position in the stack of the

--- a/PHPCSUtils/Utils/Scopes.php
+++ b/PHPCSUtils/Utils/Scopes.php
@@ -56,9 +56,10 @@ class Scopes
     }
 
     /**
-     * Check whether a T_CONST token is a class/interface constant declaration.
+     * Check whether a T_CONST token is a class/interface/enum constant declaration.
      *
      * @since 1.0.0
+     * @since 1.0.0-alpha4 Added support for PHP 8.1 enums.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
      * @param int                         $stackPtr  The position in the stack of the

--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -80,7 +80,7 @@ class UseStatements
         }
 
         $traitScopes = Tokens::$ooScopeTokens;
-        // Only classes and traits can import traits.
+        // Only classes, traits and enums can import traits.
         unset($traitScopes[\T_INTERFACE]);
 
         if (isset($traitScopes[$tokens[$lastCondition]['code']]) === true) {

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.inc
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.inc
@@ -29,6 +29,15 @@ class testFECNClassThatExtendsAndImplements extends testFECNClass implements Int
 /* testClassThatImplementsAndExtends */
 class testFECNClassThatImplementsAndExtends implements \InterfaceA, InterfaceB extends testFECNClass {}
 
+/* testBackedEnumWithoutImplements */
+enum Suit:string {}
+
+/* testEnumImplements */
+enum Suit implements Colorful {}
+
+/* testBackedEnumImplements */
+enum Suit: string implements Colorful, \Deck {}
+
 /* testAnonClassImplements */
 $anon = class() implements testFIINInterface {}
 

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
@@ -88,7 +88,7 @@ class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
     {
         $testClass = static::TEST_CLASS;
 
-        $OOToken = $this->getTargetToken($identifier, [T_CLASS, T_ANON_CLASS, T_INTERFACE]);
+        $OOToken = $this->getTargetToken($identifier, [T_CLASS, T_ANON_CLASS, T_INTERFACE, T_ENUM]);
         $result  = $testClass::findImplementedInterfaceNames(self::$phpcsFile, $OOToken);
         $this->assertSame($expected, $result);
     }
@@ -142,6 +142,21 @@ class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
                 [
                     '\InterfaceA',
                     'InterfaceB',
+                ],
+            ],
+            [
+                '/* testBackedEnumWithoutImplements */',
+                false,
+            ],
+            [
+                '/* testEnumImplements */',
+                ['Colorful'],
+            ],
+            [
+                '/* testBackedEnumImplements */',
+                [
+                    'Colorful',
+                    '\Deck',
                 ],
             ],
             [

--- a/Tests/BackCompat/BCFile/GetClassPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetClassPropertiesTest.inc
@@ -6,6 +6,9 @@ interface NotAClass {}
 /* testAnonClass */
 $anon = new class() {};
 
+/* testEnum */
+enum NotAClassEither {}
+
 /* testClassWithoutProperties */
 class ClassWithoutProperties {}
 

--- a/Tests/BackCompat/BCFile/GetClassPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetClassPropertiesTest.php
@@ -71,6 +71,10 @@ class GetClassPropertiesTest extends UtilityMethodTestCase
                 '/* testAnonClass */',
                 \T_ANON_CLASS,
             ],
+            'enum' => [
+                '/* testEnum */',
+                \T_ENUM,
+            ],
         ];
     }
 

--- a/Tests/BackCompat/BCFile/GetDeclarationNameJSTest.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameJSTest.php
@@ -93,7 +93,7 @@ class GetDeclarationNameJSTest extends UtilityMethodTestCase
     public function testGetDeclarationName($testMarker, $expected, $targetType = null)
     {
         if (isset($targetType) === false) {
-            $targetType = [\T_CLASS, \T_INTERFACE, \T_TRAIT, \T_FUNCTION];
+            $targetType = [\T_CLASS, \T_INTERFACE, \T_TRAIT, \T_ENUM, \T_FUNCTION];
         }
 
         $target = $this->getTargetToken($testMarker, $targetType);

--- a/Tests/BackCompat/BCFile/GetDeclarationNameTest.inc
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameTest.inc
@@ -69,6 +69,22 @@ class /* comment */
 /* testFunctionFn */
 function fn() {}
 
+/* testPureEnum */
+enum Foo
+{
+    case SOME_CASE;
+}
+
+/* testBackedEnumSpaceBetweenNameAndColon */
+enum Hoo : string
+{
+    case ONE = 'one';
+    case TWO = 'two';
+}
+
+/* testBackedEnumNoSpaceBetweenNameAndColon */
+enum Suit: int implements Colorful, CardGame {}
+
 /* testLiveCoding */
 // Intentional parse error. This has to be the last test in the file.
 function // Comment.

--- a/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
@@ -106,7 +106,7 @@ class GetDeclarationNameTest extends UtilityMethodTestCase
     public function testGetDeclarationName($testMarker, $expected, $targetType = null)
     {
         if (isset($targetType) === false) {
-            $targetType = [\T_CLASS, \T_INTERFACE, \T_TRAIT, \T_FUNCTION];
+            $targetType = [\T_CLASS, \T_INTERFACE, \T_TRAIT, \T_ENUM, \T_FUNCTION];
         }
 
         $target = $this->getTargetToken($testMarker, $targetType);
@@ -179,6 +179,18 @@ class GetDeclarationNameTest extends UtilityMethodTestCase
             'function-named-fn' => [
                 '/* testFunctionFn */',
                 'fn',
+            ],
+            'enum-pure' => [
+                '/* testPureEnum */',
+                'Foo',
+            ],
+            'enum-backed-space-between-name-and-colon' => [
+                '/* testBackedEnumSpaceBetweenNameAndColon */',
+                'Hoo',
+            ],
+            'enum-backed-no-space-between-name-and-colon' => [
+                '/* testBackedEnumNoSpaceBetweenNameAndColon */',
+                'Suit',
             ],
         ];
     }

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.inc
@@ -259,3 +259,18 @@ $anon = class {
     ]
     private mixed $baz;
 };
+
+enum Suit
+{
+    /* testEnumProperty */
+    protected $anonymous;
+}
+
+enum Direction implements ArrayAccess
+{
+    case Up;
+    case Down;
+
+    /* testEnumMethodParamNotProperty */
+    public function offsetGet($val) { ... }
+}

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -800,6 +800,10 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'nullable_type'   => false,
                 ],
             ],
+            'invalid-property-in-enum' => [
+                '/* testEnumProperty */',
+                [],
+            ],
         ];
     }
 
@@ -838,6 +842,7 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
             ['/* testGlobalVariable */'],
             ['/* testNestedMethodParam 1 */'],
             ['/* testNestedMethodParam 2 */'],
+            ['/* testEnumMethodParamNotProperty */'],
         ];
     }
 

--- a/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.php
@@ -41,7 +41,7 @@ class FindImplementedInterfaceNamesDiffTest extends UtilityMethodTestCase
      */
     public function testFindImplementedInterfaceNames($testMarker, $expected)
     {
-        $OOToken = $this->getTargetToken($testMarker, [\T_CLASS, \T_ANON_CLASS, \T_INTERFACE]);
+        $OOToken = $this->getTargetToken($testMarker, [\T_CLASS, \T_ANON_CLASS, \T_INTERFACE, \T_ENUM]);
         $result  = ObjectDeclarations::findImplementedInterfaceNames(self::$phpcsFile, $OOToken);
         $this->assertSame($expected, $result);
     }

--- a/Tests/Utils/ObjectDeclarations/GetNameDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameDiffTest.php
@@ -87,7 +87,7 @@ class GetNameDiffTest extends UtilityMethodTestCase
     public function testGetName($testMarker, $expected, $targetType = null)
     {
         if (isset($targetType) === false) {
-            $targetType = [\T_CLASS, \T_INTERFACE, \T_TRAIT, \T_FUNCTION];
+            $targetType = [\T_CLASS, \T_INTERFACE, \T_TRAIT, \T_ENUM, \T_FUNCTION];
         }
 
         $target = $this->getTargetToken($testMarker, $targetType);

--- a/Tests/Utils/ObjectDeclarations/GetNameJSTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameJSTest.php
@@ -54,7 +54,7 @@ class GetNameJSTest extends BCFile_GetDeclarationNameJSTest
      */
     public function testInvalidTokenPassed()
     {
-        $this->expectPhpcsException('Token type "T_STRING" is not T_FUNCTION, T_CLASS, T_INTERFACE or T_TRAIT');
+        $this->expectPhpcsException('Token type "T_STRING" is not T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT or T_ENUM');
 
         $target = $this->getTargetToken('/* testInvalidTokenPassed */', \T_STRING);
         ObjectDeclarations::getName(self::$phpcsFile, $target);
@@ -95,7 +95,7 @@ class GetNameJSTest extends BCFile_GetDeclarationNameJSTest
     public function testGetDeclarationName($testMarker, $expected, $targetType = null)
     {
         if (isset($targetType) === false) {
-            $targetType = [\T_CLASS, \T_INTERFACE, \T_TRAIT, \T_FUNCTION];
+            $targetType = [\T_CLASS, \T_INTERFACE, \T_TRAIT, \T_ENUM, \T_FUNCTION];
         }
 
         $target = $this->getTargetToken($testMarker, $targetType);

--- a/Tests/Utils/ObjectDeclarations/GetNameTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameTest.php
@@ -54,7 +54,7 @@ class GetNameTest extends BCFile_GetDeclarationNameTest
      */
     public function testInvalidTokenPassed()
     {
-        $this->expectPhpcsException('Token type "T_STRING" is not T_FUNCTION, T_CLASS, T_INTERFACE or T_TRAIT');
+        $this->expectPhpcsException('Token type "T_STRING" is not T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT or T_ENUM');
 
         $target = $this->getTargetToken('/* testInvalidTokenPassed */', \T_STRING);
         ObjectDeclarations::getName(self::$phpcsFile, $target);
@@ -95,7 +95,7 @@ class GetNameTest extends BCFile_GetDeclarationNameTest
     public function testGetDeclarationName($testMarker, $expected, $targetType = null)
     {
         if (isset($targetType) === false) {
-            $targetType = [\T_CLASS, \T_INTERFACE, \T_TRAIT, \T_FUNCTION];
+            $targetType = [\T_CLASS, \T_INTERFACE, \T_TRAIT, \T_ENUM, \T_FUNCTION];
         }
 
         $target = $this->getTargetToken($testMarker, $targetType);

--- a/Tests/Utils/Scopes/IsOOConstantTest.inc
+++ b/Tests/Utils/Scopes/IsOOConstantTest.inc
@@ -37,3 +37,14 @@ trait MyTrait {
     /* testTraitConst */
     const BAR = false;
 }
+
+enum Suit: string
+{
+    /* testEnumConst */
+    const FOO = 'bar';
+
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}

--- a/Tests/Utils/Scopes/IsOOConstantTest.php
+++ b/Tests/Utils/Scopes/IsOOConstantTest.php
@@ -109,6 +109,10 @@ class IsOOConstantTest extends UtilityMethodTestCase
                 'testMarker' => '/* testTraitConst */',
                 'expected'   => false,
             ],
+            'enum-const' => [
+                'testMarker' => '/* testEnumConst */',
+                'expected'   => true,
+            ],
         ];
     }
 }

--- a/Tests/Utils/Scopes/IsOOMethodTest.inc
+++ b/Tests/Utils/Scopes/IsOOMethodTest.inc
@@ -38,3 +38,17 @@ trait MyTrait {
     /* testTraitMethod */
     public function something() {}
 }
+
+enum Suit implements Colorful
+{
+    case Hearts;
+
+    /* testEnumMethod */
+    public function color(): string {
+        /* testEnumNestedFunction */
+        function nested() {}
+
+        /* testEnumNestedClosure */
+        $c = function() {};
+    }
+}

--- a/Tests/Utils/Scopes/IsOOMethodTest.php
+++ b/Tests/Utils/Scopes/IsOOMethodTest.php
@@ -121,6 +121,18 @@ class IsOOMethodTest extends UtilityMethodTestCase
                 'testMarker' => '/* testTraitMethod */',
                 'expected'   => true,
             ],
+            'enum-method' => [
+                'testMarker' => '/* testEnumMethod */',
+                'expected'   => true,
+            ],
+            'enum-nested-function' => [
+                'testMarker' => '/* testEnumNestedFunction */',
+                'expected'   => false,
+            ],
+            'enum-nested-closure' => [
+                'testMarker' => '/* testEnumNestedClosure */',
+                'expected'   => false,
+            ],
         ];
     }
 }

--- a/Tests/Utils/Scopes/IsOOPropertyTest.inc
+++ b/Tests/Utils/Scopes/IsOOPropertyTest.inc
@@ -87,3 +87,12 @@ if ( has_filter( 'comments_open' ) === false ) {
     /* testFunctionCallParameter */
     }, $priority, 2 );
 }
+
+enum MyEnum {
+    // Intentional parse error. Properties are not allowed in enums.
+    /* testEnumProp */
+    public $enumProp = false;
+
+    /* testEnumMethodParameter */
+    public function something($param = false);
+}

--- a/Tests/Utils/Scopes/IsOOPropertyTest.php
+++ b/Tests/Utils/Scopes/IsOOPropertyTest.php
@@ -177,6 +177,14 @@ class IsOOPropertyTest extends UtilityMethodTestCase
                 'testMarker' => '/* testFunctionCallParameter */',
                 'expected'   => false,
             ],
+            'enum-property' => [
+                'testMarker' => '/* testEnumProp */',
+                'expected'   => false,
+            ],
+            'enum-method-param' => [
+                'testMarker' => '/* testEnumMethodParameter */',
+                'expected'   => false,
+            ],
         ];
     }
 }

--- a/Tests/Utils/Variables/GetMemberPropertiesDiffTest.inc
+++ b/Tests/Utils/Variables/GetMemberPropertiesDiffTest.inc
@@ -5,3 +5,9 @@ interface Base
     /* testInterfaceProperty */
     protected $anonymous;
 }
+
+enum Suit
+{
+    /* testEnumProperty */
+    protected $anonymous;
+}

--- a/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
@@ -41,15 +41,34 @@ class GetMemberPropertiesDiffTest extends UtilityMethodTestCase
     }
 
     /**
-     * Test receiving an expected exception when an (invalid) interface property is passed.
+     * Test receiving an expected exception when an (invalid) interface or enum property is passed.
+     *
+     * @dataProvider dataNotClassPropertyException
+     *
+     * @param string $testMarker Comment which precedes the test case.
      *
      * @return void
      */
-    public function testNotClassPropertyException()
+    public function testNotClassPropertyException($testMarker)
     {
         $this->expectPhpcsException('$stackPtr is not a class member var');
 
-        $variable = $this->getTargetToken('/* testInterfaceProperty */', \T_VARIABLE);
+        $variable = $this->getTargetToken($testMarker, \T_VARIABLE);
         Variables::getMemberProperties(self::$phpcsFile, $variable);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNotClassPropertyException()
+     *
+     * @return array
+     */
+    public function dataNotClassPropertyException()
+    {
+        return [
+            'interface property' => ['/* testInterfaceProperty */'],
+            'enum property'      => ['/* testEnumProperty */'],
+        ];
     }
 }

--- a/Tests/Utils/Variables/GetMemberPropertiesTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesTest.php
@@ -68,13 +68,12 @@ class GetMemberPropertiesTest extends BCFile_GetMemberPropertiesTest
         $data = parent::dataGetMemberProperties();
 
         /*
-         * Remove the data set related to the invalid interface property.
-         * This will now throw an exception instead.
+         * Remove the data set related to the invalid interface/enum properties.
+         * These will now throw an exception instead.
          */
         foreach ($data as $key => $value) {
-            if ($value[0] === '/* testInterfaceProperty */') {
+            if ($value[0] === '/* testInterfaceProperty */' || $value[0] === '/* testEnumProperty */') {
                 unset($data[$key]);
-                break;
             }
         }
 


### PR DESCRIPTION
PHP 8.1 introduced a new type of OO structure: enumerations, which uses the `enum` keyword / `T_ENUM` token.

Refs:
* https://wiki.php.net/rfc/enumerations

---

### PHP 8.1 | Collections::closedScopes(): add the T_ENUM token

Enums, like classes, interfaces and traits, are a closed scope structure, so the `Collections::closedScopes()` token array should include it.

### PHP 8.1 | Scopes::isOOConstant(): add support for constants in enums

Alike classes, constants can be declared in an enum too.

This commit adds support for detecting whether a constant declared using the `const` keyword is within an enum structure to the `Scopes::isOOConstant()` method.

Includes adding the `T_ENUM` token to the `Collections::ooConstantScopes()` token array.

### PHP 8.1 | Scopes::isOOMethod(): add support for enums

Alike classes, methods can be declared in an enum.

As the `Scopes::isOOMethod()` method uses the PHPCS based `[BC]Tokens::$ooScopeTokens` token array, in which `T_ENUM` was added in PHPCS 3.7.0, the `Scopes::isOOMethod()` method will correctly recognize methods within enums as OO methods.

This commit updates the documentation to indicate support for enums + adds tests to safeguard support.

### PHP 8.1 | Scopes::isOOProperty(): add tests for enums

Unlike classes, properties are not allowed in enums.

This commit adds tests to ensure the `Scopes::isOOProperty()` method handles this correctly.

### PHP 8.1 | BCFile/ObjectDeclarations::get[Declaration]Name(): sync with PHPCS / support enums

Enums are a named structure, so the `BCFile/ObjectDeclarations::get[Declaration]Name()` method should handle this correctly.

This commit syncs in the changes from upstream for the same.

Refs:
* squizlabs/PHP_CodeSniffer#3482

### PHP 8.1 | BCFile/ObjectDeclarations::getClassProperties(): add test with enum

... to verify the method correctly throws an exception.

### PHP 8.1 | BCFile/ObjectDeclarations::findImplementedInterfaceNames(): sync with PHPCS / add support for enums

> An `enum` declaration can implement one or more interfaces.
>
> This commit updates the `File::findImplementedInterfaceNames()` method to allow it to find the interfaces implemented by an `enum` as well.
>
> Includes unit tests.

Includes adding the `T_ENUM` token to the `Collections::ooCanImplement()` token array.

Refs:
* squizlabs/PHP_CodeSniffer#3578

### PHP 8.1 | BCFile/Variables::getMemberProperties(): throw exception for properties in enum

Handle enums in the same way as interface properties (neither are supported by PHP).

> Neither enums nor interfaces support properties being declared on them.
>
> This adjusts the `File::getMemberProperties() method to handle properties declared on an `enum` in the same way as properties declared on an `interface` were already being handled.

Includes unit tests.

Refs:
* squizlabs/PHP_CodeSniffer#3577

### PHP 8.1 | Utils\UseStatements::getType(): update comment to document enum support