### PR TITLE
PHP 8.1 | PassedParameters::getParameters(): document test with named params after argument unpacking

### DIFF
--- a/Tests/Utils/PassedParameters/GetParametersNamedTest.inc
+++ b/Tests/Utils/PassedParameters/GetParametersNamedTest.inc
@@ -65,8 +65,8 @@ test(param: 1, param: 2);
 // Error Exception, but not the concern of PHPCSUtils. Should still be handled.
 array_fill(start_index: 0, ...[100, 50]);
 
-/* testCompileErrorIncorrectOrderWithVariadic */
-// Not the concern of PHPCSUtils. Should still be handled.
+/* testPHP81NamedParamAfterVariadic */
+// Prior to PHP 8.1, this was a compile error, but this is now supported.
 test(...$values, param: $value);
 
 /* testParseErrorNoValue */

--- a/Tests/Utils/PassedParameters/GetParametersNamedTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersNamedTest.php
@@ -519,8 +519,9 @@ class GetParametersNamedTest extends UtilityMethodTestCase
                     ],
                 ],
             ],
-            'named-args-compile-error-incorrect-order-variadic' => [
-                'testMarker' => '/* testCompileErrorIncorrectOrderWithVariadic */',
+            // Prior to PHP 8.1, this was a compile error, but this is now supported.
+            'named-args-after-variadic' => [
+                'testMarker' => '/* testPHP81NamedParamAfterVariadic */',
                 'targetType' => \T_STRING,
                 'expected'   => [
                     1 => [


### PR DESCRIPTION
Prior to PHP 8.1, using named arguments after a variadic argument in a function call was a compile error. As of PHP 8.1, this is now fully supported.

The tests already contained a code sample covering this. The documentation for the test case has now been adjusted.

Refs:
* https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.named-arg-after-unpack