### PR TITLE
AbstractArrayDeclarationSniff::getActualArrayKey(): improve handling of escaped embedded vars

### DIFF
--- a/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
+++ b/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
@@ -494,7 +494,7 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
                 $text = TextStrings::getCompleteTextString($phpcsFile, $i);
 
                 // Check if there's a variable in the heredoc.
-                if (\preg_match('`(?<![\\\\])\$`', $text) === 1) {
+                if ($text !== TextStrings::stripEmbeds($text)) {
                     return;
                 }
 

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.inc
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.inc
@@ -15,6 +15,14 @@ my $var text
 EOD
                                 => 'excluded',
     $var['key']{1}              => 'excluded',
+    <<<EOD
+my complex {${getName()}} text
+EOD
+                                => 'excluded',
+    <<<EOD
+$var text
+EOD
+                                => 'excluded',
 ];
 
 /* testAllEmptyString */
@@ -111,4 +119,20 @@ abc
 NOW
                => 6,
     "abc"      => 7,
+];
+
+/* testHeredocWithEscapedVarInKey */
+$heredocStringKeyWithEscapedVar = [
+    <<<EOD
+a{\$b}c
+EOD
+              => 1,
+    <<<EOD
+a\$bc
+EOD
+              => 2,
+    <<<EOD
+$\{abc}
+EOD
+              => 3,
 ];


### PR DESCRIPTION
... in heredocs by using the new `TextStrings::stripEmbeds()` method.

Includes additional tests.