### PR TITLE
QA: make all classes final

### DIFF
--- a/PHPCS23Utils/Sniffs/Load/LoadUtilsSniff.php
+++ b/PHPCS23Utils/Sniffs/Load/LoadUtilsSniff.php
@@ -24,7 +24,7 @@ require_once \dirname(\dirname(\dirname(__DIR__))) . '/phpcsutils-autoload.php';
  *
  * @since 1.0.0
  */
-class LoadUtilsSniff
+final class LoadUtilsSniff
 {
 
     /**

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -65,7 +65,7 @@ use PHPCSUtils\Tokens\Collections;
  * @since 1.0.0
  * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
-class BCFile
+final class BCFile
 {
 
     /**

--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -70,7 +70,7 @@ use PHPCSUtils\Tokens\Collections;
  *                                                 is about _text_ strings.
  * @method static array textStringTokens()         Tokens that represent text strings.
  */
-class BCTokens
+final class BCTokens
 {
 
     /**

--- a/PHPCSUtils/BackCompat/Helper.php
+++ b/PHPCSUtils/BackCompat/Helper.php
@@ -23,7 +23,7 @@ use PHP_CodeSniffer\Files\File;
  *                     the external PHPCompatibility & WPCS standards.
  * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
-class Helper
+final class Helper
 {
 
     /**

--- a/PHPCSUtils/Fixers/SpacesFixer.php
+++ b/PHPCSUtils/Fixers/SpacesFixer.php
@@ -20,7 +20,7 @@ use PHPCSUtils\Utils\Numbers;
  *
  * @since 1.0.0
  */
-class SpacesFixer
+final class SpacesFixer
 {
 
     /**

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -52,7 +52,7 @@ use PHPCSUtils\Exceptions\InvalidTokenArray;
  * @method static array shortListTokensBC()           Tokens which are used for short lists
  *                                                    (PHPCS cross-version compatible).
  */
-class Collections
+final class Collections
 {
 
     /**

--- a/PHPCSUtils/Tokens/TokenHelper.php
+++ b/PHPCSUtils/Tokens/TokenHelper.php
@@ -15,7 +15,7 @@ namespace PHPCSUtils\Tokens;
  *
  * @since 1.0.0
  */
-class TokenHelper
+final class TokenHelper
 {
 
     /**

--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -24,7 +24,7 @@ use PHPCSUtils\Utils\Lists;
  * @since 1.0.0
  * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
-class Arrays
+final class Arrays
 {
 
     /**

--- a/PHPCSUtils/Utils/Conditions.php
+++ b/PHPCSUtils/Utils/Conditions.php
@@ -20,7 +20,7 @@ use PHP_CodeSniffer\Files\File;
  *              PHPCS native `PHP_CodeSniffer\Files\File` class.
  *              Also see {@see \PHPCSUtils\BackCompat\BCFile}.
  */
-class Conditions
+final class Conditions
 {
 
     /**

--- a/PHPCSUtils/Utils/Context.php
+++ b/PHPCSUtils/Utils/Context.php
@@ -24,7 +24,7 @@ use PHPCSUtils\Utils\Parentheses;
  *
  * @since 1.0.0
  */
-class Context
+final class Context
 {
 
     /**

--- a/PHPCSUtils/Utils/ControlStructures.php
+++ b/PHPCSUtils/Utils/ControlStructures.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Tokens\Collections;
  * @since 1.0.0
  * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
-class ControlStructures
+final class ControlStructures
 {
 
     /**

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -30,7 +30,7 @@ use PHPCSUtils\Utils\UseStatements;
  *                     Also see {@see \PHPCSUtils\BackCompat\BCFile}.
  * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
-class FunctionDeclarations
+final class FunctionDeclarations
 {
 
     /**

--- a/PHPCSUtils/Utils/GetTokensAsString.php
+++ b/PHPCSUtils/Utils/GetTokensAsString.php
@@ -26,7 +26,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *              PHPCS native `File` class.
  *              Also see {@see \PHPCSUtils\BackCompat\BCFile::getTokensAsString()}.
  */
-class GetTokensAsString
+final class GetTokensAsString
 {
 
     /**

--- a/PHPCSUtils/Utils/Lists.php
+++ b/PHPCSUtils/Utils/Lists.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\Parentheses;
  * @since 1.0.0
  * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
-class Lists
+final class Lists
 {
 
     /**

--- a/PHPCSUtils/Utils/MessageHelper.php
+++ b/PHPCSUtils/Utils/MessageHelper.php
@@ -17,7 +17,7 @@ use PHP_CodeSniffer\Files\File;
  *
  * @since 1.0.0
  */
-class MessageHelper
+final class MessageHelper
 {
 
     /**

--- a/PHPCSUtils/Utils/Namespaces.php
+++ b/PHPCSUtils/Utils/Namespaces.php
@@ -29,7 +29,7 @@ use PHPCSUtils\Utils\Parentheses;
  * @since 1.0.0
  * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
-class Namespaces
+final class Namespaces
 {
 
     /**

--- a/PHPCSUtils/Utils/NamingConventions.php
+++ b/PHPCSUtils/Utils/NamingConventions.php
@@ -24,7 +24,7 @@ namespace PHPCSUtils\Utils;
  *
  * @since 1.0.0-alpha3
  */
-class NamingConventions
+final class NamingConventions
 {
 
     /**

--- a/PHPCSUtils/Utils/Numbers.php
+++ b/PHPCSUtils/Utils/Numbers.php
@@ -35,7 +35,7 @@ use PHP_CodeSniffer\Files\File;
  *                     - `Numbers::REGEX_HEX_NUMLIT_STRING`
  *                     - `Numbers::UNSUPPORTED_PHPCS_VERSION`
  */
-class Numbers
+final class Numbers
 {
 
     /**

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -27,7 +27,7 @@ use PHPCSUtils\Utils\GetTokensAsString;
  *                     Also see {@see \PHPCSUtils\BackCompat\BCFile}.
  * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
-class ObjectDeclarations
+final class ObjectDeclarations
 {
 
     /**

--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -28,7 +28,7 @@ use PHPCSUtils\Utils\Parentheses;
  *                     `Squiz.WhiteSpace.OperatorSpacing` sniff.
  * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
-class Operators
+final class Operators
 {
 
     /**

--- a/PHPCSUtils/Utils/Orthography.php
+++ b/PHPCSUtils/Utils/Orthography.php
@@ -21,7 +21,7 @@ use PHPCSUtils\BackCompat\Helper;
  *
  * @since 1.0.0
  */
-class Orthography
+final class Orthography
 {
 
     /**

--- a/PHPCSUtils/Utils/Parentheses.php
+++ b/PHPCSUtils/Utils/Parentheses.php
@@ -25,7 +25,7 @@ use PHP_CodeSniffer\Util\Tokens;
  *                     and `eval()` as parentheses owners to all applicable functions.
  * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
-class Parentheses
+final class Parentheses
 {
 
     /**

--- a/PHPCSUtils/Utils/PassedParameters.php
+++ b/PHPCSUtils/Utils/PassedParameters.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Utils\NamingConventions;
  * @since 1.0.0
  * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
-class PassedParameters
+final class PassedParameters
 {
 
     /**

--- a/PHPCSUtils/Utils/Scopes.php
+++ b/PHPCSUtils/Utils/Scopes.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Utils\Parentheses;
  *
  * @since 1.0.0
  */
-class Scopes
+final class Scopes
 {
 
     /**

--- a/PHPCSUtils/Utils/TextStrings.php
+++ b/PHPCSUtils/Utils/TextStrings.php
@@ -24,7 +24,7 @@ use PHPCSUtils\Utils\GetTokensAsString;
  * @since 1.0.0
  * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
-class TextStrings
+final class TextStrings
 {
 
     /**

--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\Parentheses;
  * @since 1.0.0
  * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
-class UseStatements
+final class UseStatements
 {
 
     /**

--- a/PHPCSUtils/Utils/Variables.php
+++ b/PHPCSUtils/Utils/Variables.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\TextStrings;
  *                     Also see {@see \PHPCSUtils\BackCompat\BCFile}.
  * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
-class Variables
+final class Variables
 {
 
     /**

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Tests\PolyfilledTestCase;
  *
  * @since 1.0.0
  */
-class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
+final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/ArrayDeclarationSniffTestDouble.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/ArrayDeclarationSniffTestDouble.php
@@ -18,7 +18,7 @@ use PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff;
  *
  * @since 1.0.0
  */
-class ArrayDeclarationSniffTestDouble extends AbstractArrayDeclarationSniff
+final class ArrayDeclarationSniffTestDouble extends AbstractArrayDeclarationSniff
 {
 
     /**

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.php
@@ -24,7 +24,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 1.0.0
  */
-class GetActualArrayKeyTest extends UtilityMethodTestCase
+final class GetActualArrayKeyTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
@@ -32,7 +32,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class FindEndOfStatementTest extends UtilityMethodTestCase
+final class FindEndOfStatementTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
@@ -20,7 +20,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class FindStartOfStatementTest extends UtilityMethodTestCase
+final class FindStartOfStatementTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/BackCompat/BCFile/GetMethodParametersParseError1Test.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersParseError1Test.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Tokens\Collections;
  *
  * @since 1.0.0
  */
-class GetMethodParametersParseError1Test extends UtilityMethodTestCase
+final class GetMethodParametersParseError1Test extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/BackCompat/BCFile/GetMethodParametersParseError2Test.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersParseError2Test.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Tokens\Collections;
  *
  * @since 1.0.0
  */
-class GetMethodParametersParseError2Test extends UtilityMethodTestCase
+final class GetMethodParametersParseError2Test extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/BackCompat/BCFile/GetTokensAsStringTest.php
+++ b/Tests/BackCompat/BCFile/GetTokensAsStringTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class GetTokensAsStringTest extends UtilityMethodTestCase
+final class GetTokensAsStringTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/BackCompat/BCTokens/FunctionNameTokensTest.php
+++ b/Tests/BackCompat/BCTokens/FunctionNameTokensTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class FunctionNameTokensTest extends TestCase
+final class FunctionNameTokensTest extends TestCase
 {
 
     /**

--- a/Tests/BackCompat/BCTokens/ParenthesisOpenersTest.php
+++ b/Tests/BackCompat/BCTokens/ParenthesisOpenersTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class ParenthesisOpenersTest extends TestCase
+final class ParenthesisOpenersTest extends TestCase
 {
 
     /**

--- a/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
+++ b/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
@@ -23,7 +23,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  *
  * @since 1.0.0
  */
-class UnchangedTokenArraysTest extends TestCase
+final class UnchangedTokenArraysTest extends TestCase
 {
 
     /**

--- a/Tests/BackCompat/Helper/ConfigDataTest.php
+++ b/Tests/BackCompat/Helper/ConfigDataTest.php
@@ -25,7 +25,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
  *
  * @since 1.0.0
  */
-class ConfigDataTest extends TestCase
+final class ConfigDataTest extends TestCase
 {
     use ExpectException;
 

--- a/Tests/BackCompat/Helper/GetCommandLineDataTest.php
+++ b/Tests/BackCompat/Helper/GetCommandLineDataTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class GetCommandLineDataTest extends UtilityMethodTestCase
+final class GetCommandLineDataTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/BackCompat/Helper/GetVersionTest.php
+++ b/Tests/BackCompat/Helper/GetVersionTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class GetVersionTest extends TestCase
+final class GetVersionTest extends TestCase
 {
 
     /**

--- a/Tests/Fixers/SpacesFixer/SpacesFixerExceptionsTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerExceptionsTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class SpacesFixerExceptionsTest extends UtilityMethodTestCase
+final class SpacesFixerExceptionsTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Fixers/SpacesFixer/SpacesFixerNewlineTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerNewlineTest.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Tests\Fixers\SpacesFixer\SpacesFixerTestCase;
  *
  * @since 1.0.0
  */
-class SpacesFixerNewlineTest extends SpacesFixerTestCase
+final class SpacesFixerNewlineTest extends SpacesFixerTestCase
 {
 
     /**

--- a/Tests/Fixers/SpacesFixer/SpacesFixerNoSpaceTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerNoSpaceTest.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Tests\Fixers\SpacesFixer\SpacesFixerTestCase;
  *
  * @since 1.0.0
  */
-class SpacesFixerNoSpaceTest extends SpacesFixerTestCase
+final class SpacesFixerNoSpaceTest extends SpacesFixerTestCase
 {
 
     /**

--- a/Tests/Fixers/SpacesFixer/SpacesFixerOneSpaceTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerOneSpaceTest.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Tests\Fixers\SpacesFixer\SpacesFixerTestCase;
  *
  * @since 1.0.0
  */
-class SpacesFixerOneSpaceTest extends SpacesFixerTestCase
+final class SpacesFixerOneSpaceTest extends SpacesFixerTestCase
 {
 
     /**

--- a/Tests/Fixers/SpacesFixer/SpacesFixerTwoSpaceTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerTwoSpaceTest.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Tests\Fixers\SpacesFixer\SpacesFixerTestCase;
  *
  * @since 1.0.0
  */
-class SpacesFixerTwoSpaceTest extends SpacesFixerTestCase
+final class SpacesFixerTwoSpaceTest extends SpacesFixerTestCase
 {
 
     /**

--- a/Tests/Fixers/SpacesFixer/TrailingCommentHandlingNewlineTest.php
+++ b/Tests/Fixers/SpacesFixer/TrailingCommentHandlingNewlineTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class TrailingCommentHandlingNewlineTest extends UtilityMethodTestCase
+final class TrailingCommentHandlingNewlineTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Fixers/SpacesFixer/TrailingCommentHandlingNewlineTest.php
+++ b/Tests/Fixers/SpacesFixer/TrailingCommentHandlingNewlineTest.php
@@ -87,12 +87,12 @@ final class TrailingCommentHandlingNewlineTest extends UtilityMethodTestCase
             self::$phpcsFile,
             $stackPtr,
             $secondPtr,
-            static::SPACES,
-            static::MSG,
-            static::CODE,
+            self::SPACES,
+            self::MSG,
+            self::CODE,
             'error',
             0,
-            static::METRIC
+            self::METRIC
         );
 
         $result = \array_merge(self::$phpcsFile->getErrors(), self::$phpcsFile->getWarnings());

--- a/Tests/Fixers/SpacesFixer/TrailingCommentHandlingTest.php
+++ b/Tests/Fixers/SpacesFixer/TrailingCommentHandlingTest.php
@@ -130,7 +130,7 @@ final class TrailingCommentHandlingTest extends UtilityMethodTestCase
         // Check that no metric is recorded.
         $metrics = self::$phpcsFile->getMetrics();
         $this->assertFalse(
-            isset($metrics[static::METRIC]['values'][$expected['found']]),
+            isset($metrics[self::METRIC]['values'][$expected['found']]),
             'Failed recorded metric check'
         );
     }

--- a/Tests/Fixers/SpacesFixer/TrailingCommentHandlingTest.php
+++ b/Tests/Fixers/SpacesFixer/TrailingCommentHandlingTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class TrailingCommentHandlingTest extends UtilityMethodTestCase
+final class TrailingCommentHandlingTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Internal/Cache/GetClearTest.php
+++ b/Tests/Internal/Cache/GetClearTest.php
@@ -23,7 +23,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class GetClearTest extends UtilityMethodTestCase
+final class GetClearTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Internal/Cache/SetTest.php
+++ b/Tests/Internal/Cache/SetTest.php
@@ -25,7 +25,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class SetTest extends UtilityMethodTestCase
+final class SetTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Internal/NoFileCache/GetClearTest.php
+++ b/Tests/Internal/NoFileCache/GetClearTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class GetClearTest extends TestCase
+final class GetClearTest extends TestCase
 {
 
     /**

--- a/Tests/Internal/NoFileCache/SetTest.php
+++ b/Tests/Internal/NoFileCache/SetTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class SetTest extends TestCase
+final class SetTest extends TestCase
 {
 
     /**

--- a/Tests/TestUtils/UtilityMethodTestCase/ExpectPhpcsExceptionTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/ExpectPhpcsExceptionTest.php
@@ -23,7 +23,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class ExpectPhpcsExceptionTest extends UtilityMethodTestCase
+final class ExpectPhpcsExceptionTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/TestUtils/UtilityMethodTestCase/FailedToTokenizeTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/FailedToTokenizeTest.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Tests\PolyfilledTestCase;
  *
  * @since 1.0.0
  */
-class FailedToTokenizeTest extends PolyfilledTestCase
+final class FailedToTokenizeTest extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/TestUtils/UtilityMethodTestCase/GetTargetTokenTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/GetTargetTokenTest.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Tests\PolyfilledTestCase;
  *
  * @since 1.0.0
  */
-class GetTargetTokenTest extends PolyfilledTestCase
+final class GetTargetTokenTest extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/TestUtils/UtilityMethodTestCase/MissingCaseFileTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/MissingCaseFileTest.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Tests\PolyfilledTestCase;
  *
  * @since 1.0.0
  */
-class MissingCaseFileTest extends PolyfilledTestCase
+final class MissingCaseFileTest extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/TestUtils/UtilityMethodTestCase/SkipCSJSTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/SkipCSJSTest.php
@@ -50,7 +50,7 @@ final class SkipJSCSSTest extends PolyfilledTestCase
      */
     public function testSkipJsCss()
     {
-        if (\version_compare(static::$phpcsVersion, '3.99.99', '>') === true) {
+        if (\version_compare(parent::$phpcsVersion, '3.99.99', '>') === true) {
             $msg       = 'JS and CSS support has been removed in PHPCS 4.';
             $exception = 'PHPUnit\Framework\SkippedTestError';
             if (\class_exists('PHPUnit_Framework_SkippedTestError')) {

--- a/Tests/TestUtils/UtilityMethodTestCase/SkipCSJSTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/SkipCSJSTest.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Tests\PolyfilledTestCase;
  *
  * @since 1.0.0
  */
-class SkipJSCSSTest extends PolyfilledTestCase
+final class SkipJSCSSTest extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/TestUtils/UtilityMethodTestCase/UtilityMethodTestCaseTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/UtilityMethodTestCaseTest.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Tests\PolyfilledTestCase;
  *
  * @since 1.0.0
  */
-class UtilityMethodTestCaseTest extends PolyfilledTestCase
+final class UtilityMethodTestCaseTest extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/AlternativeControlStructureSyntaxClosersTest.php
+++ b/Tests/Tokens/Collections/AlternativeControlStructureSyntaxClosersTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class AlternativeControlStructureSyntaxClosersTest extends TestCase
+final class AlternativeControlStructureSyntaxClosersTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/AlternativeControlStructureSyntaxesTest.php
+++ b/Tests/Tokens/Collections/AlternativeControlStructureSyntaxesTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class AlternativeControlStructureSyntaxesTest extends TestCase
+final class AlternativeControlStructureSyntaxesTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/ArrowFunctionTokensBCTest.php
+++ b/Tests/Tokens/Collections/ArrowFunctionTokensBCTest.php
@@ -23,7 +23,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  *
  * @since 1.0.0
  */
-class ArrowFunctionTokensBCTest extends TestCase
+final class ArrowFunctionTokensBCTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/FunctionCallTokensTest.php
+++ b/Tests/Tokens/Collections/FunctionCallTokensTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class FunctionCallTokensTest extends TestCase
+final class FunctionCallTokensTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/FunctionDeclarationTokensBCTest.php
+++ b/Tests/Tokens/Collections/FunctionDeclarationTokensBCTest.php
@@ -23,7 +23,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  *
  * @since 1.0.0
  */
-class FunctionDeclarationTokensBCTest extends TestCase
+final class FunctionDeclarationTokensBCTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/NamespacedNameTokensTest.php
+++ b/Tests/Tokens/Collections/NamespacedNameTokensTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class NamespacedNameTokensTest extends TestCase
+final class NamespacedNameTokensTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/OoCanExtendTest.php
+++ b/Tests/Tokens/Collections/OoCanExtendTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class OoCanExtendTest extends TestCase
+final class OoCanExtendTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/OoCanImplementTest.php
+++ b/Tests/Tokens/Collections/OoCanImplementTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class OoCanImplementTest extends TestCase
+final class OoCanImplementTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/OoConstantScopesTest.php
+++ b/Tests/Tokens/Collections/OoConstantScopesTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class OoConstantScopesTest extends TestCase
+final class OoConstantScopesTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/OoHierarchyKeywordsTest.php
+++ b/Tests/Tokens/Collections/OoHierarchyKeywordsTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class OoHierarchyKeywordsTest extends TestCase
+final class OoHierarchyKeywordsTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/OoPropertyScopesTest.php
+++ b/Tests/Tokens/Collections/OoPropertyScopesTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class OoPropertyScopesTest extends TestCase
+final class OoPropertyScopesTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/ParameterPassingTokensTest.php
+++ b/Tests/Tokens/Collections/ParameterPassingTokensTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class ParameterPassingTokensTest extends TestCase
+final class ParameterPassingTokensTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/ParameterTypeTokensBCTest.php
+++ b/Tests/Tokens/Collections/ParameterTypeTokensBCTest.php
@@ -23,7 +23,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  *
  * @since 1.0.0
  */
-class ParameterTypeTokensBCTest extends TestCase
+final class ParameterTypeTokensBCTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/ParameterTypeTokensTest.php
+++ b/Tests/Tokens/Collections/ParameterTypeTokensTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class ParameterTypeTokensTest extends TestCase
+final class ParameterTypeTokensTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/PropertyBasedTokenArraysTest.php
+++ b/Tests/Tokens/Collections/PropertyBasedTokenArraysTest.php
@@ -23,7 +23,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  *
  * @since 1.0.0
  */
-class PropertyBasedTokenArraysTest extends TestCase
+final class PropertyBasedTokenArraysTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/PropertyTypeTokensBCTest.php
+++ b/Tests/Tokens/Collections/PropertyTypeTokensBCTest.php
@@ -23,7 +23,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  *
  * @since 1.0.0
  */
-class PropertyTypeTokensBCTest extends TestCase
+final class PropertyTypeTokensBCTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/PropertyTypeTokensTest.php
+++ b/Tests/Tokens/Collections/PropertyTypeTokensTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class PropertyTypeTokensTest extends TestCase
+final class PropertyTypeTokensTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/ReturnTypeTokensBCTest.php
+++ b/Tests/Tokens/Collections/ReturnTypeTokensBCTest.php
@@ -23,7 +23,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  *
  * @since 1.0.0
  */
-class ReturnTypeTokensBCTest extends TestCase
+final class ReturnTypeTokensBCTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/ReturnTypeTokensTest.php
+++ b/Tests/Tokens/Collections/ReturnTypeTokensTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class ReturnTypeTokensTest extends TestCase
+final class ReturnTypeTokensTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/Collections/TextStringStartTokensTest.php
+++ b/Tests/Tokens/Collections/TextStringStartTokensTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class TextStringStartTokensTest extends TestCase
+final class TextStringStartTokensTest extends TestCase
 {
 
     /**

--- a/Tests/Tokens/TokenHelper/TokenExistsTest.php
+++ b/Tests/Tokens/TokenHelper/TokenExistsTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class TokenExistsTest extends TestCase
+final class TokenExistsTest extends TestCase
 {
 
     /**

--- a/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
+++ b/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
@@ -24,7 +24,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 1.0.0
  */
-class GetDoubleArrowPtrTest extends UtilityMethodTestCase
+final class GetDoubleArrowPtrTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Arrays/GetOpenCloseTest.php
+++ b/Tests/Utils/Arrays/GetOpenCloseTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Arrays;
  *
  * @since 1.0.0
  */
-class GetOpenCloseTest extends UtilityMethodTestCase
+final class GetOpenCloseTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Conditions/GetConditionTest.php
+++ b/Tests/Utils/Conditions/GetConditionTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Conditions;
  *
  * @since 1.0.0
  */
-class GetConditionTest extends BCFile_GetConditionTest
+final class GetConditionTest extends BCFile_GetConditionTest
 {
 
     /**

--- a/Tests/Utils/Context/InEmptyTest.php
+++ b/Tests/Utils/Context/InEmptyTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Context;
  *
  * @since 1.0.0
  */
-class InEmptyTest extends UtilityMethodTestCase
+final class InEmptyTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Context/InForConditionTest.php
+++ b/Tests/Utils/Context/InForConditionTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Context;
  *
  * @since 1.0.0
  */
-class InForConditionTest extends UtilityMethodTestCase
+final class InForConditionTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Context/InForeachConditionTest.php
+++ b/Tests/Utils/Context/InForeachConditionTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Context;
  *
  * @since 1.0.0
  */
-class InForeachConditionTest extends UtilityMethodTestCase
+final class InForeachConditionTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Context/InIssetTest.php
+++ b/Tests/Utils/Context/InIssetTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Context;
  *
  * @since 1.0.0
  */
-class InIssetTest extends UtilityMethodTestCase
+final class InIssetTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Context/InUnsetTest.php
+++ b/Tests/Utils/Context/InUnsetTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Context;
  *
  * @since 1.0.0
  */
-class InUnsetTest extends UtilityMethodTestCase
+final class InUnsetTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/ControlStructures/GetCaughtExceptionsTest.php
+++ b/Tests/Utils/ControlStructures/GetCaughtExceptionsTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\ControlStructures;
  *
  * @since 1.0.0
  */
-class GetCaughtExceptionsTest extends UtilityMethodTestCase
+final class GetCaughtExceptionsTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/ControlStructures/GetDeclareScopeOpenCloseParseError1Test.php
+++ b/Tests/Utils/ControlStructures/GetDeclareScopeOpenCloseParseError1Test.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\ControlStructures;
  *
  * @since 1.0.0
  */
-class GetDeclareScopeOpenCloseParseError1Test extends PolyfilledTestCase
+final class GetDeclareScopeOpenCloseParseError1Test extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/Utils/ControlStructures/GetDeclareScopeOpenCloseParseError2Test.php
+++ b/Tests/Utils/ControlStructures/GetDeclareScopeOpenCloseParseError2Test.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\ControlStructures;
  *
  * @since 1.0.0
  */
-class GetDeclareScopeOpenCloseParseError2Test extends PolyfilledTestCase
+final class GetDeclareScopeOpenCloseParseError2Test extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/Utils/ControlStructures/GetDeclareScopeOpenCloseParseError3Test.php
+++ b/Tests/Utils/ControlStructures/GetDeclareScopeOpenCloseParseError3Test.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\ControlStructures;
  *
  * @since 1.0.0
  */
-class GetDeclareScopeOpenCloseParseError3Test extends PolyfilledTestCase
+final class GetDeclareScopeOpenCloseParseError3Test extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/Utils/ControlStructures/GetDeclareScopeOpenCloseParseError4Test.php
+++ b/Tests/Utils/ControlStructures/GetDeclareScopeOpenCloseParseError4Test.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\ControlStructures;
  *
  * @since 1.0.0
  */
-class GetDeclareScopeOpenCloseParseError4Test extends PolyfilledTestCase
+final class GetDeclareScopeOpenCloseParseError4Test extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/Utils/ControlStructures/GetDeclareScopeOpenCloseTest.php
+++ b/Tests/Utils/ControlStructures/GetDeclareScopeOpenCloseTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\ControlStructures;
  *
  * @since 1.0.0
  */
-class GetDeclareScopeOpenCloseTest extends PolyfilledTestCase
+final class GetDeclareScopeOpenCloseTest extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/Utils/ControlStructures/HasBodyParseError1Test.php
+++ b/Tests/Utils/ControlStructures/HasBodyParseError1Test.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\ControlStructures;
  *
  * @since 1.0.0
  */
-class HasBodyParseError1Test extends UtilityMethodTestCase
+final class HasBodyParseError1Test extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/ControlStructures/HasBodyParseError2Test.php
+++ b/Tests/Utils/ControlStructures/HasBodyParseError2Test.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\ControlStructures;
  *
  * @since 1.0.0
  */
-class HasBodyParseError2Test extends UtilityMethodTestCase
+final class HasBodyParseError2Test extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/ControlStructures/HasBodyTest.php
+++ b/Tests/Utils/ControlStructures/HasBodyTest.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\ControlStructures;
  *
  * @since 1.0.0
  */
-class HasBodyTest extends UtilityMethodTestCase
+final class HasBodyTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/ControlStructures/IsElseIfTest.php
+++ b/Tests/Utils/ControlStructures/IsElseIfTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\ControlStructures;
  *
  * @since 1.0.0
  */
-class IsElseIfTest extends UtilityMethodTestCase
+final class IsElseIfTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  *
  * @since 1.0.0
  */
-class GetParametersDiffTest extends UtilityMethodTestCase
+final class GetParametersDiffTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/FunctionDeclarations/GetParametersParseError1Test.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersParseError1Test.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  *
  * @since 1.0.0
  */
-class GetParametersParseError1Test extends UtilityMethodTestCase
+final class GetParametersParseError1Test extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/FunctionDeclarations/GetParametersParseError2Test.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersParseError2Test.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  *
  * @since 1.0.0
  */
-class GetParametersParseError2Test extends UtilityMethodTestCase
+final class GetParametersParseError2Test extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/FunctionDeclarations/GetParametersTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  *
  * @since 1.0.0
  */
-class GetParametersTest extends BCFile_GetMethodParametersTest
+final class GetParametersTest extends BCFile_GetMethodParametersTest
 {
 
     /**

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  *
  * @since 1.0.0
  */
-class GetPropertiesDiffTest extends UtilityMethodTestCase
+final class GetPropertiesDiffTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  *
  * @since 1.0.0
  */
-class GetPropertiesTest extends BCFile_GetMethodPropertiesTest
+final class GetPropertiesTest extends BCFile_GetMethodPropertiesTest
 {
 
     /**

--- a/Tests/Utils/FunctionDeclarations/IsArrowFunction2926Test.php
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunction2926Test.php
@@ -30,7 +30,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  *
  * @since 1.0.0
  */
-class IsArrowFunction2926Test extends PolyfilledTestCase
+final class IsArrowFunction2926Test extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
+++ b/Tests/Utils/FunctionDeclarations/IsArrowFunctionTest.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  *
  * @since 1.0.0
  */
-class IsArrowFunctionTest extends PolyfilledTestCase
+final class IsArrowFunctionTest extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/Utils/FunctionDeclarations/IsMagicFunctionNameTest.php
+++ b/Tests/Utils/FunctionDeclarations/IsMagicFunctionNameTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class IsMagicFunctionNameTest extends TestCase
+final class IsMagicFunctionNameTest extends TestCase
 {
 
     /**

--- a/Tests/Utils/FunctionDeclarations/IsMagicMethodNameTest.php
+++ b/Tests/Utils/FunctionDeclarations/IsMagicMethodNameTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class IsMagicMethodNameTest extends TestCase
+final class IsMagicMethodNameTest extends TestCase
 {
 
     /**

--- a/Tests/Utils/FunctionDeclarations/IsPHPDoubleUnderscoreMethodNameTest.php
+++ b/Tests/Utils/FunctionDeclarations/IsPHPDoubleUnderscoreMethodNameTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class IsPHPDoubleUnderscoreMethodNameTest extends TestCase
+final class IsPHPDoubleUnderscoreMethodNameTest extends TestCase
 {
 
     /**

--- a/Tests/Utils/FunctionDeclarations/SpecialFunctionsTest.php
+++ b/Tests/Utils/FunctionDeclarations/SpecialFunctionsTest.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  *
  * @since 1.0.0
  */
-class SpecialFunctionsTest extends UtilityMethodTestCase
+final class SpecialFunctionsTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/GetTokensAsString/GetTokensAsStringTest.php
+++ b/Tests/Utils/GetTokensAsString/GetTokensAsStringTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\GetTokensAsString;
  *
  * @since 1.0.0
  */
-class GetTokensAsStringTest extends UtilityMethodTestCase
+final class GetTokensAsStringTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Lists/GetAssignmentsTest.php
+++ b/Tests/Utils/Lists/GetAssignmentsTest.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\Lists;
  *
  * @since 1.0.0
  */
-class GetAssignmentsTest extends UtilityMethodTestCase
+final class GetAssignmentsTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Lists/GetOpenCloseTest.php
+++ b/Tests/Utils/Lists/GetOpenCloseTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Lists;
  *
  * @since 1.0.0
  */
-class GetOpenCloseTest extends UtilityMethodTestCase
+final class GetOpenCloseTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Lists/IsShortArrayOrListTest.php
+++ b/Tests/Utils/Lists/IsShortArrayOrListTest.php
@@ -24,7 +24,7 @@ use PHPCSUtils\Utils\Lists;
  *
  * @since 1.0.0
  */
-class IsShortArrayOrListTest extends UtilityMethodTestCase
+final class IsShortArrayOrListTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Lists/IsShortArrayOrListTokenizerBC1Test.php
+++ b/Tests/Utils/Lists/IsShortArrayOrListTokenizerBC1Test.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\Lists;
  *
  * @since 1.0.0
  */
-class IsShortArrayOrListTokenizerBC1Test extends UtilityMethodTestCase
+final class IsShortArrayOrListTokenizerBC1Test extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Lists/IsShortArrayOrListTokenizerBC2Test.php
+++ b/Tests/Utils/Lists/IsShortArrayOrListTokenizerBC2Test.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\Lists;
  *
  * @since 1.0.0
  */
-class IsShortArrayOrListTokenizerBC2Test extends UtilityMethodTestCase
+final class IsShortArrayOrListTokenizerBC2Test extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Lists/IsShortArrayOrListTokenizerBC3Test.php
+++ b/Tests/Utils/Lists/IsShortArrayOrListTokenizerBC3Test.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\Lists;
  *
  * @since 1.0.0
  */
-class IsShortArrayOrListTokenizerBC3Test extends UtilityMethodTestCase
+final class IsShortArrayOrListTokenizerBC3Test extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Lists/IsShortArrayOrListTokenizerBC4Test.php
+++ b/Tests/Utils/Lists/IsShortArrayOrListTokenizerBC4Test.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\Lists;
  *
  * @since 1.0.0
  */
-class IsShortArrayOrListTokenizerBC4Test extends UtilityMethodTestCase
+final class IsShortArrayOrListTokenizerBC4Test extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/MessageHelper/AddMessageTest.php
+++ b/Tests/Utils/MessageHelper/AddMessageTest.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Utils\MessageHelper;
  *
  * @since 1.0.0
  */
-class AddMessageTest extends UtilityMethodTestCase
+final class AddMessageTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/MessageHelper/AddMessageTest.php
+++ b/Tests/Utils/MessageHelper/AddMessageTest.php
@@ -69,7 +69,7 @@ final class AddMessageTest extends UtilityMethodTestCase
             'Message added. Text: %s',
             $stackPtr,
             $isError,
-            static::CODE,
+            self::CODE,
             [$tokens[$stackPtr]['content']],
             $severity
         );
@@ -94,7 +94,7 @@ final class AddMessageTest extends UtilityMethodTestCase
                 'isError'    => true,
                 'expected'   => [
                     'message' => "Message added. Text: 'test 1'",
-                    'source'  => static::CODE,
+                    'source'  => self::CODE,
                     'fixable' => false,
                 ],
             ],
@@ -103,7 +103,7 @@ final class AddMessageTest extends UtilityMethodTestCase
                 'isError'    => false,
                 'expected'   => [
                     'message' => "Message added. Text: 'test 2'",
-                    'source'  => static::CODE,
+                    'source'  => self::CODE,
                     'fixable' => false,
                 ],
             ],
@@ -134,7 +134,7 @@ final class AddMessageTest extends UtilityMethodTestCase
             'Message added. Text: %s',
             $stackPtr,
             $isError,
-            static::CODE,
+            self::CODE,
             [$tokens[$stackPtr]['content']],
             $severity
         );
@@ -160,7 +160,7 @@ final class AddMessageTest extends UtilityMethodTestCase
                 'isError'    => true,
                 'expected'   => [
                     'message' => "Message added. Text: 'test 3'",
-                    'source'  => static::CODE,
+                    'source'  => self::CODE,
                     'fixable' => true,
                 ],
             ],
@@ -169,7 +169,7 @@ final class AddMessageTest extends UtilityMethodTestCase
                 'isError'    => false,
                 'expected'   => [
                     'message' => "Message added. Text: 'test 4'",
-                    'source'  => static::CODE,
+                    'source'  => self::CODE,
                     'fixable' => true,
                 ],
             ],

--- a/Tests/Utils/MessageHelper/ShowEscapeCharsTest.php
+++ b/Tests/Utils/MessageHelper/ShowEscapeCharsTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class ShowEscapeCharsTest extends TestCase
+final class ShowEscapeCharsTest extends TestCase
 {
 
     /**

--- a/Tests/Utils/MessageHelper/StringToErrorcodeTest.php
+++ b/Tests/Utils/MessageHelper/StringToErrorcodeTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class StringToErrorcodeTest extends TestCase
+final class StringToErrorcodeTest extends TestCase
 {
 
     /**

--- a/Tests/Utils/Namespaces/DetermineNamespaceTest.php
+++ b/Tests/Utils/Namespaces/DetermineNamespaceTest.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\Namespaces;
  *
  * @since 1.0.0
  */
-class DetermineNamespaceTest extends UtilityMethodTestCase
+final class DetermineNamespaceTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Namespaces/GetDeclaredNameTest.php
+++ b/Tests/Utils/Namespaces/GetDeclaredNameTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Namespaces;
  *
  * @since 1.0.0
  */
-class GetDeclaredNameTest extends UtilityMethodTestCase
+final class GetDeclaredNameTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Namespaces/NamespaceTypeTest.php
+++ b/Tests/Utils/Namespaces/NamespaceTypeTest.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Utils\Namespaces;
  *
  * @since 1.0.0
  */
-class NamespaceTypeTest extends UtilityMethodTestCase
+final class NamespaceTypeTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/NamingConventions/IsEqualTest.php
+++ b/Tests/Utils/NamingConventions/IsEqualTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class IsEqualTest extends TestCase
+final class IsEqualTest extends TestCase
 {
 
     /**

--- a/Tests/Utils/NamingConventions/IsValidIdentifierNameTest.php
+++ b/Tests/Utils/NamingConventions/IsValidIdentifierNameTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class IsValidIdentifierNameTest extends TestCase
+final class IsValidIdentifierNameTest extends TestCase
 {
 
     /**

--- a/Tests/Utils/Numbers/GetCompleteNumberTest.php
+++ b/Tests/Utils/Numbers/GetCompleteNumberTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Numbers;
  *
  * @since 1.0.0
  */
-class GetCompleteNumberTest extends UtilityMethodTestCase
+final class GetCompleteNumberTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Numbers/GetDecimalValueTest.php
+++ b/Tests/Utils/Numbers/GetDecimalValueTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class GetDecimalValueTest extends TestCase
+final class GetDecimalValueTest extends TestCase
 {
 
     /**

--- a/Tests/Utils/Numbers/NumberTypesTest.php
+++ b/Tests/Utils/Numbers/NumberTypesTest.php
@@ -26,7 +26,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class NumberTypesTest extends TestCase
+final class NumberTypesTest extends TestCase
 {
 
     /**

--- a/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  *
  * @since 1.0.0
  */
-class FindExtendedClassNameDiffTest extends UtilityMethodTestCase
+final class FindExtendedClassNameDiffTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/ObjectDeclarations/FindExtendedClassNameTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedClassNameTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Tests\BackCompat\BCFile\FindExtendedClassNameTest as BCFile_FindE
  *
  * @since 1.0.0
  */
-class FindExtendedClassNameTest extends BCFile_FindExtendedClassNameTest
+final class FindExtendedClassNameTest extends BCFile_FindExtendedClassNameTest
 {
 
     /**

--- a/Tests/Utils/ObjectDeclarations/FindExtendedInterfaceNamesTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedInterfaceNamesTest.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  *
  * @since 1.0.0
  */
-class FindExtendedInterfaceNamesTest extends UtilityMethodTestCase
+final class FindExtendedInterfaceNamesTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  *
  * @since 1.0.0
  */
-class FindImplementedInterfaceNamesDiffTest extends UtilityMethodTestCase
+final class FindImplementedInterfaceNamesDiffTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Tests\BackCompat\BCFile\FindImplementedInterfaceNamesTest as BCFi
  *
  * @since 1.0.0
  */
-class FindImplementedInterfaceNamesTest extends BCFile_FindImplInterfaceNamesTest
+final class FindImplementedInterfaceNamesTest extends BCFile_FindImplInterfaceNamesTest
 {
 
     /**

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  *
  * @since 1.0.0
  */
-class GetClassPropertiesDiffTest extends UtilityMethodTestCase
+final class GetClassPropertiesDiffTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesTest.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Tests\BackCompat\BCFile\GetClassPropertiesTest as BCFile_GetClass
  *
  * @since 1.0.0
  */
-class GetClassPropertiesTest extends BCFile_GetClassPropertiesTest
+final class GetClassPropertiesTest extends BCFile_GetClassPropertiesTest
 {
 
     /**

--- a/Tests/Utils/ObjectDeclarations/GetNameDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameDiffTest.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  *
  * @since 1.0.0
  */
-class GetNameDiffTest extends UtilityMethodTestCase
+final class GetNameDiffTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/ObjectDeclarations/GetNameJSTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameJSTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  *
  * @since 1.0.0
  */
-class GetNameJSTest extends BCFile_GetDeclarationNameJSTest
+final class GetNameJSTest extends BCFile_GetDeclarationNameJSTest
 {
 
     /**

--- a/Tests/Utils/ObjectDeclarations/GetNameTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  *
  * @since 1.0.0
  */
-class GetNameTest extends BCFile_GetDeclarationNameTest
+final class GetNameTest extends BCFile_GetDeclarationNameTest
 {
 
     /**

--- a/Tests/Utils/Operators/IsReferenceDiffTest.php
+++ b/Tests/Utils/Operators/IsReferenceDiffTest.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\Operators;
  *
  * @since 1.0.0
  */
-class IsReferenceDiffTest extends UtilityMethodTestCase
+final class IsReferenceDiffTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Operators/IsReferenceTest.php
+++ b/Tests/Utils/Operators/IsReferenceTest.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Tests\BackCompat\BCFile\IsReferenceTest as BCFile_IsReferenceTest
  *
  * @since 1.0.0
  */
-class IsReferenceTest extends BCFile_IsReferenceTest
+final class IsReferenceTest extends BCFile_IsReferenceTest
 {
 
     /**

--- a/Tests/Utils/Operators/IsShortTernaryTest.php
+++ b/Tests/Utils/Operators/IsShortTernaryTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Operators;
  *
  * @since 1.0.0
  */
-class IsShortTernaryTest extends UtilityMethodTestCase
+final class IsShortTernaryTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Operators/IsUnaryPlusMinusJSTest.php
+++ b/Tests/Utils/Operators/IsUnaryPlusMinusJSTest.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Tests\Utils\Operators\IsUnaryPlusMinusTestCase;
  *
  * @since 1.0.0
  */
-class IsUnaryPlusMinusJSTest extends IsUnaryPlusMinusTestCase
+final class IsUnaryPlusMinusJSTest extends IsUnaryPlusMinusTestCase
 {
 
     /**

--- a/Tests/Utils/Operators/IsUnaryPlusMinusTest.php
+++ b/Tests/Utils/Operators/IsUnaryPlusMinusTest.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Tests\Utils\Operators\IsUnaryPlusMinusTestCase;
  *
  * @since 1.0.0
  */
-class IsUnaryPlusMinusTest extends IsUnaryPlusMinusTestCase
+final class IsUnaryPlusMinusTest extends IsUnaryPlusMinusTestCase
 {
 
     /**

--- a/Tests/Utils/Orthography/FirstCharTest.php
+++ b/Tests/Utils/Orthography/FirstCharTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class FirstCharTest extends TestCase
+final class FirstCharTest extends TestCase
 {
 
     /**

--- a/Tests/Utils/Orthography/IsLastCharPunctuationTest.php
+++ b/Tests/Utils/Orthography/IsLastCharPunctuationTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class IsLastCharPunctuationTest extends TestCase
+final class IsLastCharPunctuationTest extends TestCase
 {
 
     /**

--- a/Tests/Utils/Parentheses/ParenthesesTest.php
+++ b/Tests/Utils/Parentheses/ParenthesesTest.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\Parentheses;
  *
  * @since 1.0.0
  */
-class ParenthesesTest extends UtilityMethodTestCase
+final class ParenthesesTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/PassedParameters/GetParameterCountTest.php
+++ b/Tests/Utils/PassedParameters/GetParameterCountTest.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 1.0.0
  */
-class GetParameterCountTest extends UtilityMethodTestCase
+final class GetParameterCountTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/PassedParameters/GetParameterFromStackTest.php
+++ b/Tests/Utils/PassedParameters/GetParameterFromStackTest.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 1.0.0
  */
-class GetParameterFromStackTest extends UtilityMethodTestCase
+final class GetParameterFromStackTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/PassedParameters/GetParametersNamedTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersNamedTest.php
@@ -27,7 +27,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 1.0.0
  */
-class GetParametersNamedTest extends UtilityMethodTestCase
+final class GetParametersNamedTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/PassedParameters/GetParametersSkipShortArrayCheckTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersSkipShortArrayCheckTest.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 1.0.0
  */
-class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase
+final class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/Utils/PassedParameters/GetParametersTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersTest.php
@@ -27,7 +27,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 1.0.0
  */
-class GetParametersTest extends UtilityMethodTestCase
+final class GetParametersTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/PassedParameters/GetParametersWithLimitTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersWithLimitTest.php
@@ -24,7 +24,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 1.0.0
  */
-class GetParametersWithLimitTest extends UtilityMethodTestCase
+final class GetParametersWithLimitTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/PassedParameters/HasParametersTest.php
+++ b/Tests/Utils/PassedParameters/HasParametersTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 1.0.0
  */
-class HasParametersTest extends UtilityMethodTestCase
+final class HasParametersTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Scopes/IsOOConstantTest.php
+++ b/Tests/Utils/Scopes/IsOOConstantTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Scopes;
  *
  * @since 1.0.0
  */
-class IsOOConstantTest extends UtilityMethodTestCase
+final class IsOOConstantTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Scopes/IsOOMethodTest.php
+++ b/Tests/Utils/Scopes/IsOOMethodTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Scopes;
  *
  * @since 1.0.0
  */
-class IsOOMethodTest extends UtilityMethodTestCase
+final class IsOOMethodTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Scopes/IsOOPropertyTest.php
+++ b/Tests/Utils/Scopes/IsOOPropertyTest.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Scopes;
  *
  * @since 1.0.0
  */
-class IsOOPropertyTest extends UtilityMethodTestCase
+final class IsOOPropertyTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/TextStrings/GetCompleteTextStringTest.php
+++ b/Tests/Utils/TextStrings/GetCompleteTextStringTest.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * @since 1.0.0
  */
-class GetCompleteTextStringTest extends UtilityMethodTestCase
+final class GetCompleteTextStringTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/TextStrings/GetEndOfCompleteTextStringTest.php
+++ b/Tests/Utils/TextStrings/GetEndOfCompleteTextStringTest.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * @since 1.0.0
  */
-class GetEndOfCompleteTextStringTest extends UtilityMethodTestCase
+final class GetEndOfCompleteTextStringTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/TextStrings/InterpolatedVariablesTest.php
+++ b/Tests/Utils/TextStrings/InterpolatedVariablesTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class InterpolatedVariablesTest extends TestCase
+final class InterpolatedVariablesTest extends TestCase
 {
 
     /**

--- a/Tests/Utils/TextStrings/StripQuotesTest.php
+++ b/Tests/Utils/TextStrings/StripQuotesTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class StripQuotesTest extends TestCase
+final class StripQuotesTest extends TestCase
 {
 
     /**

--- a/Tests/Utils/UseStatements/SplitAndMergeImportUseStatementTest.php
+++ b/Tests/Utils/UseStatements/SplitAndMergeImportUseStatementTest.php
@@ -24,7 +24,7 @@ use PHPCSUtils\Utils\UseStatements;
  *
  * @since 1.0.0
  */
-class SplitAndMergeImportUseStatementTest extends UtilityMethodTestCase
+final class SplitAndMergeImportUseStatementTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/UseStatements/SplitImportUseStatementTest.php
+++ b/Tests/Utils/UseStatements/SplitImportUseStatementTest.php
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\UseStatements;
  *
  * @since 1.0.0
  */
-class SplitImportUseStatementTest extends UtilityMethodTestCase
+final class SplitImportUseStatementTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/UseStatements/UseTypeTest.php
+++ b/Tests/Utils/UseStatements/UseTypeTest.php
@@ -28,7 +28,7 @@ use PHPCSUtils\Utils\UseStatements;
  *
  * @since 1.0.0
  */
-class UseTypeTest extends UtilityMethodTestCase
+final class UseTypeTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\Variables;
  *
  * @since 1.0.0
  */
-class GetMemberPropertiesDiffTest extends UtilityMethodTestCase
+final class GetMemberPropertiesDiffTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Utils/Variables/GetMemberPropertiesTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesTest.php
@@ -21,7 +21,7 @@ use PHPCSUtils\Tests\BackCompat\BCFile\GetMemberPropertiesTest as BCFile_GetMemb
  *
  * @since 1.0.0
  */
-class GetMemberPropertiesTest extends BCFile_GetMemberPropertiesTest
+final class GetMemberPropertiesTest extends BCFile_GetMemberPropertiesTest
 {
 
     /**

--- a/Tests/Utils/Variables/IsPHPReservedVarNameTest.php
+++ b/Tests/Utils/Variables/IsPHPReservedVarNameTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class IsPHPReservedVarNameTest extends TestCase
+final class IsPHPReservedVarNameTest extends TestCase
 {
 
     /**

--- a/Tests/Utils/Variables/IsSuperglobalTest.php
+++ b/Tests/Utils/Variables/IsSuperglobalTest.php
@@ -24,7 +24,7 @@ use PHPCSUtils\Utils\Variables;
  *
  * @since 1.0.0
  */
-class IsSuperglobalTest extends UtilityMethodTestCase
+final class IsSuperglobalTest extends UtilityMethodTestCase
 {
 
     /**

--- a/Tests/Xtra/Messages/HasNewLineSupportTest.php
+++ b/Tests/Xtra/Messages/HasNewLineSupportTest.php
@@ -26,7 +26,7 @@ use PHPCSUtils\Tests\PolyfilledTestCase;
  *
  * @since 1.0.0
  */
-class HasNewLineSupportTest extends PolyfilledTestCase
+final class HasNewLineSupportTest extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/Xtra/Messages/HasNewLineSupportTest.php
+++ b/Tests/Xtra/Messages/HasNewLineSupportTest.php
@@ -89,7 +89,7 @@ EOD;
             // phpcs:ignore Generic.Files.LineLength.TooLong
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\nAenean felis urna, dictum vitae lobortis vitae, maximus nec enim. Etiam euismod placerat efficitur. Nulla eu felis ipsum.\nCras vitae ultrices turpis. Ut consectetur ligula in justo tincidunt mattis.\n\nAliquam fermentum magna id venenatis placerat. Curabitur lobortis nulla sit amet consequat fermentum. Aenean malesuada tristique aliquam. Donec eget placerat nisl.\n\nMorbi mollis, risus vel venenatis accumsan, urna dolor faucibus risus, ut congue purus augue vel ipsum.\nCurabitur nec dolor est. Suspendisse nec quam non ligula aliquam tempus. Donec laoreet maximus leo, in eleifend odio interdum vitae.",
             $stackPtr,
-            static::CODE
+            self::CODE
         );
 
         /*

--- a/Tests/Xtra/Tokens/TokenNameTest.php
+++ b/Tests/Xtra/Tokens/TokenNameTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @since 1.0.0
  */
-class TokenNameTest extends TestCase
+final class TokenNameTest extends TestCase
 {
 
     /**


### PR DESCRIPTION
### QA: make all classes final

The "class vs sniff name" matcher in the PHPCS autoloader does not handle sniffs classes extending other sniffs well.

Now, while this "standard" doesn't actually contain any sniffs, the utilities in this library are not intended to be extended anyway, aside from the explicitly `abstract` base sniffs.

So, with that in mind, I'm making all classes in this library `final`, with the exception of some select test classes (the `BCFile` ones as those need to be extended to safeguard that the PHPCSUtils native functionality mirrors the PHPCS native functionality).

If anyone has issues with any particular class now being `final`, please report this ASAP and please include a good use-case of why that particular class should not be `final`.

### QA: don't use static for LSB in final class

... as there can never be a (grand-)child class.