### PR TITLE
FunctionDeclarations::getParameters(): add caching

### DIFF
--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -13,6 +13,7 @@ namespace PHPCSUtils\Utils;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Internal\Cache;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\GetTokensAsString;
 use PHPCSUtils\Utils\ObjectDeclarations;
@@ -363,6 +364,7 @@ final class FunctionDeclarations
      * - Clearer exception message when a non-closure use token was passed to the function.
      * - Support for PHP 8.0 identifier name tokens in parameter types, cross-version PHP & PHPCS.
      * - Support for the PHP 8.2 `true` type.
+     * - The results of this function call are cached during a PHPCS run for faster response times.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodParameters()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getMethodParameters() Cross-version compatible version of the original.
@@ -421,6 +423,10 @@ final class FunctionDeclarations
         if (isset($tokens[$opener]['parenthesis_closer']) === false) {
             // Live coding or syntax error, so no params to find.
             return [];
+        }
+
+        if (Cache::isCached($phpcsFile, __METHOD__, $stackPtr) === true) {
+            return Cache::get($phpcsFile, __METHOD__, $stackPtr);
         }
 
         $closer = $tokens[$opener]['parenthesis_closer'];
@@ -607,6 +613,7 @@ final class FunctionDeclarations
             }
         }
 
+        Cache::set($phpcsFile, __METHOD__, $stackPtr, $vars);
         return $vars;
     }
 

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
@@ -10,7 +10,9 @@
 
 namespace PHPCSUtils\Tests\Utils\FunctionDeclarations;
 
+use PHPCSUtils\Internal\Cache;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
 
 /**
@@ -112,41 +114,107 @@ final class GetParametersDiffTest extends UtilityMethodTestCase
      */
     protected function getMethodParametersTestHelper($marker, $expected, $targetType = [\T_FUNCTION, \T_CLOSURE, \T_FN])
     {
-        $target = $this->getTargetToken($marker, $targetType);
-        $found  = FunctionDeclarations::getParameters(self::$phpcsFile, $target);
+        $target   = $this->getTargetToken($marker, $targetType);
+        $found    = FunctionDeclarations::getParameters(self::$phpcsFile, $target);
+        $expected = $this->updateExpectedTokenPositions($target, $expected);
 
+        $this->assertSame($expected, $found);
+    }
+
+    /**
+     * Test helper to translate token offsets to absolute positions in an "expected" array.
+     *
+     * @param string $targetPtr The token pointer to the target token from which the offset is calculated.
+     * @param array  $expected  The expected function output containing offsets.
+     *
+     * @return array
+     */
+    private function updateExpectedTokenPositions($targetPtr, $expected)
+    {
         foreach ($expected as $key => $param) {
-            $expected[$key]['token'] += $target;
+            $expected[$key]['token'] += $targetPtr;
 
             if ($param['reference_token'] !== false) {
-                $expected[$key]['reference_token'] += $target;
+                $expected[$key]['reference_token'] += $targetPtr;
             }
             if ($param['variadic_token'] !== false) {
-                $expected[$key]['variadic_token'] += $target;
+                $expected[$key]['variadic_token'] += $targetPtr;
             }
             if ($param['type_hint_token'] !== false) {
-                $expected[$key]['type_hint_token'] += $target;
+                $expected[$key]['type_hint_token'] += $targetPtr;
             }
             if ($param['type_hint_end_token'] !== false) {
-                $expected[$key]['type_hint_end_token'] += $target;
+                $expected[$key]['type_hint_end_token'] += $targetPtr;
             }
             if ($param['comma_token'] !== false) {
-                $expected[$key]['comma_token'] += $target;
+                $expected[$key]['comma_token'] += $targetPtr;
             }
             if (isset($param['default_token'])) {
-                $expected[$key]['default_token'] += $target;
+                $expected[$key]['default_token'] += $targetPtr;
             }
             if (isset($param['default_equal_token'])) {
-                $expected[$key]['default_equal_token'] += $target;
+                $expected[$key]['default_equal_token'] += $targetPtr;
             }
             if (isset($param['visibility_token'])) {
-                $expected[$key]['visibility_token'] += $target;
+                $expected[$key]['visibility_token'] += $targetPtr;
             }
             if (isset($param['readonly_token'])) {
-                $expected[$key]['readonly_token'] += $target;
+                $expected[$key]['readonly_token'] += $targetPtr;
             }
         }
 
-        $this->assertSame($expected, $found);
+        return $expected;
+    }
+
+    /**
+     * Verify that the build-in caching is used when caching is enabled.
+     *
+     * @return void
+     */
+    public function testResultIsCached()
+    {
+        // The test case used is specifically selected to be one which will always reach the cache check.
+        $methodName = 'PHPCSUtils\\Utils\\FunctionDeclarations::getParameters';
+        $testMarker = '/* testPHP82PseudoTypeTrue */';
+        $expected   = [
+            0 => [
+                'token'               => 7, // Offset from the T_FUNCTION token.
+                'name'                => '$var',
+                'content'             => '?true $var = true',
+                'default'             => 'true',
+                'default_token'       => 11, // Offset from the T_FUNCTION token.
+                'default_equal_token' => 9,  // Offset from the T_FUNCTION token.
+                'has_attributes'      => false,
+                'pass_by_reference'   => false,
+                'reference_token'     => false,
+                'variable_length'     => false,
+                'variadic_token'      => false,
+                'type_hint'           => '?true',
+                'type_hint_token'     => 5, // Offset from the T_FUNCTION token.
+                'type_hint_end_token' => 5, // Offset from the T_FUNCTION token.
+                'nullable_type'       => true,
+                'comma_token'         => false,
+            ],
+        ];
+
+        $stackPtr = $this->getTargetToken($testMarker, Collections::functionDeclarationTokens());
+        $expected = $this->updateExpectedTokenPositions($stackPtr, $expected);
+
+        // Verify the caching works.
+        $origStatus     = Cache::$enabled;
+        Cache::$enabled = true;
+
+        $resultFirstRun  = FunctionDeclarations::getParameters(self::$phpcsFile, $stackPtr);
+        $isCached        = Cache::isCached(self::$phpcsFile, $methodName, $stackPtr);
+        $resultSecondRun = FunctionDeclarations::getParameters(self::$phpcsFile, $stackPtr);
+
+        if ($origStatus === false) {
+            Cache::clear();
+        }
+        Cache::$enabled = $origStatus;
+
+        $this->assertSame($expected, $resultFirstRun, 'First result did not match expectation');
+        $this->assertTrue($isCached, 'Cache::isCached() could not find the cached value');
+        $this->assertSame($resultFirstRun, $resultSecondRun, 'Second result did not match first');
     }
 }


### PR DESCRIPTION
Follow up on #332

While most function declarations will be quite straight-forward, for function declarations with lots of parameters, this method can be token walking intensive.

As this method is also used by the `Operators::isReference()` method and in the future potentially by yet another method, caching the results of the function seems prudent.

Includes a dedicated test to verify the cache is used and working.