### PR TITLE
PHP 8.2 | Scopes::isOOConstant(): add support for constants in traits

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -401,10 +401,11 @@ class Collections
     /**
      * DEPRECATED: OO scopes in which constants can be declared.
      *
-     * Note: traits can not declare constants.
+     * Note: traits can only declare constants since PHP 8.2.
      *
      * @since 1.0.0-alpha1
      * @since 1.0.0-alpha4 Added the PHP 8.1 T_ENUM token.
+     * @since 1.0.0-alpha4 Added the T_TRAIT token for PHP 8.2 constants in traits.
      *
      * @deprecated 1.0.0-alpha4 Use the {@see Collections::ooConstantScopes()} method instead.
      *
@@ -415,6 +416,7 @@ class Collections
         \T_ANON_CLASS => \T_ANON_CLASS,
         \T_INTERFACE  => \T_INTERFACE,
         \T_ENUM       => \T_ENUM,
+        \T_TRAIT      => \T_TRAIT,
     ];
 
     /**
@@ -846,10 +848,11 @@ class Collections
     /**
      * OO scopes in which constants can be declared.
      *
-     * Note: traits can not declare constants.
+     * Note: traits can only declare constants since PHP 8.2.
      *
      * @since 1.0.0-alpha4 This method replaces the {@see Collections::$OOConstantScopes} property.
      * @since 1.0.0-alpha4 Added the PHP 8.1 T_ENUM token.
+     * @since 1.0.0-alpha4 Added the T_TRAIT token for PHP 8.2 constants in traits.
      *
      * @return array <int|string> => <int|string>
      */

--- a/PHPCSUtils/Utils/Scopes.php
+++ b/PHPCSUtils/Utils/Scopes.php
@@ -56,10 +56,11 @@ class Scopes
     }
 
     /**
-     * Check whether a T_CONST token is a class/interface/enum constant declaration.
+     * Check whether a T_CONST token is a class/interface/trait/enum constant declaration.
      *
      * @since 1.0.0
      * @since 1.0.0-alpha4 Added support for PHP 8.1 enums.
+     * @since 1.0.0-alpha4 Added support for PHP 8.2 constants in traits.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
      * @param int                         $stackPtr  The position in the stack of the

--- a/Tests/Utils/Scopes/IsOOConstantTest.inc
+++ b/Tests/Utils/Scopes/IsOOConstantTest.inc
@@ -33,7 +33,7 @@ interface MyInterface {
 }
 
 trait MyTrait {
-    // Intentional parse error. Constants are not allowed in traits.
+    // Prior to PHP 8.2, this was a parse error. Since PHP 8.2, constants are allowed in traits.
     /* testTraitConst */
     const BAR = false;
 }

--- a/Tests/Utils/Scopes/IsOOConstantTest.php
+++ b/Tests/Utils/Scopes/IsOOConstantTest.php
@@ -107,7 +107,7 @@ class IsOOConstantTest extends UtilityMethodTestCase
             ],
             'trait-const' => [
                 'testMarker' => '/* testTraitConst */',
-                'expected'   => false,
+                'expected'   => true,
             ],
             'enum-const' => [
                 'testMarker' => '/* testEnumConst */',


### PR DESCRIPTION
As of PHP 8.2, it is allowed to declare constants in traits.

This commit adds support for detecting whether a constant declared using the `const` keyword is within an trait structure to the `Scopes::isOOConstant()` method.

Includes adding the `T_TRAIT` token to the `Collections::ooConstantScopes()` token array.

Refs:
* https://wiki.php.net/rfc/constants_in_traits