### PR TITLE
PHP 8.2: add support for `true` type

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -551,6 +551,7 @@ class Collections
      * @since 1.0.0-alpha1
      * @since 1.0.0-alpha4 Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.
      * @since 1.0.0-alpha4 Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.
+     * @since 1.0.0-alpha4 Added the T_TRUE token for PHP 8.2 true type support.
      *
      * @deprecated 1.0.0-alpha4 Use the {@see Collections::returnTypeTokens()} method instead.
      *
@@ -562,6 +563,7 @@ class Collections
         \T_PARENT            => \T_PARENT,
         \T_STATIC            => \T_STATIC,
         \T_FALSE             => \T_FALSE,
+        \T_TRUE              => \T_TRUE,
         \T_NULL              => \T_NULL,
         \T_STRING            => \T_STRING,
         \T_NS_SEPARATOR      => \T_NS_SEPARATOR,
@@ -1000,6 +1002,7 @@ class Collections
      * @since 1.0.0-alpha4 Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.
      * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokens.
      * @since 1.0.0-alpha4 Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.
+     * @since 1.0.0-alpha4 Added the T_TRUE token for PHP 8.2 true type support.
      *
      * @return array <int|string> => <int|string>
      */

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -472,6 +472,7 @@ class Collections
      * @since 1.0.0-alpha1
      * @since 1.0.0-alpha4 Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.
      * @since 1.0.0-alpha4 Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.
+     * @since 1.0.0-alpha4 Added the T_TRUE token for PHP 8.2 true type support.
      *
      * @deprecated 1.0.0-alpha4 Use the {@see Collections::parameterTypeTokens()} method instead.
      *
@@ -482,6 +483,7 @@ class Collections
         \T_SELF              => \T_SELF,
         \T_PARENT            => \T_PARENT,
         \T_FALSE             => \T_FALSE,
+        \T_TRUE              => \T_TRUE,
         \T_NULL              => \T_NULL,
         \T_STRING            => \T_STRING,
         \T_NS_SEPARATOR      => \T_NS_SEPARATOR,
@@ -921,6 +923,7 @@ class Collections
      * @since 1.0.0-alpha4 Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.
      * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokens.
      * @since 1.0.0-alpha4 Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.
+     * @since 1.0.0-alpha4 Added the T_TRUE token for PHP 8.2 true type support.
      *
      * @return array <int|string> => <int|string>
      */

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -526,6 +526,7 @@ class Collections
      * @since 1.0.0-alpha1
      * @since 1.0.0-alpha4 Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.
      * @since 1.0.0-alpha4 Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.
+     * @since 1.0.0-alpha4 Added the T_TRUE token for PHP 8.2 true type support.
      *
      * @deprecated 1.0.0-alpha4 Use the {@see Collections::propertyTypeTokens()} method instead.
      *
@@ -536,6 +537,7 @@ class Collections
         \T_SELF              => \T_SELF,
         \T_PARENT            => \T_PARENT,
         \T_FALSE             => \T_FALSE,
+        \T_TRUE              => \T_TRUE,
         \T_NULL              => \T_NULL,
         \T_STRING            => \T_STRING,
         \T_NS_SEPARATOR      => \T_NS_SEPARATOR,
@@ -957,6 +959,7 @@ class Collections
      * @since 1.0.0-alpha4 Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.
      * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokens.
      * @since 1.0.0-alpha4 Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.
+     * @since 1.0.0-alpha4 Added the T_TRUE token for PHP 8.2 true type support.
      *
      * @return array <int|string> => <int|string>
      */

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -362,6 +362,7 @@ class FunctionDeclarations
      * - More efficient and more stable looping of the default value.
      * - Clearer exception message when a non-closure use token was passed to the function.
      * - Support for PHP 8.0 identifier name tokens in parameter types, cross-version PHP & PHPCS.
+     * - Support for the PHP 8.2 `true` type.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodParameters()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getMethodParameters() Cross-version compatible version of the original.
@@ -374,6 +375,7 @@ class FunctionDeclarations
      * @since 1.0.0-alpha4 Added support for PHP 8.0 parameter attributes.
      * @since 1.0.0-alpha4 Added support for PHP 8.1 readonly keyword for constructor property promotion.
      * @since 1.0.0-alpha4 Added support for PHP 8.1 intersection types.
+     * @since 1.0.0-alpha4 Added support for PHP 8.2 true type.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the function token
@@ -441,8 +443,16 @@ class FunctionDeclarations
         $visibilityToken  = null;
         $readonlyToken    = null;
 
+        $parameterTypeTokens = Collections::parameterTypeTokens();
+
+        /*
+         * BC PHPCS < 3.x.x: The union type separator is not (yet) retokenized correctly
+         * for union types containing the `true` type.
+         */
+        $parameterTypeTokens[\T_BITWISE_OR] = \T_BITWISE_OR;
+
         for ($i = $paramStart; $i <= $closer; $i++) {
-            if (isset(Collections::parameterTypeTokens()[$tokens[$i]['code']]) === true
+            if (isset($parameterTypeTokens[$tokens[$i]['code']]) === true
                 // Self and parent are valid, static invalid, but was probably intended as type declaration.
                 || $tokens[$i]['code'] === \T_STATIC
             ) {

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -148,6 +148,7 @@ class FunctionDeclarations
      * - Defensive coding against incorrect calls to this method.
      * - More efficient checking whether a function has a body.
      * - Support for PHP 8.0 identifier name tokens in return types, cross-version PHP & PHPCS.
+     * - Support for the PHP 8.2 `true` type.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodProperties()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getMethodProperties() Cross-version compatible version of the original.
@@ -157,6 +158,7 @@ class FunctionDeclarations
      * @since 1.0.0-alpha3 Added support for PHP 8.0 static return type.
      * @since 1.0.0-alpha4 Added support for PHP 8.0 union types.
      * @since 1.0.0-alpha4 Added support for PHP 8.1 intersection types.
+     * @since 1.0.0-alpha4 Added support for PHP 8.2 true type.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the function token to
@@ -245,6 +247,12 @@ class FunctionDeclarations
         $nullableReturnType = false;
         $hasBody            = false;
         $returnTypeTokens   = Collections::returnTypeTokens();
+
+        /*
+         * BC PHPCS < 3.x.x: The union type separator is not (yet) retokenized correctly
+         * for union types containing the `true` type.
+         */
+        $returnTypeTokens[\T_BITWISE_OR] = \T_BITWISE_OR;
 
         $parenthesisCloser = null;
         if (isset($tokens[$stackPtr]['parenthesis_closer']) === true) {

--- a/PHPCSUtils/Utils/Variables.php
+++ b/PHPCSUtils/Utils/Variables.php
@@ -82,6 +82,7 @@ class Variables
      *   other non-property variables passed to the method.
      * - Defensive coding against incorrect calls to this method.
      * - Support PHP 8.0 identifier name tokens in property types, cross-version PHP & PHPCS.
+     * - Support for the PHP 8.2 `true` type.
      *
      * @see \PHP_CodeSniffer\Files\File::getMemberProperties()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getMemberProperties() Cross-version compatible version of the original.
@@ -91,6 +92,7 @@ class Variables
      * @since 1.0.0-alpha4 No longer gets confused by PHP 8.0 property attributes.
      * @since 1.0.0-alpha4 Added support for PHP 8.1 readonly properties.
      * @since 1.0.0-alpha4 Added support for PHP 8.1 intersection types.
+     * @since 1.0.0-alpha4 Added support for PHP 8.2 true type.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the `T_VARIABLE` token
@@ -180,6 +182,12 @@ class Variables
         $typeEndToken       = false;
         $nullableType       = false;
         $propertyTypeTokens = Collections::propertyTypeTokens();
+
+        /*
+         * BC PHPCS < 3.x.x: The union type separator is not (yet) retokenized correctly
+         * for union types containing the `true` type.
+         */
+        $propertyTypeTokens[\T_BITWISE_OR] = \T_BITWISE_OR;
 
         if ($i < $stackPtr) {
             // We've found a type.

--- a/Tests/Tokens/Collections/ParameterTypeTokensTest.php
+++ b/Tests/Tokens/Collections/ParameterTypeTokensTest.php
@@ -37,6 +37,7 @@ class ParameterTypeTokensTest extends TestCase
             \T_SELF                 => \T_SELF,
             \T_PARENT               => \T_PARENT,
             \T_FALSE                => \T_FALSE,
+            \T_TRUE                 => \T_TRUE,
             \T_NULL                 => \T_NULL,
             \T_STRING               => \T_STRING,
             \T_NS_SEPARATOR         => \T_NS_SEPARATOR,

--- a/Tests/Tokens/Collections/PropertyTypeTokensTest.php
+++ b/Tests/Tokens/Collections/PropertyTypeTokensTest.php
@@ -37,6 +37,7 @@ class PropertyTypeTokensTest extends TestCase
             \T_SELF                 => \T_SELF,
             \T_PARENT               => \T_PARENT,
             \T_FALSE                => \T_FALSE,
+            \T_TRUE                 => \T_TRUE,
             \T_NULL                 => \T_NULL,
             \T_STRING               => \T_STRING,
             \T_NS_SEPARATOR         => \T_NS_SEPARATOR,

--- a/Tests/Tokens/Collections/ReturnTypeTokensTest.php
+++ b/Tests/Tokens/Collections/ReturnTypeTokensTest.php
@@ -38,6 +38,7 @@ class ReturnTypeTokensTest extends TestCase
             \T_PARENT               => \T_PARENT,
             \T_STATIC               => \T_STATIC,
             \T_FALSE                => \T_FALSE,
+            \T_TRUE                 => \T_TRUE,
             \T_NULL                 => \T_NULL,
             \T_STRING               => \T_STRING,
             \T_NS_SEPARATOR         => \T_NS_SEPARATOR,

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.inc
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.inc
@@ -1,0 +1,8 @@
+<?php
+
+/* testPHP82PseudoTypeTrue */
+function pseudoTypeTrue(?true $var = true) {}
+
+/* testPHP82PseudoTypeFalseAndTrue */
+// Intentional fatal error - Type contains both true and false, bool should be used instead, but that's not the concern of the method.
+function pseudoTypeFalseAndTrue(true|false $var = true) {}

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.inc
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.inc
@@ -17,3 +17,10 @@ trait FooTrait {
             $func();
     }
 }
+
+/* testPHP82PseudoTypeTrue */
+function pseudoTypeTrue(): ?true {}
+
+/* testPHP82PseudoTypeFalseAndTrue */
+// Intentional fatal error - Type contains both true and false, bool should be used instead, but that's not the concern of the method.
+function pseudoTypeFalseAndTrue(): true|false {}

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
@@ -87,6 +87,52 @@ class GetPropertiesDiffTest extends UtilityMethodTestCase
     }
 
     /**
+     * Verify recognition of PHP 8.2 stand-alone `true` type.
+     *
+     * @return void
+     */
+    public function testPHP82PseudoTypeTrue()
+    {
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '?true',
+            'return_type_token'     => 8, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 8, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
+        ];
+
+        $this->getPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify recognition of PHP 8.2 type declaration with (illegal) type false combined with type true.
+     *
+     * @return void
+     */
+    public function testPHP82PseudoTypeFalseAndTrue()
+    {
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'true|false',
+            'return_type_token'     => 7, // Offset from the T_FUNCTION token.
+            'return_type_end_token' => 9, // Offset from the T_FUNCTION token.
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
+        ];
+
+        $this->getPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Test helper.
      *
      * @param string $commentString The comment which preceeds the test.

--- a/Tests/Utils/Variables/GetMemberPropertiesDiffTest.inc
+++ b/Tests/Utils/Variables/GetMemberPropertiesDiffTest.inc
@@ -11,3 +11,18 @@ enum Suit
     /* testEnumProperty */
     protected $anonymous;
 }
+
+$anon = class() {
+    /* testPHP82PseudoTypeTrue */
+    public true $pseudoTypeTrue;
+
+    /* testPHP82NullablePseudoTypeTrue */
+    static protected ?true $pseudoTypeNullableTrue;
+
+    /* testPHP82PseudoTypeTrueInUnion */
+    private int|string|true $pseudoTypeTrueInUnion;
+
+    /* testPHP82PseudoTypeFalseAndTrue */
+    // Intentional fatal error - Type contains both true and false, bool should be used instead, but that's not the concern of the method.
+    readonly true|FALSE $pseudoTypeFalseAndTrue;
+};

--- a/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
@@ -71,4 +71,94 @@ class GetMemberPropertiesDiffTest extends UtilityMethodTestCase
             'enum property'      => ['/* testEnumProperty */'],
         ];
     }
+
+    /**
+     * Test the getMemberProperties() method.
+     *
+     * @dataProvider dataGetMemberProperties
+     *
+     * @param string $identifier Comment which precedes the test case.
+     * @param bool   $expected   Expected function output.
+     *
+     * @return void
+     */
+    public function testGetMemberProperties($identifier, $expected)
+    {
+        $variable = $this->getTargetToken($identifier, \T_VARIABLE);
+        $result   = Variables::getMemberProperties(self::$phpcsFile, $variable);
+
+        if (isset($expected['type_token']) && $expected['type_token'] !== false) {
+            $expected['type_token'] += $variable;
+        }
+        if (isset($expected['type_end_token']) && $expected['type_end_token'] !== false) {
+            $expected['type_end_token'] += $variable;
+        }
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetMemberProperties()
+     *
+     * @return array
+     */
+    public function dataGetMemberProperties()
+    {
+        return [
+            'php8.2-pseudo-type-true' => [
+                '/* testPHP82PseudoTypeTrue */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'is_readonly'     => false,
+                    'type'            => 'true',
+                    'type_token'      => -2, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'nullable_type'   => false,
+                ],
+            ],
+            'php8.2-pseudo-type-true-nullable' => [
+                '/* testPHP82NullablePseudoTypeTrue */',
+                [
+                    'scope'           => 'protected',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                    'is_readonly'     => false,
+                    'type'            => '?true',
+                    'type_token'      => -2, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'nullable_type'   => true,
+                ],
+            ],
+            'php8.2-pseudo-type-true-in-union' => [
+                '/* testPHP82PseudoTypeTrueInUnion */',
+                [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'is_readonly'     => false,
+                    'type'            => 'int|string|true',
+                    'type_token'      => -6, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'nullable_type'   => false,
+                ],
+            ],
+            'php8.2-pseudo-type-invalid-true-false-union' => [
+                '/* testPHP82PseudoTypeFalseAndTrue */',
+                [
+                    'scope'           => 'public',
+                    'scope_specified' => false,
+                    'is_static'       => false,
+                    'is_readonly'     => true,
+                    'type'            => 'true|FALSE',
+                    'type_token'      => -4, // Offset from the T_VARIABLE token.
+                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'nullable_type'   => false,
+                ],
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
### PHP 8.2 | Variables::getMemberProperties(): handle true pseudotype

### PHP 8.2 | FunctionDeclarations::getProperties(): handle true pseudotype

### PHP 8.2 | FunctionDeclarations::getParameters(): handle true pseudotype

As pulled in upstream PR squizlabs/PHP_CodeSniffer#3662 (not yet merged)

Ref:
* squizlabs/PHP_CodeSniffer#3662
* https://wiki.php.net/rfc/true-type