### PR TITLE
GH Actions: various tweaks

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -59,7 +59,7 @@ jobs:
 
       # Show XML violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
-      - uses: korelstar/xmllint-problem-matcher@v1.1
+      - uses: korelstar/xmllint-problem-matcher@v1
 
       # Validate the XML file.
       # @link http://xmlsoft.org/xmllint.html

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -48,7 +48,7 @@ jobs:
           composer require --no-update squizlabs/php_codesniffer:"dev-master"
 
       # Install dependencies and handle caching in one go.
-      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
 

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           # Use the version as per https://pages.github.com/versions/
-          ruby-version: 2.7.1
+          ruby-version: 2.7.4
           bundler-cache: true
           working-directory: docs
 

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -64,7 +64,7 @@ jobs:
         run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
 
       # Install dependencies and handle caching in one go.
-      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,7 +171,7 @@ jobs:
         run: composer remove --dev --no-update phpcsstandards/phpcsdevcs
 
       # Install dependencies and handle caching in one go.
-      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies - normal
         if: ${{ matrix.php < 8.2 }}
         uses: "ramsey/composer-install@v2"


### PR DESCRIPTION
### GH Actions/basics: revert to xmllint-problem-matcher v1

As the `korelstar/xmllint-problem-matcher` repo now has a long-running `v1` branch, this update which was included in PR 348 is no longer needed (and would necessitate more frequent updates if it would remain).

Ref:
* korelstar/xmllint-problem-matcher#7

### GH Actions: update Ruby for GH Pages workflow

... as per https://pages.github.com/versions/

### GH Actions: update a few links in inline comments