### PR TITLE
PHP 8.2 | ObjectDeclarations::getClassProperties(): add support for readonly classes

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -164,6 +164,7 @@ class Collections
      * DEPRECATED: Modifier keywords which can be used for a class declaration.
      *
      * @since 1.0.0-alpha1
+     * @since 1.0.0-alpha4 Added the T_READONLY token for PHP 8.2 readonly classes.
      *
      * @deprecated 1.0.0-alpha4 Use the {@see Collections::classModifierKeywords()} method instead.
      *
@@ -172,6 +173,7 @@ class Collections
     public static $classModifierKeywords = [
         \T_FINAL    => \T_FINAL,
         \T_ABSTRACT => \T_ABSTRACT,
+        \T_READONLY => \T_READONLY,
     ];
 
     /**

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -138,11 +138,13 @@ class ObjectDeclarations
      *   - Handling of PHPCS annotations.
      *   - Handling of unorthodox docblock placement.
      * - Defensive coding against incorrect calls to this method.
+     * - Support for PHP 8.2 readonly classes.
      *
      * @see \PHP_CodeSniffer\Files\File::getClassProperties()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getClassProperties() Cross-version compatible version of the original.
      *
      * @since 1.0.0
+     * @since 1.0.0-alpha4 Added support for the PHP 8.2 readonly keyword.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the `T_CLASS`
@@ -154,6 +156,7 @@ class ObjectDeclarations
      *               array(
      *                 'is_abstract' => false, // TRUE if the abstract keyword was found.
      *                 'is_final'    => false, // TRUE if the final keyword was found.
+     *                 'is_readonly' => false, // TRUE if the readonly keyword was found.
      *               );
      *               ```
      *
@@ -172,6 +175,7 @@ class ObjectDeclarations
         $properties = [
             'is_abstract' => false,
             'is_final'    => false,
+            'is_readonly' => false,
         ];
 
         for ($i = ($stackPtr - 1); $i > 0; $i--) {
@@ -186,6 +190,10 @@ class ObjectDeclarations
 
                 case \T_FINAL:
                     $properties['is_final'] = true;
+                    break;
+
+                case \T_READONLY:
+                    $properties['is_readonly'] = true;
                     break;
             }
         }

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.inc
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.inc
@@ -16,3 +16,20 @@ final
  * @phpcs:disable Standard.Cat.SniffName -- Just because.
  */
 class ClassWithModifierBeforeDocblock {}
+
+/* testReadonlyClass */
+readonly class ReadOnlyClass {}
+
+/* testFinalReadonlyClass */
+final readonly class FinalReadOnlyClass extends Foo {}
+
+/* testReadonlyFinalClass */
+readonly /*comment*/ final class ReadOnlyFinalClass {}
+
+/* testAbstractReadonlyClass */
+abstract readonly class AbstractReadOnlyClass {}
+
+/* testReadonlyAbstractClass */
+readonly
+abstract
+class ReadOnlyAbstractClass {}

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
@@ -72,6 +72,7 @@ class GetClassPropertiesDiffTest extends UtilityMethodTestCase
                 'expected'   => [
                     'is_abstract' => false,
                     'is_final'    => true,
+                    'is_readonly' => false,
                 ],
             ],
             'unorthodox-docblock-placement' => [
@@ -79,6 +80,47 @@ class GetClassPropertiesDiffTest extends UtilityMethodTestCase
                 'expected'   => [
                     'is_abstract' => false,
                     'is_final'    => true,
+                    'is_readonly' => false,
+                ],
+            ],
+            'readonly' => [
+                '/* testReadonlyClass */',
+                [
+                    'is_abstract' => false,
+                    'is_final'    => false,
+                    'is_readonly' => true,
+                ],
+            ],
+            'final-readonly' => [
+                '/* testFinalReadonlyClass */',
+                [
+                    'is_abstract' => false,
+                    'is_final'    => true,
+                    'is_readonly' => true,
+                ],
+            ],
+            'readonly-final' => [
+                '/* testReadonlyFinalClass */',
+                [
+                    'is_abstract' => false,
+                    'is_final'    => true,
+                    'is_readonly' => true,
+                ],
+            ],
+            'abstract-readonly' => [
+                '/* testAbstractReadonlyClass */',
+                [
+                    'is_abstract' => true,
+                    'is_final'    => false,
+                    'is_readonly' => true,
+                ],
+            ],
+            'readonly-abstract' => [
+                '/* testReadonlyAbstractClass */',
+                [
+                    'is_abstract' => true,
+                    'is_final'    => false,
+                    'is_readonly' => true,
                 ],
             ],
         ];

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesTest.php
@@ -55,4 +55,21 @@ class GetClassPropertiesTest extends BCFile_GetClassPropertiesTest
         self::$caseFile = \dirname(\dirname(__DIR__)) . '/BackCompat/BCFile/GetClassPropertiesTest.inc';
         parent::setUpTestFile();
     }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetClassProperties() For the array format.
+     *
+     * @return array
+     */
+    public function dataGetClassProperties()
+    {
+        $data = parent::dataGetClassProperties();
+        foreach ($data as $name => $dataset) {
+            $data[$name][1]['is_readonly'] = false;
+        }
+
+        return $data;
+    }
 }


### PR DESCRIPTION
PHP 8.2 introduces `readonly` classes. The `readonly` keyword can be combined with the `abstract` or `final` keyword. See: https://3v4l.org/VIXgD

Includes unit tests.

Note: a similar PR has been pulled upstream - see squizlabs/PHP_CodeSniffer#3686.

Ref:
* https://wiki.php.net/rfc/readonly_classes