### PR TITLE
PHP 8.1: add support for intersection types

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -546,21 +546,23 @@ class Collections
      *
      * @since 1.0.0-alpha1
      * @since 1.0.0-alpha4 Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.
+     * @since 1.0.0-alpha4 Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.
      *
      * @deprecated 1.0.0-alpha4 Use the {@see Collections::returnTypeTokens()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
     public static $returnTypeTokens = [
-        \T_CALLABLE     => \T_CALLABLE,
-        \T_SELF         => \T_SELF,
-        \T_PARENT       => \T_PARENT,
-        \T_STATIC       => \T_STATIC,
-        \T_FALSE        => \T_FALSE,
-        \T_NULL         => \T_NULL,
-        \T_STRING       => \T_STRING,
-        \T_NS_SEPARATOR => \T_NS_SEPARATOR,
-        \T_TYPE_UNION   => \T_TYPE_UNION,
+        \T_CALLABLE          => \T_CALLABLE,
+        \T_SELF              => \T_SELF,
+        \T_PARENT            => \T_PARENT,
+        \T_STATIC            => \T_STATIC,
+        \T_FALSE             => \T_FALSE,
+        \T_NULL              => \T_NULL,
+        \T_STRING            => \T_STRING,
+        \T_NS_SEPARATOR      => \T_NS_SEPARATOR,
+        \T_TYPE_UNION        => \T_TYPE_UNION,
+        \T_TYPE_INTERSECTION => \T_TYPE_INTERSECTION,
     ];
 
     /**
@@ -991,6 +993,7 @@ class Collections
      * @since 1.0.0-alpha4 This method replaces the {@see Collections::$returnTypeTokens} property.
      * @since 1.0.0-alpha4 Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.
      * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokens.
+     * @since 1.0.0-alpha4 Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.
      *
      * @return array <int|string> => <int|string>
      */

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -523,20 +523,22 @@ class Collections
      *
      * @since 1.0.0-alpha1
      * @since 1.0.0-alpha4 Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.
+     * @since 1.0.0-alpha4 Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.
      *
      * @deprecated 1.0.0-alpha4 Use the {@see Collections::propertyTypeTokens()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
     public static $propertyTypeTokens = [
-        \T_CALLABLE     => \T_CALLABLE,
-        \T_SELF         => \T_SELF,
-        \T_PARENT       => \T_PARENT,
-        \T_FALSE        => \T_FALSE,
-        \T_NULL         => \T_NULL,
-        \T_STRING       => \T_STRING,
-        \T_NS_SEPARATOR => \T_NS_SEPARATOR,
-        \T_TYPE_UNION   => \T_TYPE_UNION,
+        \T_CALLABLE          => \T_CALLABLE,
+        \T_SELF              => \T_SELF,
+        \T_PARENT            => \T_PARENT,
+        \T_FALSE             => \T_FALSE,
+        \T_NULL              => \T_NULL,
+        \T_STRING            => \T_STRING,
+        \T_NS_SEPARATOR      => \T_NS_SEPARATOR,
+        \T_TYPE_UNION        => \T_TYPE_UNION,
+        \T_TYPE_INTERSECTION => \T_TYPE_INTERSECTION,
     ];
 
     /**
@@ -949,6 +951,7 @@ class Collections
      * @since 1.0.0-alpha4 This method replaces the {@see Collections::$propertyTypeTokens} property.
      * @since 1.0.0-alpha4 Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.
      * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokens.
+     * @since 1.0.0-alpha4 Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.
      *
      * @return array <int|string> => <int|string>
      */

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -471,20 +471,22 @@ class Collections
      *
      * @since 1.0.0-alpha1
      * @since 1.0.0-alpha4 Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.
+     * @since 1.0.0-alpha4 Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.
      *
      * @deprecated 1.0.0-alpha4 Use the {@see Collections::parameterTypeTokens()} method instead.
      *
      * @var array <int|string> => <int|string>
      */
     public static $parameterTypeTokens = [
-        \T_CALLABLE     => \T_CALLABLE,
-        \T_SELF         => \T_SELF,
-        \T_PARENT       => \T_PARENT,
-        \T_FALSE        => \T_FALSE,
-        \T_NULL         => \T_NULL,
-        \T_STRING       => \T_STRING,
-        \T_NS_SEPARATOR => \T_NS_SEPARATOR,
-        \T_TYPE_UNION   => \T_TYPE_UNION,
+        \T_CALLABLE          => \T_CALLABLE,
+        \T_SELF              => \T_SELF,
+        \T_PARENT            => \T_PARENT,
+        \T_FALSE             => \T_FALSE,
+        \T_NULL              => \T_NULL,
+        \T_STRING            => \T_STRING,
+        \T_NS_SEPARATOR      => \T_NS_SEPARATOR,
+        \T_TYPE_UNION        => \T_TYPE_UNION,
+        \T_TYPE_INTERSECTION => \T_TYPE_INTERSECTION,
     ];
 
     /**
@@ -914,6 +916,7 @@ class Collections
      * @since 1.0.0-alpha4 This method replaces the {@see Collections::$parameterTypeTokens} property.
      * @since 1.0.0-alpha4 Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.
      * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokens.
+     * @since 1.0.0-alpha4 Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.
      *
      * @return array <int|string> => <int|string>
      */

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -156,6 +156,7 @@ class FunctionDeclarations
      * @since 1.0.0-alpha2 Added support for PHP 7.4 arrow functions.
      * @since 1.0.0-alpha3 Added support for PHP 8.0 static return type.
      * @since 1.0.0-alpha4 Added support for PHP 8.0 union types.
+     * @since 1.0.0-alpha4 Added support for PHP 8.1 intersection types.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the function token to

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -365,6 +365,7 @@ class FunctionDeclarations
      * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokenization.
      * @since 1.0.0-alpha4 Added support for PHP 8.0 parameter attributes.
      * @since 1.0.0-alpha4 Added support for PHP 8.1 readonly keyword for constructor property promotion.
+     * @since 1.0.0-alpha4 Added support for PHP 8.1 intersection types.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the function token

--- a/PHPCSUtils/Utils/Variables.php
+++ b/PHPCSUtils/Utils/Variables.php
@@ -90,6 +90,7 @@ class Variables
      * @since 1.0.0-alpha4 Added support for PHP 8.0 union types.
      * @since 1.0.0-alpha4 No longer gets confused by PHP 8.0 property attributes.
      * @since 1.0.0-alpha4 Added support for PHP 8.1 readonly properties.
+     * @since 1.0.0-alpha4 Added support for PHP 8.1 intersection types.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the `T_VARIABLE` token

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.inc
@@ -299,3 +299,19 @@ enum Direction implements ArrayAccess
     /* testEnumMethodParamNotProperty */
     public function offsetGet($val) { ... }
 }
+
+$anon = class() {
+    /* testPHP81IntersectionTypes */
+    public Foo&Bar $intersectionType;
+
+    /* testPHP81MoreIntersectionTypes */
+    public Foo&Bar&Baz $moreIntersectionTypes;
+
+    /* testPHP81IllegalIntersectionTypes */
+    // Intentional fatal error - types which are not allowed for intersection type, but that's not the concern of the method.
+    public int&string $illegalIntersectionType;
+
+    /* testPHP81NullableIntersectionType */
+    // Intentional fatal error - nullability is not allowed with intersection type, but that's not the concern of the method.
+    public ?Foo&Bar $nullableIntersectionType;
+};

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -965,6 +965,58 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 '/* testEnumProperty */',
                 [],
             ],
+            'php8.1-single-intersection-type' => [
+                '/* testPHP81IntersectionTypes */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'is_readonly'     => false,
+                    'type'            => 'Foo&Bar',
+                    'type_token'      => -4, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'nullable_type'   => false,
+                ],
+            ],
+            'php8.1-multi-intersection-type' => [
+                '/* testPHP81MoreIntersectionTypes */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'is_readonly'     => false,
+                    'type'            => 'Foo&Bar&Baz',
+                    'type_token'      => -6, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'nullable_type'   => false,
+                ],
+            ],
+            'php8.1-illegal-intersection-type' => [
+                '/* testPHP81IllegalIntersectionTypes */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'is_readonly'     => false,
+                    'type'            => 'int&string',
+                    'type_token'      => -4, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'nullable_type'   => false,
+                ],
+            ],
+            'php8.1-nullable-intersection-type' => [
+                '/* testPHP81NullableIntersectionType */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'is_readonly'     => false,
+                    'type'            => '?Foo&Bar',
+                    'type_token'      => -4, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'nullable_type'   => true,
+                ],
+            ],
         ];
     }
 

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
@@ -239,6 +239,23 @@ class ParametersWithAttributes(
     ) {}
 }
 
+/* testPHP8IntersectionTypes */
+function intersectionTypes(Foo&Bar $obj1, Boo&Bar $obj2) {}
+
+/* testPHP81IntersectionTypesWithSpreadOperatorAndReference */
+function globalFunctionWithSpreadAndReference(Boo&Bar &$paramA, Foo&Bar ...$paramB) {}
+
+/* testPHP81MoreIntersectionTypes */
+function moreIntersectionTypes(MyClassA&\Package\MyClassB&\Package\MyClassC $var) {}
+
+/* testPHP81IllegalIntersectionTypes */
+// Intentional fatal error - simple types are not allowed with intersection types, but that's not the concern of the method.
+$closure = function (string&int $numeric_string) {};
+
+/* testPHP81NullableIntersectionTypes */
+// Intentional fatal error - nullability is not allowed with intersection types, but that's not the concern of the method.
+$closure = function (?Foo&Bar $object) {};
+
 /* testPHP81NewInInitializers */
 function newInInitializers(
     TypeA $new = new TypeA(self::CONST_VALUE),

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -2167,6 +2167,174 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     }
 
     /**
+     * Verify recognition of PHP8.1 intersection type declaration.
+     *
+     * @return void
+     */
+    public function testPHP8IntersectionTypes()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 8, // Offset from the T_FUNCTION token.
+            'name'                => '$obj1',
+            'content'             => 'Foo&Bar $obj1',
+            'has_attributes'      => false,
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'Foo&Bar',
+            'type_hint_token'     => 4, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 6, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => 9,
+        ];
+        $expected[1] = [
+            'token'               => 15, // Offset from the T_FUNCTION token.
+            'name'                => '$obj2',
+            'content'             => 'Boo&Bar $obj2',
+            'has_attributes'      => false,
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'Boo&Bar',
+            'type_hint_token'     => 11, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 13, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify recognition of PHP8 intersection type declaration when the variable
+     * has either a spread operator or a reference.
+     *
+     * @return void
+     */
+    public function testPHP81IntersectionTypesWithSpreadOperatorAndReference()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 9, // Offset from the T_FUNCTION token.
+            'name'                => '$paramA',
+            'content'             => 'Boo&Bar &$paramA',
+            'has_attributes'      => false,
+            'pass_by_reference'   => true,
+            'reference_token'     => 8, // Offset from the T_FUNCTION token.
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'Boo&Bar',
+            'type_hint_token'     => 4, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 6, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => 10,
+        ];
+        $expected[1] = [
+            'token'               => 17, // Offset from the T_FUNCTION token.
+            'name'                => '$paramB',
+            'content'             => 'Foo&Bar ...$paramB',
+            'has_attributes'      => false,
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => true,
+            'variadic_token'      => 16, // Offset from the T_FUNCTION token.
+            'type_hint'           => 'Foo&Bar',
+            'type_hint_token'     => 12, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 14, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify recognition of PHP8.1 intersection type declaration with more types.
+     *
+     * @return void
+     */
+    public function testPHP81MoreIntersectionTypes()
+    {
+        $php8Names = parent::usesPhp8NameTokens();
+
+        $expected    = [];
+        $expected[0] = [
+            'token'               => ($php8Names === true) ? 10 : 16, // Offset from the T_FUNCTION token.
+            'name'                => '$var',
+            'content'             => 'MyClassA&\Package\MyClassB&\Package\MyClassC $var',
+            'has_attributes'      => false,
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'MyClassA&\Package\MyClassB&\Package\MyClassC',
+            'type_hint_token'     => 4, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => ($php8Names === true) ? 8 : 14, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify recognition of PHP8.1 intersection type declaration with illegal simple types.
+     *
+     * @return void
+     */
+    public function testPHP81IllegalIntersectionTypes()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 7, // Offset from the T_FUNCTION token.
+            'name'                => '$numeric_string',
+            'content'             => 'string&int $numeric_string',
+            'has_attributes'      => false,
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'string&int',
+            'type_hint_token'     => 3, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 5, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify recognition of PHP8.1 intersection type declaration with (illegal) nullability.
+     *
+     * @return void
+     */
+    public function testPHP81NullableIntersectionTypes()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 8, // Offset from the T_FUNCTION token.
+            'name'                => '$object',
+            'content'             => '?Foo&Bar $object',
+            'has_attributes'      => false,
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '?Foo&Bar',
+            'type_hint_token'     => 4, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 6, // Offset from the T_FUNCTION token.
+            'nullable_type'       => true,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Verify behaviour when the default value uses the "new" keyword, as is allowed per PHP 8.1.
      *
      * @return void

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
@@ -141,6 +141,23 @@ function never(): never {}
 // Intentional fatal error - nullability is not allowed with never, but that's not the concern of the method.
 function nullableNever(): ?never {}
 
+/* testPHP8IntersectionTypes */
+function intersectionTypes(): Foo&Bar {}
+
+/* testPHP81MoreIntersectionTypes */
+function moreIntersectionTypes(): MyClassA&\Package\MyClassB&\Package\MyClassC {}
+
+/* testPHP81IntersectionArrowFunction */
+$fn = fn($var): MyClassA&\Package\MyClassB => $var;
+
+/* testPHP81IllegalIntersectionTypes */
+// Intentional fatal error - simple types are not allowed with intersection types, but that's not the concern of the method.
+$closure = function (): string&int {};
+
+/* testPHP81NullableIntersectionTypes */
+// Intentional fatal error - nullability is not allowed with intersection types, but that's not the concern of the method.
+$closure = function (): ?Foo&Bar {};
+
 /* testNotAFunction */
 return true;
 

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -896,6 +896,125 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     }
 
     /**
+     * Verify recognition of PHP8.1 intersection type declaration.
+     *
+     * @return void
+     */
+    public function testPHP8IntersectionTypes()
+    {
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'Foo&Bar',
+            'return_type_token'     => 7, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 9, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify recognition of PHP8.1 intersection type declaration with more types.
+     *
+     * @return void
+     */
+    public function testPHP81MoreIntersectionTypes()
+    {
+        $php8Names = parent::usesPhp8NameTokens();
+
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'MyClassA&\Package\MyClassB&\Package\MyClassC',
+            'return_type_token'     => 7, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => ($php8Names === true) ? 11 : 17, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify recognition of PHP8.1 intersection type declaration in arrow function.
+     *
+     * @return void
+     */
+    public function testPHP81IntersectionArrowFunction()
+    {
+        $php8Names = parent::usesPhp8NameTokens();
+
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'MyClassA&\Package\MyClassB',
+            'return_type_token'     => 6, // Offset from the T_FN token.
+            'return_type_end_token' => ($php8Names === true) ? 8 : 11, // Offset from the T_FN token.
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify recognition of PHP8.1 intersection type declaration with illegal simple types.
+     *
+     * @return void
+     */
+    public function testPHP81IllegalIntersectionTypes()
+    {
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'string&int',
+            'return_type_token'     => 6, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 8, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify recognition of PHP8.1 intersection type declaration with (illegal) nullability.
+     *
+     * @return void
+     */
+    public function testPHP81NullableIntersectionTypes()
+    {
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '?Foo&Bar',
+            'return_type_token'     => 7, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 9, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Test for incorrect tokenization of array return type declarations in PHPCS < 2.8.0.
      *
      * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/1264

--- a/Tests/Tokens/Collections/ParameterTypeTokensTest.php
+++ b/Tests/Tokens/Collections/ParameterTypeTokensTest.php
@@ -41,6 +41,7 @@ class ParameterTypeTokensTest extends TestCase
             \T_STRING               => \T_STRING,
             \T_NS_SEPARATOR         => \T_NS_SEPARATOR,
             \T_TYPE_UNION           => \T_TYPE_UNION,
+            \T_TYPE_INTERSECTION    => \T_TYPE_INTERSECTION,
             \T_NAMESPACE            => \T_NAMESPACE,
             \T_NAME_QUALIFIED       => \T_NAME_QUALIFIED,
             \T_NAME_FULLY_QUALIFIED => \T_NAME_FULLY_QUALIFIED,

--- a/Tests/Tokens/Collections/PropertyTypeTokensTest.php
+++ b/Tests/Tokens/Collections/PropertyTypeTokensTest.php
@@ -41,6 +41,7 @@ class PropertyTypeTokensTest extends TestCase
             \T_STRING               => \T_STRING,
             \T_NS_SEPARATOR         => \T_NS_SEPARATOR,
             \T_TYPE_UNION           => \T_TYPE_UNION,
+            \T_TYPE_INTERSECTION    => \T_TYPE_INTERSECTION,
             \T_NAMESPACE            => \T_NAMESPACE,
             \T_NAME_QUALIFIED       => \T_NAME_QUALIFIED,
             \T_NAME_FULLY_QUALIFIED => \T_NAME_FULLY_QUALIFIED,

--- a/Tests/Tokens/Collections/ReturnTypeTokensTest.php
+++ b/Tests/Tokens/Collections/ReturnTypeTokensTest.php
@@ -42,6 +42,7 @@ class ReturnTypeTokensTest extends TestCase
             \T_STRING               => \T_STRING,
             \T_NS_SEPARATOR         => \T_NS_SEPARATOR,
             \T_TYPE_UNION           => \T_TYPE_UNION,
+            \T_TYPE_INTERSECTION    => \T_TYPE_INTERSECTION,
             \T_NAMESPACE            => \T_NAMESPACE,
             \T_NAME_QUALIFIED       => \T_NAME_QUALIFIED,
             \T_NAME_FULLY_QUALIFIED => \T_NAME_FULLY_QUALIFIED,


### PR DESCRIPTION
### PHP 8.1 | Variables::getMemberProperties(): support intersection types

### PHP 8.1 | FunctionDeclarations::getProperties(): add support for intersection types

### PHP 8.1 | FunctionDeclarations::getParameters(): add support for intersection types

Sync with upstream PR squizlabs/PHP_CodeSniffer#3581 which added support for PHP 8.1 intersection types to these methods.

Ref:
* squizlabs/PHP_CodeSniffer#3581
* https://wiki.php.net/rfc/new_in_initializers