### PR TITLE
PHPCS: fix ruleset

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -74,10 +74,11 @@ jobs:
 
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style
-        continue-on-error: true
+        id: phpcs
         run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml
 
       - name: Show PHPCS results in PR
+        if: ${{ always() && steps.phpcs.outcome == 'failure' }}
         run: cs2pr ./phpcs-report.xml
 
   markdownlint:

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -96,9 +96,4 @@
         <exclude-pattern>/Tests/BackCompat/BCFile/*Test\.php$</exclude-pattern>
     </rule>
 
-    <!-- Allow for return value from PassedParameters::getParameters() having mixed keys. -->
-    <rule ref="Universal.Arrays.MixedArrayKeyTypes">
-        <exclude-pattern>/Tests/Utils/PassedParameters/GetParametersNamedTest\.php$</exclude-pattern>
-    </rule>
-
 </ruleset>


### PR DESCRIPTION
### GH Actions: harden the workflow against PHPCS ruleset errors

If there is a ruleset error, the `cs2pr` action doesn't receive an `xml` report and exits with a `0` error code, even though the PHPCS run failed (though not on CS errors, but on a ruleset error).

This changes the GH Actions workflow to allow for that situation and still fail the build in that case.

### PHPCS: fix ruleset

The sniff this exclusion refers to is not (yet) in use in PHPCSDevCS.