### PR TITLE
Follow up on version drop/ remove some more code

### DIFF
--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -121,25 +121,4 @@ class BCTokens
 
         return $tokens;
     }
-
-    /**
-     * Given a token, returns the name of the token.
-     *
-     * If passed an integer, the token name is sourced from PHP's token_name()
-     * function. If passed a string, it is assumed to be a PHPCS-supplied token
-     * that begins with PHPCS_T_, so the name is sourced from the token value itself.
-     *
-     * Changelog for the PHPCS native:
-     * - Introduced in PHPCS 3.0.0.
-     *
-     * @see \PHP_CodeSniffer\Util\Tokens::tokenName() Original function.
-     *
-     * @param int|string $token The token to get the name for.
-     *
-     * @return string
-     */
-    public static function tokenName($token)
-    {
-        return Tokens::tokenName($token);
-    }
 }

--- a/PHPCSUtils/Utils/Parentheses.php
+++ b/PHPCSUtils/Utils/Parentheses.php
@@ -83,8 +83,7 @@ class Parentheses
             $stackPtr = $tokens[$stackPtr]['parenthesis_opener'];
         }
 
-        $skip         = Tokens::$emptyTokens;
-        $prevNonEmpty = $phpcsFile->findPrevious($skip, ($stackPtr - 1), null, true);
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($prevNonEmpty !== false
             && isset(self::$extraParenthesesOwners[$tokens[$prevNonEmpty]['code']]) === true
         ) {

--- a/PHPCSUtils/Utils/PassedParameters.php
+++ b/PHPCSUtils/Utils/PassedParameters.php
@@ -305,8 +305,7 @@ class PassedParameters
                     );
 
                     if ($tokens[$secondNonEmpty]['code'] === \T_COLON
-                        && ($tokens[$firstNonEmpty]['type'] === 'T_PARAM_NAME'
-                            || NamingConventions::isValidIdentifierName($tokens[$firstNonEmpty]['content']) === true)
+                        && $tokens[$firstNonEmpty]['code'] === \T_PARAM_NAME
                     ) {
                         $parameters[$cnt]['name_start'] = $paramStart;
                         $parameters[$cnt]['name_end']   = $secondNonEmpty;

--- a/Tests/Utils/UseStatements/SplitImportUseStatementTest.inc
+++ b/Tests/Utils/UseStatements/SplitImportUseStatementTest.inc
@@ -95,8 +95,6 @@ use Vendor\{
 // Intentional parse error - use of reserved keyword as alias.
 use Vendor\YourNamespace\ClassName as const;
 
-echo 'foo'; // Needed for consistent handling of the above test.
-
 // Intentional parse error. This has to be the last test in the file.
 /* testParseError */
 use MyNS\Level\{

--- a/Tests/Xtra/Tokens/TokenNameTest.php
+++ b/Tests/Xtra/Tokens/TokenNameTest.php
@@ -8,17 +8,20 @@
  * @link      https://github.com/PHPCSStandards/PHPCSUtils
  */
 
-namespace PHPCSUtils\Tests\BackCompat\BCTokens;
+namespace PHPCSUtils\Tests\Xtra\Tokens;
 
-use PHPCSUtils\BackCompat\BCTokens;
+use PHP_CodeSniffer\Util\Tokens;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Test class.
+ * Test the PHPCS native `Tokens::tokenName()` method.
  *
- * @covers \PHPCSUtils\BackCompat\BCTokens::tokenName
+ * {@internal Note: this is testing PHPCS native functionality, but as PHPCS doesn't
+ * have any unit tests in place for this functionality, that's not a bad thing.}
  *
- * @group tokens
+ * @coversNothing
+ *
+ * @group xtra
  *
  * @since 1.0.0
  */
@@ -37,7 +40,7 @@ class TokenNameTest extends TestCase
      */
     public function testTokenName($tokenCode, $expected)
     {
-        $this->assertSame($expected, BCTokens::tokenName($tokenCode));
+        $this->assertSame($expected, Tokens::tokenName($tokenCode));
     }
 
     /**


### PR DESCRIPTION
### BackCompat\BCTokens: remove the tokenName() method

Follow up on #250 and #347.

PR #250 introduced a polyfill for the PHPCS native `Tokens::tokenName()` method as this method was only available in PHPCS 3.0.0 and higher.

However, after the version drop, this method is no longer needed as the PHPCS native functionality can now be used in all cases.
This was missed in the version drop PR #347.

The method can be safely removed as it was never in a tagged release.

Note: as PHPCS itself does not have any tests for the native method, I'm keeping the associated test class and moving it to a separate `Xtra` directory for tests not directly related to PHPCSUtils. These tests should probably be pulled upstream at some point.

### Utils\Parentheses: minor code simplification

### Utils\PassedParameters: minor code simplification

The "valid identifier" check was only in place to handle BC for PHPCS < 3.6.0 and should no longer be needed.

### SplitImportUseStatementTest: minor tweak

Remove a line which was only added to the test case file for a PHPCS cross-version support issue, which was fixed in PHPCS 3.7.0, meaning that this line is no longer needed.

See #287 for more information.