### PR TITLE
BCTokens: add support for new `contextSensitiveKeywords` token array

### DIFF
--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -44,30 +44,31 @@ use PHPCSUtils\Tokens\Collections;
  * @since 1.0.0
  * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  *
- * @method static array arithmeticTokens()   Tokens that represent arithmetic operators.
- * @method static array assignmentTokens()   Tokens that represent assignments.
- * @method static array blockOpeners()       Tokens that open code blocks.
- * @method static array booleanOperators()   Tokens that perform boolean operations.
- * @method static array bracketTokens()      Tokens that represent brackets and parenthesis.
- * @method static array castTokens()         Tokens that represent type casting.
- * @method static array commentTokens()      Tokens that are comments.
- * @method static array comparisonTokens()   Tokens that represent comparison operator.
- * @method static array emptyTokens()        Tokens that don't represent code.
- * @method static array equalityTokens()     Tokens that represent equality comparisons.
- * @method static array heredocTokens()      Tokens that make up a heredoc string.
- * @method static array includeTokens()      Tokens that include files.
- * @method static array magicConstants()     Tokens representing PHP magic constants.
- * @method static array methodPrefixes()     Tokens that can prefix a method name.
- * @method static array ooScopeTokens()      Tokens that open class and object scopes.
- * @method static array operators()          Tokens that perform operations.
- * @method static array parenthesisOpeners() Token types that open parenthesis.
- * @method static array phpcsCommentTokens() Tokens that are comments containing PHPCS instructions.
- * @method static array scopeModifiers()     Tokens that represent scope modifiers.
- * @method static array scopeOpeners()       Tokens that are allowed to open scopes.
- * @method static array stringTokens()       Tokens that represent strings.
- *                                           Note that `T_STRING`s are NOT represented in this list as this list
- *                                           is about _text_ strings.
- * @method static array textStringTokens()   Tokens that represent text strings.
+ * @method static array arithmeticTokens()         Tokens that represent arithmetic operators.
+ * @method static array assignmentTokens()         Tokens that represent assignments.
+ * @method static array blockOpeners()             Tokens that open code blocks.
+ * @method static array booleanOperators()         Tokens that perform boolean operations.
+ * @method static array bracketTokens()            Tokens that represent brackets and parenthesis.
+ * @method static array castTokens()               Tokens that represent type casting.
+ * @method static array commentTokens()            Tokens that are comments.
+ * @method static array comparisonTokens()         Tokens that represent comparison operator.
+ * @method static array contextSensitiveKeywords() Tokens representing context sensitive keywords in PHP.
+ * @method static array emptyTokens()              Tokens that don't represent code.
+ * @method static array equalityTokens()           Tokens that represent equality comparisons.
+ * @method static array heredocTokens()            Tokens that make up a heredoc string.
+ * @method static array includeTokens()            Tokens that include files.
+ * @method static array magicConstants()           Tokens representing PHP magic constants.
+ * @method static array methodPrefixes()           Tokens that can prefix a method name.
+ * @method static array ooScopeTokens()            Tokens that open class and object scopes.
+ * @method static array operators()                Tokens that perform operations.
+ * @method static array parenthesisOpeners()       Token types that open parenthesis.
+ * @method static array phpcsCommentTokens()       Tokens that are comments containing PHPCS instructions.
+ * @method static array scopeModifiers()           Tokens that represent scope modifiers.
+ * @method static array scopeOpeners()             Tokens that are allowed to open scopes.
+ * @method static array stringTokens()             Tokens that represent strings.
+ *                                                 Note that `T_STRING`s are NOT represented in this list as this list
+ *                                                 is about _text_ strings.
+ * @method static array textStringTokens()         Tokens that represent text strings.
  */
 class BCTokens
 {

--- a/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
+++ b/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
@@ -368,6 +368,86 @@ class UnchangedTokenArraysTest extends TestCase
     ];
 
     /**
+     * Tokens representing context sensitive keywords in PHP.
+     *
+     * @var array<int|string, int|string>
+     *
+     * https://wiki.php.net/rfc/context_sensitive_lexer
+     */
+    private $contextSensitiveKeywords = [
+        \T_ABSTRACT     => \T_ABSTRACT,
+        \T_ARRAY        => \T_ARRAY,
+        \T_AS           => \T_AS,
+        \T_BREAK        => \T_BREAK,
+        \T_CALLABLE     => \T_CALLABLE,
+        \T_CASE         => \T_CASE,
+        \T_CATCH        => \T_CATCH,
+        \T_CLASS        => \T_CLASS,
+        \T_CLONE        => \T_CLONE,
+        \T_CONST        => \T_CONST,
+        \T_CONTINUE     => \T_CONTINUE,
+        \T_DECLARE      => \T_DECLARE,
+        \T_DEFAULT      => \T_DEFAULT,
+        \T_DO           => \T_DO,
+        \T_ECHO         => \T_ECHO,
+        \T_ELSE         => \T_ELSE,
+        \T_ELSEIF       => \T_ELSEIF,
+        \T_EMPTY        => \T_EMPTY,
+        \T_ENDDECLARE   => \T_ENDDECLARE,
+        \T_ENDFOR       => \T_ENDFOR,
+        \T_ENDFOREACH   => \T_ENDFOREACH,
+        \T_ENDIF        => \T_ENDIF,
+        \T_ENDSWITCH    => \T_ENDSWITCH,
+        \T_ENDWHILE     => \T_ENDWHILE,
+        \T_ENUM         => \T_ENUM,
+        \T_EVAL         => \T_EVAL,
+        \T_EXIT         => \T_EXIT,
+        \T_EXTENDS      => \T_EXTENDS,
+        \T_FINAL        => \T_FINAL,
+        \T_FINALLY      => \T_FINALLY,
+        \T_FN           => \T_FN,
+        \T_FOR          => \T_FOR,
+        \T_FOREACH      => \T_FOREACH,
+        \T_FUNCTION     => \T_FUNCTION,
+        \T_GLOBAL       => \T_GLOBAL,
+        \T_GOTO         => \T_GOTO,
+        \T_IF           => \T_IF,
+        \T_IMPLEMENTS   => \T_IMPLEMENTS,
+        \T_INCLUDE      => \T_INCLUDE,
+        \T_INCLUDE_ONCE => \T_INCLUDE_ONCE,
+        \T_INSTANCEOF   => \T_INSTANCEOF,
+        \T_INSTEADOF    => \T_INSTEADOF,
+        \T_INTERFACE    => \T_INTERFACE,
+        \T_ISSET        => \T_ISSET,
+        \T_LIST         => \T_LIST,
+        \T_LOGICAL_AND  => \T_LOGICAL_AND,
+        \T_LOGICAL_OR   => \T_LOGICAL_OR,
+        \T_LOGICAL_XOR  => \T_LOGICAL_XOR,
+        \T_MATCH        => \T_MATCH,
+        \T_NAMESPACE    => \T_NAMESPACE,
+        \T_NEW          => \T_NEW,
+        \T_PRINT        => \T_PRINT,
+        \T_PRIVATE      => \T_PRIVATE,
+        \T_PROTECTED    => \T_PROTECTED,
+        \T_PUBLIC       => \T_PUBLIC,
+        \T_READONLY     => \T_READONLY,
+        \T_REQUIRE      => \T_REQUIRE,
+        \T_REQUIRE_ONCE => \T_REQUIRE_ONCE,
+        \T_RETURN       => \T_RETURN,
+        \T_STATIC       => \T_STATIC,
+        \T_SWITCH       => \T_SWITCH,
+        \T_THROW        => \T_THROW,
+        \T_TRAIT        => \T_TRAIT,
+        \T_TRY          => \T_TRY,
+        \T_UNSET        => \T_UNSET,
+        \T_USE          => \T_USE,
+        \T_VAR          => \T_VAR,
+        \T_WHILE        => \T_WHILE,
+        \T_YIELD        => \T_YIELD,
+        \T_YIELD_FROM   => \T_YIELD_FROM,
+    ];
+
+    /**
      * Test the method.
      *
      * @dataProvider dataUnchangedTokenArrays


### PR DESCRIPTION
... as introduced in PHPCS 3.7.0 and updated in PHPCS 3.7.1.

Upstream PR squizlabs/PHP_CodeSniffer#3484 introduces a new `$contextSensitiveKeywords` tokens array to PHPCS.

This PR backfills the PHPCS native array in the `BCTokens` class.

Includes unit test.
Includes updates to the array made in upstream PRs squizlabs/PHP_CodeSniffer#3608 and squizlabs/PHP_CodeSniffer#3610.

Refs:
* squizlabs/PHP_CodeSniffer#3484
* squizlabs/PHP_CodeSniffer#3608
* squizlabs/PHP_CodeSniffer#3610