### PR TITLE
UtilityMethodTestCase::getTargetToken(): change to a static method

### DIFF
--- a/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+++ b/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
@@ -329,6 +329,7 @@ abstract class UtilityMethodTestCase extends TestCase
      * @since 1.0.0
      * @since 1.0.0-alpha4 Will throw an exception whether the delimiter comment or the target
      *                     token is not found.
+     * @since 1.0.0-alpha4 This method is now `static`, which allows for it to be used in "set up before class".
      *
      * @param string           $commentString The complete delimiter comment to look for as a string.
      *                                        This string should include the comment opener and closer.
@@ -340,7 +341,7 @@ abstract class UtilityMethodTestCase extends TestCase
      * @throws \PHPCSUtils\Exceptions\TestMarkerNotFound When the delimiter comment for the test was not found.
      * @throws \PHPCSUtils\Exceptions\TestTargetNotFound When the target token cannot be found.
      */
-    public function getTargetToken($commentString, $tokenType, $tokenContent = null)
+    public static function getTargetToken($commentString, $tokenType, $tokenContent = null)
     {
         $start   = (self::$phpcsFile->numTokens - 1);
         $comment = self::$phpcsFile->findPrevious(

--- a/Tests/TestUtils/UtilityMethodTestCase/GetTargetTokenTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/GetTargetTokenTest.php
@@ -54,7 +54,7 @@ final class GetTargetTokenTest extends PolyfilledTestCase
         if (isset($tokenContent)) {
             $result = $this->getTargetToken($commentString, $tokenType, $tokenContent);
         } else {
-            $result = $this->getTargetToken($commentString, $tokenType);
+            $result = self::getTargetToken($commentString, $tokenType);
         }
 
         $this->assertSame($expected, $result);
@@ -147,6 +147,6 @@ final class GetTargetTokenTest extends PolyfilledTestCase
         $this->expectException('PHPCSUtils\Exceptions\TestTargetNotFound');
         $this->expectExceptionMessage('Failed to find test target token for comment string: ');
 
-        $this->getTargetToken('/* testNotFindingTarget */', [\T_VARIABLE], '$a');
+        self::getTargetToken('/* testNotFindingTarget */', [\T_VARIABLE], '$a');
     }
 }


### PR DESCRIPTION
The method effectively was already `static` as it didn't use `$this`. Making it explicitly static will allow for using it in "set up before class" test fixture methods.

This is particularly useful when a "cache" of information would need to be set up using the same code as the code under test. If this is done in a "set up" fixture, the code being run would be counted for the code coverage calculation, while when don in "set up before class", the code being run will _not_ be counted for code coverage, allowing for cleaner coverage reports.

Includes introducing some minor variations in the pre-existing tests to safeguard that both static calls as well as non-static calls to the method are supported.