### PR TITLE
Docs website: update for release of PHPCSUtils 1.0.0-alpha4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ vendor/
 /composer.lock
 /.phpcs.xml
 /phpcs.xml
+/.phpdoc.xml
 /phpdoc.xml
 /phpunit.xml
 /.phpunit.result.cache

--- a/.phpdoc.xml.dist
+++ b/.phpdoc.xml.dist
@@ -3,7 +3,7 @@
     configVersion="3"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://www.phpdoc.org"
-    xsi:noNamespaceSchemaLocation="https://docs.phpdoc.org/latest/phpdoc.xsd"
+    xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/phpDocumentor/phpDocumentor/master/data/xsd/phpdoc.xsd"
 >
 
     <title>PHPCSUtils</title>
@@ -19,6 +19,15 @@
                 <path>phpcsutils-autoload.php</path>
                 <path>PHPCSUtils</path>
             </source>
+            <ignore hidden="true" symlinks="true">
+                <path>PHPCSUtils/Internal/**/*</path>
+            </ignore>
+            <visibility>public</visibility>
+            <visibility>protected</visibility>
+            <ignore-tags>
+                <ignore-tag>codeCoverageIgnore</ignore-tag>
+                <ignore-tag>phpcs</ignore-tag>
+            </ignore-tags>
         </api>
     </version>
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -33,4 +33,34 @@ twitter:
 author:
   twitter: jrf_nl
 
-exclude: ['CNAME', '.gitignore', 'Gemfile', '*.bak', '*.orig', 'vendor']
+# Needed so the select HTML tags do not get removed *sigh*
+commonmark:
+  options: ["SMART", "FOOTNOTES", "UNSAFE"]
+  extensions: ["strikethrough", "autolink", "table"]
+
+# Files to exclude when generating the site.
+exclude:
+  - .sass-cache/
+  - .jekyll-cache/
+  - gemfiles/
+  - Gemfile
+  - Gemfile.lock
+  - node_modules/
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
+  - CNAME
+  - CONTRIBUTING.md
+  - LICENSE
+  - README.md
+  - apigen.neon
+  - buildtool.py
+  - Vagrantfile
+  - vagrant-provision.sh
+  - .gitignore
+  - .github
+  - .jekyll-metadata
+  - '*.bak'
+  - '*.orig'
+  - runit.bat

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -16,16 +16,12 @@
     <div class="wrapper">
       <header>
         <h1><a href="{{ "/" | absolute_url }}">{{ site.title | default: site.github.repository_name }}</a></h1>
-        
+
         {% if site.logo %}
           <img src="{{site.logo | absolute_url }}" alt="Logo" />
         {% endif %}
 
         <p>{{ site.description | default: site.github.project_tagline }}</p>
-
-        {% if site.github.is_project_page %}
-        <p class="view"><a href="{{ site.github.repository_url }}">Visit the Project on GitHub <small>{{ site.github.repository_nwo }}</small></a></p>
-        {% endif %}
 
         <p class="docs"><a href="{{ "/phpdoc/index.html" | absolute_url }}">Read the Documentation</a></p>
 
@@ -33,6 +29,10 @@
             <a href="https://packagist.org/packages/{{ site.phpcsutils.packagist }}">Install using Composer:</a><br>
             <div class="language-bash highlighter-rouge"><div class="highlight"><pre class="highlight"><code>composer require <span class="s">{{ site.phpcsutils.packagist }}</span></code></pre></div></div>
         </div>
+
+        {% if site.github.latest_release.tag_name %}
+        <p>Latest release: <strong>{{ site.github.latest_release.tag_name }}</strong></p>
+        {% endif %}
 
         {% if site.show_downloads %}
         <ul class="downloads">
@@ -42,9 +42,9 @@
         </ul>
         {% endif %}
 
-        <p><a href="https://twitter.com/share" class="twitter-share-button" data-related="{{ site.twitter.username }}" data-count="none" data-hashtags="{{ site.twitter.hashtags }}">Tweet about it</a></p>
+        <p class="view"><a href="{{ site.github.repository_url }}">Visit the Project on GitHub <small>{{ site.github.repository_nwo }}</small></a></p>
 
-    </header>
+        <p><a href="https://twitter.com/share" class="twitter-share-button" data-related="{{ site.twitter.username }}" data-count="none" data-hashtags="{{ site.twitter.hashtags }}">Tweet about it</a></p>
 
       </header>
       <section>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -89,13 +89,13 @@ p code {
 }
 
 /* FAQ */
-#faq h4 {
+.faq h3 {
     font-size: 18px;
     line-height: 1.1;
     margin-top: 0;
 }
 
-#faq h4::first-letter, #faq h4 + p::first-letter {
+.faq h3::first-letter, .faq h3 + p::first-letter {
     color:#267CB9;
     font-weight: bold;
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,78 +9,72 @@ seo:
         type: Organisation
 ---
 
-Features
--------------------------------------------
+## Features
 
-[PHPCSUtils](https://github.com/PHPCSStandards/PHPCSUtils) is a set of utilities to aid developers of sniffs for [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) (or "PHPCS" for short).
+[PHPCSUtils][phpcsutils-repo] is a set of utilities to aid developers of sniffs for [PHP_CodeSniffer] (or "PHPCS" for short).
 
 This package offers the following features:
 
 <div id="feature-list">
 
-### Use the latest version of PHP_CodeSniffer native utility functions.
-
-Normally to use the latest version of PHP_CodeSniffer native utility functions, you would have to raise the minimum requirements of your external PHPCS standard.
-
-Now you won't have to anymore. This package allows you to use the latest version of those utility functions in all PHP_CodeSniffer versions from PHPCS 2.6.0 and up.
-
-### Several abstract sniff classes which your sniffs can extend.
-
-These classes take most of the heavy lifting away for some frequently occurring sniff types.
-
-### A collection of static properties and methods for often-used token groups.
-
-Collections of related tokens often-used and needed for sniffs.
-These are additional "token groups" to compliment the ones available through the PHPCS native `PHP_CodeSniffer\Util\Tokens` class.
-
-### An ever-growing number of utility functions for use with PHP_CodeSniffer.
+### An ever-growing number of utility functions for use with PHP_CodeSniffer
 
 Whether you need to split an `array` into the individual items, are trying to determine which variables are being assigned to in a `list()` or are figuring out whether a function has a DocBlock, PHPCSUtils has got you covered!
 
 Includes improved versions of the PHPCS native utility functions and plenty of new utility functions.
 
-These functions are, of course, compatible with PHPCS 2.6.0 up to PHPCS `master`.
+These functions are compatible with PHPCS 3.7.1 up to PHPCS `master`.
+
+### A collection of static properties and methods for often-used token groups
+
+Collections of related tokens often-used and needed for sniffs.
+These are additional "token groups" to compliment the ones available through the PHPCS native `PHP_CodeSniffer\Util\Tokens` class.
+
+### Several abstract sniff classes which your sniffs can extend
+
+These classes take most of the heavy lifting away for some frequently occurring sniff types.
 
 ### Test utilities
 
 An abstract `UtilityMethodTestCase` class to support testing of your utility methods written for PHP_CodeSniffer.
-Compatible with both PHPCS 2.x as well as 3.x. Supports PHPUnit 4.x up to 9.x.
+Supports PHPUnit 4.x up to 9.x.
 
-### Backward compatibility layer
+### Use the latest version of PHP_CodeSniffer native utility functions
 
-A `PHPCS23Utils` standard which allows sniffs to work in both PHPCS 2.x and 3.x, as well as a few helper functions for external standards which still want to support both PHP_CodeSniffer 2.x as well as 3.x.
+Normally to use the latest version of PHP_CodeSniffer native utility functions, you would have to raise the minimum requirements of your external PHPCS standard.
+
+Now you won't have to anymore. This package allows you to use the latest version of those utility functions in all PHP_CodeSniffer versions from PHPCS 3.7.1 and up.
 
 ### Fully documented
 
-To see detailed information about all the available abstract sniffs, utility functions and PHPCS helper functions, have a read through the [extensive documentation](https://phpcsutils.com/).
+To see detailed information about all the available abstract sniffs, utility functions and PHPCS helper functions, have a read through the [extensive documentation][phpcsutils-web].
 
 </div>
 
-Minimum Requirements
--------------------------------------------
+
+## Minimum Requirements
 
 * PHP 5.4 or higher.
-* [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) 2.6.0+, 3.1.0+ (with the exception of PHPCS 3.5.3).
+* [PHP_CodeSniffer] 3.7.1+.
 * Recommended PHP extensions for optimal functionality:
     - PCRE with Unicode support (normally enabled by default)
 
 
-Integrating PHPCSUtils in your external PHPCS standard
--------------------------------------------
+## Integrating PHPCSUtils in your external PHPCS standard
 
-### Composer-based with a minimum PHPCS requirement of PHPCS 3.1.0
+### Composer-based
 
-If your external PHP_CodeSniffer standard only supports Composer-based installs and has a minimum PHPCS requirement of PHP_CodeSniffer 3.1.0, integrating PHPCSUtils is pretty straight forward.
+If your external PHP_CodeSniffer standard only supports Composer-based installs, integrating PHPCSUtils is pretty straight forward.
 
 Run the following from the root of your external PHPCS standard's project:
 
-<div class="language-bash highlighter-rouge"><div class="highlight"><pre class="highlight"><code>composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+<div class="language-bash highlighter-rouge"><div class="highlight"><pre class="highlight"><code>composer config <span class="s">allow-plugins.dealerdirect/phpcodesniffer-composer-installer</span> <span class="mf">true</span>
 composer require <span class="s">{{ site.phpcsutils.packagist }}</span>:"<span class="mf">^1.0</span>"
 </code></pre></div></div>
 
 No further action needed. You can start using all the utility functions, abstract sniff classes and other features of PHPCSUtils straight away.
 
-> :information_source: The PHPCSUtils package includes the [Composer PHPCS plugin](https://github.com/PHPCSStandards/composer-installer).
+> :information_source: The PHPCSUtils package includes the [Composer PHPCS plugin].
 >
 > This plugin will automatically register PHPCSUtils (and your own external standard) with PHP_CodeSniffer, so you and your users don't have to worry about this anymore.
 >
@@ -88,9 +82,9 @@ No further action needed. You can start using all the utility functions, abstrac
 >
 > :information_source: As of Composer 2.2, Composer will [ask for permission](https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution) to allow the Composer PHPCS plugin to execute code. For the plugin to be functional, permission needs to be granted.
 > This can be done ahead of time by instructing your users to run the following command before installing your standard:
-> ```bash
-> composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-> ```
+>
+> <div class="language-bash highlighter-rouge"><div class="highlight"><pre class="highlight"><code>composer config <span class="s">allow-plugins.dealerdirect/phpcodesniffer-composer-installer</span> <span class="mf">true</span>
+> </code></pre></div></div>
 
 #### Running your unit tests
 
@@ -101,104 +95,83 @@ If you have your own unit test suite to test your sniffs, make sure to load the 
 If you intend to use the test utilities provided in the `PHPCSUtils/TestUtils` directory, make sure you also load the `vendor/phpcsstandards/phpcsutils/phpcsutils-autoload.php` file in your PHPUnit bootstrap file.
 
 
-### Composer-based with a minimum PHPCS requirement of PHPCS 2.6.0
+## Frequently Asked Questions
 
-Follow the above instructions for use with PHPCS 3.x.
+<div class="faq">
 
-In addition to that, add the following to the `ruleset.xml` file of your standard(s):
-```xml
-<!-- Make the utility functions available in PHPCS 2.x -->
-<rule ref="PHPCS23Utils"/>
-```
-
-> :information_source: The `PHPCS23Utils` "standard" does not add any real sniffs, it only makes sure that the Utility functions will work in PHPCS 2.x as well.
-
-#### Running your unit tests
-
-If your standard supports both PHPCS 2.x as well as 3.x, you are bound to already have a PHPUnit `bootstrap.php` file in place.
-
-To allow the unit tests to find the relevant files for PHPCSUtils, make sure that the bootstrap loads both the Composer `vendor/autoload.php` file, as well as the `vendor/phpcsstandards/phpcsutils/phpcsutils-autoload.php` file.
-
-
-
-Frequently Asked Questions
--------
-
-<div id="faq">
-
-#### Q: How does this all work without an external standard needing to register an autoloader?
+### Q: How does this all work without an external standard needing to register an autoloader?
 
 A: As PHPCSUtils is registered with PHPCS as an external standard and PHPCSUtils complies with the naming requirements of PHPCS, the PHPCS native autoloader will automatically take care of loading the classes used from PHPCSUtils.
 
-#### Q: What does the `PHPCS23Utils` standard do?
-
-A: All the `PHPCS23Utils` standard does is load the `phpcsutils-autoload.php` file.
-
-PHPCS 3.x uses namespaces, while PHPCS 2.x does not. The `phpcsutils-autoload.php` file creates `class_alias`-es for the most commonly used PHPCS classes, including all PHPCS classes used by PHPCSUtils. That way, both your external standard as well as PHPCSUtils can refer to the PHPCS 3.x class names and the code will still work in PHPCS 2.x.
-
-#### Q: Why is PHP_CodeSniffer 3.5.3 not supported?
-
-A: The backfill for PHP 7.4 numeric literals with underscores in PHP_CodeSniffer 3.5.3 is broken and there is no way to reliably provide support for anything to do with numbers or `T_STRING` tokens when using PHP_CodeSniffer 3.5.3 as the tokens returned by the tokenizer are unpredictable and unreliable.
-
-The backfill was fixed in PHP_CodeSniffer 3.5.4.
-
-#### Q: Any other problematic PHPCS versions?
-
-A: Well, the arrow function backfill which was added in PHPCS 3.5.3 is still causing problems. In a very limited set of circumstances, it will even hang the Tokenizer. A fix for [one particular such problem](https://github.com/squizlabs/php_codesniffer/issues/2926) has been committed to `master`, but is not (yet) in a released version. It is expected to be released in PHP_CodeSniffer 3.5.6.
-
-As the Tokenizer hanging is a problem unrelated to PHPCSUtils and not something which can be mitigated from within PHPCSUtils in any conceivable way, PHPCSUtils won't block installation in combination with PHPCS 3.5.4 and 3.5.5.
-
-There are several other issues which can not be worked around, like scope closers being set incorrectly and throwing the scope setting off for the rest of the file, so not withstanding that PHPCSUtils can work around a lot of issues, it is still highly recommended to advise your end-users to always use the latest version of PHPCS for the most reliable results.
-
-#### Q: Does using PHPCSUtils have any effect on the PHPCS native sniffs?
+### Q: Does using PHPCSUtils have any effect on the PHPCS native sniffs?
 
 A: No. PHPCSUtils will only work for those sniffs which explicitly use the PHPCSUtils functionality.
 
 If your standard includes both PHPCS native sniffs as well as your own sniffs, your own sniffs can benefit from the back-compat layer offered by PHPCSUtils, as well as from the additional utility functions. However, the PHPCS native sniffs will not receive those benefits, as PHPCS itself does not use PHPCSUtils.
 
-#### Q: Do the utilities work with javascript/CSS files?
+### Q: Do the utilities work with javascript/CSS files?
 
-A: JS/CSS support will be removed from PHP_CodeSniffer in PHPCS 4.x.
-While at this time, some of the utilies _may_ work with JS/CSS files, PHPCSUtils does not offer formal support for JS/CSS sniffing with PHP_CodeSniffer and will stop any existing support once PHPCS 4.x has been released.
+A: JS/CSS support will be removed from `PHP_CodeSniffer` in PHPCS 4.x.
+While at this time, some of the utilities _may_ work with JS/CSS files, PHPCSUtils does not offer formal support for JS/CSS sniffing with `PHP_CodeSniffer` and will stop any existing support once PHPCS 4.x has been released.
 
-#### Q: Are all file encodings supported?
+### Q: Are all file encodings supported?
 
 A: No. The UTF-8 file encoding is the only officially supported encoding. Support for other encodings may incidentally work, but is not officially supported.
 
 > **It is recommended to advise your users to save their files as UTF-8 encoded for the best results.**
 
-PHP_CodeSniffer 3.x will default to UTF-8 as the expected file encoding.
-If your standard supports PHP_CodeSniffer 2.x, it is recommended to set the expected encoding in the ruleset to `utf-8`, like so: `<arg name="encoding" value="utf-8"/>` or to advise users to use the CLI option `--encoding=utf-8`.
+Note: `PHP_CodeSniffer` 3.x defaults to UTF-8 as the expected file encoding.
+
+</div>
 
 
-Potential Support Questions from your End-Users
--------
+## Potential Support Questions from your End-Users
 
-#### Q: A user reports a fatal "class not found" error for a class from PHPCSUtils.
+<div class="faq">
+
+### Q: A user reports a fatal "class not found" error for a class from PHPCSUtils
 
 1. Check that the version of PHPCSUtils the user has installed complies with the minimum version of PHPCSUtils your standard requires. If not, they will need to upgrade.
 2. If the version is correct, this indicates that the end-user does not have PHPCSUtils installed and/or registered with PHP_CodeSniffer.
     - Please review your standard's installation instructions to make sure that PHPCSUtils will be installed when those are followed.
     - Inform the user to install PHPCSUtils and register it with PHP_CodeSniffer.
 
+---
+
 > :bulb: **Pro-tip**: if you want to prevent the fatal error and show a _friendlier_ error message instead, add `<rule ref="PHPCSUtils"/>` to your standard's `ruleset.xml` file.
 >
-> With that in place, PHP_CodeSniffer will show a _"ERROR: the "PHPCSUtils" coding standard is not installed."_ message if PHPCSUtils is missing as soon as the ruleset loading is finished.
+> With that in place, `PHP_CodeSniffer` will show a _"ERROR: the "PHPCSUtils" coding standard is not installed."_ message if PHPCSUtils is missing as soon as the ruleset loading is finished.
+
+---
 
 > :bulb: **Pro-tip**: provide upgrade instructions for your end-users. For Composer-based installs, those should look like this:
-> <div class="language-bash highlighter-rouge"><div class="highlight"><pre class="highlight"><code>composer update <span class="s">your/cs-package</span> <span class="mf">--with-dependencies</span>
+>
+> <div class="language-bash highlighter-rouge"><div class="highlight"><pre class="highlight"><code>composer update <span class="s">your/cs-package</span> <span class="mf">--with-[all-]dependencies</span>
 > </code></pre></div></div>
+>
 > That way, when the user updates your coding standards package, they will automatically also update PHPCSUtils.
+
+---
 
 </div>
 
 
-Contributing
--------
+## Contributing
+
 Contributions to this project are welcome. Clone the repo, branch off from `develop`, make your changes, commit them and send in a pull request.
 
 If you are unsure whether the changes you are proposing would be welcome, please open an issue first to discuss your proposal.
 
-License
--------
-This code is released under the [GNU Lesser General Public License (LGPLv3)](http://www.gnu.org/copyleft/lesser.html).
+
+## License
+
+This code is released under the [GNU Lesser General Public License (LGPLv3)](https://www.gnu.org/copyleft/lesser.html).
+
+
+[PHP_CodeSniffer]:       https://github.com/squizlabs/PHP_CodeSniffer
+[Composer PHPCS plugin]: https://github.com/PHPCSStandards/composer-installer
+[phpcsutils-repo]:       https://github.com/PHPCSStandards/PHPCSUtils
+[phpcsutils-web]:        https://phpcsutils.com/
+[phpcsutils-packagist]:  https://packagist.org/packages/phpcsstandards/phpcsutils
+[phpcsutils-releases]:   https://github.com/PHPCSStandards/PHPCSUtils/releases
+[phpcsutils-tests-gha]:  https://github.com/PHPCSStandards/PHPCSUtils/actions/workflows/test.yml

--- a/docs/phpdoc/classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html
+++ b/docs/phpdoc/classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-abstractsniffs.html">AbstractSniffs</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-abstractsniffs.html">AbstractSniffs</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,6 +118,12 @@
     AbstractArrayDeclarationSniff
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
             <span class="phpdocumentor-element__implements">
             implements
@@ -82,10 +132,11 @@
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">28</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Abstract sniff to easily examine all parts of an array declaration.</p>
 
@@ -101,21 +152,23 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 
 
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
             <dt class="phpdocumentor-table-of-contents__entry -interface"><abbr title="\PHP_CodeSniffer\Sniffs\Sniff">Sniff</abbr></dt>
         <dd></dd>
+    
     
     
     </dl>
@@ -127,129 +180,129 @@
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                <dt class="phpdocumentor-table-of-contents__entry -property -protected">
-    <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_arrayCloser">$arrayCloser</a>
+                    <dt class="phpdocumentor-table-of-contents__entry -property -protected">
+    <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_arrayCloser">$arrayCloser</a>
     <span>
-                &nbsp;: int            </span>
+                        &nbsp;: int            </span>
 </dt>
 <dd>The stack pointer to the array closer.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
-    <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_arrayItems">$arrayItems</a>
+    <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_arrayItems">$arrayItems</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>A multi-dimentional array with information on each array item.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
-    <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_arrayOpener">$arrayOpener</a>
+    <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_arrayOpener">$arrayOpener</a>
     <span>
-                &nbsp;: int            </span>
+                        &nbsp;: int            </span>
 </dt>
 <dd>The stack pointer to the array opener.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
-    <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_itemCount">$itemCount</a>
+    <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_itemCount">$itemCount</a>
     <span>
-                &nbsp;: int            </span>
+                        &nbsp;: int            </span>
 </dt>
 <dd>How many items are in the array.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
-    <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_singleLine">$singleLine</a>
+    <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_singleLine">$singleLine</a>
     <span>
-                &nbsp;: bool            </span>
+                        &nbsp;: bool            </span>
 </dt>
 <dd>Whether or not the array is single line.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
-    <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_stackPtr">$stackPtr</a>
+    <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_stackPtr">$stackPtr</a>
     <span>
-                &nbsp;: int            </span>
+                        &nbsp;: int            </span>
 </dt>
 <dd>The stack pointer to the array keyword or the short array open token.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
-    <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_tokens">$tokens</a>
+    <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_tokens">$tokens</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>The token stack for the current file being examined.</dd>
 
                 <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method___construct">__construct()</a>
+    <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method___construct">__construct()</a>
     <span>
-                        &nbsp;: void    </span>
+                                &nbsp;: void    </span>
 </dt>
 <dd>Set up this class.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_getActualArrayKey">getActualArrayKey()</a>
+    <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_getActualArrayKey">getActualArrayKey()</a>
     <span>
-                        &nbsp;: string|int|void    </span>
+                                &nbsp;: string|int|void    </span>
 </dt>
 <dd>Determine what the actual array key would be.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_process">process()</a>
+    <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_process">process()</a>
     <span>
-                        &nbsp;: void    </span>
+                                &nbsp;: void    </span>
 </dt>
 <dd>Processes this test when one of its tokens is encountered.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processArray">processArray()</a>
+    <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processArray">processArray()</a>
     <span>
-                        &nbsp;: void    </span>
+                                &nbsp;: void    </span>
 </dt>
 <dd>Process every part of the array declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processArrow">processArrow()</a>
+    <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processArrow">processArrow()</a>
     <span>
-                        &nbsp;: true|void    </span>
+                                &nbsp;: true|void    </span>
 </dt>
 <dd>Process the double arrow.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processComma">processComma()</a>
+    <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processComma">processComma()</a>
     <span>
-                        &nbsp;: true|void    </span>
+                                &nbsp;: true|void    </span>
 </dt>
 <dd>Process the comma after an array item.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processKey">processKey()</a>
+    <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processKey">processKey()</a>
     <span>
-                        &nbsp;: true|void    </span>
+                                &nbsp;: true|void    </span>
 </dt>
 <dd>Process the tokens in an array key.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processNoKey">processNoKey()</a>
+    <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processNoKey">processNoKey()</a>
     <span>
-                        &nbsp;: true|void    </span>
+                                &nbsp;: true|void    </span>
 </dt>
 <dd>Process an array item without an array key.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processOpenClose">processOpenClose()</a>
+    <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processOpenClose">processOpenClose()</a>
     <span>
-                        &nbsp;: true|void    </span>
+                                &nbsp;: true|void    </span>
 </dt>
 <dd>Process the array opener and closer.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processValue">processValue()</a>
+    <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processValue">processValue()</a>
     <span>
-                        &nbsp;: true|void    </span>
+                                &nbsp;: true|void    </span>
 </dt>
 <dd>Process the tokens in an array value.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_register">register()</a>
+    <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_register">register()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Returns an array of tokens this test wants to listen for.</dd>
 
@@ -263,7 +316,7 @@
     <section class="phpdocumentor-properties">
         <h3 class="phpdocumentor-elements__header" id="properties">
             Properties
-            <a href="#properties" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#properties" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="
@@ -274,15 +327,16 @@
 >
     <h4 class="phpdocumentor-element__name" id="property_arrayCloser">
         $arrayCloser
-        <a href="#property_arrayCloser" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_arrayCloser" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">65</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">The stack pointer to the array closer.</p>
 
@@ -292,6 +346,7 @@
     <span class="phpdocumentor-signature__name">$arrayCloser</span>
     </code>
 
+    
     
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -304,8 +359,9 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -318,21 +374,22 @@
 >
     <h4 class="phpdocumentor-element__name" id="property_arrayItems">
         $arrayItems
-        <a href="#property_arrayItems" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_arrayItems" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">84</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">A multi-dimentional array with information on each array item.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">protected</span>
-        <span class="phpdocumentor-signature__type">array</span>
+        <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$arrayItems</span>
     </code>
 
@@ -342,8 +399,11 @@
   'end'   =&gt; int,    // The stack pointer to the last token in the array item.
   'raw'   =&gt; string, // A string with the contents of all tokens between `start` and `end`.
   'clean' =&gt; string, // Same as `raw`, but all comment tokens have been stripped out.
-)</code></pre></section>
+)
+</code></pre>
+</section>
 
+    
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -355,8 +415,9 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -369,15 +430,16 @@
 >
     <h4 class="phpdocumentor-element__name" id="property_arrayOpener">
         $arrayOpener
-        <a href="#property_arrayOpener" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_arrayOpener" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">56</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">The stack pointer to the array opener.</p>
 
@@ -387,6 +449,7 @@
     <span class="phpdocumentor-signature__name">$arrayOpener</span>
     </code>
 
+    
     
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -399,8 +462,9 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -413,15 +477,16 @@
 >
     <h4 class="phpdocumentor-element__name" id="property_itemCount">
         $itemCount
-        <a href="#property_itemCount" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_itemCount" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">93</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">How many items are in the array.</p>
 
@@ -431,6 +496,7 @@
     <span class="phpdocumentor-signature__name">$itemCount</span>
      = <span class="phpdocumentor-signature__default-value">0</span></code>
 
+    
     
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -443,8 +509,9 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -457,15 +524,16 @@
 >
     <h4 class="phpdocumentor-element__name" id="property_singleLine">
         $singleLine
-        <a href="#property_singleLine" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_singleLine" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">102</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Whether or not the array is single line.</p>
 
@@ -475,6 +543,7 @@
     <span class="phpdocumentor-signature__name">$singleLine</span>
     </code>
 
+    
     
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -487,8 +556,9 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -501,15 +571,16 @@
 >
     <h4 class="phpdocumentor-element__name" id="property_stackPtr">
         $stackPtr
-        <a href="#property_stackPtr" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_stackPtr" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">38</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">The stack pointer to the array keyword or the short array open token.</p>
 
@@ -519,6 +590,7 @@
     <span class="phpdocumentor-signature__name">$stackPtr</span>
     </code>
 
+    
     
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -531,8 +603,9 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -545,24 +618,26 @@
 >
     <h4 class="phpdocumentor-element__name" id="property_tokens">
         $tokens
-        <a href="#property_tokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_tokens" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">47</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">The token stack for the current file being examined.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">protected</span>
-        <span class="phpdocumentor-signature__type">array</span>
+        <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$tokens</span>
     </code>
 
+    
     
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -575,8 +650,9 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -585,7 +661,7 @@
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -595,19 +671,20 @@
 >
     <h4 class="phpdocumentor-element__name" id="method___construct">
         __construct()
-        <a href="#method___construct" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method___construct" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">135</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Set up this class.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-        <span class="phpdocumentor-signature__final">final</span>        <span class="phpdocumentor-signature__name">__construct</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
+        <span class="phpdocumentor-signature__final">final</span>            <span class="phpdocumentor-signature__name">__construct</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
 
     
     
@@ -622,16 +699,15 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">codeCoverageIgnore</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">void</span>
+            &mdash;
+        
     
 </article>
                     <article
@@ -642,22 +718,24 @@
 >
     <h4 class="phpdocumentor-element__name" id="method_getActualArrayKey">
         getActualArrayKey()
-        <a href="#method_getActualArrayKey" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_getActualArrayKey" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">459</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Determine what the actual array key would be.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                <span class="phpdocumentor-signature__name">getActualArrayKey</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$startPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$endPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|int|void</span></code>
+                    <span class="phpdocumentor-signature__name">getActualArrayKey</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$startPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$endPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|int|void</span></code>
 
         <section class="phpdocumentor-description"><p>Helper function for processsing array keys in the processKey() function.
-Using this method is up to the sniff implementation in the child class.</p></section>
+Using this method is up to the sniff implementation in the child class.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -667,7 +745,8 @@ Using this method is up to the sniff implementation in the child class.</p></sec
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The PHP_CodeSniffer file where the
-token was found.</p></section>
+token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -676,7 +755,8 @@ token was found.</p></section>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The stack pointer to the first token in the &quot;key&quot; part of
-an array item.</p></section>
+an array item.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -685,7 +765,8 @@ an array item.</p></section>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The stack pointer to the last token in the &quot;key&quot; part of
-an array item.</p></section>
+an array item.</p>
+</section>
 
             </dd>
             </dl>
@@ -701,15 +782,17 @@ an array item.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string|int|void</span>
             &mdash;
             <section class="phpdocumentor-description"><p>The string or integer array key or void if the array key could not
-reliably be determined.</p></section>
+reliably be determined.</p>
+</section>
 
     
 </article>
@@ -721,22 +804,24 @@ reliably be determined.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_process">
         process()
-        <a href="#method_process" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_process" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">182</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Processes this test when one of its tokens is encountered.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-        <span class="phpdocumentor-signature__final">final</span>        <span class="phpdocumentor-signature__name">process</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
+        <span class="phpdocumentor-signature__final">final</span>            <span class="phpdocumentor-signature__name">process</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
 
         <section class="phpdocumentor-description"><p>This method fills the properties with relevant information for examining the array
-and then passes off to the <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processArray">\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff::processArray()</a> method.</p></section>
+and then passes off to the <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processArray"><abbr title="\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff::processArray()">AbstractArrayDeclarationSniff::processArray()</abbr></a> method.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -746,7 +831,8 @@ and then passes off to the <a href="../classes/PHPCSUtils-AbstractSniffs-Abstrac
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The PHP_CodeSniffer file where the
-token was found.</p></section>
+token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -756,7 +842,8 @@ token was found.</p></section>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position in the PHP_CodeSniffer
 file's token stack where the token
-was found.</p></section>
+was found.</p>
+</section>
 
             </dd>
             </dl>
@@ -772,10 +859,15 @@ was found.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">void</span>
+            &mdash;
+        
     
 </article>
                     <article
@@ -786,51 +878,38 @@ was found.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_processArray">
         processArray()
-        <a href="#method_processArray" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processArray" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">234</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Process every part of the array declaration.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                <span class="phpdocumentor-signature__name">processArray</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
+                    <span class="phpdocumentor-signature__name">processArray</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
 
         <section class="phpdocumentor-description"><p>Controller which calls the individual <code class="prettyprint">process...()</code> methods for each part of the array.</p>
-<p>The method starts by calling the <a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processOpenClose">\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff::processOpenClose()</a> method
+<p>The method starts by calling the <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processOpenClose"><abbr title="\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff::processOpenClose()">AbstractArrayDeclarationSniff::processOpenClose()</abbr></a> method
 and subsequently calls the following methods for each array item:</p>
-<table>
-<thead>
-<tr>
-<th>Unkeyed arrays</th>
-<th>Keyed arrays</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>processNoKey()</td>
-<td>processKey()</td>
-</tr>
-<tr>
-<td>-</td>
-<td>processArrow()</td>
-</tr>
-<tr>
-<td>processValue()</td>
-<td>processValue()</td>
-</tr>
-<tr>
-<td>processComma()</td>
-<td>processComma()</td>
-</tr>
-</tbody>
-</table>
+<p>Unkeyed arrays | Keyed arrays
+-------------- | ------------
+processNoKey() | processKey()</p>
+<ul>
+<li>
+<pre class="prettyprint"><code class="prettyprint">         | processArrow()
+</code></pre>
+</li>
+</ul>
+<p>processValue() | processValue()
+processComma() | processComma()</p>
 <p>This is the default logic for the sniff, but can be overloaded in a concrete child class
-if needed.</p></section>
+if needed.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -840,7 +919,8 @@ if needed.</p></section>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The PHP_CodeSniffer file where the
-token was found.</p></section>
+token was found.</p>
+</section>
 
             </dd>
             </dl>
@@ -856,10 +936,15 @@ token was found.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">void</span>
+            &mdash;
+        
     
 </article>
                     <article
@@ -870,21 +955,23 @@ token was found.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_processArrow">
         processArrow()
-        <a href="#method_processArrow" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processArrow" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">385</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Process the double arrow.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                <span class="phpdocumentor-signature__name">processArrow</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$arrowPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$itemNr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">true|void</span></code>
+                    <span class="phpdocumentor-signature__name">processArrow</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$arrowPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$itemNr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">true|void</span></code>
 
-        <section class="phpdocumentor-description"><p>Optional method to be implemented in concrete child classes. By default, this method does nothing.</p></section>
+        <section class="phpdocumentor-description"><p>Optional method to be implemented in concrete child classes. By default, this method does nothing.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -894,7 +981,8 @@ token was found.</p></section>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The PHP_CodeSniffer file where the
-token was found.</p></section>
+token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -902,7 +990,8 @@ token was found.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The stack pointer to the double arrow for the array item.</p></section>
+                    <section class="phpdocumentor-description"><p>The stack pointer to the double arrow for the array item.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -911,7 +1000,8 @@ token was found.</p></section>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Which item in the array is being handled.
-1-based, i.e. the first item is item 1, the second 2 etc.</p></section>
+1-based, i.e. the first item is item 1, the second 2 etc.</p>
+</section>
 
             </dd>
             </dl>
@@ -927,14 +1017,9 @@ token was found.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">codeCoverageIgnore</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -942,7 +1027,8 @@ token was found.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p>Returning <code class="prettyprint">TRUE</code> will short-circuit the array item loop and stop processing.
 In effect, this means that the sniff will not examine the array value or
-comma for this array item and will not process any array items after this one.</p></section>
+comma for this array item and will not process any array items after this one.</p>
+</section>
 
     
 </article>
@@ -954,21 +1040,23 @@ comma for this array item and will not process any array items after this one.</
 >
     <h4 class="phpdocumentor-element__name" id="method_processComma">
         processComma()
-        <a href="#method_processComma" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processComma" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">437</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Process the comma after an array item.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                <span class="phpdocumentor-signature__name">processComma</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$commaPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$itemNr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">true|void</span></code>
+                    <span class="phpdocumentor-signature__name">processComma</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$commaPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$itemNr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">true|void</span></code>
 
-        <section class="phpdocumentor-description"><p>Optional method to be implemented in concrete child classes. By default, this method does nothing.</p></section>
+        <section class="phpdocumentor-description"><p>Optional method to be implemented in concrete child classes. By default, this method does nothing.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -978,7 +1066,8 @@ comma for this array item and will not process any array items after this one.</
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The PHP_CodeSniffer file where the
-token was found.</p></section>
+token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -986,7 +1075,8 @@ token was found.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The stack pointer to the comma.</p></section>
+                    <section class="phpdocumentor-description"><p>The stack pointer to the comma.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -995,7 +1085,8 @@ token was found.</p></section>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Which item in the array is being handled.
-1-based, i.e. the first item is item 1, the second 2 etc.</p></section>
+1-based, i.e. the first item is item 1, the second 2 etc.</p>
+</section>
 
             </dd>
             </dl>
@@ -1011,14 +1102,9 @@ token was found.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">codeCoverageIgnore</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -1026,7 +1112,8 @@ token was found.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p>Returning <code class="prettyprint">TRUE</code> will short-circuit the array item loop and stop processing.
 In effect, this means that the sniff will not process any array items
-after this one.</p></section>
+after this one.</p>
+</section>
 
     
 </article>
@@ -1038,23 +1125,25 @@ after this one.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_processKey">
         processKey()
-        <a href="#method_processKey" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processKey" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">332</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Process the tokens in an array key.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                <span class="phpdocumentor-signature__name">processKey</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$startPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$endPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$itemNr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">true|void</span></code>
+                    <span class="phpdocumentor-signature__name">processKey</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$startPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$endPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$itemNr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">true|void</span></code>
 
         <section class="phpdocumentor-description"><p>Optional method to be implemented in concrete child classes. By default, this method does nothing.</p>
 <p>Note: The <code class="prettyprint">$startPtr</code> and <code class="prettyprint">$endPtr</code> do not discount whitespace or comments, but are all inclusive
-to allow for examining all tokens in an array key.</p></section>
+to allow for examining all tokens in an array key.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -1064,7 +1153,8 @@ to allow for examining all tokens in an array key.</p></section>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The PHP_CodeSniffer file where the
-token was found.</p></section>
+token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1073,7 +1163,8 @@ token was found.</p></section>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The stack pointer to the first token in the &quot;key&quot; part of
-an array item.</p></section>
+an array item.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1082,7 +1173,8 @@ an array item.</p></section>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The stack pointer to the last token in the &quot;key&quot; part of
-an array item.</p></section>
+an array item.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1091,7 +1183,8 @@ an array item.</p></section>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Which item in the array is being handled.
-1-based, i.e. the first item is item 1, the second 2 etc.</p></section>
+1-based, i.e. the first item is item 1, the second 2 etc.</p>
+</section>
 
             </dd>
             </dl>
@@ -1107,22 +1200,19 @@ an array item.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">codeCoverageIgnore</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_getActualArrayKey"><abbr title="\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff::getActualArrayKey()">AbstractArrayDeclarationSniff::getActualArrayKey()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Optional helper function.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_getActualArrayKey"><abbr title="\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff::getActualArrayKey()">AbstractArrayDeclarationSniff::getActualArrayKey()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Optional helper function.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -1130,7 +1220,8 @@ an array item.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p>Returning <code class="prettyprint">TRUE</code> will short-circuit the array item loop and stop processing.
 In effect, this means that the sniff will not examine the double arrow, the array
-value or comma for this array item and will not process any array items after this one.</p></section>
+value or comma for this array item and will not process any array items after this one.</p>
+</section>
 
     
 </article>
@@ -1142,23 +1233,25 @@ value or comma for this array item and will not process any array items after th
 >
     <h4 class="phpdocumentor-element__name" id="method_processNoKey">
         processNoKey()
-        <a href="#method_processNoKey" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processNoKey" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">362</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Process an array item without an array key.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                <span class="phpdocumentor-signature__name">processNoKey</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$startPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$itemNr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">true|void</span></code>
+                    <span class="phpdocumentor-signature__name">processNoKey</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$startPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$itemNr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">true|void</span></code>
 
         <section class="phpdocumentor-description"><p>Optional method to be implemented in concrete child classes. By default, this method does nothing.</p>
 <p>Note: This method is <em>not</em> intended for processing the array <em>value</em>. Use the
-<a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processValue">\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff::processValue()</a> method to implement processing of the array value.</p></section>
+<a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processValue"><abbr title="\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff::processValue()">AbstractArrayDeclarationSniff::processValue()</abbr></a> method to implement processing of the array value.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -1168,7 +1261,8 @@ value or comma for this array item and will not process any array items after th
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The PHP_CodeSniffer file where the
-token was found.</p></section>
+token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1178,7 +1272,8 @@ token was found.</p></section>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The stack pointer to the first token in the array item,
 which in this case will be the first token of the array
-value part of the array item.</p></section>
+value part of the array item.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1187,7 +1282,8 @@ value part of the array item.</p></section>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Which item in the array is being handled.
-1-based, i.e. the first item is item 1, the second 2 etc.</p></section>
+1-based, i.e. the first item is item 1, the second 2 etc.</p>
+</section>
 
             </dd>
             </dl>
@@ -1203,22 +1299,19 @@ value part of the array item.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">codeCoverageIgnore</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processValue"><abbr title="\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff::processValue()">AbstractArrayDeclarationSniff::processValue()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Method to process the array value.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processValue"><abbr title="\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff::processValue()">AbstractArrayDeclarationSniff::processValue()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Method to process the array value.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -1226,7 +1319,8 @@ value part of the array item.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p>Returning <code class="prettyprint">TRUE</code> will short-circuit the array item loop and stop processing.
 In effect, this means that the sniff will not examine the array value or
-comma for this array item and will not process any array items after this one.</p></section>
+comma for this array item and will not process any array items after this one.</p>
+</section>
 
     
 </article>
@@ -1238,21 +1332,23 @@ comma for this array item and will not process any array items after this one.</
 >
     <h4 class="phpdocumentor-element__name" id="method_processOpenClose">
         processOpenClose()
-        <a href="#method_processOpenClose" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processOpenClose" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">301</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Process the array opener and closer.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                <span class="phpdocumentor-signature__name">processOpenClose</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$openPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$closePtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">true|void</span></code>
+                    <span class="phpdocumentor-signature__name">processOpenClose</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$openPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$closePtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">true|void</span></code>
 
-        <section class="phpdocumentor-description"><p>Optional method to be implemented in concrete child classes. By default, this method does nothing.</p></section>
+        <section class="phpdocumentor-description"><p>Optional method to be implemented in concrete child classes. By default, this method does nothing.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -1262,7 +1358,8 @@ comma for this array item and will not process any array items after this one.</
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The PHP_CodeSniffer file where the
-token was found.</p></section>
+token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1270,7 +1367,8 @@ token was found.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the array opener token in the token stack.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the array opener token in the token stack.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1278,7 +1376,8 @@ token was found.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the array closer token in the token stack.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the array closer token in the token stack.</p>
+</section>
 
             </dd>
             </dl>
@@ -1294,14 +1393,9 @@ token was found.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">codeCoverageIgnore</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -1309,7 +1403,8 @@ token was found.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p>Returning <code class="prettyprint">TRUE</code> will short-circuit the sniff and stop processing.
 In effect, this means that the sniff will not examine the individual
-array items if <code class="prettyprint">TRUE</code> is returned.</p></section>
+array items if <code class="prettyprint">TRUE</code> is returned.</p>
+</section>
 
     
 </article>
@@ -1321,23 +1416,25 @@ array items if <code class="prettyprint">TRUE</code> is returned.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_processValue">
         processValue()
-        <a href="#method_processValue" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processValue" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">414</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Process the tokens in an array value.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                <span class="phpdocumentor-signature__name">processValue</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$startPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$endPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$itemNr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">true|void</span></code>
+                    <span class="phpdocumentor-signature__name">processValue</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$startPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$endPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$itemNr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">true|void</span></code>
 
         <section class="phpdocumentor-description"><p>Optional method to be implemented in concrete child classes. By default, this method does nothing.</p>
 <p>Note: The <code class="prettyprint">$startPtr</code> and <code class="prettyprint">$endPtr</code> do not discount whitespace or comments, but are all inclusive
-to allow for examining all tokens in an array value.</p></section>
+to allow for examining all tokens in an array value.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -1347,7 +1444,8 @@ to allow for examining all tokens in an array value.</p></section>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The PHP_CodeSniffer file where the
-token was found.</p></section>
+token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1356,7 +1454,8 @@ token was found.</p></section>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The stack pointer to the first token in the &quot;value&quot; part of
-an array item.</p></section>
+an array item.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1365,7 +1464,8 @@ an array item.</p></section>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The stack pointer to the last token in the &quot;value&quot; part of
-an array item.</p></section>
+an array item.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1374,7 +1474,8 @@ an array item.</p></section>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Which item in the array is being handled.
-1-based, i.e. the first item is item 1, the second 2 etc.</p></section>
+1-based, i.e. the first item is item 1, the second 2 etc.</p>
+</section>
 
             </dd>
             </dl>
@@ -1390,14 +1491,9 @@ an array item.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">codeCoverageIgnore</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -1405,7 +1501,8 @@ an array item.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p>Returning <code class="prettyprint">TRUE</code> will short-circuit the array item loop and stop processing.
 In effect, this means that the sniff will not examine the comma for this
-array item and will not process any array items after this one.</p></section>
+array item and will not process any array items after this one.</p>
+</section>
 
     
 </article>
@@ -1417,19 +1514,20 @@ array item and will not process any array items after this one.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_register">
         register()
-        <a href="#method_register" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_register" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">157</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Returns an array of tokens this test wants to listen for.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                <span class="phpdocumentor-signature__name">register</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+                    <span class="phpdocumentor-signature__name">register</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
     
     
@@ -1444,39 +1542,105 @@ array item and will not process any array items after this one.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">codeCoverageIgnore</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
         
     
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html
+++ b/docs/phpdoc/classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -134,7 +138,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">28</span>
+    <span class="phpdocumentor-element-found-in__line">29</span>
 
     </aside>
 
@@ -154,6 +158,16 @@
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
                                                                                 
                                              
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Dropped support for PHPCS &lt; 3.7.1.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -334,7 +348,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">65</span>
+    <span class="phpdocumentor-element-found-in__line">66</span>
 
     </aside>
 
@@ -381,7 +395,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">84</span>
+    <span class="phpdocumentor-element-found-in__line">85</span>
 
     </aside>
 
@@ -437,7 +451,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">56</span>
+    <span class="phpdocumentor-element-found-in__line">57</span>
 
     </aside>
 
@@ -484,7 +498,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">93</span>
+    <span class="phpdocumentor-element-found-in__line">94</span>
 
     </aside>
 
@@ -531,7 +545,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">102</span>
+    <span class="phpdocumentor-element-found-in__line">103</span>
 
     </aside>
 
@@ -578,7 +592,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">38</span>
+    <span class="phpdocumentor-element-found-in__line">39</span>
 
     </aside>
 
@@ -625,7 +639,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">47</span>
+    <span class="phpdocumentor-element-found-in__line">48</span>
 
     </aside>
 
@@ -676,7 +690,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">135</span>
+    <span class="phpdocumentor-element-found-in__line">136</span>
 
     </aside>
 
@@ -723,7 +737,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">459</span>
+    <span class="phpdocumentor-element-found-in__line">456</span>
 
     </aside>
 
@@ -809,7 +823,7 @@ reliably be determined.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">182</span>
+    <span class="phpdocumentor-element-found-in__line">179</span>
 
     </aside>
 
@@ -883,7 +897,7 @@ was found.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">234</span>
+    <span class="phpdocumentor-element-found-in__line">231</span>
 
     </aside>
 
@@ -960,7 +974,7 @@ token was found.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">385</span>
+    <span class="phpdocumentor-element-found-in__line">382</span>
 
     </aside>
 
@@ -1045,7 +1059,7 @@ comma for this array item and will not process any array items after this one.</
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">437</span>
+    <span class="phpdocumentor-element-found-in__line">434</span>
 
     </aside>
 
@@ -1130,7 +1144,7 @@ after this one.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">332</span>
+    <span class="phpdocumentor-element-found-in__line">329</span>
 
     </aside>
 
@@ -1238,7 +1252,7 @@ value or comma for this array item and will not process any array items after th
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">362</span>
+    <span class="phpdocumentor-element-found-in__line">359</span>
 
     </aside>
 
@@ -1337,7 +1351,7 @@ comma for this array item and will not process any array items after this one.</
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">301</span>
+    <span class="phpdocumentor-element-found-in__line">298</span>
 
     </aside>
 
@@ -1421,7 +1435,7 @@ array items if <code class="prettyprint">TRUE</code> is returned.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">414</span>
+    <span class="phpdocumentor-element-found-in__line">411</span>
 
     </aside>
 
@@ -1519,7 +1533,7 @@ array item and will not process any array items after this one.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php"><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">157</span>
+    <span class="phpdocumentor-element-found-in__line">158</span>
 
     </aside>
 

--- a/docs/phpdoc/classes/PHPCSUtils-BackCompat-BCFile.html
+++ b/docs/phpdoc/classes/PHPCSUtils-BackCompat-BCFile.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -131,7 +135,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">83</span>
+    <span class="phpdocumentor-element-found-in__line">68</span>
 
     </aside>
 
@@ -143,21 +147,7 @@ older versions of the native functions had.</p>
 <p>Additionally, this class works round the following tokenizer issues for
 any affected utility functions:</p>
 <ul>
-<li>Array return type declarations were incorrectly tokenized to <code class="prettyprint">T_ARRAY_HINT</code>
-instead of <code class="prettyprint">T_RETURN_TYPE</code> in some circumstances prior to PHPCS 2.8.0.</li>
-<li>
-<code class="prettyprint">T_NULLABLE</code> was not available prior to PHPCS 2.8.0 and utility functions did
-not take nullability of types into account.</li>
-<li>The PHPCS native ignore annotations were not available prior to PHPCS 3.2.0.</li>
-<li>The way return types were tokenized has changed in PHPCS 3.3.0.
-Previously a lot of them were tokenized as <code class="prettyprint">T_RETURN_HINT</code>. For namespaced
-classnames this only tokenized the classname, not the whole return type.
-Now tokenization is &quot;normalized&quot; with most tokens being <code class="prettyprint">T_STRING</code>, including
-array return type declarations.</li>
-<li>Typed properties were not recognized prior to PHPCS 3.5.0, including the
-<code class="prettyprint">?</code> nullability token not being converted to <code class="prettyprint">T_NULLABLE</code>.</li>
-<li>Arrow functions were not recognized properly until PHPCS 3.5.3/4.</li>
-<li>General PHP cross-version incompatibilities.</li>
+<li>None at this time.</li>
 </ul>
 <p>Most functions in this class will have a related twin-function in the relevant
 class in the <code class="prettyprint">PHPCSUtils\Utils</code> namespace.
@@ -193,6 +183,16 @@ in the docblock of the respective twin-function.</p>
                                                                                 
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Dropped support for PHPCS &lt; 3.7.1.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
 
@@ -225,7 +225,7 @@ in the docblock of the respective twin-function.</p>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;|false    </span>
 </dt>
-<dd>Returns the names of the interfaces that the specified class implements.</dd>
+<dd>Returns the names of the interfaces that the specified class or enum implements.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_findStartOfStatement">findStartOfStatement()</a>
@@ -253,7 +253,7 @@ in the docblock of the respective twin-function.</p>
     <span>
                                 &nbsp;: string|null    </span>
 </dt>
-<dd>Returns the declaration names for classes, interfaces, traits, and functions.</dd>
+<dd>Returns the declaration name for classes, interfaces, traits, enums, and functions.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getMemberProperties">getMemberProperties()</a>
@@ -324,7 +324,7 @@ the token stack for the specified length.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1274</span>
+    <span class="phpdocumentor-element-found-in__line">658</span>
 
     </aside>
 
@@ -338,13 +338,7 @@ the token stack for the specified length.</dd>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
 <li>Introduced in PHPCS 2.1.0.</li>
-<li>PHPCS 2.6.2: New optional <code class="prettyprint">$ignore</code> parameter to selectively ignore stop points.</li>
-<li>PHPCS 2.7.1: Improved handling of short arrays, PHPCS #1203.</li>
-<li>PHPCS 3.3.0: Bug fix: end of statement detection when passed a scope opener, PHPCS #1863.</li>
-<li>PHPCS 3.5.0: Improved handling of group use statements.</li>
-<li>PHPCS 3.5.3: Added support for PHP 7.4 <code class="prettyprint">T_FN</code> arrow functions.</li>
-<li>PHPCS 3.5.4: Improved support for PHP 7.4 <code class="prettyprint">T_FN</code> arrow functions.</li>
-<li>PHPCS 3.5.5: Improved support for PHP 7.4 <code class="prettyprint">T_FN</code> arrow functions, PHPCS #2895.</li>
+<li>The upstream method has received no significant updates since PHPCS 3.7.1.</li>
 </ul>
 </section>
 
@@ -403,16 +397,6 @@ the token stack for the specified length.</dd>
                                                                                 
                                              
                                     </dd>
-                            <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                
-                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
-</section>
-
-                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -434,7 +418,7 @@ the token stack for the specified length.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1474</span>
+    <span class="phpdocumentor-element-found-in__line">739</span>
 
     </aside>
 
@@ -449,10 +433,7 @@ the token stack for the specified length.</dd>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
 <li>Introduced in PHPCS 1.2.0.</li>
-<li>PHPCS 2.8.0: Now supports anonymous classes.</li>
-<li>PHPCS 3.1.0: Now supports interfaces extending interfaces (incorrectly, only supporting
-single interface extension).</li>
-<li>PHPCS 3.3.2: Fixed bug causing bleed through with nested classes, PHPCS#2127.</li>
+<li>The upstream method has received no significant updates since PHPCS 3.7.1.</li>
 </ul>
 </section>
 
@@ -536,11 +517,11 @@ is no extended class name.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1537</span>
+    <span class="phpdocumentor-element-found-in__line">764</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Returns the names of the interfaces that the specified class implements.</p>
+        <p class="phpdocumentor-summary">Returns the names of the interfaces that the specified class or enum implements.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
@@ -550,7 +531,7 @@ is no extended class name.</p>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
 <li>Introduced in PHPCS 2.7.0.</li>
-<li>PHPCS 2.8.0: Now supports anonymous classes.</li>
+<li>The upstream method has received no significant updates since PHPCS 3.7.1.</li>
 </ul>
 </section>
 
@@ -570,7 +551,7 @@ is no extended class name.</p>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The stack position of the class.</p>
+                    <section class="phpdocumentor-description"><p>The stack position of the class or enum token.</p>
 </section>
 
             </dd>
@@ -634,7 +615,7 @@ error or if there are no implemented interface names.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1192</span>
+    <span class="phpdocumentor-element-found-in__line">634</span>
 
     </aside>
 
@@ -648,8 +629,7 @@ error or if there are no implemented interface names.</p>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
 <li>Introduced in PHPCS 2.1.0.</li>
-<li>PHPCS 2.6.2: New optional <code class="prettyprint">$ignore</code> parameter to selectively ignore stop points.</li>
-<li>PHPCS 3.5.5: Added support for PHP 7.4 <code class="prettyprint">T_FN</code> arrow functions.</li>
+<li>The upstream method has received no significant updates since PHPCS 3.7.1.</li>
 </ul>
 </section>
 
@@ -708,16 +688,6 @@ error or if there are no implemented interface names.</p>
                                                                                 
                                              
                                     </dd>
-                            <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                
-                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
-</section>
-
-                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -739,7 +709,7 @@ error or if there are no implemented interface names.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">922</span>
+    <span class="phpdocumentor-element-found-in__line">555</span>
 
     </aside>
 
@@ -759,10 +729,7 @@ error or if there are no implemented interface names.</p>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
 <li>Introduced in PHPCS 1.3.0.</li>
-<li>PHPCS 3.0.0: The Exception thrown changed from a <code class="prettyprint">PHP_CodeSniffer_Exception</code> to
-<code class="prettyprint">\PHP_CodeSniffer\Exceptions\TokenizerException</code>.</li>
-<li>PHPCS 3.5.0: The Exception thrown changed from a <code class="prettyprint">\PHP_CodeSniffer\Exceptions\TokenizerException</code>
-to<code class="prettyprint">\PHP_CodeSniffer\Exceptions\RuntimeException</code>.</li>
+<li>The upstream method has received no significant updates since PHPCS 3.7.1.</li>
 </ul>
 </section>
 
@@ -855,7 +822,7 @@ token to acquire the properties for.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1422</span>
+    <span class="phpdocumentor-element-found-in__line">713</span>
 
     </aside>
 
@@ -869,8 +836,7 @@ token to acquire the properties for.</p>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
 <li>Introduced in PHPCS 1.3.0.</li>
-<li>PHPCS 3.5.4: New <code class="prettyprint">$first</code> parameter which allows for the closest matching token to be returned.
-By default, it continues to return the first matched token found from the top of the file.</li>
+<li>The upstream method has received no significant updates since PHPCS 3.7.1.</li>
 </ul>
 </section>
 
@@ -951,16 +917,6 @@ closest to the passed token.</p>
                                                                                 
                                              
                                     </dd>
-                            <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                
-                                                 <section class="phpdocumentor-description"><p>Added support for the PHPCS 3.5.4 <code class="prettyprint">$first</code> parameter.</p>
-</section>
-
-                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -985,11 +941,11 @@ does not have the condition.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">129</span>
+    <span class="phpdocumentor-element-found-in__line">98</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Returns the declaration names for classes, interfaces, traits, and functions.</p>
+        <p class="phpdocumentor-summary">Returns the declaration name for classes, interfaces, traits, enums, and functions.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
@@ -999,24 +955,7 @@ does not have the condition.</p>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
 <li>Introduced in PHPCS 0.0.5.</li>
-<li>PHPCS 2.8.0: Returns <code class="prettyprint">null</code> when passed an anonymous class. Previously, the method
-would throw a &quot;<em>token not of an accepted type</em>&quot; exception.</li>
-<li>PHPCS 2.9.0: Returns <code class="prettyprint">null</code> when passed a PHP closure. Previously, the method
-would throw a &quot;<em>token not of an accepted type</em>&quot; exception.</li>
-<li>PHPCS 3.0.0: Added support for ES6 class/method syntax.</li>
-<li>PHPCS 3.0.0: The Exception thrown changed from a <code class="prettyprint">PHP_CodeSniffer_Exception</code> to
-<code class="prettyprint">\PHP_CodeSniffer\Exceptions\RuntimeException</code>.</li>
-<li>PHPCS 3.5.3: Allow for functions to be called <code class="prettyprint">fn</code> for backwards compatibility.
-Related to PHP 7.4 <code class="prettyprint">T_FN</code> arrow functions.</li>
-<li>PHPCS 3.5.5: Remove arrow function work-around which is no longer needed due to
-a change in the tokenization of arrow functions.</li>
-</ul>
-<p>Note:</p>
-<ul>
-<li>For ES6 classes in combination with PHPCS 2.x, passing a <code class="prettyprint">T_STRING</code> token to
-this method will be accepted for JS files.</li>
-<li>Support for JS ES6 method syntax has not been back-filled for PHPCS &lt; 3.0.0.
-and sniffing JS files is not officially supported by PHPCSUtils.</li>
+<li>The upstream method has received no significant updates since PHPCS 3.7.1.</li>
 </ul>
 </section>
 
@@ -1038,7 +977,7 @@ and sniffing JS files is not officially supported by PHPCSUtils.</li>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position of the declaration token
 which declared the class, interface,
-trait, or function.</p>
+trait, enum or function.</p>
 </section>
 
             </dd>
@@ -1078,16 +1017,6 @@ trait, or function.</p>
                                                                                 
                                              
                                     </dd>
-                            <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                
-                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
-</section>
-
-                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
@@ -1095,7 +1024,8 @@ trait, or function.</p>
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
                                                             
                                                  <section class="phpdocumentor-description"><p>If the specified token is not of type
-<code class="prettyprint">T_FUNCTION</code>, <code class="prettyprint">T_CLASS</code>, <code class="prettyprint">T_TRAIT</code>, or <code class="prettyprint">T_INTERFACE</code>.</p>
+<code class="prettyprint">T_FUNCTION</code>, <code class="prettyprint">T_CLASS</code>, <code class="prettyprint">T_ANON_CLASS</code>,
+<code class="prettyprint">T_CLOSURE</code>, <code class="prettyprint">T_TRAIT</code>, <code class="prettyprint">T_ENUM</code> or <code class="prettyprint">T_INTERFACE</code>.</p>
 </section>
 
                                     </dd>
@@ -1104,7 +1034,7 @@ trait, or function.</p>
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string|null</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>The name of the class, interface, trait, or function;
+            <section class="phpdocumentor-description"><p>The name of the class, interface, trait, enum, or function;
 or <code class="prettyprint">NULL</code> if the function or class is anonymous or
 in case of a parse error/live coding.</p>
 </section>
@@ -1124,7 +1054,7 @@ in case of a parse error/live coding.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">755</span>
+    <span class="phpdocumentor-element-found-in__line">519</span>
 
     </aside>
 
@@ -1139,34 +1069,21 @@ in case of a parse error/live coding.</p>
   'scope'           =&gt; string,  // Public, private, or protected.
   'scope_specified' =&gt; boolean, // TRUE if the scope was explicitly specified.
   'is_static'       =&gt; boolean, // TRUE if the static keyword was found.
+  'is_readonly'     =&gt; boolean, // TRUE if the readonly keyword was found.
   'type'            =&gt; string,  // The type of the var (empty if no type specified).
   'type_token'      =&gt; integer, // The stack pointer to the start of the type
                                 // or FALSE if there is no type.
   'type_end_token'  =&gt; integer, // The stack pointer to the end of the type
                                 // or FALSE if there is no type.
-  'nullable_type'   =&gt; boolean, // TRUE if the type is nullable.
+  'nullable_type'   =&gt; boolean, // TRUE if the type is preceded by the
+                                // nullability operator.
 );
 </code></pre>
 <p>PHPCS cross-version compatible version of the `File::getMemberProperties()  method.</p>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
 <li>Introduced in PHPCS 0.0.5.</li>
-<li>PHPCS 3.0.0: The Exception thrown changed from a <code class="prettyprint">PHP_CodeSniffer_Exception</code> to
-<code class="prettyprint">\PHP_CodeSniffer\Exceptions\TokenizerException</code>.</li>
-<li>PHPCS 3.4.0: Fixed method params being recognized as properties, PHPCS#2214.</li>
-<li>PHPCS 3.5.0: New <code class="prettyprint">&quot;type&quot;</code>, <code class="prettyprint">&quot;type_token&quot;</code>, <code class="prettyprint">&quot;type_end_token&quot;</code> and <code class="prettyprint">&quot;nullable_type&quot;</code> array indexes.
-- The <code class="prettyprint">&quot;type&quot;</code> index contains the type of the member var, or a blank string
-if not specified.
-- If the type is nullable, <code class="prettyprint">&quot;type&quot;</code> will contain the leading <code class="prettyprint">?</code>.
-- If a type is specified, the position of the first token in the type will
-be set in a <code class="prettyprint">&quot;type_token&quot;</code> array index.
-- If a type is specified, the position of the last token in the type will
-be set in a <code class="prettyprint">&quot;type_end_token&quot;</code> array index.
-- If the type is nullable, a <code class="prettyprint">&quot;nullable_type&quot;</code> array index will also be set to <code class="prettyprint">true</code>.
-- If the type contains namespace information, it will be cleaned of whitespace
-and comments in the <code class="prettyprint">&quot;type&quot;</code> value.</li>
-<li>PHPCS 3.5.0: The Exception thrown changed from a <code class="prettyprint">\PHP_CodeSniffer\Exceptions\TokenizerException</code>
-to <code class="prettyprint">\PHP_CodeSniffer\Exceptions\RuntimeException</code>.</li>
+<li>The upstream method has received no significant updates since PHPCS 3.7.1.</li>
 </ul>
 </section>
 
@@ -1260,7 +1177,7 @@ a class member variable.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">274</span>
+    <span class="phpdocumentor-element-found-in__line">171</span>
 
     </aside>
 
@@ -1276,6 +1193,7 @@ a class member variable.</p>
   'name'                =&gt; '$var',  // The variable name.
   'token'               =&gt; integer, // The stack pointer to the variable name.
   'content'             =&gt; string,  // The full content of the variable definition.
+  'has_attributes'      =&gt; boolean, // Does the parameter have one or more attributes attached ?
   'pass_by_reference'   =&gt; boolean, // Is the variable passed by reference?
   'reference_token'     =&gt; integer, // The stack pointer to the reference operator
                                     // or FALSE if the param is not passed by reference.
@@ -1287,7 +1205,8 @@ a class member variable.</p>
                                     // or FALSE if there is no type hint.
   'type_hint_end_token' =&gt; integer, // The stack pointer to the end of the type hint
                                     // or FALSE if there is no type hint.
-  'nullable_type'       =&gt; boolean, // TRUE if the var type is nullable.
+  'nullable_type'       =&gt; boolean, // TRUE if the var type is preceded by the nullability
+                                    // operator.
   'comma_token'         =&gt; integer, // The stack pointer to the comma after the param
                                     // or FALSE if this is the last param.
 )
@@ -1297,43 +1216,17 @@ a class member variable.</p>
   'default_token'       =&gt; integer, // The stack pointer to the start of the default value.
   'default_equal_token' =&gt; integer, // The stack pointer to the equals sign.
 </code></pre>
+<p>Parameters declared using PHP 8 constructor property promotion, have these additional array indexes:</p>
+<pre class="prettyprint"><code class="language-php">  'property_visibility' =&gt; string,  // The property visibility as declared.
+  'visibility_token'    =&gt; integer, // The stack pointer to the visibility modifier token.
+  'property_readonly'   =&gt; bool,    // TRUE if the readonly keyword was found.
+  'readonly_token'      =&gt; integer, // The stack pointer to the readonly modifier token.
+</code></pre>
 <p>PHPCS cross-version compatible version of the <code class="prettyprint">File::getMethodParameters()</code> method.</p>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
 <li>Introduced in PHPCS 0.0.5.</li>
-<li>PHPCS 2.8.0: Now recognises <code class="prettyprint">self</code> as a valid type declaration.</li>
-<li>PHPCS 2.8.0: The return array now contains a new <code class="prettyprint">&quot;token&quot;</code> index containing the stack pointer
-to the variable.</li>
-<li>PHPCS 2.8.0: The return array now contains a new <code class="prettyprint">&quot;content&quot;</code> index containing the raw content
-of the param definition.</li>
-<li>PHPCS 2.8.0: Added support for nullable types.
-The return array now contains a new <code class="prettyprint">&quot;nullable_type&quot;</code> index set to <code class="prettyprint">true</code> or <code class="prettyprint">false</code>
-for each method parameter.</li>
-<li>PHPCS 2.8.0: Added support for closures.</li>
-<li>PHPCS 3.0.0: The Exception thrown changed from a <code class="prettyprint">PHP_CodeSniffer_Exception</code> to
-<code class="prettyprint">\PHP_CodeSniffer\Exceptions\TokenizerException</code>.</li>
-<li>PHPCS 3.3.0: The return array now contains a new <code class="prettyprint">&quot;type_hint_token&quot;</code> array index.
-Provides the position in the token stack of the first token in the type declaration.</li>
-<li>PHPCS 3.3.1: Fixed incompatibility with PHP 7.3.</li>
-<li>PHPCS 3.5.0: The Exception thrown changed from a <code class="prettyprint">\PHP_CodeSniffer\Exceptions\TokenizerException</code>
-to <code class="prettyprint">\PHP_CodeSniffer\Exceptions\RuntimeException</code>.</li>
-<li>PHPCS 3.5.0: Added support for closure USE groups.</li>
-<li>PHPCS 3.5.0: The return array now contains yet more more information.
-- If a type hint is specified, the position of the last token in the hint will be
-set in a <code class="prettyprint">&quot;type_hint_end_token&quot;</code> array index.
-- If a default is specified, the position of the first token in the default value
-will be set in a <code class="prettyprint">&quot;default_token&quot;</code> array index.
-- If a default is specified, the position of the equals sign will be set in a
-<code class="prettyprint">&quot;default_equal_token&quot;</code> array index.
-- If the param is not the last, the position of the comma will be set in a
-<code class="prettyprint">&quot;comma_token&quot;</code> array index.
-- If the param is passed by reference, the position of the reference operator
-will be set in a <code class="prettyprint">&quot;reference_token&quot;</code> array index.
-- If the param is variable length, the position of the variadic operator will
-be set in a <code class="prettyprint">&quot;variadic_token&quot;</code> array index.</li>
-<li>PHPCS 3.5.3: Fixed a bug where the <code class="prettyprint">&quot;type_hint_end_token&quot;</code> array index for a type hinted
-parameter would bleed through to the next (non-type hinted) parameter.</li>
-<li>PHPCS 3.5.3: Added support for PHP 7.4 <code class="prettyprint">T_FN</code> arrow functions.</li>
+<li>The upstream method has received no significant updates since PHPCS 3.7.1.</li>
 </ul>
 </section>
 
@@ -1400,7 +1293,17 @@ to acquire the parameters for.</p>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
                                                                                 
-                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 7.4 arrow functions.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 identifier name tokens.</p>
 </section>
 
                                     </dd>
@@ -1437,7 +1340,7 @@ or <code class="prettyprint">T_FN</code>.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">552</span>
+    <span class="phpdocumentor-element-found-in__line">473</span>
 
     </aside>
 
@@ -1449,39 +1352,26 @@ or <code class="prettyprint">T_FN</code>.</p>
 
         <section class="phpdocumentor-description"><p>The format of the return value is:</p>
 <pre class="prettyprint"><code class="language-php">array(
-  'scope'                =&gt; 'public', // Public, private, or protected
-  'scope_specified'      =&gt; true,     // TRUE if the scope keyword was found.
-  'return_type'          =&gt; '',       // The return type of the method.
-  'return_type_token'    =&gt; integer,  // The stack pointer to the start of the return type
-                                      // or FALSE if there is no return type.
-  'nullable_return_type' =&gt; false,    // TRUE if the return type is nullable.
-  'is_abstract'          =&gt; false,    // TRUE if the abstract keyword was found.
-  'is_final'             =&gt; false,    // TRUE if the final keyword was found.
-  'is_static'            =&gt; false,    // TRUE if the static keyword was found.
-  'has_body'             =&gt; false,    // TRUE if the method has a body
+  'scope'                 =&gt; 'public', // Public, private, or protected
+  'scope_specified'       =&gt; true,     // TRUE if the scope keyword was found.
+  'return_type'           =&gt; '',       // The return type of the method.
+  'return_type_token'     =&gt; integer,  // The stack pointer to the start of the return type
+                                       // or FALSE if there is no return type.
+  'return_type_end_token' =&gt; integer,  // The stack pointer to the end of the return type
+                                       // or FALSE if there is no return type.
+  'nullable_return_type'  =&gt; false,    // TRUE if the return type is preceded by
+                                       // the nullability operator.
+  'is_abstract'           =&gt; false,    // TRUE if the abstract keyword was found.
+  'is_final'              =&gt; false,    // TRUE if the final keyword was found.
+  'is_static'             =&gt; false,    // TRUE if the static keyword was found.
+  'has_body'              =&gt; false,    // TRUE if the method has a body
 );
 </code></pre>
 <p>PHPCS cross-version compatible version of the <code class="prettyprint">File::getMethodProperties()</code> method.</p>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
 <li>Introduced in PHPCS 0.0.5.</li>
-<li>PHPCS 3.0.0: Removed the <code class="prettyprint">&quot;is_closure&quot;</code> array index which was always <code class="prettyprint">false</code> anyway.</li>
-<li>PHPCS 3.0.0: The Exception thrown changed from a <code class="prettyprint">PHP_CodeSniffer_Exception</code> to
-<code class="prettyprint">\PHP_CodeSniffer\Exceptions\TokenizerException</code>.</li>
-<li>PHPCS 3.3.0: New <code class="prettyprint">&quot;return_type&quot;</code>, <code class="prettyprint">&quot;return_type_token&quot;</code> and <code class="prettyprint">&quot;nullable_return_type&quot;</code> array indexes.
-- The <code class="prettyprint">&quot;return_type&quot;</code> index contains the return type of the function or closer,
-or a blank string if not specified.
-- If the return type is nullable, the return type will contain the leading <code class="prettyprint">?</code>.
-- A <code class="prettyprint">&quot;nullable_return_type&quot;</code> array index in the return value will also be set to <code class="prettyprint">true</code>.
-- If the return type contains namespace information, it will be cleaned of
-whitespace and comments.
-- To access the original return value string, use the main tokens array.</li>
-<li>PHPCS 3.4.0: New <code class="prettyprint">&quot;has_body&quot;</code> array index.
-<code class="prettyprint">false</code> if the method has no body (as with abstract and interface methods)
-or <code class="prettyprint">true</code> otherwise.</li>
-<li>PHPCS 3.5.0: The Exception thrown changed from a <code class="prettyprint">\PHP_CodeSniffer\Exceptions\TokenizerException</code>
-to <code class="prettyprint">\PHP_CodeSniffer\Exceptions\RuntimeException</code>.</li>
-<li>PHPCS 3.5.3: Added support for PHP 7.4 <code class="prettyprint">T_FN</code> arrow functions.</li>
+<li>The upstream method has received no significant updates since PHPCS 3.7.1.</li>
 </ul>
 </section>
 
@@ -1542,26 +1432,6 @@ acquire the properties for.</p>
                                                                                 
                                              
                                     </dd>
-                            <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                
-                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
-</section>
-
-                                    </dd>
-                            <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                
-                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 static return type (expected in future PHPCS release).</p>
-</section>
-
-                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
@@ -1594,7 +1464,7 @@ acquire the properties for.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1140</span>
+    <span class="phpdocumentor-element-found-in__line">610</span>
 
     </aside>
 
@@ -1609,12 +1479,7 @@ the token stack for the specified length.</p>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
 <li>Introduced in PHPCS 0.0.5.</li>
-<li>PHPCS 3.3.0: New <code class="prettyprint">$origContent</code> parameter to optionally return original
-(non tab-replaced) content.</li>
-<li>PHPCS 3.4.0:
-- Now throws a <code class="prettyprint">RuntimeException</code> if the <code class="prettyprint">$start</code> param is invalid.
-This stops an infinite loop when the function is passed invalid data.
-- If the <code class="prettyprint">$length</code> param is invalid, an empty string will be returned.</li>
+<li>The upstream method has received no significant updates since PHPCS 3.7.1.</li>
 </ul>
 </section>
 
@@ -1726,7 +1591,7 @@ content should be used.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1390</span>
+    <span class="phpdocumentor-element-found-in__line">683</span>
 
     </aside>
 
@@ -1740,7 +1605,7 @@ content should be used.</p>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
 <li>Introduced in PHPCS 0.0.5.</li>
-<li>This method has received no significant code updates since PHPCS 2.6.0.</li>
+<li>The upstream method has received no significant updates since PHPCS 3.7.1.</li>
 </ul>
 </section>
 
@@ -1830,7 +1695,7 @@ content should be used.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">994</span>
+    <span class="phpdocumentor-element-found-in__line">580</span>
 
     </aside>
 
@@ -1844,17 +1709,7 @@ content should be used.</p>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
 <li>Introduced in PHPCS 0.0.5.</li>
-<li>PHPCS 3.1.1: Bug fix: misidentification of reference vs bitwise operator, PHPCS#1604/#1609.
-- An array assignment of a calculated value with a bitwise and operator in it,
-was being misidentified as a reference.
-- A calculated default value for a function parameter with a bitwise and operator
-in it, was being misidentified as a reference.
-- New by reference was not recognized as a reference.
-- References to class properties with <code class="prettyprint">self::</code>, <code class="prettyprint">parent::</code>, <code class="prettyprint">static::</code>,
-<code class="prettyprint">namespace\ClassName::</code>, <code class="prettyprint">classname::</code> were not recognized as references.</li>
-<li>PHPCS 3.5.3: Added support for PHP 7.4 <code class="prettyprint">T_FN</code> arrow functions returning by reference.</li>
-<li>PHPCS 3.5.6: Bug fix: the reference operator for closures declared to return by reference was
-not recognized as a reference. PHPCS#2977.</li>
+<li>The upstream method has received no significant updates since PHPCS 3.7.1.</li>
 </ul>
 </section>
 
@@ -1913,16 +1768,6 @@ not recognized as a reference. PHPCS#2977.</li>
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
                                                                                 
                                              
-                                    </dd>
-                            <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                
-                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
-</section>
-
                                     </dd>
                         </dl>
 

--- a/docs/phpdoc/classes/PHPCSUtils-BackCompat-BCFile.html
+++ b/docs/phpdoc/classes/PHPCSUtils-BackCompat-BCFile.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-backcompat.html">BackCompat</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-backcompat.html">BackCompat</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,15 +118,22 @@
     BCFile
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="../files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">83</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">PHPCS native utility functions.</p>
 
@@ -94,7 +145,8 @@ any affected utility functions:</p>
 <ul>
 <li>Array return type declarations were incorrectly tokenized to <code class="prettyprint">T_ARRAY_HINT</code>
 instead of <code class="prettyprint">T_RETURN_TYPE</code> in some circumstances prior to PHPCS 2.8.0.</li>
-<li><code class="prettyprint">T_NULLABLE</code> was not available prior to PHPCS 2.8.0 and utility functions did
+<li>
+<code class="prettyprint">T_NULLABLE</code> was not available prior to PHPCS 2.8.0 and utility functions did
 not take nullability of types into account.</li>
 <li>The PHPCS native ignore annotations were not available prior to PHPCS 3.2.0.</li>
 <li>The way return types were tokenized has changed in PHPCS 3.3.0.
@@ -114,7 +166,8 @@ These will be indicated with <code class="prettyprint">@see</code> tags in the d
 improved functionality, but will generally be fully compatible with the PHPCS
 native functions.
 The differences between the functions here and the twin functions are documented
-in the docblock of the respective twin-function.</p></section>
+in the docblock of the respective twin-function.</p>
+</section>
 
 
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -127,16 +180,19 @@ in the docblock of the respective twin-function.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source of these utility methods.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source of these utility methods.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 
@@ -150,95 +206,95 @@ in the docblock of the respective twin-function.</p></section>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_findEndOfStatement">findEndOfStatement()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_findEndOfStatement">findEndOfStatement()</a>
     <span>
-                        &nbsp;: int    </span>
+                                &nbsp;: int    </span>
 </dt>
 <dd>Returns the position of the last non-whitespace token in a statement.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_findExtendedClassName">findExtendedClassName()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_findExtendedClassName">findExtendedClassName()</a>
     <span>
-                        &nbsp;: string|false    </span>
+                                &nbsp;: string|false    </span>
 </dt>
 <dd>Returns the name of the class that the specified class extends.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_findImplementedInterfaceNames">findImplementedInterfaceNames()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_findImplementedInterfaceNames">findImplementedInterfaceNames()</a>
     <span>
-                        &nbsp;: array|false    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;|false    </span>
 </dt>
 <dd>Returns the names of the interfaces that the specified class implements.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_findStartOfStatement">findStartOfStatement()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_findStartOfStatement">findStartOfStatement()</a>
     <span>
-                        &nbsp;: int    </span>
+                                &nbsp;: int    </span>
 </dt>
 <dd>Returns the position of the first non-whitespace token in a statement.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_getClassProperties">getClassProperties()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getClassProperties">getClassProperties()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Returns the implementation properties of a class.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_getCondition">getCondition()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getCondition">getCondition()</a>
     <span>
-                        &nbsp;: int|false    </span>
+                                &nbsp;: int|false    </span>
 </dt>
 <dd>Return the position of the condition for the passed token.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_getDeclarationName">getDeclarationName()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getDeclarationName">getDeclarationName()</a>
     <span>
-                        &nbsp;: string|null    </span>
+                                &nbsp;: string|null    </span>
 </dt>
 <dd>Returns the declaration names for classes, interfaces, traits, and functions.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_getMemberProperties">getMemberProperties()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getMemberProperties">getMemberProperties()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Returns the visibility and implementation properties of a class member var.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_getMethodParameters">getMethodParameters()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getMethodParameters">getMethodParameters()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Returns the method parameters for the specified function token.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_getMethodProperties">getMethodProperties()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getMethodProperties">getMethodProperties()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Returns the visibility and implementation properties of a method.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_getTokensAsString">getTokensAsString()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getTokensAsString">getTokensAsString()</a>
     <span>
-                        &nbsp;: string    </span>
+                                &nbsp;: string    </span>
 </dt>
 <dd>Returns the content of the tokens from the specified start position in
 the token stack for the specified length.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_hasCondition">hasCondition()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_hasCondition">hasCondition()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Determine if the passed token has a condition of one of the passed types.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_isReference">isReference()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_isReference">isReference()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Determine if the passed token is a reference operator.</dd>
 
@@ -253,7 +309,7 @@ the token stack for the specified length.</dd>
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-BackCompat-BCFile.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -263,19 +319,20 @@ the token stack for the specified length.</dd>
 >
     <h4 class="phpdocumentor-element__name" id="method_findEndOfStatement">
         findEndOfStatement()
-        <a href="#method_findEndOfStatement" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_findEndOfStatement" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="../files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">1274</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Returns the position of the last non-whitespace token in a statement.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">findEndOfStatement</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$ignore</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">findEndOfStatement</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$ignore</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int</span></code>
 
         <section class="phpdocumentor-description"><p>PHPCS cross-version compatible version of the `File::findEndOfStatement()  method.</p>
 <p>Changelog for the PHPCS native function:</p>
@@ -288,7 +345,8 @@ the token stack for the specified length.</dd>
 <li>PHPCS 3.5.3: Added support for PHP 7.4 <code class="prettyprint">T_FN</code> arrow functions.</li>
 <li>PHPCS 3.5.4: Improved support for PHP 7.4 <code class="prettyprint">T_FN</code> arrow functions.</li>
 <li>PHPCS 3.5.5: Improved support for PHP 7.4 <code class="prettyprint">T_FN</code> arrow functions, PHPCS #2895.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -297,7 +355,8 @@ the token stack for the specified length.</dd>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -305,15 +364,17 @@ the token stack for the specified length.</dd>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position to start searching from in the token stack.</p></section>
+                    <section class="phpdocumentor-description"><p>The position to start searching from in the token stack.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$ignore</span>
-                : <span class="phpdocumentor-signature__argument__return-type">int|string|array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;</span>
                  = <span class="phpdocumentor-signature__argument__default-value">null</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>Token types that should not be considered stop points.</p></section>
+                    <section class="phpdocumentor-description"><p>Token types that should not be considered stop points.</p>
+</section>
 
             </dd>
             </dl>
@@ -329,24 +390,29 @@ the token stack for the specified length.</dd>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::findEndOfStatement()">File::findEndOfStatement()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                                        <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p></section>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -363,19 +429,20 @@ the token stack for the specified length.</dd>
 >
     <h4 class="phpdocumentor-element__name" id="method_findExtendedClassName">
         findExtendedClassName()
-        <a href="#method_findExtendedClassName" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_findExtendedClassName" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="../files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">1474</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Returns the name of the class that the specified class extends.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">findExtendedClassName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">findExtendedClassName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|false</span></code>
 
         <section class="phpdocumentor-description"><p>(works for classes, anonymous classes and interfaces)</p>
 <p>PHPCS cross-version compatible version of the <code class="prettyprint">File::findExtendedClassName()</code> method.</p>
@@ -386,7 +453,8 @@ the token stack for the specified length.</dd>
 <li>PHPCS 3.1.0: Now supports interfaces extending interfaces (incorrectly, only supporting
 single interface extension).</li>
 <li>PHPCS 3.3.2: Fixed bug causing bleed through with nested classes, PHPCS#2127.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -395,7 +463,8 @@ single interface extension).</li>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -403,7 +472,8 @@ single interface extension).</li>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The stack position of the class or interface.</p></section>
+                    <section class="phpdocumentor-description"><p>The stack position of the class or interface.</p>
+</section>
 
             </dd>
             </dl>
@@ -419,31 +489,37 @@ single interface extension).</li>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::findExtendedClassName()">File::findExtendedClassName()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findExtendedClassName"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations::findExtendedClassName()">ObjectDeclarations::findExtendedClassName()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>PHPCSUtils native improved version.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findExtendedClassName"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations::findExtendedClassName()">ObjectDeclarations::findExtendedClassName()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>PHPCSUtils native improved version.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string|false</span>
             &mdash;
             <section class="phpdocumentor-description"><p>The extended class name or <code class="prettyprint">FALSE</code> on error or if there
-is no extended class name.</p></section>
+is no extended class name.</p>
+</section>
 
     
 </article>
@@ -455,26 +531,28 @@ is no extended class name.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_findImplementedInterfaceNames">
         findImplementedInterfaceNames()
-        <a href="#method_findImplementedInterfaceNames" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_findImplementedInterfaceNames" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="../files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">1537</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Returns the names of the interfaces that the specified class implements.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">findImplementedInterfaceNames</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">findImplementedInterfaceNames</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span></code>
 
         <section class="phpdocumentor-description"><p>PHPCS cross-version compatible version of the <code class="prettyprint">File::findImplementedInterfaceNames()</code> method.</p>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
 <li>Introduced in PHPCS 2.7.0.</li>
 <li>PHPCS 2.8.0: Now supports anonymous classes.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -483,7 +561,8 @@ is no extended class name.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -491,7 +570,8 @@ is no extended class name.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The stack position of the class.</p></section>
+                    <section class="phpdocumentor-description"><p>The stack position of the class.</p>
+</section>
 
             </dd>
             </dl>
@@ -507,31 +587,37 @@ is no extended class name.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::findImplementedInterfaceNames()">File::findImplementedInterfaceNames()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findImplementedInterfaceNames"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations::findImplementedInterfaceNames()">ObjectDeclarations::findImplementedInterfaceNames()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>PHPCSUtils native improved version.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findImplementedInterfaceNames"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations::findImplementedInterfaceNames()">ObjectDeclarations::findImplementedInterfaceNames()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>PHPCSUtils native improved version.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array|false</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span>
             &mdash;
             <section class="phpdocumentor-description"><p>Array with names of the implemented interfaces or <code class="prettyprint">FALSE</code> on
-error or if there are no implemented interface names.</p></section>
+error or if there are no implemented interface names.</p>
+</section>
 
     
 </article>
@@ -543,19 +629,20 @@ error or if there are no implemented interface names.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_findStartOfStatement">
         findStartOfStatement()
-        <a href="#method_findStartOfStatement" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_findStartOfStatement" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="../files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">1192</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Returns the position of the first non-whitespace token in a statement.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">findStartOfStatement</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$ignore</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">findStartOfStatement</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$ignore</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int</span></code>
 
         <section class="phpdocumentor-description"><p>PHPCS cross-version compatible version of the <code class="prettyprint">File::findStartOfStatement()</code> method.</p>
 <p>Changelog for the PHPCS native function:</p>
@@ -563,7 +650,8 @@ error or if there are no implemented interface names.</p></section>
 <li>Introduced in PHPCS 2.1.0.</li>
 <li>PHPCS 2.6.2: New optional <code class="prettyprint">$ignore</code> parameter to selectively ignore stop points.</li>
 <li>PHPCS 3.5.5: Added support for PHP 7.4 <code class="prettyprint">T_FN</code> arrow functions.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -572,7 +660,8 @@ error or if there are no implemented interface names.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -580,15 +669,17 @@ error or if there are no implemented interface names.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position to start searching from in the token stack.</p></section>
+                    <section class="phpdocumentor-description"><p>The position to start searching from in the token stack.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$ignore</span>
-                : <span class="phpdocumentor-signature__argument__return-type">int|string|array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;</span>
                  = <span class="phpdocumentor-signature__argument__default-value">null</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>Token types that should not be considered stop points.</p></section>
+                    <section class="phpdocumentor-description"><p>Token types that should not be considered stop points.</p>
+</section>
 
             </dd>
             </dl>
@@ -604,24 +695,29 @@ error or if there are no implemented interface names.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::findStartOfStatement()">File::findStartOfStatement()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                                        <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p></section>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -638,25 +734,27 @@ error or if there are no implemented interface names.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getClassProperties">
         getClassProperties()
-        <a href="#method_getClassProperties" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getClassProperties" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="../files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">922</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Returns the implementation properties of a class.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getClassProperties</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getClassProperties</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>The format of the return value is:</p>
 <pre class="prettyprint"><code class="language-php">array(
   'is_abstract' =&gt; false, // TRUE if the abstract keyword was found.
   'is_final'    =&gt; false, // TRUE if the final keyword was found.
-);</code></pre>
+);
+</code></pre>
 <p>PHPCS cross-version compatible version of the <code class="prettyprint">File::getClassProperties()</code> method.</p>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
@@ -665,7 +763,8 @@ error or if there are no implemented interface names.</p></section>
 <code class="prettyprint">\PHP_CodeSniffer\Exceptions\TokenizerException</code>.</li>
 <li>PHPCS 3.5.0: The Exception thrown changed from a <code class="prettyprint">\PHP_CodeSniffer\Exceptions\TokenizerException</code>
 to<code class="prettyprint">\PHP_CodeSniffer\Exceptions\RuntimeException</code>.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -674,7 +773,8 @@ to<code class="prettyprint">\PHP_CodeSniffer\Exceptions\RuntimeException</code>.
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -683,7 +783,8 @@ to<code class="prettyprint">\PHP_CodeSniffer\Exceptions\RuntimeException</code>.
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position in the stack of the <code class="prettyprint">T_CLASS</code>
-token to acquire the properties for.</p></section>
+token to acquire the properties for.</p>
+</section>
 
             </dd>
             </dl>
@@ -699,37 +800,44 @@ token to acquire the properties for.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getClassProperties()">File::getClassProperties()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getClassProperties"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations::getClassProperties()">ObjectDeclarations::getClassProperties()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>PHPCSUtils native improved version.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getClassProperties"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations::getClassProperties()">ObjectDeclarations::getClassProperties()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>PHPCSUtils native improved version.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified position is not a
-<code class="prettyprint">T_CLASS</code> token.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified position is not a
+<code class="prettyprint">T_CLASS</code> token.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
         
     
@@ -742,19 +850,20 @@ token to acquire the properties for.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getCondition">
         getCondition()
-        <a href="#method_getCondition" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getCondition" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="../files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">1422</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Return the position of the condition for the passed token.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getCondition</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$type</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$first</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">true</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getCondition</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$type</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$first</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">true</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
         <section class="phpdocumentor-description"><p>PHPCS cross-version compatible version of the <code class="prettyprint">File::getCondition()</code> method.</p>
 <p>Changelog for the PHPCS native function:</p>
@@ -762,7 +871,8 @@ token to acquire the properties for.</p></section>
 <li>Introduced in PHPCS 1.3.0.</li>
 <li>PHPCS 3.5.4: New <code class="prettyprint">$first</code> parameter which allows for the closest matching token to be returned.
 By default, it continues to return the first matched token found from the top of the file.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -771,7 +881,8 @@ By default, it continues to return the first matched token found from the top of
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -779,7 +890,8 @@ By default, it continues to return the first matched token found from the top of
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -787,7 +899,8 @@ By default, it continues to return the first matched token found from the top of
                 : <span class="phpdocumentor-signature__argument__return-type">int|string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The type of token to search for.</p></section>
+                    <section class="phpdocumentor-description"><p>The type of token to search for.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -798,7 +911,8 @@ By default, it continues to return the first matched token found from the top of
                     <section class="phpdocumentor-description"><p>If <code class="prettyprint">true</code>, will return the matched condition
 furthest away from the passed token.
 If <code class="prettyprint">false</code>, will return the matched condition
-closest to the passed token.</p></section>
+closest to the passed token.</p>
+</section>
 
             </dd>
             </dl>
@@ -814,39 +928,47 @@ closest to the passed token.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getCondition()">File::getCondition()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-Conditions.html#method_getCondition"><abbr title="\PHPCSUtils\Utils\Conditions::getCondition()">Conditions::getCondition()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>More versatile alternative.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-Conditions.html#method_getCondition"><abbr title="\PHPCSUtils\Utils\Conditions::getCondition()">Conditions::getCondition()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>More versatile alternative.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                                        <section class="phpdocumentor-description"><p>Added support for the PHPCS 3.5.4 <code class="prettyprint">$first</code> parameter.</p></section>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for the PHPCS 3.5.4 <code class="prettyprint">$first</code> parameter.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">int|false</span>
             &mdash;
             <section class="phpdocumentor-description"><p>Integer stack pointer to the condition or <code class="prettyprint">FALSE</code> if the token
-does not have the condition.</p></section>
+does not have the condition.</p>
+</section>
 
     
 </article>
@@ -858,19 +980,20 @@ does not have the condition.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getDeclarationName">
         getDeclarationName()
-        <a href="#method_getDeclarationName" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getDeclarationName" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="../files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">129</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Returns the declaration names for classes, interfaces, traits, and functions.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getDeclarationName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|null</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getDeclarationName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|null</span></code>
 
         <section class="phpdocumentor-description"><p>PHPCS cross-version compatible version of the <code class="prettyprint">File::getDeclarationName()</code> method.</p>
 <p>Changelog for the PHPCS native function:</p>
@@ -894,7 +1017,8 @@ a change in the tokenization of arrow functions.</li>
 this method will be accepted for JS files.</li>
 <li>Support for JS ES6 method syntax has not been back-filled for PHPCS &lt; 3.0.0.
 and sniffing JS files is not officially supported by PHPCSUtils.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -903,7 +1027,8 @@ and sniffing JS files is not officially supported by PHPCSUtils.</li>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -913,7 +1038,8 @@ and sniffing JS files is not officially supported by PHPCSUtils.</li>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position of the declaration token
 which declared the class, interface,
-trait, or function.</p></section>
+trait, or function.</p>
+</section>
 
             </dd>
             </dl>
@@ -929,41 +1055,50 @@ trait, or function.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getDeclarationName()">File::getDeclarationName()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getName"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations::getName()">ObjectDeclarations::getName()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>PHPCSUtils native improved version.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getName"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations::getName()">ObjectDeclarations::getName()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>PHPCSUtils native improved version.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                                        <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p></section>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified token is not of type
-<code class="prettyprint">T_FUNCTION</code>, <code class="prettyprint">T_CLASS</code>, <code class="prettyprint">T_TRAIT</code>, or <code class="prettyprint">T_INTERFACE</code>.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified token is not of type
+<code class="prettyprint">T_FUNCTION</code>, <code class="prettyprint">T_CLASS</code>, <code class="prettyprint">T_TRAIT</code>, or <code class="prettyprint">T_INTERFACE</code>.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -971,7 +1106,8 @@ trait, or function.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p>The name of the class, interface, trait, or function;
 or <code class="prettyprint">NULL</code> if the function or class is anonymous or
-in case of a parse error/live coding.</p></section>
+in case of a parse error/live coding.</p>
+</section>
 
     
 </article>
@@ -983,19 +1119,20 @@ in case of a parse error/live coding.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getMemberProperties">
         getMemberProperties()
-        <a href="#method_getMemberProperties" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getMemberProperties" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="../files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">755</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Returns the visibility and implementation properties of a class member var.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getMemberProperties</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getMemberProperties</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>The format of the return value is:</p>
 <pre class="prettyprint"><code class="language-php">array(
@@ -1008,7 +1145,8 @@ in case of a parse error/live coding.</p></section>
   'type_end_token'  =&gt; integer, // The stack pointer to the end of the type
                                 // or FALSE if there is no type.
   'nullable_type'   =&gt; boolean, // TRUE if the type is nullable.
-);</code></pre>
+);
+</code></pre>
 <p>PHPCS cross-version compatible version of the `File::getMemberProperties()  method.</p>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
@@ -1016,22 +1154,21 @@ in case of a parse error/live coding.</p></section>
 <li>PHPCS 3.0.0: The Exception thrown changed from a <code class="prettyprint">PHP_CodeSniffer_Exception</code> to
 <code class="prettyprint">\PHP_CodeSniffer\Exceptions\TokenizerException</code>.</li>
 <li>PHPCS 3.4.0: Fixed method params being recognized as properties, PHPCS#2214.</li>
-<li>PHPCS 3.5.0: New <code class="prettyprint">"type"</code>, <code class="prettyprint">"type_token"</code>, <code class="prettyprint">"type_end_token"</code> and <code class="prettyprint">"nullable_type"</code> array indexes.
-<ul>
-<li>The <code class="prettyprint">"type"</code> index contains the type of the member var, or a blank string
-if not specified.</li>
-<li>If the type is nullable, <code class="prettyprint">"type"</code> will contain the leading <code class="prettyprint">?</code>.</li>
-<li>If a type is specified, the position of the first token in the type will
-be set in a <code class="prettyprint">"type_token"</code> array index.</li>
-<li>If a type is specified, the position of the last token in the type will
-be set in a <code class="prettyprint">"type_end_token"</code> array index.</li>
-<li>If the type is nullable, a <code class="prettyprint">"nullable_type"</code> array index will also be set to <code class="prettyprint">true</code>.</li>
-<li>If the type contains namespace information, it will be cleaned of whitespace
-and comments in the <code class="prettyprint">"type"</code> value.</li>
-</ul></li>
+<li>PHPCS 3.5.0: New <code class="prettyprint">&quot;type&quot;</code>, <code class="prettyprint">&quot;type_token&quot;</code>, <code class="prettyprint">&quot;type_end_token&quot;</code> and <code class="prettyprint">&quot;nullable_type&quot;</code> array indexes.
+- The <code class="prettyprint">&quot;type&quot;</code> index contains the type of the member var, or a blank string
+if not specified.
+- If the type is nullable, <code class="prettyprint">&quot;type&quot;</code> will contain the leading <code class="prettyprint">?</code>.
+- If a type is specified, the position of the first token in the type will
+be set in a <code class="prettyprint">&quot;type_token&quot;</code> array index.
+- If a type is specified, the position of the last token in the type will
+be set in a <code class="prettyprint">&quot;type_end_token&quot;</code> array index.
+- If the type is nullable, a <code class="prettyprint">&quot;nullable_type&quot;</code> array index will also be set to <code class="prettyprint">true</code>.
+- If the type contains namespace information, it will be cleaned of whitespace
+and comments in the <code class="prettyprint">&quot;type&quot;</code> value.</li>
 <li>PHPCS 3.5.0: The Exception thrown changed from a <code class="prettyprint">\PHP_CodeSniffer\Exceptions\TokenizerException</code>
 to <code class="prettyprint">\PHP_CodeSniffer\Exceptions\RuntimeException</code>.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -1040,7 +1177,8 @@ to <code class="prettyprint">\PHP_CodeSniffer\Exceptions\RuntimeException</code>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1049,7 +1187,8 @@ to <code class="prettyprint">\PHP_CodeSniffer\Exceptions\RuntimeException</code>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position in the stack of the <code class="prettyprint">T_VARIABLE</code> token to
-acquire the properties for.</p></section>
+acquire the properties for.</p>
+</section>
 
             </dd>
             </dl>
@@ -1065,38 +1204,45 @@ acquire the properties for.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getMemberProperties()">File::getMemberProperties()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-Variables.html#method_getMemberProperties"><abbr title="\PHPCSUtils\Utils\Variables::getMemberProperties()">Variables::getMemberProperties()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>PHPCSUtils native improved version.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-Variables.html#method_getMemberProperties"><abbr title="\PHPCSUtils\Utils\Variables::getMemberProperties()">Variables::getMemberProperties()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>PHPCSUtils native improved version.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified position is not a
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified position is not a
 <code class="prettyprint">T_VARIABLE</code> token, or if the position is not
-a class member variable.</p></section>
+a class member variable.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
         
     
@@ -1109,19 +1255,20 @@ a class member variable.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getMethodParameters">
         getMethodParameters()
-        <a href="#method_getMethodParameters" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getMethodParameters" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="../files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">274</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Returns the method parameters for the specified function token.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getMethodParameters</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getMethodParameters</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Also supports passing in a <code class="prettyprint">T_USE</code> token for a closure use group.</p>
 <p>Each parameter is in the following format:</p>
@@ -1143,51 +1290,52 @@ a class member variable.</p></section>
   'nullable_type'       =&gt; boolean, // TRUE if the var type is nullable.
   'comma_token'         =&gt; integer, // The stack pointer to the comma after the param
                                     // or FALSE if this is the last param.
-)</code></pre>
+)
+</code></pre>
 <p>Parameters with default values have the following additional array indexes:</p>
 <pre class="prettyprint"><code class="language-php">  'default'             =&gt; string,  // The full content of the default value.
   'default_token'       =&gt; integer, // The stack pointer to the start of the default value.
-  'default_equal_token' =&gt; integer, // The stack pointer to the equals sign.</code></pre>
+  'default_equal_token' =&gt; integer, // The stack pointer to the equals sign.
+</code></pre>
 <p>PHPCS cross-version compatible version of the <code class="prettyprint">File::getMethodParameters()</code> method.</p>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
 <li>Introduced in PHPCS 0.0.5.</li>
 <li>PHPCS 2.8.0: Now recognises <code class="prettyprint">self</code> as a valid type declaration.</li>
-<li>PHPCS 2.8.0: The return array now contains a new <code class="prettyprint">"token"</code> index containing the stack pointer
+<li>PHPCS 2.8.0: The return array now contains a new <code class="prettyprint">&quot;token&quot;</code> index containing the stack pointer
 to the variable.</li>
-<li>PHPCS 2.8.0: The return array now contains a new <code class="prettyprint">"content"</code> index containing the raw content
+<li>PHPCS 2.8.0: The return array now contains a new <code class="prettyprint">&quot;content&quot;</code> index containing the raw content
 of the param definition.</li>
 <li>PHPCS 2.8.0: Added support for nullable types.
-The return array now contains a new <code class="prettyprint">"nullable_type"</code> index set to <code class="prettyprint">true</code> or <code class="prettyprint">false</code>
+The return array now contains a new <code class="prettyprint">&quot;nullable_type&quot;</code> index set to <code class="prettyprint">true</code> or <code class="prettyprint">false</code>
 for each method parameter.</li>
 <li>PHPCS 2.8.0: Added support for closures.</li>
 <li>PHPCS 3.0.0: The Exception thrown changed from a <code class="prettyprint">PHP_CodeSniffer_Exception</code> to
 <code class="prettyprint">\PHP_CodeSniffer\Exceptions\TokenizerException</code>.</li>
-<li>PHPCS 3.3.0: The return array now contains a new <code class="prettyprint">"type_hint_token"</code> array index.
+<li>PHPCS 3.3.0: The return array now contains a new <code class="prettyprint">&quot;type_hint_token&quot;</code> array index.
 Provides the position in the token stack of the first token in the type declaration.</li>
 <li>PHPCS 3.3.1: Fixed incompatibility with PHP 7.3.</li>
 <li>PHPCS 3.5.0: The Exception thrown changed from a <code class="prettyprint">\PHP_CodeSniffer\Exceptions\TokenizerException</code>
 to <code class="prettyprint">\PHP_CodeSniffer\Exceptions\RuntimeException</code>.</li>
 <li>PHPCS 3.5.0: Added support for closure USE groups.</li>
 <li>PHPCS 3.5.0: The return array now contains yet more more information.
-<ul>
-<li>If a type hint is specified, the position of the last token in the hint will be
-set in a <code class="prettyprint">"type_hint_end_token"</code> array index.</li>
-<li>If a default is specified, the position of the first token in the default value
-will be set in a <code class="prettyprint">"default_token"</code> array index.</li>
-<li>If a default is specified, the position of the equals sign will be set in a
-<code class="prettyprint">"default_equal_token"</code> array index.</li>
-<li>If the param is not the last, the position of the comma will be set in a
-<code class="prettyprint">"comma_token"</code> array index.</li>
-<li>If the param is passed by reference, the position of the reference operator
-will be set in a <code class="prettyprint">"reference_token"</code> array index.</li>
-<li>If the param is variable length, the position of the variadic operator will
-be set in a <code class="prettyprint">"variadic_token"</code> array index.</li>
-</ul></li>
-<li>PHPCS 3.5.3: Fixed a bug where the <code class="prettyprint">"type_hint_end_token"</code> array index for a type hinted
+- If a type hint is specified, the position of the last token in the hint will be
+set in a <code class="prettyprint">&quot;type_hint_end_token&quot;</code> array index.
+- If a default is specified, the position of the first token in the default value
+will be set in a <code class="prettyprint">&quot;default_token&quot;</code> array index.
+- If a default is specified, the position of the equals sign will be set in a
+<code class="prettyprint">&quot;default_equal_token&quot;</code> array index.
+- If the param is not the last, the position of the comma will be set in a
+<code class="prettyprint">&quot;comma_token&quot;</code> array index.
+- If the param is passed by reference, the position of the reference operator
+will be set in a <code class="prettyprint">&quot;reference_token&quot;</code> array index.
+- If the param is variable length, the position of the variadic operator will
+be set in a <code class="prettyprint">&quot;variadic_token&quot;</code> array index.</li>
+<li>PHPCS 3.5.3: Fixed a bug where the <code class="prettyprint">&quot;type_hint_end_token&quot;</code> array index for a type hinted
 parameter would bleed through to the next (non-type hinted) parameter.</li>
 <li>PHPCS 3.5.3: Added support for PHP 7.4 <code class="prettyprint">T_FN</code> arrow functions.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -1196,7 +1344,8 @@ parameter would bleed through to the next (non-type hinted) parameter.</li>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1205,7 +1354,8 @@ parameter would bleed through to the next (non-type hinted) parameter.</li>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position in the stack of the function token
-to acquire the parameters for.</p></section>
+to acquire the parameters for.</p>
+</section>
 
             </dd>
             </dl>
@@ -1221,46 +1371,55 @@ to acquire the parameters for.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getMethodParameters()">File::getMethodParameters()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getParameters"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations::getParameters()">FunctionDeclarations::getParameters()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>PHPCSUtils native improved version.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getParameters"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations::getParameters()">FunctionDeclarations::getParameters()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>PHPCSUtils native improved version.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                                        <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p></section>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified <code class="prettyprint">$stackPtr</code> is not of
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified <code class="prettyprint">$stackPtr</code> is not of
 type <code class="prettyprint">T_FUNCTION</code>, <code class="prettyprint">T_CLOSURE</code>, <code class="prettyprint">T_USE</code>,
-or <code class="prettyprint">T_FN</code>.</p></section>
+or <code class="prettyprint">T_FN</code>.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
         
     
@@ -1273,19 +1432,20 @@ or <code class="prettyprint">T_FN</code>.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getMethodProperties">
         getMethodProperties()
-        <a href="#method_getMethodProperties" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getMethodProperties" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="../files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">552</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Returns the visibility and implementation properties of a method.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getMethodProperties</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getMethodProperties</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>The format of the return value is:</p>
 <pre class="prettyprint"><code class="language-php">array(
@@ -1299,31 +1459,31 @@ or <code class="prettyprint">T_FN</code>.</p></section>
   'is_final'             =&gt; false,    // TRUE if the final keyword was found.
   'is_static'            =&gt; false,    // TRUE if the static keyword was found.
   'has_body'             =&gt; false,    // TRUE if the method has a body
-);</code></pre>
+);
+</code></pre>
 <p>PHPCS cross-version compatible version of the <code class="prettyprint">File::getMethodProperties()</code> method.</p>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
 <li>Introduced in PHPCS 0.0.5.</li>
-<li>PHPCS 3.0.0: Removed the <code class="prettyprint">"is_closure"</code> array index which was always <code class="prettyprint">false</code> anyway.</li>
+<li>PHPCS 3.0.0: Removed the <code class="prettyprint">&quot;is_closure&quot;</code> array index which was always <code class="prettyprint">false</code> anyway.</li>
 <li>PHPCS 3.0.0: The Exception thrown changed from a <code class="prettyprint">PHP_CodeSniffer_Exception</code> to
 <code class="prettyprint">\PHP_CodeSniffer\Exceptions\TokenizerException</code>.</li>
-<li>PHPCS 3.3.0: New <code class="prettyprint">"return_type"</code>, <code class="prettyprint">"return_type_token"</code> and <code class="prettyprint">"nullable_return_type"</code> array indexes.
-<ul>
-<li>The <code class="prettyprint">"return_type"</code> index contains the return type of the function or closer,
-or a blank string if not specified.</li>
-<li>If the return type is nullable, the return type will contain the leading <code class="prettyprint">?</code>.</li>
-<li>A <code class="prettyprint">"nullable_return_type"</code> array index in the return value will also be set to <code class="prettyprint">true</code>.</li>
-<li>If the return type contains namespace information, it will be cleaned of
-whitespace and comments.</li>
-<li>To access the original return value string, use the main tokens array.</li>
-</ul></li>
-<li>PHPCS 3.4.0: New <code class="prettyprint">"has_body"</code> array index.
+<li>PHPCS 3.3.0: New <code class="prettyprint">&quot;return_type&quot;</code>, <code class="prettyprint">&quot;return_type_token&quot;</code> and <code class="prettyprint">&quot;nullable_return_type&quot;</code> array indexes.
+- The <code class="prettyprint">&quot;return_type&quot;</code> index contains the return type of the function or closer,
+or a blank string if not specified.
+- If the return type is nullable, the return type will contain the leading <code class="prettyprint">?</code>.
+- A <code class="prettyprint">&quot;nullable_return_type&quot;</code> array index in the return value will also be set to <code class="prettyprint">true</code>.
+- If the return type contains namespace information, it will be cleaned of
+whitespace and comments.
+- To access the original return value string, use the main tokens array.</li>
+<li>PHPCS 3.4.0: New <code class="prettyprint">&quot;has_body&quot;</code> array index.
 <code class="prettyprint">false</code> if the method has no body (as with abstract and interface methods)
 or <code class="prettyprint">true</code> otherwise.</li>
 <li>PHPCS 3.5.0: The Exception thrown changed from a <code class="prettyprint">\PHP_CodeSniffer\Exceptions\TokenizerException</code>
 to <code class="prettyprint">\PHP_CodeSniffer\Exceptions\RuntimeException</code>.</li>
 <li>PHPCS 3.5.3: Added support for PHP 7.4 <code class="prettyprint">T_FN</code> arrow functions.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -1332,7 +1492,8 @@ to <code class="prettyprint">\PHP_CodeSniffer\Exceptions\RuntimeException</code>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1341,7 +1502,8 @@ to <code class="prettyprint">\PHP_CodeSniffer\Exceptions\RuntimeException</code>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position in the stack of the function token to
-acquire the properties for.</p></section>
+acquire the properties for.</p>
+</section>
 
             </dd>
             </dl>
@@ -1357,53 +1519,64 @@ acquire the properties for.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getMethodProperties()">File::getMethodProperties()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getProperties"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations::getProperties()">FunctionDeclarations::getProperties()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>PHPCSUtils native improved version.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getProperties"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations::getProperties()">FunctionDeclarations::getProperties()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>PHPCSUtils native improved version.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                                        <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p></section>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                                        <section class="phpdocumentor-description"><p>Added support for PHP 8.0 static return type (expected in future PHPCS release).</p></section>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 static return type (expected in future PHPCS release).</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified position is not a
-<code class="prettyprint">T_FUNCTION</code>, <code class="prettyprint">T_CLOSURE</code>, or <code class="prettyprint">T_FN</code> token.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified position is not a
+<code class="prettyprint">T_FUNCTION</code>, <code class="prettyprint">T_CLOSURE</code>, or <code class="prettyprint">T_FN</code> token.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
         
     
@@ -1416,20 +1589,21 @@ acquire the properties for.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getTokensAsString">
         getTokensAsString()
-        <a href="#method_getTokensAsString" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getTokensAsString" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="../files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">1140</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Returns the content of the tokens from the specified start position in
 the token stack for the specified length.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getTokensAsString</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$length</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$origContent</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">false</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getTokensAsString</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$length</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$origContent</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">false</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
         <section class="phpdocumentor-description"><p>PHPCS cross-version compatible version of the <code class="prettyprint">File::getTokensAsString()</code> method.</p>
 <p>Changelog for the PHPCS native function:</p>
@@ -1438,12 +1612,11 @@ the token stack for the specified length.</p>
 <li>PHPCS 3.3.0: New <code class="prettyprint">$origContent</code> parameter to optionally return original
 (non tab-replaced) content.</li>
 <li>PHPCS 3.4.0:
-<ul>
-<li>Now throws a <code class="prettyprint">RuntimeException</code> if the <code class="prettyprint">$start</code> param is invalid.
-This stops an infinite loop when the function is passed invalid data.</li>
-<li>If the <code class="prettyprint">$length</code> param is invalid, an empty string will be returned.</li>
-</ul></li>
-</ul></section>
+- Now throws a <code class="prettyprint">RuntimeException</code> if the <code class="prettyprint">$start</code> param is invalid.
+This stops an infinite loop when the function is passed invalid data.
+- If the <code class="prettyprint">$length</code> param is invalid, an empty string will be returned.</li>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -1452,7 +1625,8 @@ This stops an infinite loop when the function is passed invalid data.</li>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1460,7 +1634,8 @@ This stops an infinite loop when the function is passed invalid data.</li>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position to start from in the token stack.</p></section>
+                    <section class="phpdocumentor-description"><p>The position to start from in the token stack.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1468,7 +1643,8 @@ This stops an infinite loop when the function is passed invalid data.</li>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The length of tokens to traverse from the start pos.</p></section>
+                    <section class="phpdocumentor-description"><p>The length of tokens to traverse from the start pos.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1477,7 +1653,8 @@ This stops an infinite loop when the function is passed invalid data.</li>
                  = <span class="phpdocumentor-signature__argument__default-value">false</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Whether the original content or the tab replaced
-content should be used.</p></section>
+content should be used.</p>
+</section>
 
             </dd>
             </dl>
@@ -1493,38 +1670,46 @@ content should be used.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getTokensAsString()">File::getTokensAsString()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-GetTokensAsString.html"><abbr title="\PHPCSUtils\Utils\GetTokensAsString">GetTokensAsString</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Related set of functions.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-GetTokensAsString.html"><abbr title="\PHPCSUtils\Utils\GetTokensAsString">GetTokensAsString</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related set of functions.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified start position does not exist.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified start position does not exist.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>The token contents.</p></section>
+            <section class="phpdocumentor-description"><p>The token contents.</p>
+</section>
 
     
 </article>
@@ -1536,26 +1721,28 @@ content should be used.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_hasCondition">
         hasCondition()
-        <a href="#method_hasCondition" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_hasCondition" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="../files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">1390</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Determine if the passed token has a condition of one of the passed types.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">hasCondition</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$types</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">hasCondition</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$types</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
         <section class="phpdocumentor-description"><p>PHPCS cross-version compatible version of the <code class="prettyprint">File::hasCondition()</code> method.</p>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
 <li>Introduced in PHPCS 0.0.5.</li>
 <li>This method has received no significant code updates since PHPCS 2.6.0.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -1564,7 +1751,8 @@ content should be used.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1572,15 +1760,17 @@ content should be used.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$types</span>
-                : <span class="phpdocumentor-signature__argument__return-type">int|string|array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The type(s) of tokens to search for.</p></section>
+                    <section class="phpdocumentor-description"><p>The type(s) of tokens to search for.</p>
+</section>
 
             </dd>
             </dl>
@@ -1596,24 +1786,29 @@ content should be used.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::hasCondition()">File::hasCondition()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-Conditions.html#method_hasCondition"><abbr title="\PHPCSUtils\Utils\Conditions::hasCondition()">Conditions::hasCondition()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>PHPCSUtils native alternative.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-Conditions.html#method_hasCondition"><abbr title="\PHPCSUtils\Utils\Conditions::hasCondition()">Conditions::hasCondition()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>PHPCSUtils native alternative.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -1630,38 +1825,38 @@ content should be used.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_isReference">
         isReference()
-        <a href="#method_isReference" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_isReference" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="../files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCFile.php"><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">994</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Determine if the passed token is a reference operator.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isReference</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isReference</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
         <section class="phpdocumentor-description"><p>PHPCS cross-version compatible version of the <code class="prettyprint">File::isReference()</code> method.</p>
 <p>Changelog for the PHPCS native function:</p>
 <ul>
 <li>Introduced in PHPCS 0.0.5.</li>
 <li>PHPCS 3.1.1: Bug fix: misidentification of reference vs bitwise operator, PHPCS#1604/#1609.
-<ul>
-<li>An array assignment of a calculated value with a bitwise and operator in it,
-was being misidentified as a reference.</li>
-<li>A calculated default value for a function parameter with a bitwise and operator
-in it, was being misidentified as a reference.</li>
-<li>New by reference was not recognized as a reference.</li>
-<li>References to class properties with <code class="prettyprint">self::</code>, <code class="prettyprint">parent::</code>, <code class="prettyprint">static::</code>,
+- An array assignment of a calculated value with a bitwise and operator in it,
+was being misidentified as a reference.
+- A calculated default value for a function parameter with a bitwise and operator
+in it, was being misidentified as a reference.
+- New by reference was not recognized as a reference.
+- References to class properties with <code class="prettyprint">self::</code>, <code class="prettyprint">parent::</code>, <code class="prettyprint">static::</code>,
 <code class="prettyprint">namespace\ClassName::</code>, <code class="prettyprint">classname::</code> were not recognized as references.</li>
-</ul></li>
 <li>PHPCS 3.5.3: Added support for PHP 7.4 <code class="prettyprint">T_FN</code> arrow functions returning by reference.</li>
 <li>PHPCS 3.5.6: Bug fix: the reference operator for closures declared to return by reference was
 not recognized as a reference. PHPCS#2977.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -1670,7 +1865,8 @@ not recognized as a reference. PHPCS#2977.</li>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1678,7 +1874,8 @@ not recognized as a reference. PHPCS#2977.</li>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_BITWISE_AND</code> token.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_BITWISE_AND</code> token.</p>
+</section>
 
             </dd>
             </dl>
@@ -1694,59 +1891,138 @@ not recognized as a reference. PHPCS#2977.</li>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::isReference()">File::isReference()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-Operators.html#method_isReference"><abbr title="\PHPCSUtils\Utils\Operators::isReference()">Operators::isReference()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>PHPCSUtils native improved version.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-Operators.html#method_isReference"><abbr title="\PHPCSUtils\Utils\Operators::isReference()">Operators::isReference()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>PHPCSUtils native improved version.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                                        <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p></section>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">bool</span>
             &mdash;
             <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> if the specified token position represents a reference.
-<code class="prettyprint">FALSE</code> if the token represents a bitwise operator.</p></section>
+<code class="prettyprint">FALSE</code> if the token represents a bitwise operator.</p>
+</section>
 
     
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCFile.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-BackCompat-BCTokens.html
+++ b/docs/phpdoc/classes/PHPCSUtils-BackCompat-BCTokens.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-backcompat.html">BackCompat</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-backcompat.html">BackCompat</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,19 +118,26 @@
     BCTokens
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">60</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Token arrays related utility methods.</p>
 
-    <section class="phpdocumentor-description"><p>PHPCS provides a number of static token arrays in the \PHP_CodeSniffer\Util\Tokens
+    <section class="phpdocumentor-description"><p>PHPCS provides a number of static token arrays in the <abbr title="\PHP_CodeSniffer\Util\Tokens">Tokens</abbr>
 class.
 Some of these token arrays will not be available in older PHPCS versions.
 Some will not contain the same set of tokens across PHPCS versions.</p>
@@ -100,12 +151,17 @@ a PHPCS cross-version compatibility issue related to inconsistent token arrays.<
 across PHPCS versions.</p>
 <p>The names of the PHPCS native token arrays translate one-on-one to the methods in this class:</p>
 <ul>
-<li><code class="prettyprint">PHP_CodeSniffer\Util\Tokens::$emptyTokens</code> =&gt; <code class="prettyprint">PHPCSUtils\BackCompat\BCTokens::emptyTokens()</code></li>
-<li><code class="prettyprint">PHP_CodeSniffer\Util\Tokens::$operators</code>   =&gt; <code class="prettyprint">PHPCSUtils\BackCompat\BCTokens::operators()</code></li>
+<li>
+<code class="prettyprint">PHP_CodeSniffer\Util\Tokens::$emptyTokens</code> =&gt; <code class="prettyprint">PHPCSUtils\BackCompat\BCTokens::emptyTokens()</code>
+</li>
+<li>
+<code class="prettyprint">PHP_CodeSniffer\Util\Tokens::$operators</code>   =&gt; <code class="prettyprint">PHPCSUtils\BackCompat\BCTokens::operators()</code>
+</li>
 <li>... etc</li>
 </ul>
 <p>The order of the tokens in the arrays may differ between the PHPCS native token arrays and
-the token arrays returned by this class.</p></section>
+the token arrays returned by this class.</p>
+</section>
 
 
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -118,8 +174,9 @@ the token arrays returned by this class.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 
@@ -133,165 +190,165 @@ the token arrays returned by this class.</p></section>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method___callStatic">__callStatic()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method___callStatic">__callStatic()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Handle calls to (undeclared) methods for token arrays which haven&#039;t received any
 changes since PHPCS 2.6.0.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_arithmeticTokens">arithmeticTokens()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_arithmeticTokens">arithmeticTokens()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Tokens that represent arithmetic operators.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_assignmentTokens">assignmentTokens()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_assignmentTokens">assignmentTokens()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Tokens that represent assignment operators.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_blockOpeners">blockOpeners()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_blockOpeners">blockOpeners()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_booleanOperators">booleanOperators()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_booleanOperators">booleanOperators()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_bracketTokens">bracketTokens()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_bracketTokens">bracketTokens()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_castTokens">castTokens()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_castTokens">castTokens()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_commentTokens">commentTokens()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_commentTokens">commentTokens()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_comparisonTokens">comparisonTokens()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_comparisonTokens">comparisonTokens()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Tokens that represent comparison operators.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_emptyTokens">emptyTokens()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_emptyTokens">emptyTokens()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_equalityTokens">equalityTokens()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_equalityTokens">equalityTokens()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_functionNameTokens">functionNameTokens()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_functionNameTokens">functionNameTokens()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Tokens that represent the names of called functions.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_heredocTokens">heredocTokens()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_heredocTokens">heredocTokens()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_includeTokens">includeTokens()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_includeTokens">includeTokens()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_methodPrefixes">methodPrefixes()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_methodPrefixes">methodPrefixes()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_ooScopeTokens">ooScopeTokens()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_ooScopeTokens">ooScopeTokens()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Tokens that open class and object scopes.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_operators">operators()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_operators">operators()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Tokens that perform operations.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_parenthesisOpeners">parenthesisOpeners()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_parenthesisOpeners">parenthesisOpeners()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Token types that open parentheses.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_phpcsCommentTokens">phpcsCommentTokens()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_phpcsCommentTokens">phpcsCommentTokens()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Tokens that are comments containing PHPCS instructions.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_scopeModifiers">scopeModifiers()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_scopeModifiers">scopeModifiers()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_scopeOpeners">scopeOpeners()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_scopeOpeners">scopeOpeners()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_stringTokens">stringTokens()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_stringTokens">stringTokens()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-BCTokens.html#method_textStringTokens">textStringTokens()</a>
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_textStringTokens">textStringTokens()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Tokens that represent text strings.</dd>
 
@@ -306,7 +363,7 @@ changes since PHPCS 2.6.0.</dd>
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -316,20 +373,21 @@ changes since PHPCS 2.6.0.</dd>
 >
     <h4 class="phpdocumentor-element__name" id="method___callStatic">
         __callStatic()
-        <a href="#method___callStatic" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method___callStatic" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">122</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Handle calls to (undeclared) methods for token arrays which haven&#039;t received any
 changes since PHPCS 2.6.0.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">__callStatic</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$args</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">__callStatic</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$args</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -339,16 +397,18 @@ changes since PHPCS 2.6.0.</p>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The name of the method which has been called.</p></section>
+                    <section class="phpdocumentor-description"><p>The name of the method which has been called.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$args</span>
-                : <span class="phpdocumentor-signature__argument__return-type">array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Any arguments passed to the method.
-Unused as none of the methods take arguments.</p></section>
+Unused as none of the methods take arguments.</p>
+</section>
 
             </dd>
             </dl>
@@ -364,14 +424,16 @@ Unused as none of the methods take arguments.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array</p></section>
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array</p>
+</section>
 
     
 </article>
@@ -383,19 +445,20 @@ Unused as none of the methods take arguments.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_arithmeticTokens">
         arithmeticTokens()
-        <a href="#method_arithmeticTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_arithmeticTokens" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">215</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens that represent arithmetic operators.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">arithmeticTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">arithmeticTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Retrieve the PHPCS arithmetic tokens array in a cross-version compatible manner.</p>
 <p>Changelog for the PHPCS native array:</p>
@@ -403,7 +466,8 @@ Unused as none of the methods take arguments.</p></section>
 <li>Introduced in PHPCS 0.5.0.</li>
 <li>PHPCS 2.9.0: The PHP 5.6 <code class="prettyprint">T_POW</code> token was added to the array.
 The <code class="prettyprint">T_POW</code> token was introduced in PHPCS 2.4.0.</li>
-</ul></section>
+</ul>
+</section>
 
     
     
@@ -417,23 +481,27 @@ The <code class="prettyprint">T_POW</code> token was introduced in PHPCS 2.4.0.<
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Util\Tokens::$arithmeticTokens">Tokens::$arithmeticTokens</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original array.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original array.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
             <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array or an empty array for PHPCS versions in
-which the PHPCS native comment tokens did not exist yet.</p></section>
+which the PHPCS native comment tokens did not exist yet.</p>
+</section>
 
     
 </article>
@@ -445,19 +513,20 @@ which the PHPCS native comment tokens did not exist yet.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_assignmentTokens">
         assignmentTokens()
-        <a href="#method_assignmentTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_assignmentTokens" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">150</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens that represent assignment operators.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">assignmentTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">assignmentTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Retrieve the PHPCS assignment tokens array in a cross-version compatible manner.</p>
 <p>Changelog for the PHPCS native array:</p>
@@ -467,7 +536,8 @@ which the PHPCS native comment tokens did not exist yet.</p></section>
 The <code class="prettyprint">T_COALESCE_EQUAL</code> token was introduced in PHPCS 2.8.1.</li>
 <li>PHPCS 3.2.0: The JS <code class="prettyprint">T_ZSR_EQUAL</code> token was added to the array.
 The <code class="prettyprint">T_ZSR_EQUAL</code> token was introduced in PHPCS 2.8.0.</li>
-</ul></section>
+</ul>
+</section>
 
     
     
@@ -481,22 +551,26 @@ The <code class="prettyprint">T_ZSR_EQUAL</code> token was introduced in PHPCS 2
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Util\Tokens::$assignmentTokens">Tokens::$assignmentTokens</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original array.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original array.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p></section>
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p>
+</section>
 
     
 </article>
@@ -508,26 +582,28 @@ The <code class="prettyprint">T_ZSR_EQUAL</code> token was introduced in PHPCS 2
 >
     <h4 class="phpdocumentor-element__name" id="method_blockOpeners">
         blockOpeners()
-        <a href="#method_blockOpeners" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_blockOpeners" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">0</span>
-</aside>
+
+    </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">blockOpeners</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">blockOpeners</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Tokens that open code blocks.</p></section>
+        <section class="phpdocumentor-description"><p>Tokens that open code blocks.</p>
+</section>
 
     
     
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
         
     
@@ -540,26 +616,28 @@ The <code class="prettyprint">T_ZSR_EQUAL</code> token was introduced in PHPCS 2
 >
     <h4 class="phpdocumentor-element__name" id="method_booleanOperators">
         booleanOperators()
-        <a href="#method_booleanOperators" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_booleanOperators" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">0</span>
-</aside>
+
+    </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">booleanOperators</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">booleanOperators</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Tokens that perform boolean operations.</p></section>
+        <section class="phpdocumentor-description"><p>Tokens that perform boolean operations.</p>
+</section>
 
     
     
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
         
     
@@ -572,26 +650,28 @@ The <code class="prettyprint">T_ZSR_EQUAL</code> token was introduced in PHPCS 2
 >
     <h4 class="phpdocumentor-element__name" id="method_bracketTokens">
         bracketTokens()
-        <a href="#method_bracketTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_bracketTokens" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">0</span>
-</aside>
+
+    </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">bracketTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">bracketTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Tokens that represent brackets and parenthesis.</p></section>
+        <section class="phpdocumentor-description"><p>Tokens that represent brackets and parenthesis.</p>
+</section>
 
     
     
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
         
     
@@ -604,26 +684,28 @@ The <code class="prettyprint">T_ZSR_EQUAL</code> token was introduced in PHPCS 2
 >
     <h4 class="phpdocumentor-element__name" id="method_castTokens">
         castTokens()
-        <a href="#method_castTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_castTokens" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">0</span>
-</aside>
+
+    </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">castTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">castTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Tokens that represent type casting.</p></section>
+        <section class="phpdocumentor-description"><p>Tokens that represent type casting.</p>
+</section>
 
     
     
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
         
     
@@ -636,26 +718,28 @@ The <code class="prettyprint">T_ZSR_EQUAL</code> token was introduced in PHPCS 2
 >
     <h4 class="phpdocumentor-element__name" id="method_commentTokens">
         commentTokens()
-        <a href="#method_commentTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_commentTokens" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">0</span>
-</aside>
+
+    </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">commentTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">commentTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Tokens that are comments.</p></section>
+        <section class="phpdocumentor-description"><p>Tokens that are comments.</p>
+</section>
 
     
     
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
         
     
@@ -668,19 +752,20 @@ The <code class="prettyprint">T_ZSR_EQUAL</code> token was introduced in PHPCS 2
 >
     <h4 class="phpdocumentor-element__name" id="method_comparisonTokens">
         comparisonTokens()
-        <a href="#method_comparisonTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_comparisonTokens" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">187</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens that represent comparison operators.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">comparisonTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">comparisonTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Retrieve the PHPCS comparison tokens array in a cross-version compatible manner.</p>
 <p>Changelog for the PHPCS native array:</p>
@@ -690,7 +775,8 @@ The <code class="prettyprint">T_ZSR_EQUAL</code> token was introduced in PHPCS 2
 The <code class="prettyprint">T_COALESCE</code> token was introduced in PHPCS 2.6.1.</li>
 <li>PHPCS 2.9.0: The PHP 7.0 <code class="prettyprint">T_SPACESHIP</code> token was added to the array.
 The <code class="prettyprint">T_SPACESHIP</code> token was introduced in PHPCS 2.5.1.</li>
-</ul></section>
+</ul>
+</section>
 
     
     
@@ -704,22 +790,26 @@ The <code class="prettyprint">T_SPACESHIP</code> token was introduced in PHPCS 2
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Util\Tokens::$comparisonTokens">Tokens::$comparisonTokens</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original array.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original array.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p></section>
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p>
+</section>
 
     
 </article>
@@ -731,26 +821,28 @@ The <code class="prettyprint">T_SPACESHIP</code> token was introduced in PHPCS 2
 >
     <h4 class="phpdocumentor-element__name" id="method_emptyTokens">
         emptyTokens()
-        <a href="#method_emptyTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_emptyTokens" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">0</span>
-</aside>
+
+    </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">emptyTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">emptyTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Tokens that don't represent code.</p></section>
+        <section class="phpdocumentor-description"><p>Tokens that don't represent code.</p>
+</section>
 
     
     
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
         
     
@@ -763,26 +855,28 @@ The <code class="prettyprint">T_SPACESHIP</code> token was introduced in PHPCS 2
 >
     <h4 class="phpdocumentor-element__name" id="method_equalityTokens">
         equalityTokens()
-        <a href="#method_equalityTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_equalityTokens" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">0</span>
-</aside>
+
+    </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">equalityTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">equalityTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Tokens that represent equality comparisons.</p></section>
+        <section class="phpdocumentor-description"><p>Tokens that represent equality comparisons.</p>
+</section>
 
     
     
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
         
     
@@ -795,26 +889,28 @@ The <code class="prettyprint">T_SPACESHIP</code> token was introduced in PHPCS 2
 >
     <h4 class="phpdocumentor-element__name" id="method_functionNameTokens">
         functionNameTokens()
-        <a href="#method_functionNameTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_functionNameTokens" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">367</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens that represent the names of called functions.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">functionNameTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">functionNameTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Retrieve the PHPCS function name tokens array in a cross-version compatible manner.</p>
 <p>Changelog for the PHPCS native array:</p>
 <ul>
 <li>Introduced in PHPCS 2.3.3.</li>
 <li>PHPCS 3.1.0: <code class="prettyprint">T_SELF</code> and <code class="prettyprint">T_STATIC</code> added to the array.</li>
-</ul></section>
+</ul>
+</section>
 
     
     
@@ -828,22 +924,26 @@ The <code class="prettyprint">T_SPACESHIP</code> token was introduced in PHPCS 2
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Util\Tokens::$functionNameTokens">Tokens::$functionNameTokens</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original array.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original array.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p></section>
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p>
+</section>
 
     
 </article>
@@ -855,26 +955,28 @@ The <code class="prettyprint">T_SPACESHIP</code> token was introduced in PHPCS 2
 >
     <h4 class="phpdocumentor-element__name" id="method_heredocTokens">
         heredocTokens()
-        <a href="#method_heredocTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_heredocTokens" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">0</span>
-</aside>
+
+    </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">heredocTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">heredocTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Tokens that make up a heredoc string.</p></section>
+        <section class="phpdocumentor-description"><p>Tokens that make up a heredoc string.</p>
+</section>
 
     
     
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
         
     
@@ -887,26 +989,28 @@ The <code class="prettyprint">T_SPACESHIP</code> token was introduced in PHPCS 2
 >
     <h4 class="phpdocumentor-element__name" id="method_includeTokens">
         includeTokens()
-        <a href="#method_includeTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_includeTokens" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">0</span>
-</aside>
+
+    </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">includeTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">includeTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Tokens that include files.</p></section>
+        <section class="phpdocumentor-description"><p>Tokens that include files.</p>
+</section>
 
     
     
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
         
     
@@ -919,26 +1023,28 @@ The <code class="prettyprint">T_SPACESHIP</code> token was introduced in PHPCS 2
 >
     <h4 class="phpdocumentor-element__name" id="method_methodPrefixes">
         methodPrefixes()
-        <a href="#method_methodPrefixes" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_methodPrefixes" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">0</span>
-</aside>
+
+    </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">methodPrefixes</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">methodPrefixes</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Tokens that can prefix a method name.</p></section>
+        <section class="phpdocumentor-description"><p>Tokens that can prefix a method name.</p>
+</section>
 
     
     
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
         
     
@@ -951,25 +1057,27 @@ The <code class="prettyprint">T_SPACESHIP</code> token was introduced in PHPCS 2
 >
     <h4 class="phpdocumentor-element__name" id="method_ooScopeTokens">
         ooScopeTokens()
-        <a href="#method_ooScopeTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_ooScopeTokens" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">390</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens that open class and object scopes.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">ooScopeTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">ooScopeTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Retrieve the OO scope tokens array in a cross-version compatible manner.</p>
 <p>Changelog for the PHPCS native array:</p>
 <ul>
 <li>Introduced in PHPCS 3.1.0.</li>
-</ul></section>
+</ul>
+</section>
 
     
     
@@ -983,22 +1091,26 @@ The <code class="prettyprint">T_SPACESHIP</code> token was introduced in PHPCS 2
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Util\Tokens::$ooScopeTokens">Tokens::$ooScopeTokens</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original array.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original array.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p></section>
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p>
+</section>
 
     
 </article>
@@ -1010,19 +1122,20 @@ The <code class="prettyprint">T_SPACESHIP</code> token was introduced in PHPCS 2
 >
     <h4 class="phpdocumentor-element__name" id="method_operators">
         operators()
-        <a href="#method_operators" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_operators" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">238</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens that perform operations.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">operators</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">operators</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Retrieve the PHPCS operator tokens array in a cross-version compatible manner.</p>
 <p>Changelog for the PHPCS native array:</p>
@@ -1032,7 +1145,8 @@ The <code class="prettyprint">T_SPACESHIP</code> token was introduced in PHPCS 2
 <li>PHPCS 2.8.1: The PHP 7.4 <code class="prettyprint">T_COALESCE_EQUAL</code> token was backfilled and (incorrectly)
 added to the array.</li>
 <li>PHPCS 2.9.0: The <code class="prettyprint">T_COALESCE_EQUAL</code> token was removed from the array.</li>
-</ul></section>
+</ul>
+</section>
 
     
     
@@ -1046,22 +1160,26 @@ added to the array.</li>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Util\Tokens::$operators">Tokens::$operators</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original array.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original array.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p></section>
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p>
+</section>
 
     
 </article>
@@ -1073,19 +1191,20 @@ added to the array.</li>
 >
     <h4 class="phpdocumentor-element__name" id="method_parenthesisOpeners">
         parenthesisOpeners()
-        <a href="#method_parenthesisOpeners" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_parenthesisOpeners" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">281</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Token types that open parentheses.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">parenthesisOpeners</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">parenthesisOpeners</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Retrieve the PHPCS parenthesis openers tokens array in a cross-version compatible manner.</p>
 <p>Changelog for the PHPCS native array:</p>
@@ -1095,9 +1214,10 @@ added to the array.</li>
 </ul>
 <p>Note: While <code class="prettyprint">T_LIST</code> and <code class="prettyprint">T_ANON_CLASS</code> will be included in the return value for this
 method, the associated parentheses will not have the <code class="prettyprint">'parenthesis_owner'</code> index set
-until PHPCS 3.5.0. Use the <a href="../classes/PHPCSUtils-Utils-Parentheses.html#method_getOwner">\PHPCSUtils\Utils\Parentheses::getOwner()</a>
-or <a href="../classes/PHPCSUtils-Utils-Parentheses.html#method_hasOwner">\PHPCSUtils\Utils\Parentheses::hasOwner()</a> methods if you need to check for
-a <code class="prettyprint">T_LIST</code> or <code class="prettyprint">T_ANON_CLASS</code> parentheses owner.</p></section>
+until PHPCS 3.5.0. Use the <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getOwner"><abbr title="\PHPCSUtils\Utils\Parentheses::getOwner()">Parentheses::getOwner()</abbr></a>
+or <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_hasOwner"><abbr title="\PHPCSUtils\Utils\Parentheses::hasOwner()">Parentheses::hasOwner()</abbr></a> methods if you need to check for
+a <code class="prettyprint">T_LIST</code> or <code class="prettyprint">T_ANON_CLASS</code> parentheses owner.</p>
+</section>
 
     
     
@@ -1111,32 +1231,38 @@ a <code class="prettyprint">T_LIST</code> or <code class="prettyprint">T_ANON_CL
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Util\Tokens::$parenthesisOpeners">Tokens::$parenthesisOpeners</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original array.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original array.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-Parentheses.html"><abbr title="\PHPCSUtils\Utils\Parentheses">Parentheses</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Class holding utility methods for
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-Parentheses.html"><abbr title="\PHPCSUtils\Utils\Parentheses">Parentheses</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Class holding utility methods for
 working with the <code class="prettyprint">'parenthesis_...'</code>
-index keys in a token array.</p></section>
+index keys in a token array.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p></section>
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p>
+</section>
 
     
 </article>
@@ -1148,26 +1274,28 @@ index keys in a token array.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_phpcsCommentTokens">
         phpcsCommentTokens()
-        <a href="#method_phpcsCommentTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_phpcsCommentTokens" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">307</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens that are comments containing PHPCS instructions.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">phpcsCommentTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">phpcsCommentTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Retrieve the PHPCS comment tokens array in a cross-version compatible manner.</p>
 <p>Changelog for the PHPCS native array:</p>
 <ul>
 <li>Introduced in PHPCS 3.2.3. The PHPCS comment tokens, however, were introduced in
 PHPCS 3.2.0.</li>
-</ul></section>
+</ul>
+</section>
 
     
     
@@ -1181,24 +1309,28 @@ PHPCS 3.2.0.</li>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Util\Tokens::$phpcsCommentTokens">Tokens::$phpcsCommentTokens</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original array.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original array.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;string&gt; =&gt; &lt;string&gt; Token array or an empty array for PHPCS
+            <section class="phpdocumentor-description"><p><string> =&gt; <string> Token array or an empty array for PHPCS
 versions in which the PHPCS native annotation
-tokens did not exist yet.</p></section>
+tokens did not exist yet.</p>
+</section>
 
     
 </article>
@@ -1210,26 +1342,28 @@ tokens did not exist yet.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_scopeModifiers">
         scopeModifiers()
-        <a href="#method_scopeModifiers" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_scopeModifiers" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">0</span>
-</aside>
+
+    </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">scopeModifiers</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">scopeModifiers</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Tokens that represent scope modifiers.</p></section>
+        <section class="phpdocumentor-description"><p>Tokens that represent scope modifiers.</p>
+</section>
 
     
     
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
         
     
@@ -1242,26 +1376,28 @@ tokens did not exist yet.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_scopeOpeners">
         scopeOpeners()
-        <a href="#method_scopeOpeners" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_scopeOpeners" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">0</span>
-</aside>
+
+    </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">scopeOpeners</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">scopeOpeners</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Tokens that are allowed to open scopes.</p></section>
+        <section class="phpdocumentor-description"><p>Tokens that are allowed to open scopes.</p>
+</section>
 
     
     
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
         
     
@@ -1274,28 +1410,30 @@ tokens did not exist yet.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_stringTokens">
         stringTokens()
-        <a href="#method_stringTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_stringTokens" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">0</span>
-</aside>
+
+    </aside>
 
     
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">stringTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">stringTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Tokens that represent strings.
 Note that <code class="prettyprint">T_STRINGS</code> are NOT represented in this list as this list
-is about <em>text</em> strings.</p></section>
+is about <em>text</em> strings.</p>
+</section>
 
     
     
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
         
     
@@ -1308,25 +1446,27 @@ is about <em>text</em> strings.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_textStringTokens">
         textStringTokens()
-        <a href="#method_textStringTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_textStringTokens" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">343</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens that represent text strings.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">textStringTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">textStringTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Retrieve the PHPCS text string tokens array in a cross-version compatible manner.</p>
 <p>Changelog for the PHPCS native array:</p>
 <ul>
 <li>Introduced in PHPCS 2.9.0.</li>
-</ul></section>
+</ul>
+</section>
 
     
     
@@ -1340,42 +1480,117 @@ is about <em>text</em> strings.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Util\Tokens::$textStringTokens">Tokens::$textStringTokens</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original array.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original array.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p></section>
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p>
+</section>
 
     
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-BackCompat-BCTokens.html
+++ b/docs/phpdoc/classes/PHPCSUtils-BackCompat-BCTokens.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -131,7 +135,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">60</span>
+    <span class="phpdocumentor-element-found-in__line">73</span>
 
     </aside>
 
@@ -177,6 +181,16 @@ the token arrays returned by this class.</p>
                                                                                 
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Dropped support for PHPCS &lt; 3.7.1.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
 
@@ -196,21 +210,21 @@ the token arrays returned by this class.</p>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Handle calls to (undeclared) methods for token arrays which haven&#039;t received any
-changes since PHPCS 2.6.0.</dd>
+changes since PHPCS 3.7.1.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_arithmeticTokens">arithmeticTokens()</a>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
-<dd>Tokens that represent arithmetic operators.</dd>
+<dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_assignmentTokens">assignmentTokens()</a>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
-<dd>Tokens that represent assignment operators.</dd>
+<dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_blockOpeners">blockOpeners()</a>
@@ -252,7 +266,14 @@ changes since PHPCS 2.6.0.</dd>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
-<dd>Tokens that represent comparison operators.</dd>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_contextSensitiveKeywords">contextSensitiveKeywords()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_emptyTokens">emptyTokens()</a>
@@ -290,6 +311,13 @@ changes since PHPCS 2.6.0.</dd>
 <dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_magicConstants">magicConstants()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_methodPrefixes">methodPrefixes()</a>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
@@ -301,28 +329,28 @@ changes since PHPCS 2.6.0.</dd>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
-<dd>Tokens that open class and object scopes.</dd>
+<dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_operators">operators()</a>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
-<dd>Tokens that perform operations.</dd>
+<dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_parenthesisOpeners">parenthesisOpeners()</a>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
-<dd>Token types that open parentheses.</dd>
+<dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_phpcsCommentTokens">phpcsCommentTokens()</a>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
-<dd>Tokens that are comments containing PHPCS instructions.</dd>
+<dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_scopeModifiers">scopeModifiers()</a>
@@ -350,7 +378,7 @@ changes since PHPCS 2.6.0.</dd>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
-<dd>Tokens that represent text strings.</dd>
+<dd></dd>
 
         </dl>
 
@@ -378,12 +406,12 @@ changes since PHPCS 2.6.0.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">122</span>
+    <span class="phpdocumentor-element-found-in__line">90</span>
 
     </aside>
 
         <p class="phpdocumentor-summary">Handle calls to (undeclared) methods for token arrays which haven&#039;t received any
-changes since PHPCS 2.6.0.</p>
+changes since PHPCS 3.7.1.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
@@ -427,6 +455,16 @@ Unused as none of the methods take arguments.</p>
                                                                                 
                                              
                                     </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">throws</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Exceptions-InvalidTokenArray.html"><abbr title="\PHPCSUtils\Exceptions\InvalidTokenArray">InvalidTokenArray</abbr></a></span>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>When an invalid token array is requested.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -450,59 +488,25 @@ Unused as none of the methods take arguments.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">215</span>
+    <span class="phpdocumentor-element-found-in__line">0</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens that represent arithmetic operators.</p>
-
+    
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">arithmeticTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Retrieve the PHPCS arithmetic tokens array in a cross-version compatible manner.</p>
-<p>Changelog for the PHPCS native array:</p>
-<ul>
-<li>Introduced in PHPCS 0.5.0.</li>
-<li>PHPCS 2.9.0: The PHP 5.6 <code class="prettyprint">T_POW</code> token was added to the array.
-The <code class="prettyprint">T_POW</code> token was introduced in PHPCS 2.4.0.</li>
-</ul>
+        <section class="phpdocumentor-description"><p>Tokens that represent arithmetic operators.</p>
 </section>
 
     
     
-    <h5 class="phpdocumentor-tag-list__heading" id="tags">
-        Tags
-        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
-    </h5>
-    <dl class="phpdocumentor-tag-list">
-                                    <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">see</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Util\Tokens::$arithmeticTokens">Tokens::$arithmeticTokens</abbr></span>
-                                        
-                                                 <section class="phpdocumentor-description"><p>Original array.</p>
-</section>
-
-                                    </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                
-                                             
-                                    </dd>
-                        </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array or an empty array for PHPCS versions in
-which the PHPCS native comment tokens did not exist yet.</p>
-</section>
-
+        
     
 </article>
                     <article
@@ -518,60 +522,25 @@ which the PHPCS native comment tokens did not exist yet.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">150</span>
+    <span class="phpdocumentor-element-found-in__line">0</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens that represent assignment operators.</p>
-
+    
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">assignmentTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Retrieve the PHPCS assignment tokens array in a cross-version compatible manner.</p>
-<p>Changelog for the PHPCS native array:</p>
-<ul>
-<li>Introduced in PHPCS 0.0.5.</li>
-<li>PHPCS 2.9.0: The PHP 7.4 <code class="prettyprint">T_COALESCE_EQUAL</code> token was added to the array.
-The <code class="prettyprint">T_COALESCE_EQUAL</code> token was introduced in PHPCS 2.8.1.</li>
-<li>PHPCS 3.2.0: The JS <code class="prettyprint">T_ZSR_EQUAL</code> token was added to the array.
-The <code class="prettyprint">T_ZSR_EQUAL</code> token was introduced in PHPCS 2.8.0.</li>
-</ul>
+        <section class="phpdocumentor-description"><p>Tokens that represent assignments.</p>
 </section>
 
     
     
-    <h5 class="phpdocumentor-tag-list__heading" id="tags">
-        Tags
-        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
-    </h5>
-    <dl class="phpdocumentor-tag-list">
-                                    <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">see</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Util\Tokens::$assignmentTokens">Tokens::$assignmentTokens</abbr></span>
-                                        
-                                                 <section class="phpdocumentor-description"><p>Original array.</p>
-</section>
-
-                                    </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                
-                                             
-                                    </dd>
-                        </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p>
-</section>
-
+        
     
 </article>
                     <article
@@ -757,60 +726,59 @@ The <code class="prettyprint">T_ZSR_EQUAL</code> token was introduced in PHPCS 2
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">187</span>
+    <span class="phpdocumentor-element-found-in__line">0</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens that represent comparison operators.</p>
-
+    
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">comparisonTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Retrieve the PHPCS comparison tokens array in a cross-version compatible manner.</p>
-<p>Changelog for the PHPCS native array:</p>
-<ul>
-<li>Introduced in PHPCS 0.5.0.</li>
-<li>PHPCS 2.9.0: The PHP 7.0 <code class="prettyprint">T_COALESCE</code> token was added to the array.
-The <code class="prettyprint">T_COALESCE</code> token was introduced in PHPCS 2.6.1.</li>
-<li>PHPCS 2.9.0: The PHP 7.0 <code class="prettyprint">T_SPACESHIP</code> token was added to the array.
-The <code class="prettyprint">T_SPACESHIP</code> token was introduced in PHPCS 2.5.1.</li>
-</ul>
+        <section class="phpdocumentor-description"><p>Tokens that represent comparison operator.</p>
 </section>
 
     
     
-    <h5 class="phpdocumentor-tag-list__heading" id="tags">
-        Tags
-        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
-    </h5>
-    <dl class="phpdocumentor-tag-list">
-                                    <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">see</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Util\Tokens::$comparisonTokens">Tokens::$comparisonTokens</abbr></span>
-                                        
-                                                 <section class="phpdocumentor-description"><p>Original array.</p>
-</section>
-
-                                    </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                
-                                             
-                                    </dd>
-                        </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p>
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_contextSensitiveKeywords">
+        contextSensitiveKeywords()
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_contextSensitiveKeywords" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">contextSensitiveKeywords</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Tokens representing context sensitive keywords in PHP.</p>
 </section>
 
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
     
 </article>
                     <article
@@ -894,7 +862,7 @@ The <code class="prettyprint">T_SPACESHIP</code> token was introduced in PHPCS 2
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">367</span>
+    <span class="phpdocumentor-element-found-in__line">116</span>
 
     </aside>
 
@@ -908,7 +876,8 @@ The <code class="prettyprint">T_SPACESHIP</code> token was introduced in PHPCS 2
 <p>Changelog for the PHPCS native array:</p>
 <ul>
 <li>Introduced in PHPCS 2.3.3.</li>
-<li>PHPCS 3.1.0: <code class="prettyprint">T_SELF</code> and <code class="prettyprint">T_STATIC</code> added to the array.</li>
+<li>PHPCS 3.7.2: <code class="prettyprint">T_PARENT</code> added to the array.</li>
+<li>PHPCS 4.0.0: <code class="prettyprint">T_NAME_QUALIFIED</code>, <code class="prettyprint">T_NAME_FULLY_QUALIFIED</code> and <code class="prettyprint">T_NAME_RELATIVE</code> added to the array.</li>
 </ul>
 </section>
 
@@ -1021,6 +990,40 @@ The <code class="prettyprint">T_SPACESHIP</code> token was introduced in PHPCS 2
             -public
                                     -static                    "
 >
+    <h4 class="phpdocumentor-element__name" id="method_magicConstants">
+        magicConstants()
+        <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_magicConstants" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">magicConstants</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Tokens representing PHP magic constants.</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
     <h4 class="phpdocumentor-element__name" id="method_methodPrefixes">
         methodPrefixes()
         <a href="classes/PHPCSUtils-BackCompat-BCTokens.html#method_methodPrefixes" class="headerlink"><i class="fas fa-link"></i></a>
@@ -1062,56 +1065,25 @@ The <code class="prettyprint">T_SPACESHIP</code> token was introduced in PHPCS 2
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">390</span>
+    <span class="phpdocumentor-element-found-in__line">0</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens that open class and object scopes.</p>
-
+    
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">ooScopeTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Retrieve the OO scope tokens array in a cross-version compatible manner.</p>
-<p>Changelog for the PHPCS native array:</p>
-<ul>
-<li>Introduced in PHPCS 3.1.0.</li>
-</ul>
+        <section class="phpdocumentor-description"><p>Tokens that open class and object scopes.</p>
 </section>
 
     
     
-    <h5 class="phpdocumentor-tag-list__heading" id="tags">
-        Tags
-        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
-    </h5>
-    <dl class="phpdocumentor-tag-list">
-                                    <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">see</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Util\Tokens::$ooScopeTokens">Tokens::$ooScopeTokens</abbr></span>
-                                        
-                                                 <section class="phpdocumentor-description"><p>Original array.</p>
-</section>
-
-                                    </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                
-                                             
-                                    </dd>
-                        </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p>
-</section>
-
+        
     
 </article>
                     <article
@@ -1127,60 +1099,25 @@ The <code class="prettyprint">T_SPACESHIP</code> token was introduced in PHPCS 2
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">238</span>
+    <span class="phpdocumentor-element-found-in__line">0</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens that perform operations.</p>
-
+    
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">operators</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Retrieve the PHPCS operator tokens array in a cross-version compatible manner.</p>
-<p>Changelog for the PHPCS native array:</p>
-<ul>
-<li>Introduced in PHPCS 0.0.5.</li>
-<li>PHPCS 2.6.1: The PHP 7.0 <code class="prettyprint">T_COALESCE</code> token was backfilled and added to the array.</li>
-<li>PHPCS 2.8.1: The PHP 7.4 <code class="prettyprint">T_COALESCE_EQUAL</code> token was backfilled and (incorrectly)
-added to the array.</li>
-<li>PHPCS 2.9.0: The <code class="prettyprint">T_COALESCE_EQUAL</code> token was removed from the array.</li>
-</ul>
+        <section class="phpdocumentor-description"><p>Tokens that perform operations.</p>
 </section>
 
     
     
-    <h5 class="phpdocumentor-tag-list__heading" id="tags">
-        Tags
-        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
-    </h5>
-    <dl class="phpdocumentor-tag-list">
-                                    <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">see</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Util\Tokens::$operators">Tokens::$operators</abbr></span>
-                                        
-                                                 <section class="phpdocumentor-description"><p>Original array.</p>
-</section>
-
-                                    </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                
-                                             
-                                    </dd>
-                        </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p>
-</section>
-
+        
     
 </article>
                     <article
@@ -1196,74 +1133,25 @@ added to the array.</li>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">281</span>
+    <span class="phpdocumentor-element-found-in__line">0</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Token types that open parentheses.</p>
-
+    
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">parenthesisOpeners</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Retrieve the PHPCS parenthesis openers tokens array in a cross-version compatible manner.</p>
-<p>Changelog for the PHPCS native array:</p>
-<ul>
-<li>Introduced in PHPCS 0.0.5.</li>
-<li>PHPCS 3.5.0: <code class="prettyprint">T_LIST</code> and <code class="prettyprint">T_ANON_CLASS</code> added to the array.</li>
-</ul>
-<p>Note: While <code class="prettyprint">T_LIST</code> and <code class="prettyprint">T_ANON_CLASS</code> will be included in the return value for this
-method, the associated parentheses will not have the <code class="prettyprint">'parenthesis_owner'</code> index set
-until PHPCS 3.5.0. Use the <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getOwner"><abbr title="\PHPCSUtils\Utils\Parentheses::getOwner()">Parentheses::getOwner()</abbr></a>
-or <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_hasOwner"><abbr title="\PHPCSUtils\Utils\Parentheses::hasOwner()">Parentheses::hasOwner()</abbr></a> methods if you need to check for
-a <code class="prettyprint">T_LIST</code> or <code class="prettyprint">T_ANON_CLASS</code> parentheses owner.</p>
+        <section class="phpdocumentor-description"><p>Token types that open parenthesis.</p>
 </section>
 
     
     
-    <h5 class="phpdocumentor-tag-list__heading" id="tags">
-        Tags
-        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
-    </h5>
-    <dl class="phpdocumentor-tag-list">
-                                    <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">see</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Util\Tokens::$parenthesisOpeners">Tokens::$parenthesisOpeners</abbr></span>
-                                        
-                                                 <section class="phpdocumentor-description"><p>Original array.</p>
-</section>
-
-                                    </dd>
-                            <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">see</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-Parentheses.html"><abbr title="\PHPCSUtils\Utils\Parentheses">Parentheses</abbr></a></span>
-                                        
-                                                 <section class="phpdocumentor-description"><p>Class holding utility methods for
-working with the <code class="prettyprint">'parenthesis_...'</code>
-index keys in a token array.</p>
-</section>
-
-                                    </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                
-                                             
-                                    </dd>
-                        </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p>
-</section>
-
+        
     
 </article>
                     <article
@@ -1279,59 +1167,25 @@ index keys in a token array.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">307</span>
+    <span class="phpdocumentor-element-found-in__line">0</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens that are comments containing PHPCS instructions.</p>
-
+    
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">phpcsCommentTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Retrieve the PHPCS comment tokens array in a cross-version compatible manner.</p>
-<p>Changelog for the PHPCS native array:</p>
-<ul>
-<li>Introduced in PHPCS 3.2.3. The PHPCS comment tokens, however, were introduced in
-PHPCS 3.2.0.</li>
-</ul>
+        <section class="phpdocumentor-description"><p>Tokens that are comments containing PHPCS instructions.</p>
 </section>
 
     
     
-    <h5 class="phpdocumentor-tag-list__heading" id="tags">
-        Tags
-        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
-    </h5>
-    <dl class="phpdocumentor-tag-list">
-                                    <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">see</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Util\Tokens::$phpcsCommentTokens">Tokens::$phpcsCommentTokens</abbr></span>
-                                        
-                                                 <section class="phpdocumentor-description"><p>Original array.</p>
-</section>
-
-                                    </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                
-                                             
-                                    </dd>
-                        </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p><string> =&gt; <string> Token array or an empty array for PHPCS
-versions in which the PHPCS native annotation
-tokens did not exist yet.</p>
-</section>
-
+        
     
 </article>
                     <article
@@ -1425,7 +1279,7 @@ tokens did not exist yet.</p>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">stringTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Tokens that represent strings.
-Note that <code class="prettyprint">T_STRINGS</code> are NOT represented in this list as this list
+Note that <code class="prettyprint">T_STRING</code>s are NOT represented in this list as this list
 is about <em>text</em> strings.</p>
 </section>
 
@@ -1451,56 +1305,25 @@ is about <em>text</em> strings.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/BCTokens.php"><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">343</span>
+    <span class="phpdocumentor-element-found-in__line">0</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens that represent text strings.</p>
-
+    
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">textStringTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Retrieve the PHPCS text string tokens array in a cross-version compatible manner.</p>
-<p>Changelog for the PHPCS native array:</p>
-<ul>
-<li>Introduced in PHPCS 2.9.0.</li>
-</ul>
+        <section class="phpdocumentor-description"><p>Tokens that represent text strings.</p>
 </section>
 
     
     
-    <h5 class="phpdocumentor-tag-list__heading" id="tags">
-        Tags
-        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
-    </h5>
-    <dl class="phpdocumentor-tag-list">
-                                    <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">see</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Util\Tokens::$textStringTokens">Tokens::$textStringTokens</abbr></span>
-                                        
-                                                 <section class="phpdocumentor-description"><p>Original array.</p>
-</section>
-
-                                    </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                
-                                             
-                                    </dd>
-                        </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array.</p>
-</section>
-
+        
     
 </article>
             </section>

--- a/docs/phpdoc/classes/PHPCSUtils-BackCompat-Helper.html
+++ b/docs/phpdoc/classes/PHPCSUtils-BackCompat-Helper.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -131,17 +135,13 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">29</span>
+    <span class="phpdocumentor-element-found-in__line">26</span>
 
     </aside>
 
             <p class="phpdocumentor-summary">Utility methods to retrieve (configuration) information from PHP_CodeSniffer.</p>
 
-    <section class="phpdocumentor-description"><p>PHP_CodeSniffer cross-version compatibility helper for PHPCS 2.x vs PHPCS 3.x.</p>
-<p>A number of PHPCS classes were split up into several classes in PHPCS 3.x
-Those classes cannot be aliased as they don't represent the same object.
-This class provides helper methods for functions which were contained in
-one of these classes and which are commonly used by external standards.</p>
+    <section class="phpdocumentor-description"><p>PHP_CodeSniffer cross-version compatibility helper.</p>
 </section>
 
 
@@ -158,6 +158,16 @@ one of these classes and which are commonly used by external standards.</p>
                                                                                 
                                                  <section class="phpdocumentor-description"><p>The initial methods in this class have been ported over from
 the external PHPCompatibility &amp; WPCS standards.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Dropped support for PHPCS &lt; 3.7.1.</p>
 </section>
 
                                     </dd>
@@ -251,7 +261,7 @@ command-line or the ruleset.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">39</span>
+    <span class="phpdocumentor-element-found-in__line">36</span>
 
     </aside>
 
@@ -306,7 +316,7 @@ command-line or the ruleset.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">133</span>
+    <span class="phpdocumentor-element-found-in__line">113</span>
 
     </aside>
 
@@ -377,7 +387,7 @@ on the command-line or in a ruleset.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">109</span>
+    <span class="phpdocumentor-element-found-in__line">95</span>
 
     </aside>
 
@@ -447,7 +457,7 @@ if the <code class="prettyprint">$phpcsFile</code> object is available.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">183</span>
+    <span class="phpdocumentor-element-found-in__line">153</span>
 
     </aside>
 
@@ -492,7 +502,7 @@ command-line or the ruleset.</p>
     <span class="phpdocumentor-signature__response_type">string</span>
             &mdash;
             <section class="phpdocumentor-description"><p>Encoding. Defaults to the PHPCS native default, which is 'utf-8'
-for PHPCS 3.x and was 'iso-8859-1' for PHPCS 2.x.</p>
+for PHPCS 3.x.</p>
 </section>
 
     
@@ -510,7 +520,7 @@ for PHPCS 3.x and was 'iso-8859-1' for PHPCS 2.x.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">162</span>
+    <span class="phpdocumentor-element-found-in__line">132</span>
 
     </aside>
 
@@ -572,7 +582,7 @@ command-line or the ruleset.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">48</span>
+    <span class="phpdocumentor-element-found-in__line">45</span>
 
     </aside>
 
@@ -619,7 +629,7 @@ command-line or the ruleset.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">223</span>
+    <span class="phpdocumentor-element-found-in__line">185</span>
 
     </aside>
 
@@ -680,7 +690,7 @@ command-line or the ruleset.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">77</span>
+    <span class="phpdocumentor-element-found-in__line">68</span>
 
     </aside>
 

--- a/docs/phpdoc/classes/PHPCSUtils-BackCompat-Helper.html
+++ b/docs/phpdoc/classes/PHPCSUtils-BackCompat-Helper.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-backcompat.html">BackCompat</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-backcompat.html">BackCompat</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,15 +118,22 @@
     Helper
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="../files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">29</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility methods to retrieve (configuration) information from PHP_CodeSniffer.</p>
 
@@ -90,7 +141,8 @@
 <p>A number of PHPCS classes were split up into several classes in PHPCS 3.x
 Those classes cannot be aliased as they don't represent the same object.
 This class provides helper methods for functions which were contained in
-one of these classes and which are commonly used by external standards.</p></section>
+one of these classes and which are commonly used by external standards.</p>
+</section>
 
 
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -103,10 +155,12 @@ one of these classes and which are commonly used by external standards.</p></sec
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                        <section class="phpdocumentor-description"><p>The initial methods in this class have been ported over from
-the external PHPCompatibility &amp; WPCS standards.</p></section>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>The initial methods in this class have been ported over from
+the external PHPCompatibility &amp; WPCS standards.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
 
@@ -121,60 +175,60 @@ the external PHPCompatibility &amp; WPCS standards.</p></section>
 
 <dl class="phpdocumentor-table-of-contents">
             <dt class="phpdocumentor-table-of-contents__entry -constant -public">
-    <a href="../classes/PHPCSUtils-BackCompat-Helper.html#constant_DEFAULT_TABWIDTH">DEFAULT_TABWIDTH</a>
+    <a href="classes/PHPCSUtils-BackCompat-Helper.html#constant_DEFAULT_TABWIDTH">DEFAULT_TABWIDTH</a>
     <span>
-        &nbsp;= 4                    </span>
+        &nbsp;= 4                            </span>
 </dt>
 <dd>The default tab width used by PHP_CodeSniffer.</dd>
 
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-Helper.html#method_getCommandLineData">getCommandLineData()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-BackCompat-Helper.html#method_getCommandLineData">getCommandLineData()</a>
     <span>
-                        &nbsp;: string|null    </span>
+                                &nbsp;: string|null    </span>
 </dt>
 <dd>Get the value of a CLI overrulable single PHP_CodeSniffer config key.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-Helper.html#method_getConfigData">getConfigData()</a>
+    <a href="classes/PHPCSUtils-BackCompat-Helper.html#method_getConfigData">getConfigData()</a>
     <span>
-                        &nbsp;: string|null    </span>
+                                &nbsp;: string|null    </span>
 </dt>
 <dd>Get the value of a single PHP_CodeSniffer config key.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-Helper.html#method_getEncoding">getEncoding()</a>
+    <a href="classes/PHPCSUtils-BackCompat-Helper.html#method_getEncoding">getEncoding()</a>
     <span>
-                        &nbsp;: string    </span>
+                                &nbsp;: string    </span>
 </dt>
 <dd>Get the applicable (file) encoding as passed to PHP_CodeSniffer from the
 command-line or the ruleset.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-Helper.html#method_getTabWidth">getTabWidth()</a>
+    <a href="classes/PHPCSUtils-BackCompat-Helper.html#method_getTabWidth">getTabWidth()</a>
     <span>
-                        &nbsp;: int    </span>
+                                &nbsp;: int    </span>
 </dt>
 <dd>Get the applicable tab width as passed to PHP_CodeSniffer from the
 command-line or the ruleset.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-Helper.html#method_getVersion">getVersion()</a>
+    <a href="classes/PHPCSUtils-BackCompat-Helper.html#method_getVersion">getVersion()</a>
     <span>
-                        &nbsp;: string    </span>
+                                &nbsp;: string    </span>
 </dt>
 <dd>Get the PHP_CodeSniffer version number.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-Helper.html#method_ignoreAnnotations">ignoreAnnotations()</a>
+    <a href="classes/PHPCSUtils-BackCompat-Helper.html#method_ignoreAnnotations">ignoreAnnotations()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Check whether the &quot;--ignore-annotations&quot; option is in effect.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-BackCompat-Helper.html#method_setConfigData">setConfigData()</a>
+    <a href="classes/PHPCSUtils-BackCompat-Helper.html#method_setConfigData">setConfigData()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Pass config data to PHP_CodeSniffer.</dd>
 
@@ -186,30 +240,32 @@ command-line or the ruleset.</dd>
     <section class="phpdocumentor-constants">
         <h3 class="phpdocumentor-elements__header" id="constants">
             Constants
-            <a href="#constants" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-BackCompat-Helper.html#constants" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article class="phpdocumentor-element -constant -public ">
     <h4 class="phpdocumentor-element__name" id="constant_DEFAULT_TABWIDTH">
         DEFAULT_TABWIDTH
-        <a href="#constant_DEFAULT_TABWIDTH" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-Helper.html#constant_DEFAULT_TABWIDTH" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
 
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="../files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">39</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">The default tab width used by PHP_CodeSniffer.</p>
 
     <code class="phpdocumentor-signature phpdocumentor-code ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__type">int</span>
+        <span class="phpdocumentor-signature__type">int</span>
     <span class="phpdocumentor-signature__name">DEFAULT_TABWIDTH</span>
     = <span class="phpdocumentor-signature__default-value">4</span>
 </code>
 
 
+    
     
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -222,8 +278,9 @@ command-line or the ruleset.</dd>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -234,7 +291,7 @@ command-line or the ruleset.</dd>
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-BackCompat-Helper.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -244,22 +301,24 @@ command-line or the ruleset.</dd>
 >
     <h4 class="phpdocumentor-element__name" id="method_getCommandLineData">
         getCommandLineData()
-        <a href="#method_getCommandLineData" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-Helper.html#method_getCommandLineData" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="../files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">133</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Get the value of a CLI overrulable single PHP_CodeSniffer config key.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getCommandLineData</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$key</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|null</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getCommandLineData</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$key</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|null</span></code>
 
         <section class="phpdocumentor-description"><p>Use this for config keys which can be set in the <code class="prettyprint">CodeSniffer.conf</code> file,
-on the command-line or in a ruleset.</p></section>
+on the command-line or in a ruleset.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -268,7 +327,8 @@ on the command-line or in a ruleset.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being processed.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being processed.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -276,7 +336,8 @@ on the command-line or in a ruleset.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The name of the config value.</p></section>
+                    <section class="phpdocumentor-description"><p>The name of the config value.</p>
+</section>
 
             </dd>
             </dl>
@@ -292,8 +353,9 @@ on the command-line or in a ruleset.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -310,19 +372,20 @@ on the command-line or in a ruleset.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getConfigData">
         getConfigData()
-        <a href="#method_getConfigData" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-Helper.html#method_getConfigData" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="../files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">109</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Get the value of a single PHP_CodeSniffer config key.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getConfigData</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$key</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|null</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getConfigData</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$key</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|null</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -332,7 +395,8 @@ on the command-line or in a ruleset.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The name of the config value.</p></section>
+                    <section class="phpdocumentor-description"><p>The name of the config value.</p>
+</section>
 
             </dd>
             </dl>
@@ -347,18 +411,21 @@ on the command-line or in a ruleset.</p></section>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-BackCompat-Helper.html#method_getCommandLineData"><abbr title="\PHPCSUtils\BackCompat\Helper::getCommandLineData()">Helper::getCommandLineData()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Alternative for the same which is more reliable
-if the <code class="prettyprint">$phpcsFile</code> object is available.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-BackCompat-Helper.html#method_getCommandLineData"><abbr title="\PHPCSUtils\BackCompat\Helper::getCommandLineData()">Helper::getCommandLineData()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Alternative for the same which is more reliable
+if the <code class="prettyprint">$phpcsFile</code> object is available.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -375,20 +442,21 @@ if the <code class="prettyprint">$phpcsFile</code> object is available.</p></sec
 >
     <h4 class="phpdocumentor-element__name" id="method_getEncoding">
         getEncoding()
-        <a href="#method_getEncoding" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-Helper.html#method_getEncoding" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="../files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">183</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Get the applicable (file) encoding as passed to PHP_CodeSniffer from the
 command-line or the ruleset.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getEncoding</span><span>(</span><span class="phpdocumentor-signature__argument"><span>[</span><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getEncoding</span><span>(</span><span class="phpdocumentor-signature__argument"><span>[</span><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -398,7 +466,8 @@ command-line or the ruleset.</p>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>|null</span>
                  = <span class="phpdocumentor-signature__argument__default-value">null</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>Optional. The current file being processed.</p></section>
+                    <section class="phpdocumentor-description"><p>Optional. The current file being processed.</p>
+</section>
 
             </dd>
             </dl>
@@ -414,15 +483,17 @@ command-line or the ruleset.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string</span>
             &mdash;
             <section class="phpdocumentor-description"><p>Encoding. Defaults to the PHPCS native default, which is 'utf-8'
-for PHPCS 3.x and was 'iso-8859-1' for PHPCS 2.x.</p></section>
+for PHPCS 3.x and was 'iso-8859-1' for PHPCS 2.x.</p>
+</section>
 
     
 </article>
@@ -434,20 +505,21 @@ for PHPCS 3.x and was 'iso-8859-1' for PHPCS 2.x.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getTabWidth">
         getTabWidth()
-        <a href="#method_getTabWidth" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-Helper.html#method_getTabWidth" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="../files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">162</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Get the applicable tab width as passed to PHP_CodeSniffer from the
 command-line or the ruleset.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getTabWidth</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getTabWidth</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -457,7 +529,8 @@ command-line or the ruleset.</p>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being processed.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being processed.</p>
+</section>
 
             </dd>
             </dl>
@@ -473,14 +546,16 @@ command-line or the ruleset.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">int</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>Tab width. Defaults to the PHPCS native default of 4.</p></section>
+            <section class="phpdocumentor-description"><p>Tab width. Defaults to the PHPCS native default of 4.</p>
+</section>
 
     
 </article>
@@ -492,19 +567,20 @@ command-line or the ruleset.</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_getVersion">
         getVersion()
-        <a href="#method_getVersion" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-Helper.html#method_getVersion" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="../files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">48</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Get the PHP_CodeSniffer version number.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getVersion</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getVersion</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
     
     
@@ -519,8 +595,9 @@ command-line or the ruleset.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -537,19 +614,20 @@ command-line or the ruleset.</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_ignoreAnnotations">
         ignoreAnnotations()
-        <a href="#method_ignoreAnnotations" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-Helper.html#method_ignoreAnnotations" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="../files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">223</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Check whether the &quot;--ignore-annotations&quot; option is in effect.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">ignoreAnnotations</span><span>(</span><span class="phpdocumentor-signature__argument"><span>[</span><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">ignoreAnnotations</span><span>(</span><span class="phpdocumentor-signature__argument"><span>[</span><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -559,7 +637,8 @@ command-line or the ruleset.</p>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>|null</span>
                  = <span class="phpdocumentor-signature__argument__default-value">null</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>Optional. The current file being processed.</p></section>
+                    <section class="phpdocumentor-description"><p>Optional. The current file being processed.</p>
+</section>
 
             </dd>
             </dl>
@@ -575,14 +654,16 @@ command-line or the ruleset.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">bool</span>
             &mdash;
-            <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> if annotations should be ignored, <code class="prettyprint">FALSE</code> otherwise.</p></section>
+            <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> if annotations should be ignored, <code class="prettyprint">FALSE</code> otherwise.</p>
+</section>
 
     
 </article>
@@ -594,19 +675,20 @@ command-line or the ruleset.</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_setConfigData">
         setConfigData()
-        <a href="#method_setConfigData" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-Helper.html#method_setConfigData" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="../files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/BackCompat/Helper.php"><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">77</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Pass config data to PHP_CodeSniffer.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">setConfigData</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$key</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$value</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$temp</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">false</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Config">Config</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$config</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">setConfigData</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$key</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$value</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$temp</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">false</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Config">Config</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$config</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -616,7 +698,8 @@ command-line or the ruleset.</p>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The name of the config value.</p></section>
+                    <section class="phpdocumentor-description"><p>The name of the config value.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -625,7 +708,8 @@ command-line or the ruleset.</p>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The value to set. If <code class="prettyprint">null</code>, the config entry
-is deleted, reverting it to the default value.</p></section>
+is deleted, reverting it to the default value.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -634,7 +718,8 @@ is deleted, reverting it to the default value.</p></section>
                  = <span class="phpdocumentor-signature__argument__default-value">false</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Set this config data temporarily for this script run.
-This will not write the config data to the config file.</p></section>
+This will not write the config data to the config file.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -646,7 +731,8 @@ This will not write the config data to the config file.</p></section>
 This parameter is required for PHPCS 4.x, optional
 for PHPCS 3.x and not possible to pass for PHPCS 2.x.
 Passing the <code class="prettyprint">$phpcsFile-&gt;config</code> property should work
-in PHPCS 3.x and higher.</p></section>
+in PHPCS 3.x and higher.</p>
+</section>
 
             </dd>
             </dl>
@@ -662,34 +748,107 @@ in PHPCS 3.x and higher.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">bool</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>Whether the setting of the data was successfull.</p></section>
+            <section class="phpdocumentor-description"><p>Whether the setting of the data was successfull.</p>
+</section>
 
     
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-BackCompat-Helper.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Exceptions-InvalidTokenArray.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Exceptions-InvalidTokenArray.html
@@ -1,0 +1,344 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+            <title>PHPCSUtils</title>
+    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
+                <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
+        <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
+    </head>
+<body id="top">
+    <header class="phpdocumentor-header phpdocumentor-section">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
+    <section data-search-form class="phpdocumentor-search">
+    <label>
+        <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
+        <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
+    </label>
+</section>
+
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
+
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
+                        </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
+
+                        </section>
+            
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
+    </section>
+
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
+    </section>
+</aside>
+
+            <div class="phpdocumentor-column -eight phpdocumentor-content">
+                    <ul class="phpdocumentor-breadcrumbs">
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-exceptions.html">Exceptions</a></li>
+    </ul>
+
+    <article class="phpdocumentor-element -class">
+        <h2 class="phpdocumentor-content__title">
+    InvalidTokenArray
+
+        <span class="phpdocumentor-element__extends">
+        extends <abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr>
+    </span>
+    
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
+    
+    
+    </h2>
+
+        <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Exceptions/InvalidTokenArray.php"><a href="files/phpcsutils-exceptions-invalidtokenarray.html"><abbr title="PHPCSUtils/Exceptions/InvalidTokenArray.php">InvalidTokenArray.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">20</span>
+
+    </aside>
+
+            <p class="phpdocumentor-summary">Exception thrown when an non-existent token array is requested.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+
+
+
+
+
+<h3 id="toc">
+    Table of Contents
+    <a href="#toc" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Exceptions-InvalidTokenArray.html#method_create">create()</a>
+    <span>
+                                &nbsp;: <a href="classes/PHPCSUtils-Exceptions-InvalidTokenArray.html"><abbr title="\PHPCSUtils\Exceptions\InvalidTokenArray">InvalidTokenArray</abbr></a>    </span>
+</dt>
+<dd>Create a new invalid token array exception with a standardized text.</dd>
+
+        </dl>
+
+
+
+        
+
+        
+
+            <section class="phpdocumentor-methods">
+        <h3 class="phpdocumentor-elements__header" id="methods">
+            Methods
+            <a href="classes/PHPCSUtils-Exceptions-InvalidTokenArray.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
+        </h3>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_create">
+        create()
+        <a href="classes/PHPCSUtils-Exceptions-InvalidTokenArray.html#method_create" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Exceptions/InvalidTokenArray.php"><a href="files/phpcsutils-exceptions-invalidtokenarray.html"><abbr title="PHPCSUtils/Exceptions/InvalidTokenArray.php">InvalidTokenArray.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">32</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Create a new invalid token array exception with a standardized text.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">create</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/PHPCSUtils-Exceptions-InvalidTokenArray.html"><abbr title="\PHPCSUtils\Exceptions\InvalidTokenArray">InvalidTokenArray</abbr></a></span></code>
+
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$name</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The name of the token array requested.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type"><a href="classes/PHPCSUtils-Exceptions-InvalidTokenArray.html"><abbr title="\PHPCSUtils\Exceptions\InvalidTokenArray">InvalidTokenArray</abbr></a></span>
+            &mdash;
+        
+    
+</article>
+            </section>
+
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
+
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
+            </div>
+        </div>
+        <a href="classes/PHPCSUtils-Exceptions-InvalidTokenArray.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+
+    </main>
+
+    <script>
+        cssVars({});
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
+</body>
+</html>

--- a/docs/phpdoc/classes/PHPCSUtils-Exceptions-TestFileNotFound.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Exceptions-TestFileNotFound.html
@@ -1,0 +1,363 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+            <title>PHPCSUtils</title>
+    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
+                <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
+        <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
+    </head>
+<body id="top">
+    <header class="phpdocumentor-header phpdocumentor-section">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
+    <section data-search-form class="phpdocumentor-search">
+    <label>
+        <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
+        <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
+    </label>
+</section>
+
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
+
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
+                        </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
+
+                        </section>
+            
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
+    </section>
+
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
+    </section>
+</aside>
+
+            <div class="phpdocumentor-column -eight phpdocumentor-content">
+                    <ul class="phpdocumentor-breadcrumbs">
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-exceptions.html">Exceptions</a></li>
+    </ul>
+
+    <article class="phpdocumentor-element -class">
+        <h2 class="phpdocumentor-content__title">
+    TestFileNotFound
+
+        <span class="phpdocumentor-element__extends">
+        extends <abbr title="\BadMethodCallException">BadMethodCallException</abbr>
+    </span>
+    
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
+    
+    
+    </h2>
+
+        <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Exceptions/TestFileNotFound.php"><a href="files/phpcsutils-exceptions-testfilenotfound.html"><abbr title="PHPCSUtils/Exceptions/TestFileNotFound.php">TestFileNotFound.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">21</span>
+
+    </aside>
+
+            <p class="phpdocumentor-summary">Exception thrown when the UtilityMethodTestCase::getTargetToken() method is run without a
+tokenized test case file being available.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+
+
+
+
+
+<h3 id="toc">
+    Table of Contents
+    <a href="#toc" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Exceptions-TestFileNotFound.html#method___construct">__construct()</a>
+    <span>
+                                &nbsp;: void    </span>
+</dt>
+<dd>Create a new &quot;test file not found&quot; exception with a standardized text.</dd>
+
+        </dl>
+
+
+
+        
+
+        
+
+            <section class="phpdocumentor-methods">
+        <h3 class="phpdocumentor-elements__header" id="methods">
+            Methods
+            <a href="classes/PHPCSUtils-Exceptions-TestFileNotFound.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
+        </h3>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                                        "
+>
+    <h4 class="phpdocumentor-element__name" id="method___construct">
+        __construct()
+        <a href="classes/PHPCSUtils-Exceptions-TestFileNotFound.html#method___construct" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Exceptions/TestFileNotFound.php"><a href="files/phpcsutils-exceptions-testfilenotfound.html"><abbr title="PHPCSUtils/Exceptions/TestFileNotFound.php">TestFileNotFound.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">35</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Create a new &quot;test file not found&quot; exception with a standardized text.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+                    <span class="phpdocumentor-signature__name">__construct</span><span>(</span><span class="phpdocumentor-signature__argument"><span>[</span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$message</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">&#039;&#039;</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$code</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type"><abbr title="\Throwable">Throwable</abbr>|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$previous</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
+
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$message</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                 = <span class="phpdocumentor-signature__argument__default-value">&#039;&#039;</span>            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The Exception message to throw.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$code</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The Exception code.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$previous</span>
+                : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\Throwable">Throwable</abbr>|null</span>
+                 = <span class="phpdocumentor-signature__argument__default-value">null</span>            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The previous exception used for the exception chaining.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">void</span>
+            &mdash;
+        
+    
+</article>
+            </section>
+
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
+
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
+            </div>
+        </div>
+        <a href="classes/PHPCSUtils-Exceptions-TestFileNotFound.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+
+    </main>
+
+    <script>
+        cssVars({});
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
+</body>
+</html>

--- a/docs/phpdoc/classes/PHPCSUtils-Exceptions-TestMarkerNotFound.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Exceptions-TestMarkerNotFound.html
@@ -1,0 +1,353 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+            <title>PHPCSUtils</title>
+    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
+                <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
+        <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
+    </head>
+<body id="top">
+    <header class="phpdocumentor-header phpdocumentor-section">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
+    <section data-search-form class="phpdocumentor-search">
+    <label>
+        <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
+        <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
+    </label>
+</section>
+
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
+
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
+                        </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
+
+                        </section>
+            
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
+    </section>
+
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
+    </section>
+</aside>
+
+            <div class="phpdocumentor-column -eight phpdocumentor-content">
+                    <ul class="phpdocumentor-breadcrumbs">
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-exceptions.html">Exceptions</a></li>
+    </ul>
+
+    <article class="phpdocumentor-element -class">
+        <h2 class="phpdocumentor-content__title">
+    TestMarkerNotFound
+
+        <span class="phpdocumentor-element__extends">
+        extends <abbr title="\OutOfBoundsException">OutOfBoundsException</abbr>
+    </span>
+    
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
+    
+    
+    </h2>
+
+        <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Exceptions/TestMarkerNotFound.php"><a href="files/phpcsutils-exceptions-testmarkernotfound.html"><abbr title="PHPCSUtils/Exceptions/TestMarkerNotFound.php">TestMarkerNotFound.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">20</span>
+
+    </aside>
+
+            <p class="phpdocumentor-summary">Exception thrown when a delimiter comment can not be found in a test case file.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+
+
+
+
+
+<h3 id="toc">
+    Table of Contents
+    <a href="#toc" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Exceptions-TestMarkerNotFound.html#method_create">create()</a>
+    <span>
+                                &nbsp;: <a href="classes/PHPCSUtils-Exceptions-TestMarkerNotFound.html"><abbr title="\PHPCSUtils\Exceptions\TestMarkerNotFound">TestMarkerNotFound</abbr></a>    </span>
+</dt>
+<dd>Create a new &quot;test marker not found&quot; exception with a standardized text.</dd>
+
+        </dl>
+
+
+
+        
+
+        
+
+            <section class="phpdocumentor-methods">
+        <h3 class="phpdocumentor-elements__header" id="methods">
+            Methods
+            <a href="classes/PHPCSUtils-Exceptions-TestMarkerNotFound.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
+        </h3>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_create">
+        create()
+        <a href="classes/PHPCSUtils-Exceptions-TestMarkerNotFound.html#method_create" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Exceptions/TestMarkerNotFound.php"><a href="files/phpcsutils-exceptions-testmarkernotfound.html"><abbr title="PHPCSUtils/Exceptions/TestMarkerNotFound.php">TestMarkerNotFound.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">33</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Create a new &quot;test marker not found&quot; exception with a standardized text.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">create</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$marker</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$file</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/PHPCSUtils-Exceptions-TestMarkerNotFound.html"><abbr title="\PHPCSUtils\Exceptions\TestMarkerNotFound">TestMarkerNotFound</abbr></a></span></code>
+
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$marker</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The delimiter comment.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$file</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The file in which the delimiter was not found.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type"><a href="classes/PHPCSUtils-Exceptions-TestMarkerNotFound.html"><abbr title="\PHPCSUtils\Exceptions\TestMarkerNotFound">TestMarkerNotFound</abbr></a></span>
+            &mdash;
+        
+    
+</article>
+            </section>
+
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
+
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
+            </div>
+        </div>
+        <a href="classes/PHPCSUtils-Exceptions-TestMarkerNotFound.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+
+    </main>
+
+    <script>
+        cssVars({});
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
+</body>
+</html>

--- a/docs/phpdoc/classes/PHPCSUtils-Exceptions-TestTargetNotFound.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Exceptions-TestTargetNotFound.html
@@ -1,0 +1,362 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+            <title>PHPCSUtils</title>
+    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
+                <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
+        <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
+    </head>
+<body id="top">
+    <header class="phpdocumentor-header phpdocumentor-section">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
+    <section data-search-form class="phpdocumentor-search">
+    <label>
+        <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
+        <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
+    </label>
+</section>
+
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
+
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
+                        </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
+
+                        </section>
+            
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
+    </section>
+
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
+    </section>
+</aside>
+
+            <div class="phpdocumentor-column -eight phpdocumentor-content">
+                    <ul class="phpdocumentor-breadcrumbs">
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-exceptions.html">Exceptions</a></li>
+    </ul>
+
+    <article class="phpdocumentor-element -class">
+        <h2 class="phpdocumentor-content__title">
+    TestTargetNotFound
+
+        <span class="phpdocumentor-element__extends">
+        extends <abbr title="\OutOfBoundsException">OutOfBoundsException</abbr>
+    </span>
+    
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
+    
+    
+    </h2>
+
+        <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Exceptions/TestTargetNotFound.php"><a href="files/phpcsutils-exceptions-testtargetnotfound.html"><abbr title="PHPCSUtils/Exceptions/TestTargetNotFound.php">TestTargetNotFound.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">20</span>
+
+    </aside>
+
+            <p class="phpdocumentor-summary">Exception thrown when a test target token can not be found in a test case file.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+
+
+
+
+
+<h3 id="toc">
+    Table of Contents
+    <a href="#toc" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Exceptions-TestTargetNotFound.html#method_create">create()</a>
+    <span>
+                                &nbsp;: <a href="classes/PHPCSUtils-Exceptions-TestMarkerNotFound.html"><abbr title="\PHPCSUtils\Exceptions\TestMarkerNotFound">TestMarkerNotFound</abbr></a>    </span>
+</dt>
+<dd>Create a new &quot;test target token not found&quot; exception with a standardized text.</dd>
+
+        </dl>
+
+
+
+        
+
+        
+
+            <section class="phpdocumentor-methods">
+        <h3 class="phpdocumentor-elements__header" id="methods">
+            Methods
+            <a href="classes/PHPCSUtils-Exceptions-TestTargetNotFound.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
+        </h3>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_create">
+        create()
+        <a href="classes/PHPCSUtils-Exceptions-TestTargetNotFound.html#method_create" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Exceptions/TestTargetNotFound.php"><a href="files/phpcsutils-exceptions-testtargetnotfound.html"><abbr title="PHPCSUtils/Exceptions/TestTargetNotFound.php">TestTargetNotFound.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">34</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Create a new &quot;test target token not found&quot; exception with a standardized text.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">create</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$marker</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$content</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$file</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/PHPCSUtils-Exceptions-TestMarkerNotFound.html"><abbr title="\PHPCSUtils\Exceptions\TestMarkerNotFound">TestMarkerNotFound</abbr></a></span></code>
+
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$marker</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The delimiter comment.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$content</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The (optional) target token content.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$file</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The file in which the target token was not found.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type"><a href="classes/PHPCSUtils-Exceptions-TestMarkerNotFound.html"><abbr title="\PHPCSUtils\Exceptions\TestMarkerNotFound">TestMarkerNotFound</abbr></a></span>
+            &mdash;
+        
+    
+</article>
+            </section>
+
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
+
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
+            </div>
+        </div>
+        <a href="classes/PHPCSUtils-Exceptions-TestTargetNotFound.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+
+    </main>
+
+    <script>
+        cssVars({});
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
+</body>
+</html>

--- a/docs/phpdoc/classes/PHPCSUtils-Fixers-SpacesFixer.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Fixers-SpacesFixer.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -258,7 +262,7 @@ when reporting an issue.</p>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The stack pointer to the second token.
 This token can be before or after the <code class="prettyprint">$stackPtr</code>,
-but should only be seperated from the <code class="prettyprint">$stackPtr</code>
+but should only be separated from the <code class="prettyprint">$stackPtr</code>
 by whitespace and/or comments/annotations.</p>
 </section>
 

--- a/docs/phpdoc/classes/PHPCSUtils-Fixers-SpacesFixer.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Fixers-SpacesFixer.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-fixers.html">Fixers</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-fixers.html">Fixers</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,15 +118,22 @@
     SpacesFixer
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Fixers/SpacesFixer.php"><a href="../files/phpcsutils-fixers-spacesfixer.html"><abbr title="PHPCSUtils/Fixers/SpacesFixer.php">SpacesFixer.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Fixers/SpacesFixer.php"><a href="files/phpcsutils-fixers-spacesfixer.html"><abbr title="PHPCSUtils/Fixers/SpacesFixer.php">SpacesFixer.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">23</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility to check and, if necessary, fix the whitespace between two tokens.</p>
 
@@ -98,8 +149,9 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 
@@ -113,10 +165,10 @@
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Fixers-SpacesFixer.html#method_checkAndFix">checkAndFix()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Fixers-SpacesFixer.html#method_checkAndFix">checkAndFix()</a>
     <span>
-                        &nbsp;: void    </span>
+                                &nbsp;: void    </span>
 </dt>
 <dd>Check the whitespace between two tokens, throw an error if it doesn&#039;t match the
 expected whitespace and if relevant, fix it.</dd>
@@ -132,7 +184,7 @@ expected whitespace and if relevant, fix it.</dd>
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Fixers-SpacesFixer.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -142,20 +194,21 @@ expected whitespace and if relevant, fix it.</dd>
 >
     <h4 class="phpdocumentor-element__name" id="method_checkAndFix">
         checkAndFix()
-        <a href="#method_checkAndFix" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Fixers-SpacesFixer.html#method_checkAndFix" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Fixers/SpacesFixer.php"><a href="../files/phpcsutils-fixers-spacesfixer.html"><abbr title="PHPCSUtils/Fixers/SpacesFixer.php">SpacesFixer.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Fixers/SpacesFixer.php"><a href="files/phpcsutils-fixers-spacesfixer.html"><abbr title="PHPCSUtils/Fixers/SpacesFixer.php">SpacesFixer.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">89</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Check the whitespace between two tokens, throw an error if it doesn&#039;t match the
 expected whitespace and if relevant, fix it.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">checkAndFix</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$secondPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$expectedSpaces</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$errorTemplate</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$errorCode</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">&#039;Found&#039;</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$errorType</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">&#039;error&#039;</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$errorSeverity</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$metricName</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">&#039;&#039;</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">checkAndFix</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$secondPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$expectedSpaces</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$errorTemplate</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$errorCode</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">&#039;Found&#039;</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$errorType</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">&#039;error&#039;</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$errorSeverity</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$metricName</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">&#039;&#039;</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
 
         <section class="phpdocumentor-description"><p>Note:</p>
 <ul>
@@ -167,14 +220,15 @@ This should be handled by a (separate) indentation sniff.</li>
 <li>If <code class="prettyprint">'newline'</code> is expected and multiple new lines are encountered, this will be accepted
 as valid.
 No assumptions are made about whether additional blank lines are allowed or not.
-If <em>exactly</em> one line is desired, combine this fixer with the \PHPCSUtils\Fixers\BlankLineFixer
+If <em>exactly</em> one line is desired, combine this fixer with the <abbr title="\PHPCSUtils\Fixers\BlankLineFixer">BlankLineFixer</abbr>
 (upcoming).</li>
 <li>The fixer will not leave behind any trailing spaces on the original line when fixing
 to <code class="prettyprint">'newline'</code>, but it will not correct <em>existing</em> trailing spaces when there already
 is a new line in place.</li>
 <li>This method can optionally record a metric for this check which will be displayed
 when the end-user requests the &quot;info&quot; report.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -183,7 +237,8 @@ when the end-user requests the &quot;info&quot; report.</li>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -192,7 +247,8 @@ when the end-user requests the &quot;info&quot; report.</li>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position of the token which should be used
-when reporting an issue.</p></section>
+when reporting an issue.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -203,7 +259,8 @@ when reporting an issue.</p></section>
                     <section class="phpdocumentor-description"><p>The stack pointer to the second token.
 This token can be before or after the <code class="prettyprint">$stackPtr</code>,
 but should only be seperated from the <code class="prettyprint">$stackPtr</code>
-by whitespace and/or comments/annotations.</p></section>
+by whitespace and/or comments/annotations.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -216,7 +273,8 @@ Valid values:</p>
 <ul>
 <li>(int) Number of spaces. Must be <code class="prettyprint">0</code> or more.</li>
 <li>(string) <code class="prettyprint">'newline'</code>.</li>
-</ul></section>
+</ul>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -230,9 +288,12 @@ in human readable English and include &quot;spaces&quot;/
 &quot;new line&quot;, so no need to include that in the template.</em>
 This string should contain two placeholders:</p>
 <ul>
-<li><code class="prettyprint">%1$s</code> = expected spaces phrase.</li>
-<li><code class="prettyprint">%2$s</code> = found spaces phrase.</li>
-</ul></section>
+<li>
+<code class="prettyprint">%1$s</code> = expected spaces phrase.</li>
+<li>
+<code class="prettyprint">%2$s</code> = found spaces phrase.</li>
+</ul>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -241,10 +302,11 @@ This string should contain two placeholders:</p>
                  = <span class="phpdocumentor-signature__argument__default-value">&#039;Found&#039;</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>A violation code unique to the sniff message.
-Defaults to <code class="prettyprint">"Found"</code>.
+Defaults to <code class="prettyprint">&quot;Found&quot;</code>.
 It is strongly recommended to change this if
 this fixer is used for different errors in the
-same sniff.</p></section>
+same sniff.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -253,7 +315,8 @@ same sniff.</p></section>
                  = <span class="phpdocumentor-signature__argument__default-value">&#039;error&#039;</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Optional. Whether to report the issue as a
-<code class="prettyprint">"warning"</code> or an <code class="prettyprint">"error"</code>. Defaults to <code class="prettyprint">"error"</code>.</p></section>
+<code class="prettyprint">&quot;warning&quot;</code> or an <code class="prettyprint">&quot;error&quot;</code>. Defaults to <code class="prettyprint">&quot;error&quot;</code>.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -263,7 +326,8 @@ same sniff.</p></section>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Optional. The severity level for this message.
 A value of <code class="prettyprint">0</code> will be converted into the default
-severity level.</p></section>
+severity level.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -273,7 +337,8 @@ severity level.</p></section>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Optional. The name of the metric to record.
 This can be a short description phrase.
-Leave empty to not record metrics.</p></section>
+Leave empty to not record metrics.</p>
+</section>
 
             </dd>
             </dl>
@@ -289,55 +354,137 @@ Leave empty to not record metrics.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the tokens passed do not exist or are whitespace
-tokens.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the tokens passed do not exist or are whitespace
+tokens.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If <code class="prettyprint">$expectedSpaces</code> is not a valid value.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If <code class="prettyprint">$expectedSpaces</code> is not a valid value.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the tokens passed are separated by more than just
-empty (whitespace + comments/annotations) tokens.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the tokens passed are separated by more than just
+empty (whitespace + comments/annotations) tokens.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">void</span>
+            &mdash;
+        
     
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Fixers-SpacesFixer.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html
+++ b/docs/phpdoc/classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -134,14 +138,15 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">100</span>
+    <span class="phpdocumentor-element-found-in__line">105</span>
 
     </aside>
 
             <p class="phpdocumentor-summary">Base class for use when testing utility methods for PHP_CodeSniffer.</p>
 
-    <section class="phpdocumentor-description"><p>This class is compatible with PHP_CodeSniffer 2.x as well as 3.x.</p>
-<p>This class is compatible with <a href="http://phpunit.de/">PHPUnit</a> 4.5 - 9.x providing the PHPCSUtils
+    <section class="phpdocumentor-description"><p>This class is compatible with PHP_CodeSniffer 3.x and contains preliminary compatibility with 4.x
+based on its currently known state/roadmap.</p>
+<p>This class is compatible with <a href="https://phpunit.de/">PHPUnit</a> 4.5 - 9.x providing the PHPCSUtils
 autoload file is included in the test bootstrap. For more information about that, please consult
 the project's <a href="https://github.com/PHPCSStandards/PHPCSUtils/blob/develop/README.md">README</a>.</p>
 <p>To allow for testing of tab vs space content, the <code class="prettyprint">tabWidth</code> is set to <code class="prettyprint">4</code> by default.</p>
@@ -225,6 +230,16 @@ for the PHPCSUtils utility functions themselves.</li>
                                                                                 
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Dropped support for PHPCS &lt; 3.7.1.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
 
@@ -300,7 +315,7 @@ compatible manner.</dd>
     <span>
                                 &nbsp;: void    </span>
 </dt>
-<dd>Clean up after finished test.</dd>
+<dd>Clean up after finished test by resetting all static properties to their default values.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_setUpTestFile">setUpTestFile()</a>
@@ -315,6 +330,13 @@ compatible manner.</dd>
                                 &nbsp;: void    </span>
 </dt>
 <dd>Skip JS and CSS related tests on PHPCS 4.x.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_usesPhp8NameTokens">usesPhp8NameTokens()</a>
+    <span>
+                                &nbsp;: bool    </span>
+</dt>
+<dd>Check whether or not the PHP 8.0 identifier name tokens will be in use.</dd>
 
         </dl>
 
@@ -344,7 +366,7 @@ compatible manner.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">135</span>
+    <span class="phpdocumentor-element-found-in__line">140</span>
 
     </aside>
 
@@ -395,7 +417,7 @@ the same directory and named the same as the test class, but with an
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">122</span>
+    <span class="phpdocumentor-element-found-in__line">127</span>
 
     </aside>
 
@@ -445,7 +467,7 @@ the same directory and named the same as the test class, but with an
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">155</span>
+    <span class="phpdocumentor-element-found-in__line">160</span>
 
     </aside>
 
@@ -492,7 +514,7 @@ the same directory and named the same as the test class, but with an
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">110</span>
+    <span class="phpdocumentor-element-found-in__line">115</span>
 
     </aside>
 
@@ -539,7 +561,7 @@ the same directory and named the same as the test class, but with an
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">169</span>
+    <span class="phpdocumentor-element-found-in__line">174</span>
 
     </aside>
 
@@ -591,7 +613,7 @@ the recording of these violations, as well as testing the fixer.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">146</span>
+    <span class="phpdocumentor-element-found-in__line">151</span>
 
     </aside>
 
@@ -644,7 +666,7 @@ the recording of these violations, as well as testing the fixer.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">389</span>
+    <span class="phpdocumentor-element-found-in__line">407</span>
 
     </aside>
 
@@ -705,7 +727,7 @@ Defaults to 'runtime'.</p>
         class="phpdocumentor-element
             -method
             -public
-                                                        "
+                                    -static                    "
 >
     <h4 class="phpdocumentor-element__name" id="method_getTargetToken">
         getTargetToken()
@@ -714,7 +736,7 @@ Defaults to 'runtime'.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">331</span>
+    <span class="phpdocumentor-element-found-in__line">346</span>
 
     </aside>
 
@@ -722,11 +744,10 @@ Defaults to 'runtime'.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                    <span class="phpdocumentor-signature__name">getTargetToken</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$commentString</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$tokenType</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$tokenContent</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getTargetToken</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$commentString</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$tokenType</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$tokenContent</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int</span></code>
 
         <section class="phpdocumentor-description"><p>Note: the test delimiter comment MUST start with <code class="prettyprint">/* test</code> to allow this function to
 distinguish between comments used <em>in</em> a test and test delimiters.</p>
-<p>If the delimiter comment is not found, the test will automatically be failed.</p>
 </section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -775,6 +796,47 @@ This string should include the comment opener and closer.</p>
                                                                                 
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Will throw an exception whether the delimiter comment or the target
+token is not found.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>This method is now <code class="prettyprint">static</code>, which allows for it to be used in &quot;set up before class&quot;.</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">throws</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Exceptions-TestMarkerNotFound.html"><abbr title="\PHPCSUtils\Exceptions\TestMarkerNotFound">TestMarkerNotFound</abbr></a></span>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>When the delimiter comment for the test was not found.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">throws</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Exceptions-TestTargetNotFound.html"><abbr title="\PHPCSUtils\Exceptions\TestTargetNotFound">TestTargetNotFound</abbr></a></span>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>When the target token cannot be found.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -796,11 +858,11 @@ This string should include the comment opener and closer.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">309</span>
+    <span class="phpdocumentor-element-found-in__line">294</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Clean up after finished test.</p>
+        <p class="phpdocumentor-summary">Clean up after finished test by resetting all static properties to their default values.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
@@ -853,7 +915,7 @@ method.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">188</span>
+    <span class="phpdocumentor-element-found-in__line">193</span>
 
     </aside>
 
@@ -914,7 +976,7 @@ method.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">284</span>
+    <span class="phpdocumentor-element-found-in__line">269</span>
 
     </aside>
 
@@ -957,6 +1019,59 @@ method.</p>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">void</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_usesPhp8NameTokens">
+        usesPhp8NameTokens()
+        <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_usesPhp8NameTokens" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">320</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Check whether or not the PHP 8.0 identifier name tokens will be in use.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">usesPhp8NameTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+
+        <section class="phpdocumentor-description"><p>The expected token positions/token counts for certain tokens will differ depending
+on whether the PHP 8.0 identifier name tokenization is used or the PHP &lt; 8.0
+identifier name tokenization.</p>
+<p>Tests can use this method to determine which flavour of tokenization to expect and
+to set test expectations accordingly.</p>
+</section>
+
+    
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">bool</span>
             &mdash;
         
     

--- a/docs/phpdoc/classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html
+++ b/docs/phpdoc/classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-testutils.html">TestUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-testutils.html">TestUtils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -77,15 +121,22 @@
         extends <abbr title="\PHPUnit\Framework\TestCase">TestCase</abbr>
     </span>
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="../files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">100</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Base class for use when testing utility methods for PHP_CodeSniffer.</p>
 
@@ -99,7 +150,8 @@ the project's <a href="https://github.com/PHPCSStandards/PHPCSUtils/blob/develop
 <pre class="prettyprint"><code class="language-php">&lt;?php
 
 /* testTestCaseDescription * /
-const BAR = false;</code></pre>
+const BAR = false;
+</code></pre>
 <p>Test file <code class="prettyprint">path/to/ClassUnderTestUnitTest.php</code>:</p>
 <pre class="prettyprint"><code class="language-php">&lt;?php
 
@@ -144,18 +196,20 @@ class ClassUnderTestUnitTest extends UtilityMethodTestCase {
             array('/* testTestCaseDescription * /', false),
         );
     }
-}</code></pre>
+}
+</code></pre>
 <p>Note:</p>
 <ul>
 <li>Remove the space between the comment closers <code class="prettyprint">* /</code> for a working example.</li>
 <li>Each test case separator comment MUST start with <code class="prettyprint">/* test</code>.
-This is to allow the <a href="../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_getTargetToken">\PHPCSUtils\TestUtils\UtilityMethodTestCase::getTargetToken()</a> method to
+This is to allow the <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_getTargetToken"><abbr title="\PHPCSUtils\TestUtils\UtilityMethodTestCase::getTargetToken()">UtilityMethodTestCase::getTargetToken()</abbr></a> method to
 distinquish between the test separation comments and comments which may be part
 of the test case.</li>
 <li>The test case file and unit test file should be placed in the same directory.</li>
 <li>For working examples using this abstract class, have a look at the unit tests
 for the PHPCSUtils utility functions themselves.</li>
-</ul></section>
+</ul>
+</section>
 
 
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -168,8 +222,9 @@ for the PHPCSUtils utility functions themselves.</li>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 
@@ -183,81 +238,81 @@ for the PHPCSUtils utility functions themselves.</li>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                <dt class="phpdocumentor-table-of-contents__entry -property -protected">
-    <a href="../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_caseFile">$caseFile</a>
+                    <dt class="phpdocumentor-table-of-contents__entry -property -protected">
+    <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_caseFile">$caseFile</a>
     <span>
-                &nbsp;: string            </span>
+                        &nbsp;: string            </span>
 </dt>
 <dd>Full path to the test case file associated with the concrete test class.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
-    <a href="../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_fileExtension">$fileExtension</a>
+    <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_fileExtension">$fileExtension</a>
     <span>
-                &nbsp;: string            </span>
+                        &nbsp;: string            </span>
 </dt>
 <dd>The file extension of the test case file (without leading dot).</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
-    <a href="../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_phpcsFile">$phpcsFile</a>
+    <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_phpcsFile">$phpcsFile</a>
     <span>
-                &nbsp;: <abbr title="\PHP_CodeSniffer\Files\File">File</abbr>            </span>
+                        &nbsp;: <abbr title="\PHP_CodeSniffer\Files\File">File</abbr>            </span>
 </dt>
 <dd>The \PHP_CodeSniffer\Files\File object containing the parsed contents of the test case file.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
-    <a href="../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_phpcsVersion">$phpcsVersion</a>
+    <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_phpcsVersion">$phpcsVersion</a>
     <span>
-                &nbsp;: string            </span>
+                        &nbsp;: string            </span>
 </dt>
 <dd>The PHPCS version the tests are being run on.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
-    <a href="../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_selectedSniff">$selectedSniff</a>
+    <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_selectedSniff">$selectedSniff</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Set the name of a sniff to pass to PHPCS to limit the run (and force it to record errors).</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
-    <a href="../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_tabWidth">$tabWidth</a>
+    <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_tabWidth">$tabWidth</a>
     <span>
-                &nbsp;: int            </span>
+                        &nbsp;: int            </span>
 </dt>
 <dd>The tab width setting to use when tokenizing the file.</dd>
 
                 <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_expectPhpcsException">expectPhpcsException()</a>
+    <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_expectPhpcsException">expectPhpcsException()</a>
     <span>
-                        &nbsp;: void    </span>
+                                &nbsp;: void    </span>
 </dt>
 <dd>Helper method to tell PHPUnit to expect a PHPCS Exception in a PHPUnit and PHPCS cross-version
 compatible manner.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_getTargetToken">getTargetToken()</a>
+    <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_getTargetToken">getTargetToken()</a>
     <span>
-                        &nbsp;: int    </span>
+                                &nbsp;: int    </span>
 </dt>
 <dd>Get the token pointer for a target token based on a specific comment.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_resetTestFile">resetTestFile()</a>
+    <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_resetTestFile">resetTestFile()</a>
     <span>
-                        &nbsp;: void    </span>
+                                &nbsp;: void    </span>
 </dt>
 <dd>Clean up after finished test.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_setUpTestFile">setUpTestFile()</a>
+    <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_setUpTestFile">setUpTestFile()</a>
     <span>
-                        &nbsp;: void    </span>
+                                &nbsp;: void    </span>
 </dt>
 <dd>Initialize PHPCS &amp; tokenize the test case file.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_skipJSCSSTestsOnPHPCS4">skipJSCSSTestsOnPHPCS4()</a>
+    <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_skipJSCSSTestsOnPHPCS4">skipJSCSSTestsOnPHPCS4()</a>
     <span>
-                        &nbsp;: void    </span>
+                                &nbsp;: void    </span>
 </dt>
 <dd>Skip JS and CSS related tests on PHPCS 4.x.</dd>
 
@@ -271,7 +326,7 @@ compatible manner.</dd>
     <section class="phpdocumentor-properties">
         <h3 class="phpdocumentor-elements__header" id="properties">
             Properties
-            <a href="#properties" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#properties" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="
@@ -282,15 +337,16 @@ compatible manner.</dd>
 >
     <h4 class="phpdocumentor-element__name" id="property_caseFile">
         $caseFile
-        <a href="#property_caseFile" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_caseFile" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="../files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">135</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Full path to the test case file associated with the concrete test class.</p>
 
@@ -302,8 +358,10 @@ compatible manner.</dd>
 
         <section class="phpdocumentor-description"><p>Optional. If left empty, the case file will be presumed to be in
 the same directory and named the same as the test class, but with an
-<code class="prettyprint">"inc"</code> file extension.</p></section>
+<code class="prettyprint">&quot;inc&quot;</code> file extension.</p>
+</section>
 
+    
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -315,8 +373,9 @@ the same directory and named the same as the test class, but with an
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -329,15 +388,16 @@ the same directory and named the same as the test class, but with an
 >
     <h4 class="phpdocumentor-element__name" id="property_fileExtension">
         $fileExtension
-        <a href="#property_fileExtension" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_fileExtension" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="../files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">122</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">The file extension of the test case file (without leading dot).</p>
 
@@ -347,9 +407,11 @@ the same directory and named the same as the test class, but with an
     <span class="phpdocumentor-signature__name">$fileExtension</span>
      = <span class="phpdocumentor-signature__default-value">&#039;inc&#039;</span></code>
 
-        <section class="phpdocumentor-description"><p>This allows concrete test classes to overrule the default <code class="prettyprint">"inc"</code> with, for instance,
-<code class="prettyprint">"js"</code> or <code class="prettyprint">"css"</code> when applicable.</p></section>
+        <section class="phpdocumentor-description"><p>This allows concrete test classes to overrule the default <code class="prettyprint">&quot;inc&quot;</code> with, for instance,
+<code class="prettyprint">&quot;js&quot;</code> or <code class="prettyprint">&quot;css&quot;</code> when applicable.</p>
+</section>
 
+    
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -361,8 +423,9 @@ the same directory and named the same as the test class, but with an
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -375,15 +438,16 @@ the same directory and named the same as the test class, but with an
 >
     <h4 class="phpdocumentor-element__name" id="property_phpcsFile">
         $phpcsFile
-        <a href="#property_phpcsFile" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_phpcsFile" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="../files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">155</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">The \PHP_CodeSniffer\Files\File object containing the parsed contents of the test case file.</p>
 
@@ -393,6 +457,7 @@ the same directory and named the same as the test class, but with an
     <span class="phpdocumentor-signature__name">$phpcsFile</span>
     </code>
 
+    
     
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -405,8 +470,9 @@ the same directory and named the same as the test class, but with an
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -419,15 +485,16 @@ the same directory and named the same as the test class, but with an
 >
     <h4 class="phpdocumentor-element__name" id="property_phpcsVersion">
         $phpcsVersion
-        <a href="#property_phpcsVersion" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_phpcsVersion" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="../files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">110</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">The PHPCS version the tests are being run on.</p>
 
@@ -437,6 +504,7 @@ the same directory and named the same as the test class, but with an
     <span class="phpdocumentor-signature__name">$phpcsVersion</span>
      = <span class="phpdocumentor-signature__default-value">&#039;0&#039;</span></code>
 
+    
     
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -449,8 +517,9 @@ the same directory and named the same as the test class, but with an
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -463,29 +532,32 @@ the same directory and named the same as the test class, but with an
 >
     <h4 class="phpdocumentor-element__name" id="property_selectedSniff">
         $selectedSniff
-        <a href="#property_selectedSniff" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_selectedSniff" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="../files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">169</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Set the name of a sniff to pass to PHPCS to limit the run (and force it to record errors).</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">protected</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$selectedSniff</span>
      = <span class="phpdocumentor-signature__default-value">[&#039;Dummy.Dummy.Dummy&#039;]</span></code>
 
         <section class="phpdocumentor-description"><p>Normally, this propery won't need to be overloaded, but for utility methods which record
 violations and contain fixers, setting a dummy sniff name equal to the sniff name passed
 in the error code for <code class="prettyprint">addError()</code>/<code class="prettyprint">addWarning()</code> during the test, will allow for testing
-the recording of these violations, as well as testing the fixer.</p></section>
+the recording of these violations, as well as testing the fixer.</p>
+</section>
 
+    
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -497,8 +569,9 @@ the recording of these violations, as well as testing the fixer.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -511,15 +584,16 @@ the recording of these violations, as well as testing the fixer.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_tabWidth">
         $tabWidth
-        <a href="#property_tabWidth" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_tabWidth" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="../files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">146</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">The tab width setting to use when tokenizing the file.</p>
 
@@ -529,8 +603,10 @@ the recording of these violations, as well as testing the fixer.</p></section>
     <span class="phpdocumentor-signature__name">$tabWidth</span>
      = <span class="phpdocumentor-signature__default-value">4</span></code>
 
-        <section class="phpdocumentor-description"><p>This allows for test case files to use a different tab width than the default.</p></section>
+        <section class="phpdocumentor-description"><p>This allows for test case files to use a different tab width than the default.</p>
+</section>
 
+    
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -542,8 +618,9 @@ the recording of these violations, as well as testing the fixer.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -552,7 +629,7 @@ the recording of these violations, as well as testing the fixer.</p></section>
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -562,20 +639,21 @@ the recording of these violations, as well as testing the fixer.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_expectPhpcsException">
         expectPhpcsException()
-        <a href="#method_expectPhpcsException" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_expectPhpcsException" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="../files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">389</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Helper method to tell PHPUnit to expect a PHPCS Exception in a PHPUnit and PHPCS cross-version
 compatible manner.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                <span class="phpdocumentor-signature__name">expectPhpcsException</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$msg</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$type</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">&#039;runtime&#039;</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
+                    <span class="phpdocumentor-signature__name">expectPhpcsException</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$msg</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$type</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">&#039;runtime&#039;</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -585,7 +663,8 @@ compatible manner.</p>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The expected exception message.</p></section>
+                    <section class="phpdocumentor-description"><p>The expected exception message.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -594,7 +673,8 @@ compatible manner.</p>
                  = <span class="phpdocumentor-signature__argument__default-value">&#039;runtime&#039;</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The PHPCS native exception type to expect. Either 'runtime' or 'tokenizer'.
-Defaults to 'runtime'.</p></section>
+Defaults to 'runtime'.</p>
+</section>
 
             </dd>
             </dl>
@@ -610,10 +690,15 @@ Defaults to 'runtime'.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">void</span>
+            &mdash;
+        
     
 </article>
                     <article
@@ -624,23 +709,25 @@ Defaults to 'runtime'.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getTargetToken">
         getTargetToken()
-        <a href="#method_getTargetToken" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_getTargetToken" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="../files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">331</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Get the token pointer for a target token based on a specific comment.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                <span class="phpdocumentor-signature__name">getTargetToken</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$commentString</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$tokenType</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$tokenContent</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int</span></code>
+                    <span class="phpdocumentor-signature__name">getTargetToken</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$commentString</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$tokenType</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$tokenContent</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int</span></code>
 
         <section class="phpdocumentor-description"><p>Note: the test delimiter comment MUST start with <code class="prettyprint">/* test</code> to allow this function to
 distinguish between comments used <em>in</em> a test and test delimiters.</p>
-<p>If the delimiter comment is not found, the test will automatically be failed.</p></section>
+<p>If the delimiter comment is not found, the test will automatically be failed.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -650,15 +737,17 @@ distinguish between comments used <em>in</em> a test and test delimiters.</p>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The complete delimiter comment to look for as a string.
-This string should include the comment opener and closer.</p></section>
+This string should include the comment opener and closer.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$tokenType</span>
-                : <span class="phpdocumentor-signature__argument__return-type">int|string|array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The type of token(s) to look for.</p></section>
+                    <section class="phpdocumentor-description"><p>The type of token(s) to look for.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -666,7 +755,8 @@ This string should include the comment opener and closer.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                  = <span class="phpdocumentor-signature__argument__default-value">null</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>Optional. The token content for the target token.</p></section>
+                    <section class="phpdocumentor-description"><p>Optional. The token content for the target token.</p>
+</section>
 
             </dd>
             </dl>
@@ -682,8 +772,9 @@ This string should include the comment opener and closer.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -700,22 +791,24 @@ This string should include the comment opener and closer.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_resetTestFile">
         resetTestFile()
-        <a href="#method_resetTestFile" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_resetTestFile" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="../files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">309</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Clean up after finished test.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">resetTestFile</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">resetTestFile</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
 
-        <section class="phpdocumentor-description"><p>Note: This is a PHPUnit cross-version compatible \PHPUnit\Framework\TestCase::tearDownAfterClass()
-method.</p></section>
+        <section class="phpdocumentor-description"><p>Note: This is a PHPUnit cross-version compatible <abbr title="\PHPUnit\Framework\TestCase::tearDownAfterClass()">TestCase::tearDownAfterClass()</abbr>
+method.</p>
+</section>
 
     
     
@@ -729,16 +822,22 @@ method.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">afterClass</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">void</span>
+            &mdash;
+        
     
 </article>
                     <article
@@ -749,26 +848,28 @@ method.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_setUpTestFile">
         setUpTestFile()
-        <a href="#method_setUpTestFile" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_setUpTestFile" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="../files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">188</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Initialize PHPCS &amp; tokenize the test case file.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">setUpTestFile</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">setUpTestFile</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
 
         <section class="phpdocumentor-description"><p>The test case file for a unit test class has to be in the same directory
 directory and use the same file name as the test class, using the <code class="prettyprint">.inc</code> extension
-or be explicitly set using the <a href="../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_fileExtension">\PHPCSUtils\TestUtils\UtilityMethodTestCase::$fileExtension</a>/
-<a href="../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_caseFile">\PHPCSUtils\TestUtils\UtilityMethodTestCase::$caseFile</a> properties.</p>
-<p>Note: This is a PHPUnit cross-version compatible \PHPUnit\Framework\TestCase::setUpBeforeClass()
-method.</p></section>
+or be explicitly set using the <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_fileExtension"><abbr title="\PHPCSUtils\TestUtils\UtilityMethodTestCase::$fileExtension">UtilityMethodTestCase::$fileExtension</abbr></a>/
+<a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_caseFile"><abbr title="\PHPCSUtils\TestUtils\UtilityMethodTestCase::$caseFile">UtilityMethodTestCase::$caseFile</abbr></a> properties.</p>
+<p>Note: This is a PHPUnit cross-version compatible <abbr title="\PHPUnit\Framework\TestCase::setUpBeforeClass()">TestCase::setUpBeforeClass()</abbr>
+method.</p>
+</section>
 
     
     
@@ -782,16 +883,22 @@ method.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">beforeClass</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">void</span>
+            &mdash;
+        
     
 </article>
                     <article
@@ -802,25 +909,27 @@ method.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_skipJSCSSTestsOnPHPCS4">
         skipJSCSSTestsOnPHPCS4()
-        <a href="#method_skipJSCSSTestsOnPHPCS4" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_skipJSCSSTestsOnPHPCS4" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="../files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php"><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">284</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Skip JS and CSS related tests on PHPCS 4.x.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                <span class="phpdocumentor-signature__name">skipJSCSSTestsOnPHPCS4</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
+                    <span class="phpdocumentor-signature__name">skipJSCSSTestsOnPHPCS4</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">void</span></code>
 
         <section class="phpdocumentor-description"><p>PHPCS 4.x drops support for the JS and CSS tokenizers.
 This method takes care of automatically skipping tests involving JS/CSS case files
 when the tests are being run with PHPCS 4.x.</p>
-<p>Note: This is a PHPUnit cross-version compatible \PHPUnit\Framework\TestCase::setUp()
-method.</p></section>
+<p>Note: This is a PHPUnit cross-version compatible <abbr title="\PHPUnit\Framework\TestCase::setUp()">TestCase::setUp()</abbr>
+method.</p>
+</section>
 
     
     
@@ -834,35 +943,112 @@ method.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">before</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">void</span>
+            &mdash;
+        
     
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Tokens-Collections.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Tokens-Collections.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -131,7 +135,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">26</span>
+    <span class="phpdocumentor-element-found-in__line">57</span>
 
     </aside>
 
@@ -175,6 +179,27 @@ native <abbr title="\PHP_CodeSniffer\Util\Tokens">Tokens</abbr> class.</p>
                                                                                 
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Dropped support for PHPCS &lt; 3.7.1.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Direct property access is deprecated for forward-compatibility reasons.
+Use the methods of the same name as the property instead.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
 
@@ -193,238 +218,476 @@ native <abbr title="\PHP_CodeSniffer\Util\Tokens">Tokens</abbr> class.</p>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Alternative control structure syntax closer keyword tokens.</dd>
+<dd>DEPRECATED: Tokens representing alternative control structure syntax closer keywords.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_alternativeControlStructureSyntaxTokens">$alternativeControlStructureSyntaxTokens</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Control structures which can use the alternative control structure syntax.</dd>
+<dd>DEPRECATED: Tokens for control structures which can use the alternative control structure syntax.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokens">$arrayTokens</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Tokens which are used to create arrays.</dd>
+<dd>DEPRECATED: Tokens which are used to create arrays.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokensBC">$arrayTokensBC</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Tokens which are used to create arrays.</dd>
+<dd>DEPRECATED: Tokens which are used to create arrays (PHPCS cross-version compatible).</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_classModifierKeywords">$classModifierKeywords</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Modifier keywords which can be used for a class declaration.</dd>
+<dd>DEPRECATED: Modifier keywords which can be used for a class declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_closedScopes">$closedScopes</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>List of tokens which represent &quot;closed&quot; scopes.</dd>
+<dd>DEPRECATED: List of tokens which represent &quot;closed&quot; scopes.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_controlStructureTokens">$controlStructureTokens</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Control structure tokens.</dd>
+<dd>DEPRECATED: Control structure tokens.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_incrementDecrementOperators">$incrementDecrementOperators</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Increment/decrement operator tokens.</dd>
+<dd>DEPRECATED: Increment/decrement operator tokens.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_listTokens">$listTokens</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Tokens which are used to create lists.</dd>
+<dd>DEPRECATED: Tokens which are used to create lists.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_listTokensBC">$listTokensBC</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Tokens which are used to create lists.</dd>
+<dd>DEPRECATED: Tokens which are used to create lists (PHPCS cross-version compatible).</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_magicConstants">$magicConstants</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Tokens for the PHP magic constants.</dd>
+<dd>DEPRECATED: Tokens for the PHP magic constants.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_namespaceDeclarationClosers">$namespaceDeclarationClosers</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>List of tokens which can end a namespace declaration statement.</dd>
+<dd>DEPRECATED: List of tokens which can end a namespace declaration statement.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_objectOperators">$objectOperators</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Object operators.</dd>
+<dd>DEPRECATED: Object operator tokens.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOCanExtend">$OOCanExtend</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>OO structures which can use the &quot;extends&quot; keyword.</dd>
+<dd>DEPRECATED: OO structures which can use the &quot;extends&quot; keyword.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOCanImplement">$OOCanImplement</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>OO structures which can use the &quot;implements&quot; keyword.</dd>
+<dd>DEPRECATED: OO structures which can use the &quot;implements&quot; keyword.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOConstantScopes">$OOConstantScopes</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>OO scopes in which constants can be declared.</dd>
+<dd>DEPRECATED: OO scopes in which constants can be declared.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOHierarchyKeywords">$OOHierarchyKeywords</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Tokens types used for &quot;forwarding&quot; calls within OO structures.</dd>
+<dd>DEPRECATED: Tokens types used for &quot;forwarding&quot; calls within OO structures.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OONameTokens">$OONameTokens</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Tokens types which can be encountered in the fully/partially qualified name of an OO structure.</dd>
+<dd>DEPRECATED: Tokens types which can be encountered in the fully/partially qualified name of an OO structure.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOPropertyScopes">$OOPropertyScopes</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>OO scopes in which properties can be declared.</dd>
+<dd>DEPRECATED: OO scopes in which properties can be declared.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_parameterTypeTokens">$parameterTypeTokens</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Token types which can be encountered in a parameter type declaration.</dd>
+<dd>DEPRECATED: Token types which can be encountered in a parameter type declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_propertyModifierKeywords">$propertyModifierKeywords</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Modifier keywords which can be used for a property declaration.</dd>
+<dd>DEPRECATED: Modifier keywords which can be used for a property declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_propertyTypeTokens">$propertyTypeTokens</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Token types which can be encountered in a property type declaration.</dd>
+<dd>DEPRECATED: Token types which can be encountered in a property type declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_returnTypeTokens">$returnTypeTokens</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Token types which can be encountered in a return type declaration.</dd>
+<dd>DEPRECATED: Token types which can be encountered in a return type declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokens">$shortArrayTokens</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Tokens which are used for short arrays.</dd>
+<dd>DEPRECATED: Tokens which are used for short arrays.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokensBC">$shortArrayTokensBC</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Tokens which are used for short arrays.</dd>
+<dd>DEPRECATED: Tokens which are used for short arrays (PHPCS cross-version compatible).</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokens">$shortListTokens</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Tokens which are used for short lists.</dd>
+<dd>DEPRECATED: Tokens which are used for short lists.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokensBC">$shortListTokensBC</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Tokens which are used for short lists.</dd>
+<dd>DEPRECATED: Tokens which are used for short lists (PHPCS cross-version compatible).</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#property_textStingStartTokens">$textStingStartTokens</a>
     <span>
                         &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
-<dd>Tokens which can start a - potentially multi-line - text string.</dd>
+<dd>DEPRECATED: Tokens which can start a - potentially multi-line - text string.</dd>
 
                 <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method___callStatic">__callStatic()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd>Handle calls to (undeclared) methods for token arrays which don&#039;t need special handling.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_alternativeControlStructureSyntaxClosers">alternativeControlStructureSyntaxClosers()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd>Tokens representing alternative control structure syntax closer keywords.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_alternativeControlStructureSyntaxes">alternativeControlStructureSyntaxes()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd>Tokens for control structures which can use the alternative control structure syntax.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_arrayOpenTokensBC">arrayOpenTokensBC()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_arrayTokens">arrayTokens()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_arrayTokensBC">arrayTokensBC()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#method_arrowFunctionTokensBC">arrowFunctionTokensBC()</a>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
-<dd>Tokens which can represent the arrow function keyword.</dd>
+<dd>DEPRECATED: Tokens which can represent the arrow function keyword.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_classModifierKeywords">classModifierKeywords()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_closedScopes">closedScopes()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_controlStructureTokens">controlStructureTokens()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionCallTokens">functionCallTokens()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd>Tokens which can represent function calls and function-call-like language constructs.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokens">functionDeclarationTokens()</a>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
-<dd>Tokens which can represent a keyword which starts a function declaration.</dd>
+<dd></dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokensBC">functionDeclarationTokensBC()</a>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
-<dd>Tokens which can represent a keyword which starts a function declaration.</dd>
+<dd>DEPRECATED: Tokens which represent a keyword which starts a function declaration.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_incrementDecrementOperators">incrementDecrementOperators()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_listTokens">listTokens()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_listTokensBC">listTokensBC()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_namespaceDeclarationClosers">namespaceDeclarationClosers()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_namespacedNameTokens">namespacedNameTokens()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd>Tokens types which can be encountered in a fully, partially or unqualified name.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_nameTokens">nameTokens()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_objectOperators">objectOperators()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooCanExtend">ooCanExtend()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd>OO structures which can use the &quot;extends&quot; keyword.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooCanImplement">ooCanImplement()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd>OO structures which can use the &quot;implements&quot; keyword.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooConstantScopes">ooConstantScopes()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd>OO scopes in which constants can be declared.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooHierarchyKeywords">ooHierarchyKeywords()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd>Tokens types used for &quot;forwarding&quot; calls within OO structures.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooPropertyScopes">ooPropertyScopes()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd>OO scopes in which properties can be declared.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_parameterPassingTokens">parameterPassingTokens()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd>Tokens which can be passed to the methods in the PassedParameter class.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_parameterTypeTokens">parameterTypeTokens()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd>Token types which can be encountered in a parameter type declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#method_parameterTypeTokensBC">parameterTypeTokensBC()</a>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
-<dd>Token types which can be encountered in a parameter type declaration (cross-version).</dd>
+<dd>DEPRECATED: Token types which can be encountered in a parameter type declaration (cross-version).</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_phpOpenTags">phpOpenTags()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_propertyModifierKeywords">propertyModifierKeywords()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_propertyTypeTokens">propertyTypeTokens()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd>Token types which can be encountered in a property type declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#method_propertyTypeTokensBC">propertyTypeTokensBC()</a>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
-<dd>Token types which can be encountered in a property type declaration (cross-version).</dd>
+<dd>DEPRECATED: Token types which can be encountered in a property type declaration (cross-version).</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokens">returnTypeTokens()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd>Token types which can be encountered in a return type declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokensBC">returnTypeTokensBC()</a>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
-<dd>Token types which can be encountered in a return type declaration (cross-version).</dd>
+<dd>DEPRECATED: Token types which can be encountered in a return type declaration (cross-version).</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_shortArrayListOpenTokensBC">shortArrayListOpenTokensBC()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_shortArrayTokens">shortArrayTokens()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_shortArrayTokensBC">shortArrayTokensBC()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_shortListTokens">shortListTokens()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_shortListTokensBC">shortListTokensBC()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_textStringStartTokens">textStringStartTokens()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd>Tokens which can start a - potentially multi-line - text string.</dd>
 
         </dl>
 
@@ -443,7 +706,7 @@ native <abbr title="\PHP_CodeSniffer\Util\Tokens">Tokens</abbr> class.</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_alternativeControlStructureSyntaxCloserTokens">
         $alternativeControlStructureSyntaxCloserTokens
@@ -454,13 +717,13 @@ native <abbr title="\PHP_CodeSniffer\Util\Tokens">Tokens</abbr> class.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">54</span>
+    <span class="phpdocumentor-element-found-in__line">91</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Alternative control structure syntax closer keyword tokens.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Tokens representing alternative control structure syntax closer keywords.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$alternativeControlStructureSyntaxCloserTokens</span>
@@ -484,6 +747,17 @@ native <abbr title="\PHP_CodeSniffer\Util\Tokens">Tokens</abbr> class.</p>
                                                                                 
                                              
                                     </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_alternativeControlStructureSyntaxClosers"><abbr title="\PHPCSUtils\Tokens\Collections::alternativeControlStructureSyntaxClosers()">Collections::alternativeControlStructureSyntaxClosers()</abbr></a>
+method instead.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
 </article>
@@ -492,7 +766,7 @@ native <abbr title="\PHP_CodeSniffer\Util\Tokens">Tokens</abbr> class.</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_alternativeControlStructureSyntaxTokens">
         $alternativeControlStructureSyntaxTokens
@@ -503,13 +777,13 @@ native <abbr title="\PHP_CodeSniffer\Util\Tokens">Tokens</abbr> class.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">36</span>
+    <span class="phpdocumentor-element-found-in__line">70</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Control structures which can use the alternative control structure syntax.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Tokens for control structures which can use the alternative control structure syntax.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$alternativeControlStructureSyntaxTokens</span>
@@ -533,6 +807,17 @@ native <abbr title="\PHP_CodeSniffer\Util\Tokens">Tokens</abbr> class.</p>
                                                                                 
                                              
                                     </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_alternativeControlStructureSyntaxes"><abbr title="\PHPCSUtils\Tokens\Collections::alternativeControlStructureSyntaxes()">Collections::alternativeControlStructureSyntaxes()</abbr></a>
+method instead.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
 </article>
@@ -541,7 +826,7 @@ native <abbr title="\PHP_CodeSniffer\Util\Tokens">Tokens</abbr> class.</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_arrayTokens">
         $arrayTokens
@@ -552,13 +837,13 @@ native <abbr title="\PHP_CodeSniffer\Util\Tokens">Tokens</abbr> class.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">73</span>
+    <span class="phpdocumentor-element-found-in__line">138</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens which are used to create arrays.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Tokens which are used to create arrays.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$arrayTokens</span>
@@ -578,9 +863,31 @@ native <abbr title="\PHP_CodeSniffer\Util\Tokens">Tokens</abbr> class.</p>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$shortArrayTokens">Collections::$shortArrayTokens</abbr></a></span>
+                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Tokens\Collections::arrayOpenTokensBC()">Collections::arrayOpenTokensBC()</abbr></span>
                                         
-                                                 <section class="phpdocumentor-description"><p>Related property containing only tokens used
+                                                 <section class="phpdocumentor-description"><p>Related method to retrieve only the &quot;open&quot; tokens
+used for arrays (PHPCS cross-version compatible).</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">see</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Tokens\Collections::arrayTokensBC()">Collections::arrayTokensBC()</abbr></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related method to retrieve tokens used
+for arrays (PHPCS cross-version compatible).</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">see</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Tokens\Collections::shortArrayTokens()">Collections::shortArrayTokens()</abbr></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related method to retrieve only tokens used
 for short arrays.</p>
 </section>
 
@@ -589,9 +896,19 @@ for short arrays.</p>
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
                                                                                 
                                              
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::arrayTokens()">Collections::arrayTokens()</abbr> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -601,7 +918,7 @@ for short arrays.</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_arrayTokensBC">
         $arrayTokensBC
@@ -612,19 +929,20 @@ for short arrays.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">92</span>
+    <span class="phpdocumentor-element-found-in__line">162</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens which are used to create arrays.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Tokens which are used to create arrays (PHPCS cross-version compatible).</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$arrayTokensBC</span>
      = <span class="phpdocumentor-signature__default-value">[\T_ARRAY =&gt; \T_ARRAY, \T_OPEN_SHORT_ARRAY =&gt; \T_OPEN_SHORT_ARRAY, \T_CLOSE_SHORT_ARRAY =&gt; \T_CLOSE_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET =&gt; \T_OPEN_SQUARE_BRACKET, \T_CLOSE_SQUARE_BRACKET =&gt; \T_CLOSE_SQUARE_BRACKET]</span></code>
 
-        <section class="phpdocumentor-description"><p>List which is backward-compatible with PHPCS &lt; 3.3.0.
+        <section class="phpdocumentor-description"><p>Includes <code class="prettyprint">T_OPEN_SQUARE_BRACKET</code> and <code class="prettyprint">T_CLOSE_SQUARE_BRACKET</code> to allow for handling
+intermittent tokenizer issues related to the retokenization to <code class="prettyprint">T_OPEN_SHORT_ARRAY</code>.
 Should only be used selectively.</p>
 </section>
 
@@ -641,10 +959,21 @@ Should only be used selectively.</p>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::$shortArrayTokensBC">Collections::$shortArrayTokensBC</abbr></a></span>
+                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Tokens\Collections::arrayOpenTokensBC()">Collections::arrayOpenTokensBC()</abbr></span>
                                         
-                                                 <section class="phpdocumentor-description"><p>Related property containing only tokens used
-for short arrays (cross-version).</p>
+                                                 <section class="phpdocumentor-description"><p>Related method to retrieve only the &quot;open&quot; tokens
+used for arrays (PHPCS cross-version compatible).</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">see</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Tokens\Collections::shortArrayTokensBC()">Collections::shortArrayTokensBC()</abbr></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related method to retrieve only tokens used
+for short arrays (PHPCS cross-version compatible).</p>
 </section>
 
                                     </dd>
@@ -652,9 +981,19 @@ for short arrays (cross-version).</p>
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
                                                                                 
                                              
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::arrayTokensBC()">Collections::arrayTokensBC()</abbr> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -664,7 +1003,7 @@ for short arrays (cross-version).</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_classModifierKeywords">
         $classModifierKeywords
@@ -675,17 +1014,17 @@ for short arrays (cross-version).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">107</span>
+    <span class="phpdocumentor-element-found-in__line">180</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Modifier keywords which can be used for a class declaration.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Modifier keywords which can be used for a class declaration.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$classModifierKeywords</span>
-     = <span class="phpdocumentor-signature__default-value">[\T_FINAL =&gt; \T_FINAL, \T_ABSTRACT =&gt; \T_ABSTRACT]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_FINAL =&gt; \T_FINAL, \T_ABSTRACT =&gt; \T_ABSTRACT, \T_READONLY =&gt; \T_READONLY]</span></code>
 
     
         <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
@@ -701,9 +1040,29 @@ for short arrays (cross-version).</p>
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
                                                                                 
                                              
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_READONLY token for PHP 8.2 readonly classes.</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::classModifierKeywords()">Collections::classModifierKeywords()</abbr> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -713,7 +1072,7 @@ for short arrays (cross-version).</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_closedScopes">
         $closedScopes
@@ -724,17 +1083,17 @@ for short arrays (cross-version).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">125</span>
+    <span class="phpdocumentor-element-found-in__line">202</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">List of tokens which represent &quot;closed&quot; scopes.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: List of tokens which represent &quot;closed&quot; scopes.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$closedScopes</span>
-     = <span class="phpdocumentor-signature__default-value">[\T_CLASS =&gt; \T_CLASS, \T_ANON_CLASS =&gt; \T_ANON_CLASS, \T_INTERFACE =&gt; \T_INTERFACE, \T_TRAIT =&gt; \T_TRAIT, \T_FUNCTION =&gt; \T_FUNCTION, \T_CLOSURE =&gt; \T_CLOSURE]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_CLASS =&gt; \T_CLASS, \T_ANON_CLASS =&gt; \T_ANON_CLASS, \T_INTERFACE =&gt; \T_INTERFACE, \T_TRAIT =&gt; \T_TRAIT, \T_ENUM =&gt; \T_ENUM, \T_FUNCTION =&gt; \T_FUNCTION, \T_CLOSURE =&gt; \T_CLOSURE]</span></code>
 
         <section class="phpdocumentor-description"><p>I.e. anything declared within that scope - except for other closed scopes - is
 outside of the global namespace.</p>
@@ -755,9 +1114,29 @@ within a namespace scope are still global and not limited to that namespace.</p>
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
                                                                                 
                                              
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the PHP 8.1 T_ENUM token.</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::closedScopes()">Collections::closedScopes()</abbr> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -767,7 +1146,7 @@ within a namespace scope are still global and not limited to that namespace.</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_controlStructureTokens">
         $controlStructureTokens
@@ -778,17 +1157,17 @@ within a namespace scope are still global and not limited to that namespace.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">141</span>
+    <span class="phpdocumentor-element-found-in__line">222</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Control structure tokens.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Control structure tokens.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$controlStructureTokens</span>
-     = <span class="phpdocumentor-signature__default-value">[\T_IF =&gt; \T_IF, \T_ELSEIF =&gt; \T_ELSEIF, \T_ELSE =&gt; \T_ELSE, \T_FOR =&gt; \T_FOR, \T_FOREACH =&gt; \T_FOREACH, \T_SWITCH =&gt; \T_SWITCH, \T_DO =&gt; \T_DO, \T_WHILE =&gt; \T_WHILE, \T_DECLARE =&gt; \T_DECLARE]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_IF =&gt; \T_IF, \T_ELSEIF =&gt; \T_ELSEIF, \T_ELSE =&gt; \T_ELSE, \T_FOR =&gt; \T_FOR, \T_FOREACH =&gt; \T_FOREACH, \T_SWITCH =&gt; \T_SWITCH, \T_DO =&gt; \T_DO, \T_WHILE =&gt; \T_WHILE, \T_DECLARE =&gt; \T_DECLARE, \T_MATCH =&gt; \T_MATCH]</span></code>
 
     
         <section class="phpdocumentor-description"><p><int> =&gt; <int></p>
@@ -808,6 +1187,26 @@ within a namespace scope are still global and not limited to that namespace.</p>
                                                                                 
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_MATCH token for PHP 8.0 match expressions.</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::controlStructureTokens()">Collections::controlStructureTokens()</abbr> method instead.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
 </article>
@@ -816,7 +1215,7 @@ within a namespace scope are still global and not limited to that namespace.</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_incrementDecrementOperators">
         $incrementDecrementOperators
@@ -827,13 +1226,13 @@ within a namespace scope are still global and not limited to that namespace.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">160</span>
+    <span class="phpdocumentor-element-found-in__line">257</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Increment/decrement operator tokens.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Increment/decrement operator tokens.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$incrementDecrementOperators</span>
@@ -857,6 +1256,16 @@ within a namespace scope are still global and not limited to that namespace.</p>
                                                                                 
                                              
                                     </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::incrementDecrementOperators()">Collections::incrementDecrementOperators()</abbr> method instead.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
 </article>
@@ -865,7 +1274,7 @@ within a namespace scope are still global and not limited to that namespace.</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_listTokens">
         $listTokens
@@ -876,13 +1285,13 @@ within a namespace scope are still global and not limited to that namespace.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">175</span>
+    <span class="phpdocumentor-element-found-in__line">276</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens which are used to create lists.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Tokens which are used to create lists.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$listTokens</span>
@@ -902,9 +1311,20 @@ within a namespace scope are still global and not limited to that namespace.</p>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$shortListTokens">Collections::$shortListTokens</abbr></a></span>
+                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Tokens\Collections::listTokensBC()">Collections::listTokensBC()</abbr></span>
                                         
-                                                 <section class="phpdocumentor-description"><p>Related property containing only tokens used
+                                                 <section class="phpdocumentor-description"><p>Related method to retrieve tokens used
+for lists (PHPCS cross-version).</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">see</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Tokens\Collections::shortListTokens()">Collections::shortListTokens()</abbr></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related method to retrieve only tokens used
 for short lists.</p>
 </section>
 
@@ -913,9 +1333,19 @@ for short lists.</p>
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
                                                                                 
                                              
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::listTokens()">Collections::listTokens()</abbr> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -925,7 +1355,7 @@ for short lists.</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_listTokensBC">
         $listTokensBC
@@ -936,19 +1366,20 @@ for short lists.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">194</span>
+    <span class="phpdocumentor-element-found-in__line">298</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens which are used to create lists.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Tokens which are used to create lists (PHPCS cross-version compatible).</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$listTokensBC</span>
      = <span class="phpdocumentor-signature__default-value">[\T_LIST =&gt; \T_LIST, \T_OPEN_SHORT_ARRAY =&gt; \T_OPEN_SHORT_ARRAY, \T_CLOSE_SHORT_ARRAY =&gt; \T_CLOSE_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET =&gt; \T_OPEN_SQUARE_BRACKET, \T_CLOSE_SQUARE_BRACKET =&gt; \T_CLOSE_SQUARE_BRACKET]</span></code>
 
-        <section class="phpdocumentor-description"><p>List which is backward-compatible with PHPCS &lt; 3.3.0.
+        <section class="phpdocumentor-description"><p>Includes <code class="prettyprint">T_OPEN_SQUARE_BRACKET</code> and <code class="prettyprint">T_CLOSE_SQUARE_BRACKET</code> to allow for handling
+intermittent tokenizer issues related to the retokenization to <code class="prettyprint">T_OPEN_SHORT_ARRAY</code>.
 Should only be used selectively.</p>
 </section>
 
@@ -965,9 +1396,9 @@ Should only be used selectively.</p>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::$shortListTokensBC">Collections::$shortListTokensBC</abbr></a></span>
+                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Tokens\Collections::shortListTokensBC()">Collections::shortListTokensBC()</abbr></span>
                                         
-                                                 <section class="phpdocumentor-description"><p>Related property containing only tokens used
+                                                 <section class="phpdocumentor-description"><p>Related method to retrieve only tokens used
 for short lists (cross-version).</p>
 </section>
 
@@ -976,9 +1407,19 @@ for short lists (cross-version).</p>
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
                                                                                 
                                              
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::listTokensBC()">Collections::listTokensBC()</abbr> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -988,7 +1429,7 @@ for short lists (cross-version).</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_magicConstants">
         $magicConstants
@@ -999,13 +1440,13 @@ for short lists (cross-version).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">211</span>
+    <span class="phpdocumentor-element-found-in__line">316</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens for the PHP magic constants.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Tokens for the PHP magic constants.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$magicConstants</span>
@@ -1022,20 +1463,23 @@ for short lists (cross-version).</p>
     </h5>
     <dl class="phpdocumentor-tag-list">
                                     <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">link</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.php.net/language.constants.predefined"> <p>PHP Manual on magic constants</p>
- </a>
-                    
-                                    </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
                                                                                 
                                              
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHP_CodeSniffer\Util\Tokens::$magicConstants">Tokens::$magicConstants</abbr> property
+or the <abbr title="\PHPCSUtils\BackCompat\BCTokens::magicConstants()">BCTokens::magicConstants()</abbr> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -1045,7 +1489,7 @@ for short lists (cross-version).</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_namespaceDeclarationClosers">
         $namespaceDeclarationClosers
@@ -1056,13 +1500,13 @@ for short lists (cross-version).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">229</span>
+    <span class="phpdocumentor-element-found-in__line">336</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">List of tokens which can end a namespace declaration statement.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: List of tokens which can end a namespace declaration statement.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$namespaceDeclarationClosers</span>
@@ -1082,9 +1526,19 @@ for short lists (cross-version).</p>
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
                                                                                 
                                              
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::namespaceDeclarationClosers()">Collections::namespaceDeclarationClosers()</abbr> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -1094,7 +1548,7 @@ for short lists (cross-version).</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_objectOperators">
         $objectOperators
@@ -1105,17 +1559,17 @@ for short lists (cross-version).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">242</span>
+    <span class="phpdocumentor-element-found-in__line">374</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Object operators.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Object operator tokens.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$objectOperators</span>
-     = <span class="phpdocumentor-signature__default-value">[\T_OBJECT_OPERATOR =&gt; \T_OBJECT_OPERATOR, \T_DOUBLE_COLON =&gt; \T_DOUBLE_COLON]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_DOUBLE_COLON =&gt; \T_DOUBLE_COLON, \T_OBJECT_OPERATOR =&gt; \T_OBJECT_OPERATOR, \T_NULLSAFE_OBJECT_OPERATOR =&gt; \T_NULLSAFE_OBJECT_OPERATOR]</span></code>
 
     
         <section class="phpdocumentor-description"><p><int> =&gt; <int></p>
@@ -1135,6 +1589,26 @@ for short lists (cross-version).</p>
                                                                                 
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the PHP 8.0 T_NULLSAFE_OBJECT_OPERATOR token.</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::objectOperators()">Collections::objectOperators()</abbr> method instead.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
 </article>
@@ -1143,7 +1617,7 @@ for short lists (cross-version).</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_OOCanExtend">
         $OOCanExtend
@@ -1154,13 +1628,13 @@ for short lists (cross-version).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">254</span>
+    <span class="phpdocumentor-element-found-in__line">389</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">OO structures which can use the &quot;extends&quot; keyword.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: OO structures which can use the &quot;extends&quot; keyword.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$OOCanExtend</span>
@@ -1180,9 +1654,19 @@ for short lists (cross-version).</p>
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
                                                                                 
                                              
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooCanExtend"><abbr title="\PHPCSUtils\Tokens\Collections::ooCanExtend()">Collections::ooCanExtend()</abbr></a> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -1192,7 +1676,7 @@ for short lists (cross-version).</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_OOCanImplement">
         $OOCanImplement
@@ -1203,17 +1687,17 @@ for short lists (cross-version).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">267</span>
+    <span class="phpdocumentor-element-found-in__line">405</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">OO structures which can use the &quot;implements&quot; keyword.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: OO structures which can use the &quot;implements&quot; keyword.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$OOCanImplement</span>
-     = <span class="phpdocumentor-signature__default-value">[\T_CLASS =&gt; \T_CLASS, \T_ANON_CLASS =&gt; \T_ANON_CLASS]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_CLASS =&gt; \T_CLASS, \T_ANON_CLASS =&gt; \T_ANON_CLASS, \T_ENUM =&gt; \T_ENUM]</span></code>
 
     
         <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
@@ -1229,9 +1713,29 @@ for short lists (cross-version).</p>
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
                                                                                 
                                              
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the PHP 8.1 T_ENUM token.</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooCanImplement"><abbr title="\PHPCSUtils\Tokens\Collections::ooCanImplement()">Collections::ooCanImplement()</abbr></a> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -1241,7 +1745,7 @@ for short lists (cross-version).</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_OOConstantScopes">
         $OOConstantScopes
@@ -1252,19 +1756,19 @@ for short lists (cross-version).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">281</span>
+    <span class="phpdocumentor-element-found-in__line">424</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">OO scopes in which constants can be declared.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: OO scopes in which constants can be declared.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$OOConstantScopes</span>
-     = <span class="phpdocumentor-signature__default-value">[\T_CLASS =&gt; \T_CLASS, \T_ANON_CLASS =&gt; \T_ANON_CLASS, \T_INTERFACE =&gt; \T_INTERFACE]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_CLASS =&gt; \T_CLASS, \T_ANON_CLASS =&gt; \T_ANON_CLASS, \T_INTERFACE =&gt; \T_INTERFACE, \T_ENUM =&gt; \T_ENUM, \T_TRAIT =&gt; \T_TRAIT]</span></code>
 
-        <section class="phpdocumentor-description"><p>Note: traits can not declare constants.</p>
+        <section class="phpdocumentor-description"><p>Note: traits can only declare constants since PHP 8.2.</p>
 </section>
 
         <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
@@ -1280,9 +1784,39 @@ for short lists (cross-version).</p>
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
                                                                                 
                                              
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the PHP 8.1 T_ENUM token.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TRAIT token for PHP 8.2 constants in traits.</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooConstantScopes"><abbr title="\PHPCSUtils\Tokens\Collections::ooConstantScopes()">Collections::ooConstantScopes()</abbr></a> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -1292,7 +1826,7 @@ for short lists (cross-version).</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_OOHierarchyKeywords">
         $OOHierarchyKeywords
@@ -1303,13 +1837,13 @@ for short lists (cross-version).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">296</span>
+    <span class="phpdocumentor-element-found-in__line">443</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens types used for &quot;forwarding&quot; calls within OO structures.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Tokens types used for &quot;forwarding&quot; calls within OO structures.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$OOHierarchyKeywords</span>
@@ -1341,6 +1875,16 @@ for short lists (cross-version).</p>
                                                                                 
                                              
                                     </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooHierarchyKeywords"><abbr title="\PHPCSUtils\Tokens\Collections::ooHierarchyKeywords()">Collections::ooHierarchyKeywords()</abbr></a> method instead.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
 </article>
@@ -1349,7 +1893,7 @@ for short lists (cross-version).</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_OONameTokens">
         $OONameTokens
@@ -1360,23 +1904,19 @@ for short lists (cross-version).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">314</span>
+    <span class="phpdocumentor-element-found-in__line">458</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens types which can be encountered in the fully/partially qualified name of an OO structure.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Tokens types which can be encountered in the fully/partially qualified name of an OO structure.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$OONameTokens</span>
      = <span class="phpdocumentor-signature__default-value">[\T_NS_SEPARATOR =&gt; \T_NS_SEPARATOR, \T_STRING =&gt; \T_STRING, \T_NAMESPACE =&gt; \T_NAMESPACE]</span></code>
 
-        <section class="phpdocumentor-description"><p>Example:</p>
-<pre class="prettyprint"><code class="language-php">echo namespace\Sub\ClassName::method();
-</code></pre>
-</section>
-
+    
         <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
 </section>
 
@@ -1394,6 +1934,16 @@ for short lists (cross-version).</p>
                                                                                 
                                              
                                     </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_namespacedNameTokens"><abbr title="\PHPCSUtils\Tokens\Collections::namespacedNameTokens()">Collections::namespacedNameTokens()</abbr></a> method instead.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
 </article>
@@ -1402,7 +1952,7 @@ for short lists (cross-version).</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_OOPropertyScopes">
         $OOPropertyScopes
@@ -1413,13 +1963,13 @@ for short lists (cross-version).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">329</span>
+    <span class="phpdocumentor-element-found-in__line">475</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">OO scopes in which properties can be declared.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: OO scopes in which properties can be declared.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$OOPropertyScopes</span>
@@ -1441,9 +1991,19 @@ for short lists (cross-version).</p>
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
                                                                                 
                                              
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooPropertyScopes"><abbr title="\PHPCSUtils\Tokens\Collections::ooPropertyScopes()">Collections::ooPropertyScopes()</abbr></a> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -1453,7 +2013,7 @@ for short lists (cross-version).</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_parameterTypeTokens">
         $parameterTypeTokens
@@ -1464,30 +2024,19 @@ for short lists (cross-version).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">355</span>
+    <span class="phpdocumentor-element-found-in__line">493</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Token types which can be encountered in a parameter type declaration.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Token types which can be encountered in a parameter type declaration.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$parameterTypeTokens</span>
-     = <span class="phpdocumentor-signature__default-value">[\T_CALLABLE =&gt; \T_CALLABLE, \T_SELF =&gt; \T_SELF, \T_PARENT =&gt; \T_PARENT, \T_STRING =&gt; \T_STRING, \T_NS_SEPARATOR =&gt; \T_NS_SEPARATOR]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_CALLABLE =&gt; \T_CALLABLE, \T_SELF =&gt; \T_SELF, \T_PARENT =&gt; \T_PARENT, \T_FALSE =&gt; \T_FALSE, \T_TRUE =&gt; \T_TRUE, \T_NULL =&gt; \T_NULL, \T_STRING =&gt; \T_STRING, \T_NS_SEPARATOR =&gt; \T_NS_SEPARATOR, \T_TYPE_UNION =&gt; \T_TYPE_UNION, \T_TYPE_INTERSECTION =&gt; \T_TYPE_INTERSECTION]</span></code>
 
-        <section class="phpdocumentor-description"><p>Sister-property to the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_parameterTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::parameterTypeTokensBC()">Collections::parameterTypeTokensBC()</abbr></a> method.
-The property supports PHPCS 3.3.0 and up.
-The method supports PHPCS 2.6.0 and up.</p>
-<p>Notable difference:</p>
-<ul>
-<li>The method will include the <code class="prettyprint">T_ARRAY_HINT</code> token when used with PHPCS 2.x and 3.x.
-This token constant will no longer exist in PHPCS 4.x.</li>
-</ul>
-<p>It is recommended to use the property instead of the method if a standard supports does
-not need to support PHPCS &lt; 3.3.0.</p>
-</section>
-
+    
         <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
 </section>
 
@@ -1498,22 +2047,52 @@ not need to support PHPCS &lt; 3.3.0.</p>
     </h5>
     <dl class="phpdocumentor-tag-list">
                                     <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">see</span>
+                    <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#method_parameterTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::parameterTypeTokensBC()">Collections::parameterTypeTokensBC()</abbr></a></span>
-                                        
-                                                 <section class="phpdocumentor-description"><p>Related method (cross-version).</p>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
+                                                                                
+                                             
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TRUE token for PHP 8.2 true type support.</p>
 </section>
 
                                     </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
+                    <span class="phpdocumentor-tag__name">deprecated</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
                                                                                 
-                                             
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::parameterTypeTokens()">Collections::parameterTypeTokens()</abbr> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -1523,7 +2102,7 @@ not need to support PHPCS &lt; 3.3.0.</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_propertyModifierKeywords">
         $propertyModifierKeywords
@@ -1534,17 +2113,17 @@ not need to support PHPCS &lt; 3.3.0.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">370</span>
+    <span class="phpdocumentor-element-found-in__line">528</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Modifier keywords which can be used for a property declaration.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Modifier keywords which can be used for a property declaration.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$propertyModifierKeywords</span>
-     = <span class="phpdocumentor-signature__default-value">[\T_PUBLIC =&gt; \T_PUBLIC, \T_PRIVATE =&gt; \T_PRIVATE, \T_PROTECTED =&gt; \T_PROTECTED, \T_STATIC =&gt; \T_STATIC, \T_VAR =&gt; \T_VAR]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_PUBLIC =&gt; \T_PUBLIC, \T_PRIVATE =&gt; \T_PRIVATE, \T_PROTECTED =&gt; \T_PROTECTED, \T_STATIC =&gt; \T_STATIC, \T_VAR =&gt; \T_VAR, \T_READONLY =&gt; \T_READONLY]</span></code>
 
     
         <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
@@ -1560,9 +2139,29 @@ not need to support PHPCS &lt; 3.3.0.</p>
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
                                                                                 
                                              
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_READONLY token for PHP 8.1 readonly properties.</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::propertyModifierKeywords()">Collections::propertyModifierKeywords()</abbr> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -1572,7 +2171,7 @@ not need to support PHPCS &lt; 3.3.0.</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_propertyTypeTokens">
         $propertyTypeTokens
@@ -1583,30 +2182,19 @@ not need to support PHPCS &lt; 3.3.0.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">398</span>
+    <span class="phpdocumentor-element-found-in__line">549</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Token types which can be encountered in a property type declaration.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Token types which can be encountered in a property type declaration.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$propertyTypeTokens</span>
-     = <span class="phpdocumentor-signature__default-value">[\T_CALLABLE =&gt; \T_CALLABLE, \T_SELF =&gt; \T_SELF, \T_PARENT =&gt; \T_PARENT, \T_STRING =&gt; \T_STRING, \T_NS_SEPARATOR =&gt; \T_NS_SEPARATOR]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_CALLABLE =&gt; \T_CALLABLE, \T_SELF =&gt; \T_SELF, \T_PARENT =&gt; \T_PARENT, \T_FALSE =&gt; \T_FALSE, \T_TRUE =&gt; \T_TRUE, \T_NULL =&gt; \T_NULL, \T_STRING =&gt; \T_STRING, \T_NS_SEPARATOR =&gt; \T_NS_SEPARATOR, \T_TYPE_UNION =&gt; \T_TYPE_UNION, \T_TYPE_INTERSECTION =&gt; \T_TYPE_INTERSECTION]</span></code>
 
-        <section class="phpdocumentor-description"><p>Sister-property to the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_propertyTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::propertyTypeTokensBC()">Collections::propertyTypeTokensBC()</abbr></a> method.
-The property supports PHPCS 3.3.0 and up.
-The method supports PHPCS 2.6.0 and up.</p>
-<p>Notable difference:</p>
-<ul>
-<li>The method will include the <code class="prettyprint">T_ARRAY_HINT</code> token when used with PHPCS 2.x and 3.x.
-This token constant will no longer exist in PHPCS 4.x.</li>
-</ul>
-<p>It is recommended to use the property instead of the method if a standard supports does
-not need to support PHPCS &lt; 3.3.0.</p>
-</section>
-
+    
         <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
 </section>
 
@@ -1617,22 +2205,52 @@ not need to support PHPCS &lt; 3.3.0.</p>
     </h5>
     <dl class="phpdocumentor-tag-list">
                                     <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">see</span>
+                    <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#method_propertyTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::propertyTypeTokensBC()">Collections::propertyTypeTokensBC()</abbr></a></span>
-                                        
-                                                 <section class="phpdocumentor-description"><p>Related method (cross-version).</p>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
+                                                                                
+                                             
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TRUE token for PHP 8.2 true type support.</p>
 </section>
 
                                     </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
+                    <span class="phpdocumentor-tag__name">deprecated</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
                                                                                 
-                                             
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::propertyTypeTokens()">Collections::propertyTypeTokens()</abbr> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -1642,7 +2260,7 @@ not need to support PHPCS &lt; 3.3.0.</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_returnTypeTokens">
         $returnTypeTokens
@@ -1653,31 +2271,19 @@ not need to support PHPCS &lt; 3.3.0.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">427</span>
+    <span class="phpdocumentor-element-found-in__line">574</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Token types which can be encountered in a return type declaration.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Token types which can be encountered in a return type declaration.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$returnTypeTokens</span>
-     = <span class="phpdocumentor-signature__default-value">[\T_STRING =&gt; \T_STRING, \T_CALLABLE =&gt; \T_CALLABLE, \T_SELF =&gt; \T_SELF, \T_PARENT =&gt; \T_PARENT, \T_STATIC =&gt; \T_STATIC, \T_NS_SEPARATOR =&gt; \T_NS_SEPARATOR]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_CALLABLE =&gt; \T_CALLABLE, \T_SELF =&gt; \T_SELF, \T_PARENT =&gt; \T_PARENT, \T_STATIC =&gt; \T_STATIC, \T_FALSE =&gt; \T_FALSE, \T_TRUE =&gt; \T_TRUE, \T_NULL =&gt; \T_NULL, \T_STRING =&gt; \T_STRING, \T_NS_SEPARATOR =&gt; \T_NS_SEPARATOR, \T_TYPE_UNION =&gt; \T_TYPE_UNION, \T_TYPE_INTERSECTION =&gt; \T_TYPE_INTERSECTION]</span></code>
 
-        <section class="phpdocumentor-description"><p>Sister-property to the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::returnTypeTokensBC()">Collections::returnTypeTokensBC()</abbr></a> method.
-The property supports PHPCS 3.5.4 and up.
-The method supports PHPCS 2.6.0 and up.</p>
-<p>Notable differences:</p>
-<ul>
-<li>The method will include the <code class="prettyprint">T_ARRAY_HINT</code> and the <code class="prettyprint">T_RETURN_TYPE</code> tokens when used with PHPCS 2.x and 3.x.
-These token constants will no longer exist in PHPCS 4.x.</li>
-<li>The method will include the <code class="prettyprint">T_ARRAY</code> token which is needed for select arrow functions in PHPCS &lt; 3.5.4.</li>
-</ul>
-<p>It is recommended to use the property instead of the method if a standard supports does
-not need to support PHPCS &lt; 3.5.4.</p>
-</section>
-
+    
         <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
 </section>
 
@@ -1688,22 +2294,52 @@ not need to support PHPCS &lt; 3.5.4.</p>
     </h5>
     <dl class="phpdocumentor-tag-list">
                                     <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">see</span>
+                    <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::returnTypeTokensBC()">Collections::returnTypeTokensBC()</abbr></a></span>
-                                        
-                                                 <section class="phpdocumentor-description"><p>Related method (cross-version).</p>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
+                                                                                
+                                             
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TRUE token for PHP 8.2 true type support.</p>
 </section>
 
                                     </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
+                    <span class="phpdocumentor-tag__name">deprecated</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
                                                                                 
-                                             
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::returnTypeTokens()">Collections::returnTypeTokens()</abbr> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -1713,7 +2349,7 @@ not need to support PHPCS &lt; 3.5.4.</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_shortArrayTokens">
         $shortArrayTokens
@@ -1724,13 +2360,13 @@ not need to support PHPCS &lt; 3.5.4.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">445</span>
+    <span class="phpdocumentor-element-found-in__line">615</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens which are used for short arrays.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Tokens which are used for short arrays.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$shortArrayTokens</span>
@@ -1750,9 +2386,9 @@ not need to support PHPCS &lt; 3.5.4.</p>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$arrayTokens">Collections::$arrayTokens</abbr></a></span>
+                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Tokens\Collections::arrayTokens()">Collections::arrayTokens()</abbr></span>
                                         
-                                                 <section class="phpdocumentor-description"><p>Related property containing all tokens used for arrays.</p>
+                                                 <section class="phpdocumentor-description"><p>Related method to retrieve all tokens used for arrays.</p>
 </section>
 
                                     </dd>
@@ -1760,9 +2396,19 @@ not need to support PHPCS &lt; 3.5.4.</p>
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
                                                                                 
                                              
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::shortArrayTokens()">Collections::shortArrayTokens()</abbr> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -1772,7 +2418,7 @@ not need to support PHPCS &lt; 3.5.4.</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_shortArrayTokensBC">
         $shortArrayTokensBC
@@ -1783,19 +2429,20 @@ not need to support PHPCS &lt; 3.5.4.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">463</span>
+    <span class="phpdocumentor-element-found-in__line">636</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens which are used for short arrays.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Tokens which are used for short arrays (PHPCS cross-version compatible).</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$shortArrayTokensBC</span>
      = <span class="phpdocumentor-signature__default-value">[\T_OPEN_SHORT_ARRAY =&gt; \T_OPEN_SHORT_ARRAY, \T_CLOSE_SHORT_ARRAY =&gt; \T_CLOSE_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET =&gt; \T_OPEN_SQUARE_BRACKET, \T_CLOSE_SQUARE_BRACKET =&gt; \T_CLOSE_SQUARE_BRACKET]</span></code>
 
-        <section class="phpdocumentor-description"><p>List which is backward-compatible with PHPCS &lt; 3.3.0.
+        <section class="phpdocumentor-description"><p>Includes <code class="prettyprint">T_OPEN_SQUARE_BRACKET</code> and <code class="prettyprint">T_CLOSE_SQUARE_BRACKET</code> to allow for handling
+intermittent tokenizer issues related to the retokenization to <code class="prettyprint">T_OPEN_SHORT_ARRAY</code>.
 Should only be used selectively.</p>
 </section>
 
@@ -1812,9 +2459,9 @@ Should only be used selectively.</p>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::$arrayTokensBC">Collections::$arrayTokensBC</abbr></a></span>
+                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Tokens\Collections::arrayTokensBC()">Collections::arrayTokensBC()</abbr></span>
                                         
-                                                 <section class="phpdocumentor-description"><p>Related property containing all tokens used for arrays
+                                                 <section class="phpdocumentor-description"><p>Related method to retrieve all tokens used for arrays
 (cross-version).</p>
 </section>
 
@@ -1823,9 +2470,19 @@ Should only be used selectively.</p>
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
                                                                                 
                                              
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::shortArrayTokensBC()">Collections::shortArrayTokensBC()</abbr> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -1835,7 +2492,7 @@ Should only be used selectively.</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_shortListTokens">
         $shortListTokens
@@ -1846,13 +2503,13 @@ Should only be used selectively.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">479</span>
+    <span class="phpdocumentor-element-found-in__line">654</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens which are used for short lists.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Tokens which are used for short lists.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$shortListTokens</span>
@@ -1872,9 +2529,9 @@ Should only be used selectively.</p>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_listTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$listTokens">Collections::$listTokens</abbr></a></span>
+                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Tokens\Collections::listTokens()">Collections::listTokens()</abbr></span>
                                         
-                                                 <section class="phpdocumentor-description"><p>Related property containing all tokens used for lists.</p>
+                                                 <section class="phpdocumentor-description"><p>Related method to retrieve all tokens used for lists.</p>
 </section>
 
                                     </dd>
@@ -1882,9 +2539,19 @@ Should only be used selectively.</p>
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
                                                                                 
                                              
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::shortListTokens()">Collections::shortListTokens()</abbr> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -1894,7 +2561,7 @@ Should only be used selectively.</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_shortListTokensBC">
         $shortListTokensBC
@@ -1905,19 +2572,20 @@ Should only be used selectively.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">497</span>
+    <span class="phpdocumentor-element-found-in__line">675</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens which are used for short lists.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Tokens which are used for short lists (PHPCS cross-version compatible).</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$shortListTokensBC</span>
      = <span class="phpdocumentor-signature__default-value">[\T_OPEN_SHORT_ARRAY =&gt; \T_OPEN_SHORT_ARRAY, \T_CLOSE_SHORT_ARRAY =&gt; \T_CLOSE_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET =&gt; \T_OPEN_SQUARE_BRACKET, \T_CLOSE_SQUARE_BRACKET =&gt; \T_CLOSE_SQUARE_BRACKET]</span></code>
 
-        <section class="phpdocumentor-description"><p>List which is backward-compatible with PHPCS &lt; 3.3.0.
+        <section class="phpdocumentor-description"><p>Includes <code class="prettyprint">T_OPEN_SQUARE_BRACKET</code> and <code class="prettyprint">T_CLOSE_SQUARE_BRACKET</code> to allow for handling
+intermittent tokenizer issues related to the retokenization to <code class="prettyprint">T_OPEN_SHORT_ARRAY</code>.
 Should only be used selectively.</p>
 </section>
 
@@ -1934,9 +2602,9 @@ Should only be used selectively.</p>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_listTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::$listTokensBC">Collections::$listTokensBC</abbr></a></span>
+                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Tokens\Collections::listTokensBC()">Collections::listTokensBC()</abbr></span>
                                         
-                                                 <section class="phpdocumentor-description"><p>Related property containing all tokens used for lists
+                                                 <section class="phpdocumentor-description"><p>Related method to retrieve all tokens used for lists
 (cross-version).</p>
 </section>
 
@@ -1945,9 +2613,19 @@ Should only be used selectively.</p>
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
                                                                                 
                                              
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::shortListTokensBC()">Collections::shortListTokensBC()</abbr> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -1957,7 +2635,7 @@ Should only be used selectively.</p>
             phpdocumentor-element
             -property
             -public
-            -static                                            "
+            -static            -deprecated                                "
 >
     <h4 class="phpdocumentor-element__name" id="property_textStingStartTokens">
         $textStingStartTokens
@@ -1968,13 +2646,13 @@ Should only be used selectively.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">511</span>
+    <span class="phpdocumentor-element-found-in__line">691</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens which can start a - potentially multi-line - text string.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Tokens which can start a - potentially multi-line - text string.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
     <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$textStingStartTokens</span>
@@ -1994,9 +2672,19 @@ Should only be used selectively.</p>
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha1</span>
                                                                                 
                                              
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_textStringStartTokens"><abbr title="\PHPCSUtils\Tokens\Collections::textStringStartTokens()">Collections::textStringStartTokens()</abbr></a> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -2014,6 +2702,294 @@ Should only be used selectively.</p>
             -public
                                     -static                    "
 >
+    <h4 class="phpdocumentor-element__name" id="method___callStatic">
+        __callStatic()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method___callStatic" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">711</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Handle calls to (undeclared) methods for token arrays which don&#039;t need special handling.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">__callStatic</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$args</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$name</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The name of the method which has been called.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$args</span>
+                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Any arguments passed to the method.
+Unused as none of the methods take arguments.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">throws</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Exceptions-InvalidTokenArray.html"><abbr title="\PHPCSUtils\Exceptions\InvalidTokenArray">InvalidTokenArray</abbr></a></span>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>When an invalid token array is requested.</p>
+</section>
+
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt; Token array</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_alternativeControlStructureSyntaxClosers">
+        alternativeControlStructureSyntaxClosers()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_alternativeControlStructureSyntaxClosers" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">768</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Tokens representing alternative control structure syntax closer keywords.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">alternativeControlStructureSyntaxClosers</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+    
+    
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>This method replaces the <a href="classes/PHPCSUtils-Tokens-Collections.html#property_alternativeControlStructureSyntaxCloserTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$alternativeControlStructureSyntaxCloserTokens">Collections::$alternativeControlStructureSyntaxCloserTokens</abbr></a>
+property.</p>
+</section>
+
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p><int> =&gt; <int></p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_alternativeControlStructureSyntaxes">
+        alternativeControlStructureSyntaxes()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_alternativeControlStructureSyntaxes" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">755</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Tokens for control structures which can use the alternative control structure syntax.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">alternativeControlStructureSyntaxes</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+    
+    
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>This method replaces the <a href="classes/PHPCSUtils-Tokens-Collections.html#property_alternativeControlStructureSyntaxTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$alternativeControlStructureSyntaxTokens">Collections::$alternativeControlStructureSyntaxTokens</abbr></a>
+property.</p>
+</section>
+
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p><int> =&gt; <int></p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_arrayOpenTokensBC">
+        arrayOpenTokensBC()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_arrayOpenTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">arrayOpenTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Tokens which can open an array (PHPCS cross-version compatible).</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_arrayTokens">
+        arrayTokens()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_arrayTokens" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">arrayTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Tokens which are used to create arrays.</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_arrayTokensBC">
+        arrayTokensBC()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_arrayTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">arrayTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Tokens which are used to create arrays
+(PHPCS cross-version compatible).</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+            -deprecated                        -static                    "
+>
     <h4 class="phpdocumentor-element__name" id="method_arrowFunctionTokensBC">
         arrowFunctionTokensBC()
         <a href="classes/PHPCSUtils-Tokens-Collections.html#method_arrowFunctionTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
@@ -2021,19 +2997,17 @@ Should only be used selectively.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">527</span>
+    <span class="phpdocumentor-element-found-in__line">782</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens which can represent the arrow function keyword.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Tokens which can represent the arrow function keyword.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">arrowFunctionTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Note: this is a method, not a property as the <code class="prettyprint">T_FN</code> token for arrow functions may not exist.</p>
-</section>
-
+    
     
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -2046,6 +3020,177 @@ Should only be used selectively.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
+                                                                                
+                                             
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <code class="prettyprint">T_FN</code> token constant instead.</p>
+</section>
+
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_classModifierKeywords">
+        classModifierKeywords()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_classModifierKeywords" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">classModifierKeywords</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Modifier keywords which can be used for a class declaration.</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_closedScopes">
+        closedScopes()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_closedScopes" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">closedScopes</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>List of tokens which represent &quot;closed&quot; scopes.</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_controlStructureTokens">
+        controlStructureTokens()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_controlStructureTokens" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">controlStructureTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Control structure tokens.</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_functionCallTokens">
+        functionCallTokens()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionCallTokens" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">798</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Tokens which can represent function calls and function-call-like language constructs.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">functionCallTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+    
+    
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">see</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#method_parameterPassingTokens"><abbr title="\PHPCSUtils\Tokens\Collections::parameterPassingTokens()">Collections::parameterPassingTokens()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related method.</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
                                                                                 
                                              
                                     </dd>
@@ -2072,62 +3217,33 @@ Should only be used selectively.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">556</span>
+    <span class="phpdocumentor-element-found-in__line">0</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens which can represent a keyword which starts a function declaration.</p>
-
+    
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">functionDeclarationTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Note: this is a method, not a property as the <code class="prettyprint">T_FN</code> token for arrow functions may not exist.</p>
-<p>Sister-method to the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::functionDeclarationTokensBC()">Collections::functionDeclarationTokensBC()</abbr></a> method.
-This  method supports PHPCS 3.5.3 and up.
-The <a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::functionDeclarationTokensBC()">Collections::functionDeclarationTokensBC()</abbr></a> method supports PHPCS 2.6.0 and up.</p>
+        <section class="phpdocumentor-description"><p>Tokens which represent a keyword which starts
+a function declaration.</p>
 </section>
 
     
     
-    <h5 class="phpdocumentor-tag-list__heading" id="tags">
-        Tags
-        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
-    </h5>
-    <dl class="phpdocumentor-tag-list">
-                                    <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">see</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::functionDeclarationTokensBC()">Collections::functionDeclarationTokensBC()</abbr></a></span>
-                                        
-                                                 <section class="phpdocumentor-description"><p>Related method (PHPCS 2.6.0+).</p>
-</section>
-
-                                    </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                
-                                             
-                                    </dd>
-                        </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
-</section>
-
+        
     
 </article>
                     <article
         class="phpdocumentor-element
             -method
             -public
-                                    -static                    "
+            -deprecated                        -static                    "
 >
     <h4 class="phpdocumentor-element__name" id="method_functionDeclarationTokensBC">
         functionDeclarationTokensBC()
@@ -2136,29 +3252,215 @@ The <a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarati
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">597</span>
+    <span class="phpdocumentor-element-found-in__line">820</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Tokens which can represent a keyword which starts a function declaration.</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Tokens which represent a keyword which starts a function declaration.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">functionDeclarationTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Note: this is a method, not a property as the <code class="prettyprint">T_FN</code> token for arrow functions may not exist.</p>
-<p>Sister-method to the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokens"><abbr title="\PHPCSUtils\Tokens\Collections::functionDeclarationTokens()">Collections::functionDeclarationTokens()</abbr></a> method.
-The <a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokens"><abbr title="\PHPCSUtils\Tokens\Collections::functionDeclarationTokens()">Collections::functionDeclarationTokens()</abbr></a> method supports PHPCS 3.5.3 and up.
-This method supports PHPCS 2.6.0 and up.</p>
-<p>Notable difference:</p>
-<ul>
-<li>This method accounts for when the <code class="prettyprint">T_FN</code> token doesn't exist.</li>
-</ul>
-<p>Note: if this method is used, the <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isArrowFunction"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction()">FunctionDeclarations::isArrowFunction()</abbr></a>
-method needs to be used on arrow function tokens to verify whether it really is an arrow function
-declaration or not.</p>
-<p>It is recommended to use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokens"><abbr title="\PHPCSUtils\Tokens\Collections::functionDeclarationTokens()">Collections::functionDeclarationTokens()</abbr></a> method instead of
-this method if a standard supports does not need to support PHPCS &lt; 3.5.3.</p>
+    
+    
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
+                                                                                
+                                             
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::functionDeclarationTokens()">Collections::functionDeclarationTokens()</abbr> method instead.</p>
+</section>
+
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_incrementDecrementOperators">
+        incrementDecrementOperators()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_incrementDecrementOperators" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">incrementDecrementOperators</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Increment/decrement operator tokens.</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_listTokens">
+        listTokens()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_listTokens" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">listTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Tokens which are used to create lists.</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_listTokensBC">
+        listTokensBC()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_listTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">listTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Tokens which are used to create lists
+(PHPCS cross-version compatible)</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_namespaceDeclarationClosers">
+        namespaceDeclarationClosers()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_namespaceDeclarationClosers" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">namespaceDeclarationClosers</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>List of tokens which can end a namespace declaration statement.</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_namespacedNameTokens">
+        namespacedNameTokens()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_namespacedNameTokens" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">843</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Tokens types which can be encountered in a fully, partially or unqualified name.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">namespacedNameTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Example:</p>
+<pre class="prettyprint"><code class="language-php">echo namespace\Sub\ClassName::method();
+</code></pre>
 </section>
 
     
@@ -2169,30 +3471,10 @@ this method if a standard supports does not need to support PHPCS &lt; 3.5.3.</p
     </h5>
     <dl class="phpdocumentor-tag-list">
                                     <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">see</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokens"><abbr title="\PHPCSUtils\Tokens\Collections::functionDeclarationTokens()">Collections::functionDeclarationTokens()</abbr></a></span>
-                                        
-                                                 <section class="phpdocumentor-description"><p>Related method (PHPCS 3.5.3+).</p>
-</section>
-
-                                    </dd>
-                            <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">see</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isArrowFunction"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction()">FunctionDeclarations::isArrowFunction()</abbr></a></span>
-                                        
-                                                 <section class="phpdocumentor-description"><p>Arrow function verification.</p>
-</section>
-
-                                    </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
                                                                                 
                                              
                                     </dd>
@@ -2211,6 +3493,520 @@ this method if a standard supports does not need to support PHPCS &lt; 3.5.3.</p
             -method
             -public
                                     -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_nameTokens">
+        nameTokens()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_nameTokens" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">nameTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Tokens used for &quot;names&quot;, be it namespace, OO, function
+or constant names.</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_objectOperators">
+        objectOperators()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_objectOperators" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">objectOperators</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Object operator tokens.</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_ooCanExtend">
+        ooCanExtend()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooCanExtend" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">862</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">OO structures which can use the &quot;extends&quot; keyword.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">ooCanExtend</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+    
+    
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>This method replaces the <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOCanExtend"><abbr title="\PHPCSUtils\Tokens\Collections::$OOCanExtend">Collections::$OOCanExtend</abbr></a> property.</p>
+</section>
+
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_ooCanImplement">
+        ooCanImplement()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooCanImplement" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">875</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">OO structures which can use the &quot;implements&quot; keyword.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">ooCanImplement</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+    
+    
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>This method replaces the <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOCanImplement"><abbr title="\PHPCSUtils\Tokens\Collections::$OOCanImplement">Collections::$OOCanImplement</abbr></a> property.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the PHP 8.1 T_ENUM token.</p>
+</section>
+
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_ooConstantScopes">
+        ooConstantScopes()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooConstantScopes" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">891</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">OO scopes in which constants can be declared.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">ooConstantScopes</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Note: traits can only declare constants since PHP 8.2.</p>
+</section>
+
+    
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>This method replaces the <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOConstantScopes"><abbr title="\PHPCSUtils\Tokens\Collections::$OOConstantScopes">Collections::$OOConstantScopes</abbr></a> property.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the PHP 8.1 T_ENUM token.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TRAIT token for PHP 8.2 constants in traits.</p>
+</section>
+
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_ooHierarchyKeywords">
+        ooHierarchyKeywords()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooHierarchyKeywords" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">905</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Tokens types used for &quot;forwarding&quot; calls within OO structures.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">ooHierarchyKeywords</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+    
+    
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.php.net/language.oop5.paamayim-nekudotayim"> <p>PHP Manual on OO forwarding calls</p>
+ </a>
+                    
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>This method replaces the <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOHierarchyKeywords"><abbr title="\PHPCSUtils\Tokens\Collections::$OOHierarchyKeywords">Collections::$OOHierarchyKeywords</abbr></a> property.</p>
+</section>
+
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_ooPropertyScopes">
+        ooPropertyScopes()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooPropertyScopes" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">919</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">OO scopes in which properties can be declared.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">ooPropertyScopes</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Note: interfaces can not declare properties.</p>
+</section>
+
+    
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>This method replaces the <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOPropertyScopes"><abbr title="\PHPCSUtils\Tokens\Collections::$OOPropertyScopes">Collections::$OOPropertyScopes</abbr></a> property.</p>
+</section>
+
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_parameterPassingTokens">
+        parameterPassingTokens()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_parameterPassingTokens" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">933</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Tokens which can be passed to the methods in the PassedParameter class.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">parameterPassingTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+    
+    
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">see</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-PassedParameters.html"><abbr title="\PHPCSUtils\Utils\PassedParameters">PassedParameters</abbr></a></span>
+                                        
+                                             
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_parameterTypeTokens">
+        parameterTypeTokens()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_parameterTypeTokens" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">959</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Token types which can be encountered in a parameter type declaration.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">parameterTypeTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+    
+    
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>This method replaces the <a href="classes/PHPCSUtils-Tokens-Collections.html#property_parameterTypeTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$parameterTypeTokens">Collections::$parameterTypeTokens</abbr></a> property.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 identifier name tokens.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TRUE token for PHP 8.2 true type support.</p>
+</section>
+
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+            -deprecated                        -static                    "
 >
     <h4 class="phpdocumentor-element__name" id="method_parameterTypeTokensBC">
         parameterTypeTokensBC()
@@ -2219,28 +4015,17 @@ this method if a standard supports does not need to support PHPCS &lt; 3.5.3.</p
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">629</span>
+    <span class="phpdocumentor-element-found-in__line">978</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Token types which can be encountered in a parameter type declaration (cross-version).</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Token types which can be encountered in a parameter type declaration (cross-version).</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">parameterTypeTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Sister-method to the <a href="classes/PHPCSUtils-Tokens-Collections.html#property_parameterTypeTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$parameterTypeTokens">Collections::$parameterTypeTokens</abbr></a> property.
-The property supports PHPCS 3.3.0 and up.
-The method supports PHPCS 2.6.0 and up.</p>
-<p>Notable difference:</p>
-<ul>
-<li>The method will include the <code class="prettyprint">T_ARRAY_HINT</code> token when used with PHPCS 2.x and 3.x.
-This token constant will no longer exist in PHPCS 4.x.</li>
-</ul>
-<p>It is recommended to use the property instead of the method if a standard supports does
-not need to support PHPCS &lt; 3.3.0.</p>
-</section>
-
+    
     
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -2252,9 +4037,9 @@ not need to support PHPCS &lt; 3.3.0.</p>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_parameterTypeTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$parameterTypeTokens">Collections::$parameterTypeTokens</abbr></a></span>
+                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Tokens\Collections::parameterTypeTokens()">Collections::parameterTypeTokens()</abbr></span>
                                         
-                                                 <section class="phpdocumentor-description"><p>Related property (PHPCS 3.3.0+).</p>
+                                                 <section class="phpdocumentor-description"><p>Related method (PHPCS 3.3.0+).</p>
 </section>
 
                                     </dd>
@@ -2265,6 +4050,16 @@ not need to support PHPCS &lt; 3.3.0.</p>
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
                                                                                 
                                              
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::parameterTypeTokens()">Collections::parameterTypeTokens()</abbr> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -2281,6 +4076,165 @@ not need to support PHPCS &lt; 3.3.0.</p>
             -method
             -public
                                     -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_phpOpenTags">
+        phpOpenTags()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_phpOpenTags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">phpOpenTags</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Tokens which open PHP.</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_propertyModifierKeywords">
+        propertyModifierKeywords()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_propertyModifierKeywords" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">propertyModifierKeywords</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Modifier keywords which can be used for a property declaration.</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_propertyTypeTokens">
+        propertyTypeTokens()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_propertyTypeTokens" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">1000</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Token types which can be encountered in a property type declaration.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">propertyTypeTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+    
+    
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>This method replaces the <a href="classes/PHPCSUtils-Tokens-Collections.html#property_propertyTypeTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$propertyTypeTokens">Collections::$propertyTypeTokens</abbr></a> property.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 identifier name tokens.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TRUE token for PHP 8.2 true type support.</p>
+</section>
+
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+            -deprecated                        -static                    "
 >
     <h4 class="phpdocumentor-element__name" id="method_propertyTypeTokensBC">
         propertyTypeTokensBC()
@@ -2289,28 +4243,17 @@ not need to support PHPCS &lt; 3.3.0.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">661</span>
+    <span class="phpdocumentor-element-found-in__line">1019</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Token types which can be encountered in a property type declaration (cross-version).</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Token types which can be encountered in a property type declaration (cross-version).</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">propertyTypeTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Sister-method to the <a href="classes/PHPCSUtils-Tokens-Collections.html#property_propertyTypeTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$propertyTypeTokens">Collections::$propertyTypeTokens</abbr></a> property.
-The property supports PHPCS 3.3.0 and up.
-The method supports PHPCS 2.6.0 and up.</p>
-<p>Notable difference:</p>
-<ul>
-<li>The method will include the <code class="prettyprint">T_ARRAY_HINT</code> token when used with PHPCS 2.x and 3.x.
-This token constant will no longer exist in PHPCS 4.x.</li>
-</ul>
-<p>It is recommended to use the property instead of the method if a standard supports does
-not need to support PHPCS &lt; 3.3.0.</p>
-</section>
-
+    
     
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -2322,9 +4265,9 @@ not need to support PHPCS &lt; 3.3.0.</p>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_propertyTypeTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$propertyTypeTokens">Collections::$propertyTypeTokens</abbr></a></span>
+                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Tokens\Collections::propertyTypeTokens()">Collections::propertyTypeTokens()</abbr></span>
                                         
-                                                 <section class="phpdocumentor-description"><p>Related property (PHPCS 3.3.0+).</p>
+                                                 <section class="phpdocumentor-description"><p>Related method (PHPCS 3.3.0+).</p>
 </section>
 
                                     </dd>
@@ -2335,6 +4278,16 @@ not need to support PHPCS &lt; 3.3.0.</p>
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
                                                                                 
                                              
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::propertyTypeTokens()">Collections::propertyTypeTokens()</abbr> method instead.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -2352,6 +4305,97 @@ not need to support PHPCS &lt; 3.3.0.</p>
             -public
                                     -static                    "
 >
+    <h4 class="phpdocumentor-element__name" id="method_returnTypeTokens">
+        returnTypeTokens()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokens" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">1041</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Token types which can be encountered in a return type declaration.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">returnTypeTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+    
+    
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>This method replaces the <a href="classes/PHPCSUtils-Tokens-Collections.html#property_returnTypeTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$returnTypeTokens">Collections::$returnTypeTokens</abbr></a> property.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 identifier name tokens.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the T_TRUE token for PHP 8.2 true type support.</p>
+</section>
+
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+            -deprecated                        -static                    "
+>
     <h4 class="phpdocumentor-element__name" id="method_returnTypeTokensBC">
         returnTypeTokensBC()
         <a href="classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
@@ -2359,29 +4403,17 @@ not need to support PHPCS &lt; 3.3.0.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">687</span>
+    <span class="phpdocumentor-element-found-in__line">1061</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Token types which can be encountered in a return type declaration (cross-version).</p>
+        <p class="phpdocumentor-summary">DEPRECATED: Token types which can be encountered in a return type declaration (cross-version).</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">returnTypeTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Sister-property to the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::returnTypeTokensBC()">Collections::returnTypeTokensBC()</abbr></a> method.
-The property supports PHPCS 3.5.4 and up.
-The method supports PHPCS 2.6.0 and up.</p>
-<p>Notable differences:</p>
-<ul>
-<li>The method will include the <code class="prettyprint">T_ARRAY_HINT</code> and the <code class="prettyprint">T_RETURN_TYPE</code> tokens when used with PHPCS 2.x and 3.x.
-These token constants will no longer exist in PHPCS 4.x.</li>
-<li>The method will include the <code class="prettyprint">T_ARRAY</code> token which is needed for select arrow functions in PHPCS &lt; 3.5.4.</li>
-</ul>
-<p>It is recommended to use the property instead of the method if a standard supports does
-not need to support PHPCS &lt; 3.5.4.</p>
-</section>
-
+    
     
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -2393,9 +4425,9 @@ not need to support PHPCS &lt; 3.5.4.</p>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_returnTypeTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$returnTypeTokens">Collections::$returnTypeTokens</abbr></a></span>
+                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Tokens\Collections::returnTypeTokens()">Collections::returnTypeTokens()</abbr></span>
                                         
-                                                 <section class="phpdocumentor-description"><p>Related property (PHPCS 3.5.4+).</p>
+                                                 <section class="phpdocumentor-description"><p>Related method (PHPCS 3.3.0+).</p>
 </section>
 
                                     </dd>
@@ -2406,6 +4438,240 @@ not need to support PHPCS &lt; 3.5.4.</p>
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
                                                                                 
                                              
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::returnTypeTokens()">Collections::returnTypeTokens()</abbr> method instead.</p>
+</section>
+
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_shortArrayListOpenTokensBC">
+        shortArrayListOpenTokensBC()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_shortArrayListOpenTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">shortArrayListOpenTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Tokens which can open a short array or short list
+(PHPCS cross-version compatible).</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_shortArrayTokens">
+        shortArrayTokens()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_shortArrayTokens" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">shortArrayTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Tokens which are used for short arrays.</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_shortArrayTokensBC">
+        shortArrayTokensBC()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_shortArrayTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">shortArrayTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Tokens which are used for short arrays
+(PHPCS cross-version compatible).</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_shortListTokens">
+        shortListTokens()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_shortListTokens" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">shortListTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Tokens which are used for short lists.</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_shortListTokensBC">
+        shortListTokensBC()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_shortListTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">0</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">shortListTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Tokens which are used for short lists
+(PHPCS cross-version compatible).</p>
+</section>
+
+    
+    
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_textStringStartTokens">
+        textStringStartTokens()
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_textStringStartTokens" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">1079</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Tokens which can start a - potentially multi-line - text string.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">textStringStartTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+    
+    
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>This method replaces the <a href="classes/PHPCSUtils-Tokens-Collections.html#property_textStingStartTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$textStingStartTokens">Collections::$textStingStartTokens</abbr></a> property.</p>
+</section>
+
                                     </dd>
                         </dl>
 

--- a/docs/phpdoc/classes/PHPCSUtils-Tokens-Collections.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Tokens-Collections.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-tokens.html">Tokens</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-tokens.html">Tokens</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,20 +118,28 @@
     Collections
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">26</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Collections of related tokens as often used and needed for sniffs.</p>
 
     <section class="phpdocumentor-description"><p>These are additional &quot;token groups&quot; to compliment the ones available through the PHPCS
-native \PHP_CodeSniffer\Util\Tokens class.</p></section>
+native <abbr title="\PHP_CodeSniffer\Util\Tokens">Tokens</abbr> class.</p>
+</section>
 
 
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -100,24 +152,29 @@ native \PHP_CodeSniffer\Util\Tokens class.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Util\Tokens">Tokens</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>PHPCS native token groups.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>PHPCS native token groups.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-BackCompat-BCTokens.html"><abbr title="\PHPCSUtils\BackCompat\BCTokens">BCTokens</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Backward compatible version of the PHPCS native token groups.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-BackCompat-BCTokens.html"><abbr title="\PHPCSUtils\BackCompat\BCTokens">BCTokens</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Backward compatible version of the PHPCS native token groups.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 
@@ -131,241 +188,241 @@ native \PHP_CodeSniffer\Util\Tokens class.</p></section>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_alternativeControlStructureSyntaxCloserTokens">$alternativeControlStructureSyntaxCloserTokens</a>
+                    <dt class="phpdocumentor-table-of-contents__entry -property -public">
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_alternativeControlStructureSyntaxCloserTokens">$alternativeControlStructureSyntaxCloserTokens</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Alternative control structure syntax closer keyword tokens.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_alternativeControlStructureSyntaxTokens">$alternativeControlStructureSyntaxTokens</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_alternativeControlStructureSyntaxTokens">$alternativeControlStructureSyntaxTokens</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Control structures which can use the alternative control structure syntax.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokens">$arrayTokens</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokens">$arrayTokens</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Tokens which are used to create arrays.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokensBC">$arrayTokensBC</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokensBC">$arrayTokensBC</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Tokens which are used to create arrays.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_classModifierKeywords">$classModifierKeywords</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_classModifierKeywords">$classModifierKeywords</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Modifier keywords which can be used for a class declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_closedScopes">$closedScopes</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_closedScopes">$closedScopes</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>List of tokens which represent &quot;closed&quot; scopes.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_controlStructureTokens">$controlStructureTokens</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_controlStructureTokens">$controlStructureTokens</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Control structure tokens.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_incrementDecrementOperators">$incrementDecrementOperators</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_incrementDecrementOperators">$incrementDecrementOperators</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Increment/decrement operator tokens.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_listTokens">$listTokens</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_listTokens">$listTokens</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Tokens which are used to create lists.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_listTokensBC">$listTokensBC</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_listTokensBC">$listTokensBC</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Tokens which are used to create lists.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_magicConstants">$magicConstants</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_magicConstants">$magicConstants</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Tokens for the PHP magic constants.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_namespaceDeclarationClosers">$namespaceDeclarationClosers</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_namespaceDeclarationClosers">$namespaceDeclarationClosers</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>List of tokens which can end a namespace declaration statement.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_objectOperators">$objectOperators</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_objectOperators">$objectOperators</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Object operators.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_OOCanExtend">$OOCanExtend</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOCanExtend">$OOCanExtend</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>OO structures which can use the &quot;extends&quot; keyword.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_OOCanImplement">$OOCanImplement</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOCanImplement">$OOCanImplement</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>OO structures which can use the &quot;implements&quot; keyword.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_OOConstantScopes">$OOConstantScopes</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOConstantScopes">$OOConstantScopes</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>OO scopes in which constants can be declared.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_OOHierarchyKeywords">$OOHierarchyKeywords</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOHierarchyKeywords">$OOHierarchyKeywords</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Tokens types used for &quot;forwarding&quot; calls within OO structures.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_OONameTokens">$OONameTokens</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OONameTokens">$OONameTokens</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Tokens types which can be encountered in the fully/partially qualified name of an OO structure.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_OOPropertyScopes">$OOPropertyScopes</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOPropertyScopes">$OOPropertyScopes</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>OO scopes in which properties can be declared.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_parameterTypeTokens">$parameterTypeTokens</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_parameterTypeTokens">$parameterTypeTokens</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Token types which can be encountered in a parameter type declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_propertyModifierKeywords">$propertyModifierKeywords</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_propertyModifierKeywords">$propertyModifierKeywords</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Modifier keywords which can be used for a property declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_propertyTypeTokens">$propertyTypeTokens</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_propertyTypeTokens">$propertyTypeTokens</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Token types which can be encountered in a property type declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_returnTypeTokens">$returnTypeTokens</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_returnTypeTokens">$returnTypeTokens</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Token types which can be encountered in a return type declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokens">$shortArrayTokens</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokens">$shortArrayTokens</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Tokens which are used for short arrays.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokensBC">$shortArrayTokensBC</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokensBC">$shortArrayTokensBC</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Tokens which are used for short arrays.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokens">$shortListTokens</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokens">$shortListTokens</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Tokens which are used for short lists.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokensBC">$shortListTokensBC</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokensBC">$shortListTokensBC</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Tokens which are used for short lists.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_textStingStartTokens">$textStingStartTokens</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#property_textStingStartTokens">$textStingStartTokens</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>Tokens which can start a - potentially multi-line - text string.</dd>
 
                 <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#method_arrowFunctionTokensBC">arrowFunctionTokensBC()</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_arrowFunctionTokensBC">arrowFunctionTokensBC()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Tokens which can represent the arrow function keyword.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokens">functionDeclarationTokens()</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokens">functionDeclarationTokens()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Tokens which can represent a keyword which starts a function declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokensBC">functionDeclarationTokensBC()</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokensBC">functionDeclarationTokensBC()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Tokens which can represent a keyword which starts a function declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#method_parameterTypeTokensBC">parameterTypeTokensBC()</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_parameterTypeTokensBC">parameterTypeTokensBC()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Token types which can be encountered in a parameter type declaration (cross-version).</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#method_propertyTypeTokensBC">propertyTypeTokensBC()</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_propertyTypeTokensBC">propertyTypeTokensBC()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Token types which can be encountered in a property type declaration (cross-version).</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokensBC">returnTypeTokensBC()</a>
+    <a href="classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokensBC">returnTypeTokensBC()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Token types which can be encountered in a return type declaration (cross-version).</dd>
 
@@ -379,7 +436,7 @@ native \PHP_CodeSniffer\Util\Tokens class.</p></section>
     <section class="phpdocumentor-properties">
         <h3 class="phpdocumentor-elements__header" id="properties">
             Properties
-            <a href="#properties" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Tokens-Collections.html#properties" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="
@@ -390,25 +447,29 @@ native \PHP_CodeSniffer\Util\Tokens class.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_alternativeControlStructureSyntaxCloserTokens">
         $alternativeControlStructureSyntaxCloserTokens
-        <a href="#property_alternativeControlStructureSyntaxCloserTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_alternativeControlStructureSyntaxCloserTokens" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">54</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Alternative control structure syntax closer keyword tokens.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$alternativeControlStructureSyntaxCloserTokens</span>
-     = <span class="phpdocumentor-signature__default-value">[T_ENDIF =&gt; T_ENDIF, T_ENDFOR =&gt; T_ENDFOR, T_ENDFOREACH =&gt; T_ENDFOREACH, T_ENDWHILE =&gt; T_ENDWHILE, T_ENDSWITCH =&gt; T_ENDSWITCH, T_ENDDECLARE =&gt; T_ENDDECLARE]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_ENDIF =&gt; \T_ENDIF, \T_ENDFOR =&gt; \T_ENDFOR, \T_ENDFOREACH =&gt; \T_ENDFOREACH, \T_ENDWHILE =&gt; \T_ENDWHILE, \T_ENDSWITCH =&gt; \T_ENDSWITCH, \T_ENDDECLARE =&gt; \T_ENDDECLARE]</span></code>
 
     
+        <section class="phpdocumentor-description"><p><int> =&gt; <int></p>
+</section>
+
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -420,8 +481,9 @@ native \PHP_CodeSniffer\Util\Tokens class.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -434,25 +496,29 @@ native \PHP_CodeSniffer\Util\Tokens class.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_alternativeControlStructureSyntaxTokens">
         $alternativeControlStructureSyntaxTokens
-        <a href="#property_alternativeControlStructureSyntaxTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_alternativeControlStructureSyntaxTokens" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">36</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Control structures which can use the alternative control structure syntax.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$alternativeControlStructureSyntaxTokens</span>
-     = <span class="phpdocumentor-signature__default-value">[T_IF =&gt; T_IF, T_ELSEIF =&gt; T_ELSEIF, T_ELSE =&gt; T_ELSE, T_FOR =&gt; T_FOR, T_FOREACH =&gt; T_FOREACH, T_SWITCH =&gt; T_SWITCH, T_WHILE =&gt; T_WHILE, T_DECLARE =&gt; T_DECLARE]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_IF =&gt; \T_IF, \T_ELSEIF =&gt; \T_ELSEIF, \T_ELSE =&gt; \T_ELSE, \T_FOR =&gt; \T_FOR, \T_FOREACH =&gt; \T_FOREACH, \T_SWITCH =&gt; \T_SWITCH, \T_WHILE =&gt; \T_WHILE, \T_DECLARE =&gt; \T_DECLARE]</span></code>
 
     
+        <section class="phpdocumentor-description"><p><int> =&gt; <int></p>
+</section>
+
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -464,8 +530,9 @@ native \PHP_CodeSniffer\Util\Tokens class.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -478,25 +545,29 @@ native \PHP_CodeSniffer\Util\Tokens class.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_arrayTokens">
         $arrayTokens
-        <a href="#property_arrayTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokens" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">73</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens which are used to create arrays.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$arrayTokens</span>
-     = <span class="phpdocumentor-signature__default-value">[T_ARRAY =&gt; T_ARRAY, T_OPEN_SHORT_ARRAY =&gt; T_OPEN_SHORT_ARRAY, T_CLOSE_SHORT_ARRAY =&gt; T_CLOSE_SHORT_ARRAY]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_ARRAY =&gt; \T_ARRAY, \T_OPEN_SHORT_ARRAY =&gt; \T_OPEN_SHORT_ARRAY, \T_CLOSE_SHORT_ARRAY =&gt; \T_CLOSE_SHORT_ARRAY]</span></code>
 
     
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -507,18 +578,21 @@ native \PHP_CodeSniffer\Util\Tokens class.</p></section>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$shortArrayTokens">Collections::$shortArrayTokens</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Related property containing only tokens used
-for short arrays.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$shortArrayTokens">Collections::$shortArrayTokens</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related property containing only tokens used
+for short arrays.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -531,26 +605,31 @@ for short arrays.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_arrayTokensBC">
         $arrayTokensBC
-        <a href="#property_arrayTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">92</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens which are used to create arrays.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$arrayTokensBC</span>
-     = <span class="phpdocumentor-signature__default-value">[T_ARRAY =&gt; T_ARRAY, T_OPEN_SHORT_ARRAY =&gt; T_OPEN_SHORT_ARRAY, T_CLOSE_SHORT_ARRAY =&gt; T_CLOSE_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET =&gt; T_OPEN_SQUARE_BRACKET, T_CLOSE_SQUARE_BRACKET =&gt; T_CLOSE_SQUARE_BRACKET]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_ARRAY =&gt; \T_ARRAY, \T_OPEN_SHORT_ARRAY =&gt; \T_OPEN_SHORT_ARRAY, \T_CLOSE_SHORT_ARRAY =&gt; \T_CLOSE_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET =&gt; \T_OPEN_SQUARE_BRACKET, \T_CLOSE_SQUARE_BRACKET =&gt; \T_CLOSE_SQUARE_BRACKET]</span></code>
 
         <section class="phpdocumentor-description"><p>List which is backward-compatible with PHPCS &lt; 3.3.0.
-Should only be used selectively.</p></section>
+Should only be used selectively.</p>
+</section>
+
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
 
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -562,18 +641,21 @@ Should only be used selectively.</p></section>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::$shortArrayTokensBC">Collections::$shortArrayTokensBC</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Related property containing only tokens used
-for short arrays (cross-version).</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::$shortArrayTokensBC">Collections::$shortArrayTokensBC</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related property containing only tokens used
+for short arrays (cross-version).</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -586,25 +668,29 @@ for short arrays (cross-version).</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_classModifierKeywords">
         $classModifierKeywords
-        <a href="#property_classModifierKeywords" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_classModifierKeywords" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">107</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Modifier keywords which can be used for a class declaration.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$classModifierKeywords</span>
-     = <span class="phpdocumentor-signature__default-value">[T_FINAL =&gt; T_FINAL, T_ABSTRACT =&gt; T_ABSTRACT]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_FINAL =&gt; \T_FINAL, \T_ABSTRACT =&gt; \T_ABSTRACT]</span></code>
 
     
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -616,8 +702,9 @@ for short arrays (cross-version).</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -630,28 +717,33 @@ for short arrays (cross-version).</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_closedScopes">
         $closedScopes
-        <a href="#property_closedScopes" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_closedScopes" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">125</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">List of tokens which represent &quot;closed&quot; scopes.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$closedScopes</span>
-     = <span class="phpdocumentor-signature__default-value">[T_CLASS =&gt; T_CLASS, T_ANON_CLASS =&gt; T_ANON_CLASS, T_INTERFACE =&gt; T_INTERFACE, T_TRAIT =&gt; T_TRAIT, T_FUNCTION =&gt; T_FUNCTION, T_CLOSURE =&gt; T_CLOSURE]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_CLASS =&gt; \T_CLASS, \T_ANON_CLASS =&gt; \T_ANON_CLASS, \T_INTERFACE =&gt; \T_INTERFACE, \T_TRAIT =&gt; \T_TRAIT, \T_FUNCTION =&gt; \T_FUNCTION, \T_CLOSURE =&gt; \T_CLOSURE]</span></code>
 
         <section class="phpdocumentor-description"><p>I.e. anything declared within that scope - except for other closed scopes - is
 outside of the global namespace.</p>
 <p>This list doesn't contain the <code class="prettyprint">T_NAMESPACE</code> token on purpose as variables declared
-within a namespace scope are still global and not limited to that namespace.</p></section>
+within a namespace scope are still global and not limited to that namespace.</p>
+</section>
+
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
 
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -664,8 +756,9 @@ within a namespace scope are still global and not limited to that namespace.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -678,25 +771,29 @@ within a namespace scope are still global and not limited to that namespace.</p>
 >
     <h4 class="phpdocumentor-element__name" id="property_controlStructureTokens">
         $controlStructureTokens
-        <a href="#property_controlStructureTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_controlStructureTokens" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">141</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Control structure tokens.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$controlStructureTokens</span>
-     = <span class="phpdocumentor-signature__default-value">[T_IF =&gt; T_IF, T_ELSEIF =&gt; T_ELSEIF, T_ELSE =&gt; T_ELSE, T_FOR =&gt; T_FOR, T_FOREACH =&gt; T_FOREACH, T_SWITCH =&gt; T_SWITCH, T_DO =&gt; T_DO, T_WHILE =&gt; T_WHILE, T_DECLARE =&gt; T_DECLARE]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_IF =&gt; \T_IF, \T_ELSEIF =&gt; \T_ELSEIF, \T_ELSE =&gt; \T_ELSE, \T_FOR =&gt; \T_FOR, \T_FOREACH =&gt; \T_FOREACH, \T_SWITCH =&gt; \T_SWITCH, \T_DO =&gt; \T_DO, \T_WHILE =&gt; \T_WHILE, \T_DECLARE =&gt; \T_DECLARE]</span></code>
 
     
+        <section class="phpdocumentor-description"><p><int> =&gt; <int></p>
+</section>
+
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -708,8 +805,9 @@ within a namespace scope are still global and not limited to that namespace.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -722,25 +820,29 @@ within a namespace scope are still global and not limited to that namespace.</p>
 >
     <h4 class="phpdocumentor-element__name" id="property_incrementDecrementOperators">
         $incrementDecrementOperators
-        <a href="#property_incrementDecrementOperators" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_incrementDecrementOperators" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">160</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Increment/decrement operator tokens.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$incrementDecrementOperators</span>
-     = <span class="phpdocumentor-signature__default-value">[T_DEC =&gt; T_DEC, T_INC =&gt; T_INC]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_DEC =&gt; \T_DEC, \T_INC =&gt; \T_INC]</span></code>
 
     
+        <section class="phpdocumentor-description"><p><int> =&gt; <int></p>
+</section>
+
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -752,8 +854,9 @@ within a namespace scope are still global and not limited to that namespace.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -766,25 +869,29 @@ within a namespace scope are still global and not limited to that namespace.</p>
 >
     <h4 class="phpdocumentor-element__name" id="property_listTokens">
         $listTokens
-        <a href="#property_listTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_listTokens" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">175</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens which are used to create lists.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$listTokens</span>
-     = <span class="phpdocumentor-signature__default-value">[T_LIST =&gt; T_LIST, T_OPEN_SHORT_ARRAY =&gt; T_OPEN_SHORT_ARRAY, T_CLOSE_SHORT_ARRAY =&gt; T_CLOSE_SHORT_ARRAY]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_LIST =&gt; \T_LIST, \T_OPEN_SHORT_ARRAY =&gt; \T_OPEN_SHORT_ARRAY, \T_CLOSE_SHORT_ARRAY =&gt; \T_CLOSE_SHORT_ARRAY]</span></code>
 
     
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -795,18 +902,21 @@ within a namespace scope are still global and not limited to that namespace.</p>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$shortListTokens">Collections::$shortListTokens</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Related property containing only tokens used
-for short lists.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$shortListTokens">Collections::$shortListTokens</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related property containing only tokens used
+for short lists.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -819,26 +929,31 @@ for short lists.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_listTokensBC">
         $listTokensBC
-        <a href="#property_listTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_listTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">194</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens which are used to create lists.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$listTokensBC</span>
-     = <span class="phpdocumentor-signature__default-value">[T_LIST =&gt; T_LIST, T_OPEN_SHORT_ARRAY =&gt; T_OPEN_SHORT_ARRAY, T_CLOSE_SHORT_ARRAY =&gt; T_CLOSE_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET =&gt; T_OPEN_SQUARE_BRACKET, T_CLOSE_SQUARE_BRACKET =&gt; T_CLOSE_SQUARE_BRACKET]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_LIST =&gt; \T_LIST, \T_OPEN_SHORT_ARRAY =&gt; \T_OPEN_SHORT_ARRAY, \T_CLOSE_SHORT_ARRAY =&gt; \T_CLOSE_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET =&gt; \T_OPEN_SQUARE_BRACKET, \T_CLOSE_SQUARE_BRACKET =&gt; \T_CLOSE_SQUARE_BRACKET]</span></code>
 
         <section class="phpdocumentor-description"><p>List which is backward-compatible with PHPCS &lt; 3.3.0.
-Should only be used selectively.</p></section>
+Should only be used selectively.</p>
+</section>
+
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
 
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -850,18 +965,21 @@ Should only be used selectively.</p></section>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::$shortListTokensBC">Collections::$shortListTokensBC</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Related property containing only tokens used
-for short lists (cross-version).</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::$shortListTokensBC">Collections::$shortListTokensBC</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related property containing only tokens used
+for short lists (cross-version).</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -874,25 +992,29 @@ for short lists (cross-version).</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_magicConstants">
         $magicConstants
-        <a href="#property_magicConstants" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_magicConstants" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">211</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens for the PHP magic constants.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$magicConstants</span>
-     = <span class="phpdocumentor-signature__default-value">[T_CLASS_C =&gt; T_CLASS_C, T_DIR =&gt; T_DIR, T_FILE =&gt; T_FILE, T_FUNC_C =&gt; T_FUNC_C, T_LINE =&gt; T_LINE, T_METHOD_C =&gt; T_METHOD_C, T_NS_C =&gt; T_NS_C, T_TRAIT_C =&gt; T_TRAIT_C]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_CLASS_C =&gt; \T_CLASS_C, \T_DIR =&gt; \T_DIR, \T_FILE =&gt; \T_FILE, \T_FUNC_C =&gt; \T_FUNC_C, \T_LINE =&gt; \T_LINE, \T_METHOD_C =&gt; \T_METHOD_C, \T_NS_C =&gt; \T_NS_C, \T_TRAIT_C =&gt; \T_TRAIT_C]</span></code>
 
     
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -903,17 +1025,18 @@ for short lists (cross-version).</p></section>
                     <span class="phpdocumentor-tag__name">link</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.php.net/language.constants.predefined">https://www.php.net/language.constants.predefined</a>
-                                            <section class="phpdocumentor-description"><p>PHP Manual on magic constants</p></section>
-
-                </dd>
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.php.net/language.constants.predefined"> <p>PHP Manual on magic constants</p>
+ </a>
+                    
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -926,25 +1049,29 @@ for short lists (cross-version).</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_namespaceDeclarationClosers">
         $namespaceDeclarationClosers
-        <a href="#property_namespaceDeclarationClosers" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_namespaceDeclarationClosers" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">229</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">List of tokens which can end a namespace declaration statement.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$namespaceDeclarationClosers</span>
-     = <span class="phpdocumentor-signature__default-value">[T_SEMICOLON =&gt; T_SEMICOLON, T_OPEN_CURLY_BRACKET =&gt; T_OPEN_CURLY_BRACKET, T_CLOSE_TAG =&gt; T_CLOSE_TAG]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_SEMICOLON =&gt; \T_SEMICOLON, \T_OPEN_CURLY_BRACKET =&gt; \T_OPEN_CURLY_BRACKET, \T_CLOSE_TAG =&gt; \T_CLOSE_TAG]</span></code>
 
     
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -956,8 +1083,9 @@ for short lists (cross-version).</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -970,25 +1098,29 @@ for short lists (cross-version).</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_objectOperators">
         $objectOperators
-        <a href="#property_objectOperators" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_objectOperators" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">242</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Object operators.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$objectOperators</span>
-     = <span class="phpdocumentor-signature__default-value">[T_OBJECT_OPERATOR =&gt; T_OBJECT_OPERATOR, T_DOUBLE_COLON =&gt; T_DOUBLE_COLON]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_OBJECT_OPERATOR =&gt; \T_OBJECT_OPERATOR, \T_DOUBLE_COLON =&gt; \T_DOUBLE_COLON]</span></code>
 
     
+        <section class="phpdocumentor-description"><p><int> =&gt; <int></p>
+</section>
+
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -1000,8 +1132,9 @@ for short lists (cross-version).</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -1014,25 +1147,29 @@ for short lists (cross-version).</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_OOCanExtend">
         $OOCanExtend
-        <a href="#property_OOCanExtend" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOCanExtend" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">254</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">OO structures which can use the &quot;extends&quot; keyword.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$OOCanExtend</span>
-     = <span class="phpdocumentor-signature__default-value">[T_CLASS =&gt; T_CLASS, T_ANON_CLASS =&gt; T_ANON_CLASS, T_INTERFACE =&gt; T_INTERFACE]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_CLASS =&gt; \T_CLASS, \T_ANON_CLASS =&gt; \T_ANON_CLASS, \T_INTERFACE =&gt; \T_INTERFACE]</span></code>
 
     
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -1044,8 +1181,9 @@ for short lists (cross-version).</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -1058,25 +1196,29 @@ for short lists (cross-version).</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_OOCanImplement">
         $OOCanImplement
-        <a href="#property_OOCanImplement" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOCanImplement" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">267</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">OO structures which can use the &quot;implements&quot; keyword.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$OOCanImplement</span>
-     = <span class="phpdocumentor-signature__default-value">[T_CLASS =&gt; T_CLASS, T_ANON_CLASS =&gt; T_ANON_CLASS]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_CLASS =&gt; \T_CLASS, \T_ANON_CLASS =&gt; \T_ANON_CLASS]</span></code>
 
     
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -1088,8 +1230,9 @@ for short lists (cross-version).</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -1102,25 +1245,30 @@ for short lists (cross-version).</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_OOConstantScopes">
         $OOConstantScopes
-        <a href="#property_OOConstantScopes" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOConstantScopes" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">281</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">OO scopes in which constants can be declared.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$OOConstantScopes</span>
-     = <span class="phpdocumentor-signature__default-value">[T_CLASS =&gt; T_CLASS, T_ANON_CLASS =&gt; T_ANON_CLASS, T_INTERFACE =&gt; T_INTERFACE]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_CLASS =&gt; \T_CLASS, \T_ANON_CLASS =&gt; \T_ANON_CLASS, \T_INTERFACE =&gt; \T_INTERFACE]</span></code>
 
-        <section class="phpdocumentor-description"><p>Note: traits can not declare constants.</p></section>
+        <section class="phpdocumentor-description"><p>Note: traits can not declare constants.</p>
+</section>
+
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
 
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -1133,8 +1281,9 @@ for short lists (cross-version).</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -1147,25 +1296,29 @@ for short lists (cross-version).</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_OOHierarchyKeywords">
         $OOHierarchyKeywords
-        <a href="#property_OOHierarchyKeywords" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOHierarchyKeywords" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">296</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens types used for &quot;forwarding&quot; calls within OO structures.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$OOHierarchyKeywords</span>
-     = <span class="phpdocumentor-signature__default-value">[T_PARENT =&gt; T_PARENT, T_SELF =&gt; T_SELF, T_STATIC =&gt; T_STATIC]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_PARENT =&gt; \T_PARENT, \T_SELF =&gt; \T_SELF, \T_STATIC =&gt; \T_STATIC]</span></code>
 
     
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -1176,17 +1329,18 @@ for short lists (cross-version).</p></section>
                     <span class="phpdocumentor-tag__name">link</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.php.net/language.oop5.paamayim-nekudotayim">https://www.php.net/language.oop5.paamayim-nekudotayim</a>
-                                            <section class="phpdocumentor-description"><p>PHP Manual on OO forwarding calls</p></section>
-
-                </dd>
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.php.net/language.oop5.paamayim-nekudotayim"> <p>PHP Manual on OO forwarding calls</p>
+ </a>
+                    
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -1199,26 +1353,32 @@ for short lists (cross-version).</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_OONameTokens">
         $OONameTokens
-        <a href="#property_OONameTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OONameTokens" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">314</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens types which can be encountered in the fully/partially qualified name of an OO structure.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$OONameTokens</span>
-     = <span class="phpdocumentor-signature__default-value">[T_NS_SEPARATOR =&gt; T_NS_SEPARATOR, T_STRING =&gt; T_STRING, T_NAMESPACE =&gt; T_NAMESPACE]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_NS_SEPARATOR =&gt; \T_NS_SEPARATOR, \T_STRING =&gt; \T_STRING, \T_NAMESPACE =&gt; \T_NAMESPACE]</span></code>
 
         <section class="phpdocumentor-description"><p>Example:</p>
-<pre class="prettyprint"><code class="language-php">echo namespace\Sub\ClassName::method();</code></pre></section>
+<pre class="prettyprint"><code class="language-php">echo namespace\Sub\ClassName::method();
+</code></pre>
+</section>
+
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
 
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -1231,8 +1391,9 @@ for short lists (cross-version).</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -1245,25 +1406,30 @@ for short lists (cross-version).</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_OOPropertyScopes">
         $OOPropertyScopes
-        <a href="#property_OOPropertyScopes" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOPropertyScopes" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">329</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">OO scopes in which properties can be declared.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$OOPropertyScopes</span>
-     = <span class="phpdocumentor-signature__default-value">[T_CLASS =&gt; T_CLASS, T_ANON_CLASS =&gt; T_ANON_CLASS, T_TRAIT =&gt; T_TRAIT]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_CLASS =&gt; \T_CLASS, \T_ANON_CLASS =&gt; \T_ANON_CLASS, \T_TRAIT =&gt; \T_TRAIT]</span></code>
 
-        <section class="phpdocumentor-description"><p>Note: interfaces can not declare properties.</p></section>
+        <section class="phpdocumentor-description"><p>Note: interfaces can not declare properties.</p>
+</section>
+
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
 
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -1276,8 +1442,9 @@ for short lists (cross-version).</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -1290,25 +1457,26 @@ for short lists (cross-version).</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_parameterTypeTokens">
         $parameterTypeTokens
-        <a href="#property_parameterTypeTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_parameterTypeTokens" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">355</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Token types which can be encountered in a parameter type declaration.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$parameterTypeTokens</span>
-     = <span class="phpdocumentor-signature__default-value">[T_CALLABLE =&gt; T_CALLABLE, T_SELF =&gt; T_SELF, T_PARENT =&gt; T_PARENT, T_STRING =&gt; T_STRING, T_NS_SEPARATOR =&gt; T_NS_SEPARATOR]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_CALLABLE =&gt; \T_CALLABLE, \T_SELF =&gt; \T_SELF, \T_PARENT =&gt; \T_PARENT, \T_STRING =&gt; \T_STRING, \T_NS_SEPARATOR =&gt; \T_NS_SEPARATOR]</span></code>
 
-        <section class="phpdocumentor-description"><p>Sister-property to the <a href="../classes/PHPCSUtils-Tokens-Collections.html#method_parameterTypeTokensBC">\PHPCSUtils\Tokens\Collections::parameterTypeTokensBC()</a> method.
+        <section class="phpdocumentor-description"><p>Sister-property to the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_parameterTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::parameterTypeTokensBC()">Collections::parameterTypeTokensBC()</abbr></a> method.
 The property supports PHPCS 3.3.0 and up.
 The method supports PHPCS 2.6.0 and up.</p>
 <p>Notable difference:</p>
@@ -1317,7 +1485,11 @@ The method supports PHPCS 2.6.0 and up.</p>
 This token constant will no longer exist in PHPCS 4.x.</li>
 </ul>
 <p>It is recommended to use the property instead of the method if a standard supports does
-not need to support PHPCS &lt; 3.3.0.</p></section>
+not need to support PHPCS &lt; 3.3.0.</p>
+</section>
+
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
 
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -1329,17 +1501,20 @@ not need to support PHPCS &lt; 3.3.0.</p></section>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Tokens-Collections.html#method_parameterTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::parameterTypeTokensBC()">Collections::parameterTypeTokensBC()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Related method (cross-version).</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#method_parameterTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::parameterTypeTokensBC()">Collections::parameterTypeTokensBC()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related method (cross-version).</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -1352,25 +1527,29 @@ not need to support PHPCS &lt; 3.3.0.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_propertyModifierKeywords">
         $propertyModifierKeywords
-        <a href="#property_propertyModifierKeywords" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_propertyModifierKeywords" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">370</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Modifier keywords which can be used for a property declaration.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$propertyModifierKeywords</span>
-     = <span class="phpdocumentor-signature__default-value">[T_PUBLIC =&gt; T_PUBLIC, T_PRIVATE =&gt; T_PRIVATE, T_PROTECTED =&gt; T_PROTECTED, T_STATIC =&gt; T_STATIC, T_VAR =&gt; T_VAR]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_PUBLIC =&gt; \T_PUBLIC, \T_PRIVATE =&gt; \T_PRIVATE, \T_PROTECTED =&gt; \T_PROTECTED, \T_STATIC =&gt; \T_STATIC, \T_VAR =&gt; \T_VAR]</span></code>
 
     
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -1382,8 +1561,9 @@ not need to support PHPCS &lt; 3.3.0.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -1396,25 +1576,26 @@ not need to support PHPCS &lt; 3.3.0.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_propertyTypeTokens">
         $propertyTypeTokens
-        <a href="#property_propertyTypeTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_propertyTypeTokens" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">398</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Token types which can be encountered in a property type declaration.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$propertyTypeTokens</span>
-     = <span class="phpdocumentor-signature__default-value">[T_CALLABLE =&gt; T_CALLABLE, T_SELF =&gt; T_SELF, T_PARENT =&gt; T_PARENT, T_STRING =&gt; T_STRING, T_NS_SEPARATOR =&gt; T_NS_SEPARATOR]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_CALLABLE =&gt; \T_CALLABLE, \T_SELF =&gt; \T_SELF, \T_PARENT =&gt; \T_PARENT, \T_STRING =&gt; \T_STRING, \T_NS_SEPARATOR =&gt; \T_NS_SEPARATOR]</span></code>
 
-        <section class="phpdocumentor-description"><p>Sister-property to the <a href="../classes/PHPCSUtils-Tokens-Collections.html#method_propertyTypeTokensBC">\PHPCSUtils\Tokens\Collections::propertyTypeTokensBC()</a> method.
+        <section class="phpdocumentor-description"><p>Sister-property to the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_propertyTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::propertyTypeTokensBC()">Collections::propertyTypeTokensBC()</abbr></a> method.
 The property supports PHPCS 3.3.0 and up.
 The method supports PHPCS 2.6.0 and up.</p>
 <p>Notable difference:</p>
@@ -1423,7 +1604,11 @@ The method supports PHPCS 2.6.0 and up.</p>
 This token constant will no longer exist in PHPCS 4.x.</li>
 </ul>
 <p>It is recommended to use the property instead of the method if a standard supports does
-not need to support PHPCS &lt; 3.3.0.</p></section>
+not need to support PHPCS &lt; 3.3.0.</p>
+</section>
+
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
 
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -1435,17 +1620,20 @@ not need to support PHPCS &lt; 3.3.0.</p></section>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Tokens-Collections.html#method_propertyTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::propertyTypeTokensBC()">Collections::propertyTypeTokensBC()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Related method (cross-version).</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#method_propertyTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::propertyTypeTokensBC()">Collections::propertyTypeTokensBC()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related method (cross-version).</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -1458,25 +1646,26 @@ not need to support PHPCS &lt; 3.3.0.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_returnTypeTokens">
         $returnTypeTokens
-        <a href="#property_returnTypeTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_returnTypeTokens" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">427</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Token types which can be encountered in a return type declaration.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$returnTypeTokens</span>
-     = <span class="phpdocumentor-signature__default-value">[T_STRING =&gt; T_STRING, T_CALLABLE =&gt; T_CALLABLE, T_SELF =&gt; T_SELF, T_PARENT =&gt; T_PARENT, T_STATIC =&gt; T_STATIC, T_NS_SEPARATOR =&gt; T_NS_SEPARATOR]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_STRING =&gt; \T_STRING, \T_CALLABLE =&gt; \T_CALLABLE, \T_SELF =&gt; \T_SELF, \T_PARENT =&gt; \T_PARENT, \T_STATIC =&gt; \T_STATIC, \T_NS_SEPARATOR =&gt; \T_NS_SEPARATOR]</span></code>
 
-        <section class="phpdocumentor-description"><p>Sister-property to the <a href="../classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokensBC">\PHPCSUtils\Tokens\Collections::returnTypeTokensBC()</a> method.
+        <section class="phpdocumentor-description"><p>Sister-property to the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::returnTypeTokensBC()">Collections::returnTypeTokensBC()</abbr></a> method.
 The property supports PHPCS 3.5.4 and up.
 The method supports PHPCS 2.6.0 and up.</p>
 <p>Notable differences:</p>
@@ -1486,7 +1675,11 @@ These token constants will no longer exist in PHPCS 4.x.</li>
 <li>The method will include the <code class="prettyprint">T_ARRAY</code> token which is needed for select arrow functions in PHPCS &lt; 3.5.4.</li>
 </ul>
 <p>It is recommended to use the property instead of the method if a standard supports does
-not need to support PHPCS &lt; 3.5.4.</p></section>
+not need to support PHPCS &lt; 3.5.4.</p>
+</section>
+
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
 
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -1498,17 +1691,20 @@ not need to support PHPCS &lt; 3.5.4.</p></section>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::returnTypeTokensBC()">Collections::returnTypeTokensBC()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Related method (cross-version).</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::returnTypeTokensBC()">Collections::returnTypeTokensBC()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related method (cross-version).</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -1521,25 +1717,29 @@ not need to support PHPCS &lt; 3.5.4.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_shortArrayTokens">
         $shortArrayTokens
-        <a href="#property_shortArrayTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokens" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">445</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens which are used for short arrays.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$shortArrayTokens</span>
-     = <span class="phpdocumentor-signature__default-value">[T_OPEN_SHORT_ARRAY =&gt; T_OPEN_SHORT_ARRAY, T_CLOSE_SHORT_ARRAY =&gt; T_CLOSE_SHORT_ARRAY]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_OPEN_SHORT_ARRAY =&gt; \T_OPEN_SHORT_ARRAY, \T_CLOSE_SHORT_ARRAY =&gt; \T_CLOSE_SHORT_ARRAY]</span></code>
 
     
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -1550,17 +1750,20 @@ not need to support PHPCS &lt; 3.5.4.</p></section>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$arrayTokens">Collections::$arrayTokens</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Related property containing all tokens used for arrays.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$arrayTokens">Collections::$arrayTokens</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related property containing all tokens used for arrays.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -1573,26 +1776,31 @@ not need to support PHPCS &lt; 3.5.4.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_shortArrayTokensBC">
         $shortArrayTokensBC
-        <a href="#property_shortArrayTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">463</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens which are used for short arrays.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$shortArrayTokensBC</span>
-     = <span class="phpdocumentor-signature__default-value">[T_OPEN_SHORT_ARRAY =&gt; T_OPEN_SHORT_ARRAY, T_CLOSE_SHORT_ARRAY =&gt; T_CLOSE_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET =&gt; T_OPEN_SQUARE_BRACKET, T_CLOSE_SQUARE_BRACKET =&gt; T_CLOSE_SQUARE_BRACKET]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_OPEN_SHORT_ARRAY =&gt; \T_OPEN_SHORT_ARRAY, \T_CLOSE_SHORT_ARRAY =&gt; \T_CLOSE_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET =&gt; \T_OPEN_SQUARE_BRACKET, \T_CLOSE_SQUARE_BRACKET =&gt; \T_CLOSE_SQUARE_BRACKET]</span></code>
 
         <section class="phpdocumentor-description"><p>List which is backward-compatible with PHPCS &lt; 3.3.0.
-Should only be used selectively.</p></section>
+Should only be used selectively.</p>
+</section>
+
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
 
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -1604,18 +1812,21 @@ Should only be used selectively.</p></section>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::$arrayTokensBC">Collections::$arrayTokensBC</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Related property containing all tokens used for arrays
-(cross-version).</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::$arrayTokensBC">Collections::$arrayTokensBC</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related property containing all tokens used for arrays
+(cross-version).</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -1628,25 +1839,29 @@ Should only be used selectively.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_shortListTokens">
         $shortListTokens
-        <a href="#property_shortListTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokens" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">479</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens which are used for short lists.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$shortListTokens</span>
-     = <span class="phpdocumentor-signature__default-value">[T_OPEN_SHORT_ARRAY =&gt; T_OPEN_SHORT_ARRAY, T_CLOSE_SHORT_ARRAY =&gt; T_CLOSE_SHORT_ARRAY]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_OPEN_SHORT_ARRAY =&gt; \T_OPEN_SHORT_ARRAY, \T_CLOSE_SHORT_ARRAY =&gt; \T_CLOSE_SHORT_ARRAY]</span></code>
 
     
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -1657,17 +1872,20 @@ Should only be used selectively.</p></section>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Tokens-Collections.html#property_listTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$listTokens">Collections::$listTokens</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Related property containing all tokens used for lists.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_listTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$listTokens">Collections::$listTokens</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related property containing all tokens used for lists.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -1680,26 +1898,31 @@ Should only be used selectively.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_shortListTokensBC">
         $shortListTokensBC
-        <a href="#property_shortListTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">497</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens which are used for short lists.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$shortListTokensBC</span>
-     = <span class="phpdocumentor-signature__default-value">[T_OPEN_SHORT_ARRAY =&gt; T_OPEN_SHORT_ARRAY, T_CLOSE_SHORT_ARRAY =&gt; T_CLOSE_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET =&gt; T_OPEN_SQUARE_BRACKET, T_CLOSE_SQUARE_BRACKET =&gt; T_CLOSE_SQUARE_BRACKET]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_OPEN_SHORT_ARRAY =&gt; \T_OPEN_SHORT_ARRAY, \T_CLOSE_SHORT_ARRAY =&gt; \T_CLOSE_SHORT_ARRAY, \T_OPEN_SQUARE_BRACKET =&gt; \T_OPEN_SQUARE_BRACKET, \T_CLOSE_SQUARE_BRACKET =&gt; \T_CLOSE_SQUARE_BRACKET]</span></code>
 
         <section class="phpdocumentor-description"><p>List which is backward-compatible with PHPCS &lt; 3.3.0.
-Should only be used selectively.</p></section>
+Should only be used selectively.</p>
+</section>
+
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
 
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -1711,18 +1934,21 @@ Should only be used selectively.</p></section>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Tokens-Collections.html#property_listTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::$listTokensBC">Collections::$listTokensBC</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Related property containing all tokens used for lists
-(cross-version).</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_listTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::$listTokensBC">Collections::$listTokensBC</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related property containing all tokens used for lists
+(cross-version).</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -1735,25 +1961,29 @@ Should only be used selectively.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_textStingStartTokens">
         $textStingStartTokens
-        <a href="#property_textStingStartTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#property_textStingStartTokens" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">511</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens which can start a - potentially multi-line - text string.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$textStingStartTokens</span>
-     = <span class="phpdocumentor-signature__default-value">[T_START_HEREDOC =&gt; T_START_HEREDOC, T_START_NOWDOC =&gt; T_START_NOWDOC, T_CONSTANT_ENCAPSED_STRING =&gt; T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING =&gt; T_DOUBLE_QUOTED_STRING]</span></code>
+     = <span class="phpdocumentor-signature__default-value">[\T_START_HEREDOC =&gt; \T_START_HEREDOC, \T_START_NOWDOC =&gt; \T_START_NOWDOC, \T_CONSTANT_ENCAPSED_STRING =&gt; \T_CONSTANT_ENCAPSED_STRING, \T_DOUBLE_QUOTED_STRING =&gt; \T_DOUBLE_QUOTED_STRING]</span></code>
 
     
+        <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
+
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -1765,8 +1995,9 @@ Should only be used selectively.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -1775,7 +2006,7 @@ Should only be used selectively.</p></section>
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Tokens-Collections.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -1785,21 +2016,23 @@ Should only be used selectively.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_arrowFunctionTokensBC">
         arrowFunctionTokensBC()
-        <a href="#method_arrowFunctionTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_arrowFunctionTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">527</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens which can represent the arrow function keyword.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">arrowFunctionTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">arrowFunctionTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Note: this is a method, not a property as the <code class="prettyprint">T_FN</code> token for arrow functions may not exist.</p></section>
+        <section class="phpdocumentor-description"><p>Note: this is a method, not a property as the <code class="prettyprint">T_FN</code> token for arrow functions may not exist.</p>
+</section>
 
     
     
@@ -1813,14 +2046,16 @@ Should only be used selectively.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p></section>
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
 
     
 </article>
@@ -1832,24 +2067,26 @@ Should only be used selectively.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_functionDeclarationTokens">
         functionDeclarationTokens()
-        <a href="#method_functionDeclarationTokens" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokens" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">556</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens which can represent a keyword which starts a function declaration.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">functionDeclarationTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">functionDeclarationTokens</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Note: this is a method, not a property as the <code class="prettyprint">T_FN</code> token for arrow functions may not exist.</p>
-<p>Sister-method to the <a href="../classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokensBC">\PHPCSUtils\Tokens\Collections::functionDeclarationTokensBC()</a> method.
+<p>Sister-method to the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::functionDeclarationTokensBC()">Collections::functionDeclarationTokensBC()</abbr></a> method.
 This  method supports PHPCS 3.5.3 and up.
-The <a href="../classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokensBC">\PHPCSUtils\Tokens\Collections::functionDeclarationTokensBC()</a> method supports PHPCS 2.6.0 and up.</p></section>
+The <a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::functionDeclarationTokensBC()">Collections::functionDeclarationTokensBC()</abbr></a> method supports PHPCS 2.6.0 and up.</p>
+</section>
 
     
     
@@ -1862,23 +2099,27 @@ The <a href="../classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclar
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::functionDeclarationTokensBC()">Collections::functionDeclarationTokensBC()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Related method (PHPCS 2.6.0+).</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::functionDeclarationTokensBC()">Collections::functionDeclarationTokensBC()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related method (PHPCS 2.6.0+).</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p></section>
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
 
     
 </article>
@@ -1890,33 +2131,35 @@ The <a href="../classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclar
 >
     <h4 class="phpdocumentor-element__name" id="method_functionDeclarationTokensBC">
         functionDeclarationTokensBC()
-        <a href="#method_functionDeclarationTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">597</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Tokens which can represent a keyword which starts a function declaration.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">functionDeclarationTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">functionDeclarationTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Note: this is a method, not a property as the <code class="prettyprint">T_FN</code> token for arrow functions may not exist.</p>
-<p>Sister-method to the <a href="../classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokens">\PHPCSUtils\Tokens\Collections::functionDeclarationTokens()</a> method.
-The <a href="../classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokens">\PHPCSUtils\Tokens\Collections::functionDeclarationTokens()</a> method supports PHPCS 3.5.3 and up.
+<p>Sister-method to the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokens"><abbr title="\PHPCSUtils\Tokens\Collections::functionDeclarationTokens()">Collections::functionDeclarationTokens()</abbr></a> method.
+The <a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokens"><abbr title="\PHPCSUtils\Tokens\Collections::functionDeclarationTokens()">Collections::functionDeclarationTokens()</abbr></a> method supports PHPCS 3.5.3 and up.
 This method supports PHPCS 2.6.0 and up.</p>
 <p>Notable difference:</p>
 <ul>
 <li>This method accounts for when the <code class="prettyprint">T_FN</code> token doesn't exist.</li>
 </ul>
-<p>Note: if this method is used, the <a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isArrowFunction">\PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction()</a>
+<p>Note: if this method is used, the <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isArrowFunction"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction()">FunctionDeclarations::isArrowFunction()</abbr></a>
 method needs to be used on arrow function tokens to verify whether it really is an arrow function
 declaration or not.</p>
-<p>It is recommended to use the <a href="../classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokens">\PHPCSUtils\Tokens\Collections::functionDeclarationTokens()</a> method instead of
-this method if a standard supports does not need to support PHPCS &lt; 3.5.3.</p></section>
+<p>It is recommended to use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokens"><abbr title="\PHPCSUtils\Tokens\Collections::functionDeclarationTokens()">Collections::functionDeclarationTokens()</abbr></a> method instead of
+this method if a standard supports does not need to support PHPCS &lt; 3.5.3.</p>
+</section>
 
     
     
@@ -1929,31 +2172,37 @@ this method if a standard supports does not need to support PHPCS &lt; 3.5.3.</p
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokens"><abbr title="\PHPCSUtils\Tokens\Collections::functionDeclarationTokens()">Collections::functionDeclarationTokens()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Related method (PHPCS 3.5.3+).</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokens"><abbr title="\PHPCSUtils\Tokens\Collections::functionDeclarationTokens()">Collections::functionDeclarationTokens()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related method (PHPCS 3.5.3+).</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isArrowFunction"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction()">FunctionDeclarations::isArrowFunction()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Arrow function verification.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isArrowFunction"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction()">FunctionDeclarations::isArrowFunction()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Arrow function verification.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p></section>
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
 
     
 </article>
@@ -1965,21 +2214,22 @@ this method if a standard supports does not need to support PHPCS &lt; 3.5.3.</p
 >
     <h4 class="phpdocumentor-element__name" id="method_parameterTypeTokensBC">
         parameterTypeTokensBC()
-        <a href="#method_parameterTypeTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_parameterTypeTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">629</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Token types which can be encountered in a parameter type declaration (cross-version).</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">parameterTypeTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">parameterTypeTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Sister-method to the <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_parameterTypeTokens">\PHPCSUtils\Tokens\Collections::$parameterTypeTokens</a> property.
+        <section class="phpdocumentor-description"><p>Sister-method to the <a href="classes/PHPCSUtils-Tokens-Collections.html#property_parameterTypeTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$parameterTypeTokens">Collections::$parameterTypeTokens</abbr></a> property.
 The property supports PHPCS 3.3.0 and up.
 The method supports PHPCS 2.6.0 and up.</p>
 <p>Notable difference:</p>
@@ -1988,7 +2238,8 @@ The method supports PHPCS 2.6.0 and up.</p>
 This token constant will no longer exist in PHPCS 4.x.</li>
 </ul>
 <p>It is recommended to use the property instead of the method if a standard supports does
-not need to support PHPCS &lt; 3.3.0.</p></section>
+not need to support PHPCS &lt; 3.3.0.</p>
+</section>
 
     
     
@@ -2001,23 +2252,27 @@ not need to support PHPCS &lt; 3.3.0.</p></section>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Tokens-Collections.html#property_parameterTypeTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$parameterTypeTokens">Collections::$parameterTypeTokens</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Related property (PHPCS 3.3.0+).</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_parameterTypeTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$parameterTypeTokens">Collections::$parameterTypeTokens</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related property (PHPCS 3.3.0+).</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p></section>
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
 
     
 </article>
@@ -2029,21 +2284,22 @@ not need to support PHPCS &lt; 3.3.0.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_propertyTypeTokensBC">
         propertyTypeTokensBC()
-        <a href="#method_propertyTypeTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_propertyTypeTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">661</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Token types which can be encountered in a property type declaration (cross-version).</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">propertyTypeTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">propertyTypeTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Sister-method to the <a href="../classes/PHPCSUtils-Tokens-Collections.html#property_propertyTypeTokens">\PHPCSUtils\Tokens\Collections::$propertyTypeTokens</a> property.
+        <section class="phpdocumentor-description"><p>Sister-method to the <a href="classes/PHPCSUtils-Tokens-Collections.html#property_propertyTypeTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$propertyTypeTokens">Collections::$propertyTypeTokens</abbr></a> property.
 The property supports PHPCS 3.3.0 and up.
 The method supports PHPCS 2.6.0 and up.</p>
 <p>Notable difference:</p>
@@ -2052,7 +2308,8 @@ The method supports PHPCS 2.6.0 and up.</p>
 This token constant will no longer exist in PHPCS 4.x.</li>
 </ul>
 <p>It is recommended to use the property instead of the method if a standard supports does
-not need to support PHPCS &lt; 3.3.0.</p></section>
+not need to support PHPCS &lt; 3.3.0.</p>
+</section>
 
     
     
@@ -2065,23 +2322,27 @@ not need to support PHPCS &lt; 3.3.0.</p></section>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Tokens-Collections.html#property_propertyTypeTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$propertyTypeTokens">Collections::$propertyTypeTokens</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Related property (PHPCS 3.3.0+).</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_propertyTypeTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$propertyTypeTokens">Collections::$propertyTypeTokens</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related property (PHPCS 3.3.0+).</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p></section>
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
 
     
 </article>
@@ -2093,21 +2354,22 @@ not need to support PHPCS &lt; 3.3.0.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_returnTypeTokensBC">
         returnTypeTokensBC()
-        <a href="#method_returnTypeTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokensBC" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/Collections.php"><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">687</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Token types which can be encountered in a return type declaration (cross-version).</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">returnTypeTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">returnTypeTokensBC</span><span>(</span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Sister-property to the <a href="../classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokensBC">\PHPCSUtils\Tokens\Collections::returnTypeTokensBC()</a> method.
+        <section class="phpdocumentor-description"><p>Sister-property to the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::returnTypeTokensBC()">Collections::returnTypeTokensBC()</abbr></a> method.
 The property supports PHPCS 3.5.4 and up.
 The method supports PHPCS 2.6.0 and up.</p>
 <p>Notable differences:</p>
@@ -2117,7 +2379,8 @@ These token constants will no longer exist in PHPCS 4.x.</li>
 <li>The method will include the <code class="prettyprint">T_ARRAY</code> token which is needed for select arrow functions in PHPCS &lt; 3.5.4.</li>
 </ul>
 <p>It is recommended to use the property instead of the method if a standard supports does
-not need to support PHPCS &lt; 3.5.4.</p></section>
+not need to support PHPCS &lt; 3.5.4.</p>
+</section>
 
     
     
@@ -2130,43 +2393,118 @@ not need to support PHPCS &lt; 3.5.4.</p></section>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Tokens-Collections.html#property_returnTypeTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$returnTypeTokens">Collections::$returnTypeTokens</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Related property (PHPCS 3.5.4+).</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_returnTypeTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$returnTypeTokens">Collections::$returnTypeTokens</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related property (PHPCS 3.5.4+).</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p></section>
+            <section class="phpdocumentor-description"><p>&lt;int|string&gt; =&gt; &lt;int|string&gt;</p>
+</section>
 
     
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Tokens-Collections.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Tokens-TokenHelper.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Tokens-TokenHelper.html
@@ -1,0 +1,369 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+            <title>PHPCSUtils</title>
+    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
+                <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
+        <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
+    </head>
+<body id="top">
+    <header class="phpdocumentor-header phpdocumentor-section">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
+    <section data-search-form class="phpdocumentor-search">
+    <label>
+        <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
+        <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
+    </label>
+</section>
+
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
+
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
+                        </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
+
+                        </section>
+            
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
+    </section>
+
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
+    </section>
+</aside>
+
+            <div class="phpdocumentor-column -eight phpdocumentor-content">
+                    <ul class="phpdocumentor-breadcrumbs">
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-tokens.html">Tokens</a></li>
+    </ul>
+
+    <article class="phpdocumentor-element -class">
+        <h2 class="phpdocumentor-content__title">
+    TokenHelper
+
+    
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
+    
+    
+    </h2>
+
+        <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/TokenHelper.php"><a href="files/phpcsutils-tokens-tokenhelper.html"><abbr title="PHPCSUtils/Tokens/TokenHelper.php">TokenHelper.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">18</span>
+
+    </aside>
+
+            <p class="phpdocumentor-summary">Helpers for working with tokens.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+
+
+
+
+
+<h3 id="toc">
+    Table of Contents
+    <a href="#toc" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Tokens-TokenHelper.html#method_tokenExists">tokenExists()</a>
+    <span>
+                                &nbsp;: bool    </span>
+</dt>
+<dd>Check whether a PHP native token exists (for real).</dd>
+
+        </dl>
+
+
+
+        
+
+        
+
+            <section class="phpdocumentor-methods">
+        <h3 class="phpdocumentor-elements__header" id="methods">
+            Methods
+            <a href="classes/PHPCSUtils-Tokens-TokenHelper.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
+        </h3>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_tokenExists">
+        tokenExists()
+        <a href="classes/PHPCSUtils-Tokens-TokenHelper.html#method_tokenExists" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Tokens/TokenHelper.php"><a href="files/phpcsutils-tokens-tokenhelper.html"><abbr title="PHPCSUtils/Tokens/TokenHelper.php">TokenHelper.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">51</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Check whether a PHP native token exists (for real).</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">tokenExists</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+
+        <section class="phpdocumentor-description"><p>Under normal circumstances, checking whether a token exists (either defined by PHP or by PHPCS)
+is as straight-forward as running <code class="prettyprint">defined('T_TOKEN_NAME')</code>.</p>
+<p>Unfortunately, this doesn't work in all circumstances, most notably, if an external standard
+also uses PHP-Parser or when code coverage is run on a standard using PHPUnit &gt;= 9.3 (which uses PHP-Parser),
+this logic breaks because PHP-Parser also polyfills tokens.
+This method takes potentially polyfilled tokens from PHP-Parser into account and will regard the token
+as undefined if it was declared by PHP-Parser.</p>
+<p>Note: this method only <em>needs</em> to be used for PHP native tokens, not for PHPCS specific tokens.
+Also, realistically, it only needs to be used for tokens introduced in PHP in recent versions (PHP 7.4 and up).
+Having said that, the method <em>will</em> also work correctly when a name of a PHPCS native token is passed or
+of an older PHP native token.</p>
+</section>
+
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$name</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The token name.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/sebastianbergmann/php-code-coverage/issues/798"> <p>PHP-Code-Coverage#798</p>
+ </a>
+                    
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/nikic/PHP-Parser/blob/master/lib/PhpParser/Lexer.php"> <p>PHP-Parser Lexer code</p>
+ </a>
+                    
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">bool</span>
+            &mdash;
+        
+    
+</article>
+            </section>
+
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
+
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
+            </div>
+        </div>
+        <a href="classes/PHPCSUtils-Tokens-TokenHelper.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+
+    </main>
+
+    <script>
+        cssVars({});
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
+</body>
+</html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Arrays.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Arrays.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-utils.html">Utils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,15 +118,22 @@
     Arrays
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Arrays.php"><a href="../files/phpcsutils-utils-arrays.html"><abbr title="PHPCSUtils/Utils/Arrays.php">Arrays.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Arrays.php"><a href="files/phpcsutils-utils-arrays.html"><abbr title="PHPCSUtils/Utils/Arrays.php">Arrays.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">26</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility functions for use when examining arrays.</p>
 
@@ -98,8 +149,9 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 
@@ -113,24 +165,24 @@
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Arrays.html#method_getDoubleArrowPtr">getDoubleArrowPtr()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-Arrays.html#method_getDoubleArrowPtr">getDoubleArrowPtr()</a>
     <span>
-                        &nbsp;: int|false    </span>
+                                &nbsp;: int|false    </span>
 </dt>
 <dd>Get the stack pointer position of the double arrow within an array item.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Arrays.html#method_getOpenClose">getOpenClose()</a>
+    <a href="classes/PHPCSUtils-Utils-Arrays.html#method_getOpenClose">getOpenClose()</a>
     <span>
-                        &nbsp;: array|false    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;|false    </span>
 </dt>
 <dd>Find the array opener and closer based on a T_ARRAY or T_OPEN_SHORT_ARRAY token.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Arrays.html#method_isShortArray">isShortArray()</a>
+    <a href="classes/PHPCSUtils-Utils-Arrays.html#method_isShortArray">isShortArray()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Determine whether a T_OPEN/CLOSE_SHORT_ARRAY token is a short array construct
 and not a short list.</dd>
@@ -146,7 +198,7 @@ and not a short list.</dd>
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-Arrays.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -156,22 +208,24 @@ and not a short list.</dd>
 >
     <h4 class="phpdocumentor-element__name" id="method_getDoubleArrowPtr">
         getDoubleArrowPtr()
-        <a href="#method_getDoubleArrowPtr" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Arrays.html#method_getDoubleArrowPtr" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Arrays.php"><a href="../files/phpcsutils-utils-arrays.html"><abbr title="PHPCSUtils/Utils/Arrays.php">Arrays.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Arrays.php"><a href="files/phpcsutils-utils-arrays.html"><abbr title="PHPCSUtils/Utils/Arrays.php">Arrays.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">263</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Get the stack pointer position of the double arrow within an array item.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getDoubleArrowPtr</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getDoubleArrowPtr</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
         <section class="phpdocumentor-description"><p>Expects to be passed the array item start and end tokens as retrieved via
-<a href="../classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameters">\PHPCSUtils\Utils\PassedParameters::getParameters()</a>.</p></section>
+<a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameters"><abbr title="\PHPCSUtils\Utils\PassedParameters::getParameters()">PassedParameters::getParameters()</abbr></a>.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -180,7 +234,8 @@ and not a short list.</dd>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being examined.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being examined.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -188,7 +243,8 @@ and not a short list.</dd>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>Stack pointer to the start of the array item.</p></section>
+                    <section class="phpdocumentor-description"><p>Stack pointer to the start of the array item.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -196,7 +252,8 @@ and not a short list.</dd>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>Stack pointer to the last token in the array item.</p></section>
+                    <section class="phpdocumentor-description"><p>Stack pointer to the last token in the array item.</p>
+</section>
 
             </dd>
             </dl>
@@ -212,30 +269,36 @@ and not a short list.</dd>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                                        <section class="phpdocumentor-description"><p>Now allows for arrow functions in arrays.</p></section>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Now allows for arrow functions in arrays.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the start or end positions are invalid.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the start or end positions are invalid.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">int|false</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>Stack pointer to the double arrow if this array item has a key; or <code class="prettyprint">FALSE</code> otherwise.</p></section>
+            <section class="phpdocumentor-description"><p>Stack pointer to the double arrow if this array item has a key; or <code class="prettyprint">FALSE</code> otherwise.</p>
+</section>
 
     
 </article>
@@ -247,23 +310,25 @@ and not a short list.</dd>
 >
     <h4 class="phpdocumentor-element__name" id="method_getOpenClose">
         getOpenClose()
-        <a href="#method_getOpenClose" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Arrays.html#method_getOpenClose" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Arrays.php"><a href="../files/phpcsutils-utils-arrays.html"><abbr title="PHPCSUtils/Utils/Arrays.php">Arrays.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Arrays.php"><a href="files/phpcsutils-utils-arrays.html"><abbr title="PHPCSUtils/Utils/Arrays.php">Arrays.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">205</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Find the array opener and closer based on a T_ARRAY or T_OPEN_SHORT_ARRAY token.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getOpenClose</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">true|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$isShortArray</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getOpenClose</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">true|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$isShortArray</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span></code>
 
         <section class="phpdocumentor-description"><p>This method also accepts <code class="prettyprint">T_OPEN_SQUARE_BRACKET</code> tokens to allow it to be
 PHPCS cross-version compatible as the short array tokenizing has been plagued by
-a number of bugs over time, which affects the short array determination.</p></section>
+a number of bugs over time, which affects the short array determination.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -272,7 +337,8 @@ a number of bugs over time, which affects the short array determination.</p></se
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -281,7 +347,8 @@ a number of bugs over time, which affects the short array determination.</p></se
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_ARRAY</code> or <code class="prettyprint">T_OPEN_SHORT_ARRAY</code>
-token in the stack.</p></section>
+token in the stack.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -294,7 +361,8 @@ tokens if it isn't necessary.
 Efficiency tweak for when this has already been established,
 i.e. when encountering a nested array while walking the
 tokens in an array.
-Use with care.</p></section>
+Use with care.</p>
+</section>
 
             </dd>
             </dl>
@@ -310,12 +378,13 @@ Use with care.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array|false</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span>
             &mdash;
             <section class="phpdocumentor-description"><p>An array with the token pointers; or <code class="prettyprint">FALSE</code> if this is not a
 (short) array token or if the opener/closer could not be determined.
@@ -323,7 +392,9 @@ The format of the array return value is:</p>
 <pre class="prettyprint"><code class="language-php">array(
   'opener' =&gt; integer, // Stack pointer to the array open bracket.
   'closer' =&gt; integer, // Stack pointer to the array close bracket.
-)</code></pre></section>
+)
+</code></pre>
+</section>
 
     
 </article>
@@ -335,24 +406,26 @@ The format of the array return value is:</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_isShortArray">
         isShortArray()
-        <a href="#method_isShortArray" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Arrays.html#method_isShortArray" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Arrays.php"><a href="../files/phpcsutils-utils-arrays.html"><abbr title="PHPCSUtils/Utils/Arrays.php">Arrays.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Arrays.php"><a href="files/phpcsutils-utils-arrays.html"><abbr title="PHPCSUtils/Utils/Arrays.php">Arrays.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">63</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Determine whether a T_OPEN/CLOSE_SHORT_ARRAY token is a short array construct
 and not a short list.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isShortArray</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isShortArray</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
         <section class="phpdocumentor-description"><p>This method also accepts <code class="prettyprint">T_OPEN/CLOSE_SQUARE_BRACKET</code> tokens to allow it to be
 PHPCS cross-version compatible as the short array tokenizing has been plagued by
-a number of bugs over time.</p></section>
+a number of bugs over time.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -361,7 +434,8 @@ a number of bugs over time.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -369,7 +443,8 @@ a number of bugs over time.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the short array bracket token.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the short array bracket token.</p>
+</section>
 
             </dd>
             </dl>
@@ -385,8 +460,9 @@ a number of bugs over time.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -394,27 +470,99 @@ a number of bugs over time.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> if the token passed is the open/close bracket of a short array.
 <code class="prettyprint">FALSE</code> if the token is a short list bracket, a plain square bracket
-or not one of the accepted tokens.</p></section>
+or not one of the accepted tokens.</p>
+</section>
 
     
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Arrays.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Arrays.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Arrays.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -131,7 +135,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Arrays.php"><a href="files/phpcsutils-utils-arrays.html"><abbr title="PHPCSUtils/Utils/Arrays.php">Arrays.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">26</span>
+    <span class="phpdocumentor-element-found-in__line">25</span>
 
     </aside>
 
@@ -151,6 +155,16 @@
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
                                                                                 
                                              
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Dropped support for PHPCS &lt; 3.7.1.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -213,7 +227,7 @@ and not a short list.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Arrays.php"><a href="files/phpcsutils-utils-arrays.html"><abbr title="PHPCSUtils/Utils/Arrays.php">Arrays.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">263</span>
+    <span class="phpdocumentor-element-found-in__line">159</span>
 
     </aside>
 
@@ -282,6 +296,26 @@ and not a short list.</dd>
 </section>
 
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Now allows for match expressions in arrays.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Now allows for attributes in arrays.</p>
+</section>
+
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
@@ -315,7 +349,7 @@ and not a short list.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Arrays.php"><a href="files/phpcsutils-utils-arrays.html"><abbr title="PHPCSUtils/Utils/Arrays.php">Arrays.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">205</span>
+    <span class="phpdocumentor-element-found-in__line">99</span>
 
     </aside>
 
@@ -411,7 +445,7 @@ The format of the array return value is:</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Arrays.php"><a href="files/phpcsutils-utils-arrays.html"><abbr title="PHPCSUtils/Utils/Arrays.php">Arrays.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">63</span>
+    <span class="phpdocumentor-element-found-in__line">65</span>
 
     </aside>
 

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Conditions.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Conditions.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Conditions.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Conditions.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-utils.html">Utils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,15 +118,22 @@
     Conditions
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Conditions.php"><a href="../files/phpcsutils-utils-conditions.html"><abbr title="PHPCSUtils/Utils/Conditions.php">Conditions.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Conditions.php"><a href="files/phpcsutils-utils-conditions.html"><abbr title="PHPCSUtils/Utils/Conditions.php">Conditions.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">23</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility functions for use when examining token conditions.</p>
 
@@ -98,12 +149,14 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                        <section class="phpdocumentor-description"><p>The <code class="prettyprint">Conditions::getCondition()</code> and <code class="prettyprint">Conditions::hasCondition()</code>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>The <code class="prettyprint">Conditions::getCondition()</code> and <code class="prettyprint">Conditions::hasCondition()</code>
 methods are based on and inspired by the methods of the same name in the
 PHPCS native <code class="prettyprint">PHP_CodeSniffer\Files\File</code> class.
-Also see {@see \PHPCSUtils\BackCompat\BCFile}.</p></section>
+Also see <a href="classes/PHPCSUtils-BackCompat-BCFile.html"><abbr title="\PHPCSUtils\BackCompat\BCFile">BCFile</abbr></a>.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
 
@@ -117,31 +170,31 @@ Also see {@see \PHPCSUtils\BackCompat\BCFile}.</p></section>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Conditions.html#method_getCondition">getCondition()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-Conditions.html#method_getCondition">getCondition()</a>
     <span>
-                        &nbsp;: int|false    </span>
+                                &nbsp;: int|false    </span>
 </dt>
 <dd>Retrieve the position of a condition for the passed token.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Conditions.html#method_getFirstCondition">getFirstCondition()</a>
+    <a href="classes/PHPCSUtils-Utils-Conditions.html#method_getFirstCondition">getFirstCondition()</a>
     <span>
-                        &nbsp;: int|false    </span>
+                                &nbsp;: int|false    </span>
 </dt>
 <dd>Return the position of the first (outermost) condition of a certain type for the passed token.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Conditions.html#method_getLastCondition">getLastCondition()</a>
+    <a href="classes/PHPCSUtils-Utils-Conditions.html#method_getLastCondition">getLastCondition()</a>
     <span>
-                        &nbsp;: int|false    </span>
+                                &nbsp;: int|false    </span>
 </dt>
 <dd>Return the position of the last (innermost) condition of a certain type for the passed token.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Conditions.html#method_hasCondition">hasCondition()</a>
+    <a href="classes/PHPCSUtils-Utils-Conditions.html#method_hasCondition">hasCondition()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Determine if the passed token has a condition of one of the passed types.</dd>
 
@@ -156,7 +209,7 @@ Also see {@see \PHPCSUtils\BackCompat\BCFile}.</p></section>
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-Conditions.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -166,19 +219,20 @@ Also see {@see \PHPCSUtils\BackCompat\BCFile}.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getCondition">
         getCondition()
-        <a href="#method_getCondition" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Conditions.html#method_getCondition" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Conditions.php"><a href="../files/phpcsutils-utils-conditions.html"><abbr title="PHPCSUtils/Utils/Conditions.php">Conditions.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Conditions.php"><a href="files/phpcsutils-utils-conditions.html"><abbr title="PHPCSUtils/Utils/Conditions.php">Conditions.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">56</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieve the position of a condition for the passed token.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getCondition</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$types</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$first</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">true</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getCondition</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$types</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$first</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">true</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
         <section class="phpdocumentor-description"><p>If no types are specified, the first condition for the token - or if <code class="prettyprint">$first=false</code>,
 the last condition - will be returned.</p>
@@ -187,7 +241,8 @@ the last condition - will be returned.</p>
 <li>The singular <code class="prettyprint">$type</code> parameter has become the more flexible <code class="prettyprint">$types</code> parameter allowing to
 search for several types of conditions in one go.</li>
 <li>The <code class="prettyprint">$types</code> parameter is now optional.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -196,7 +251,8 @@ search for several types of conditions in one go.</li>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -204,15 +260,17 @@ search for several types of conditions in one go.</li>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$types</span>
-                : <span class="phpdocumentor-signature__argument__return-type">int|string|array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;</span>
                  = <span class="phpdocumentor-signature__argument__default-value">[]</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>Optional. The type(s) of tokens to search for.</p></section>
+                    <section class="phpdocumentor-description"><p>Optional. The type(s) of tokens to search for.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -222,7 +280,8 @@ search for several types of conditions in one go.</li>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Optional. Whether to search for the first (outermost)
 (<code class="prettyprint">true</code>) or the last (innermost) condition (<code class="prettyprint">false</code>) of
-the specified type(s).</p></section>
+the specified type(s).</p>
+</section>
 
             </dd>
             </dl>
@@ -238,42 +297,50 @@ the specified type(s).</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getCondition()">File::getCondition()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_getCondition"><abbr title="\PHPCSUtils\BackCompat\BCFile::getCondition()">BCFile::getCondition()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getCondition"><abbr title="\PHPCSUtils\BackCompat\BCFile::getCondition()">BCFile::getCondition()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                                        <section class="phpdocumentor-description"><p>The <code class="prettyprint">$reverse</code> parameter has been renamed to <code class="prettyprint">$first</code> and the meaning of the
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>The <code class="prettyprint">$reverse</code> parameter has been renamed to <code class="prettyprint">$first</code> and the meaning of the
 boolean reversed (<code class="prettyprint">true</code> = first, <code class="prettyprint">false</code> = last, was: <code class="prettyprint">true</code> = last, <code class="prettyprint">false</code> = first)
 to be in line with PHPCS itself which added the <code class="prettyprint">$first</code> parameter in v 3.5.4
-to allow for the same/similar functionality as <code class="prettyprint">$reverse</code> already offered.</p></section>
+to allow for the same/similar functionality as <code class="prettyprint">$reverse</code> already offered.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">int|false</span>
             &mdash;
             <section class="phpdocumentor-description"><p>Integer stack pointer to the condition; or <code class="prettyprint">FALSE</code> if the token
-does not have the condition or has no conditions at all.</p></section>
+does not have the condition or has no conditions at all.</p>
+</section>
 
     
 </article>
@@ -285,22 +352,24 @@ does not have the condition or has no conditions at all.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getFirstCondition">
         getFirstCondition()
-        <a href="#method_getFirstCondition" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Conditions.html#method_getFirstCondition" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Conditions.php"><a href="../files/phpcsutils-utils-conditions.html"><abbr title="PHPCSUtils/Utils/Conditions.php">Conditions.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Conditions.php"><a href="files/phpcsutils-utils-conditions.html"><abbr title="PHPCSUtils/Utils/Conditions.php">Conditions.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">136</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Return the position of the first (outermost) condition of a certain type for the passed token.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getFirstCondition</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$types</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getFirstCondition</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$types</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
         <section class="phpdocumentor-description"><p>If no types are specified, the first condition for the token, independently of type,
-will be returned.</p></section>
+will be returned.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -309,7 +378,8 @@ will be returned.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -317,15 +387,17 @@ will be returned.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$types</span>
-                : <span class="phpdocumentor-signature__argument__return-type">int|string|array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;</span>
                  = <span class="phpdocumentor-signature__argument__default-value">[]</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>Optional. The type(s) of tokens to search for.</p></section>
+                    <section class="phpdocumentor-description"><p>Optional. The type(s) of tokens to search for.</p>
+</section>
 
             </dd>
             </dl>
@@ -341,15 +413,17 @@ will be returned.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">int|false</span>
             &mdash;
             <section class="phpdocumentor-description"><p>Integer stack pointer to the condition; or <code class="prettyprint">FALSE</code> if the token
-does not have the condition or has no conditions at all.</p></section>
+does not have the condition or has no conditions at all.</p>
+</section>
 
     
 </article>
@@ -361,22 +435,24 @@ does not have the condition or has no conditions at all.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getLastCondition">
         getLastCondition()
-        <a href="#method_getLastCondition" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Conditions.html#method_getLastCondition" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Conditions.php"><a href="../files/phpcsutils-utils-conditions.html"><abbr title="PHPCSUtils/Utils/Conditions.php">Conditions.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Conditions.php"><a href="files/phpcsutils-utils-conditions.html"><abbr title="PHPCSUtils/Utils/Conditions.php">Conditions.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">156</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Return the position of the last (innermost) condition of a certain type for the passed token.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getLastCondition</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$types</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getLastCondition</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$types</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
         <section class="phpdocumentor-description"><p>If no types are specified, the last condition for the token, independently of type,
-will be returned.</p></section>
+will be returned.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -385,7 +461,8 @@ will be returned.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -393,15 +470,17 @@ will be returned.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$types</span>
-                : <span class="phpdocumentor-signature__argument__return-type">int|string|array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;</span>
                  = <span class="phpdocumentor-signature__argument__default-value">[]</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>Optional. The type(s) of tokens to search for.</p></section>
+                    <section class="phpdocumentor-description"><p>Optional. The type(s) of tokens to search for.</p>
+</section>
 
             </dd>
             </dl>
@@ -417,15 +496,17 @@ will be returned.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">int|false</span>
             &mdash;
             <section class="phpdocumentor-description"><p>Integer stack pointer to the condition; or <code class="prettyprint">FALSE</code> if the token
-does not have the condition or has no conditions at all.</p></section>
+does not have the condition or has no conditions at all.</p>
+</section>
 
     
 </article>
@@ -437,21 +518,23 @@ does not have the condition or has no conditions at all.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_hasCondition">
         hasCondition()
-        <a href="#method_hasCondition" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Conditions.html#method_hasCondition" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Conditions.php"><a href="../files/phpcsutils-utils-conditions.html"><abbr title="PHPCSUtils/Utils/Conditions.php">Conditions.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Conditions.php"><a href="files/phpcsutils-utils-conditions.html"><abbr title="PHPCSUtils/Utils/Conditions.php">Conditions.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">116</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Determine if the passed token has a condition of one of the passed types.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">hasCondition</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$types</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">hasCondition</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$types</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
-        <section class="phpdocumentor-description"><p>This method is not significantly different from the PHPCS native version.</p></section>
+        <section class="phpdocumentor-description"><p>This method is not significantly different from the PHPCS native version.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -460,7 +543,8 @@ does not have the condition or has no conditions at all.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -468,15 +552,17 @@ does not have the condition or has no conditions at all.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$types</span>
-                : <span class="phpdocumentor-signature__argument__return-type">int|string|array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The type(s) of tokens to search for.</p></section>
+                    <section class="phpdocumentor-description"><p>The type(s) of tokens to search for.</p>
+</section>
 
             </dd>
             </dl>
@@ -492,24 +578,29 @@ does not have the condition or has no conditions at all.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::hasCondition()">File::hasCondition()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_hasCondition"><abbr title="\PHPCSUtils\BackCompat\BCFile::hasCondition()">BCFile::hasCondition()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_hasCondition"><abbr title="\PHPCSUtils\BackCompat\BCFile::hasCondition()">BCFile::hasCondition()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -520,21 +611,92 @@ does not have the condition or has no conditions at all.</p></section>
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Conditions.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Context.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Context.html
@@ -1,0 +1,760 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+            <title>PHPCSUtils</title>
+    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
+                <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
+        <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
+    </head>
+<body id="top">
+    <header class="phpdocumentor-header phpdocumentor-section">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
+    <section data-search-form class="phpdocumentor-search">
+    <label>
+        <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
+        <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
+    </label>
+</section>
+
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
+
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
+                        </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
+
+                        </section>
+            
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
+    </section>
+
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
+    </section>
+</aside>
+
+            <div class="phpdocumentor-column -eight phpdocumentor-content">
+                    <ul class="phpdocumentor-breadcrumbs">
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
+    </ul>
+
+    <article class="phpdocumentor-element -class">
+        <h2 class="phpdocumentor-content__title">
+    Context
+
+    
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
+    
+    
+    </h2>
+
+        <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Context.php"><a href="files/phpcsutils-utils-context.html"><abbr title="PHPCSUtils/Utils/Context.php">Context.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">27</span>
+
+    </aside>
+
+            <p class="phpdocumentor-summary">Utility functions for examining in which context a certain token is used.</p>
+
+    <section class="phpdocumentor-description"><p>Example use-cases:</p>
+<ul>
+<li>A sniff looking for the use of certain variables may want to disregard the &quot;use&quot;
+of these variables within a call to <code class="prettyprint">isset()</code> or <code class="prettyprint">empty()</code>.</li>
+<li>A sniff looking for incrementor/decrementors may want to disregard these when used
+as the third expression in a <code class="prettyprint">for()</code> condition.</li>
+</ul>
+</section>
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+
+
+
+
+
+<h3 id="toc">
+    Table of Contents
+    <a href="#toc" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-Context.html#method_inAttribute">inAttribute()</a>
+    <span>
+                                &nbsp;: bool    </span>
+</dt>
+<dd>Check whether an arbitrary token is within an attribute.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-Context.html#method_inEmpty">inEmpty()</a>
+    <span>
+                                &nbsp;: bool    </span>
+</dt>
+<dd>Check whether an arbitrary token is within a call to empty().</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-Context.html#method_inForCondition">inForCondition()</a>
+    <span>
+                                &nbsp;: string|false    </span>
+</dt>
+<dd>Check whether an arbitrary token is in a for condition and if so, in which part:
+the first, second or third expression.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-Context.html#method_inForeachCondition">inForeachCondition()</a>
+    <span>
+                                &nbsp;: string|false    </span>
+</dt>
+<dd>Check whether an arbitrary token is in a foreach condition and if so, in which part:
+before or after the &quot;as&quot;.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-Context.html#method_inIsset">inIsset()</a>
+    <span>
+                                &nbsp;: bool    </span>
+</dt>
+<dd>Check whether an arbitrary token is within a call to isset().</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-Context.html#method_inUnset">inUnset()</a>
+    <span>
+                                &nbsp;: bool    </span>
+</dt>
+<dd>Check whether an arbitrary token is within a call to unset().</dd>
+
+        </dl>
+
+
+
+        
+
+        
+
+            <section class="phpdocumentor-methods">
+        <h3 class="phpdocumentor-elements__header" id="methods">
+            Methods
+            <a href="classes/PHPCSUtils-Utils-Context.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
+        </h3>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_inAttribute">
+        inAttribute()
+        <a href="classes/PHPCSUtils-Utils-Context.html#method_inAttribute" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Context.php"><a href="files/phpcsutils-utils-context.html"><abbr title="PHPCSUtils/Utils/Context.php">Context.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">97</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Check whether an arbitrary token is within an attribute.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">inAttribute</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$phpcsFile</span>
+                : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$stackPtr</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">bool</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_inEmpty">
+        inEmpty()
+        <a href="classes/PHPCSUtils-Utils-Context.html#method_inEmpty" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Context.php"><a href="files/phpcsutils-utils-context.html"><abbr title="PHPCSUtils/Utils/Context.php">Context.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">44</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Check whether an arbitrary token is within a call to empty().</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">inEmpty</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+
+        <section class="phpdocumentor-description"><p><em>This method is a thin, descriptive wrapper around the <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOwner"><abbr title="\PHPCSUtils\Utils\Parentheses::getLastOwner()">Parentheses::getLastOwner()</abbr></a> method.
+For more complex/combined queries, it is recommended to call the <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOwner"><abbr title="\PHPCSUtils\Utils\Parentheses::getLastOwner()">Parentheses::getLastOwner()</abbr></a>
+method directly.</em></p>
+</section>
+
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$phpcsFile</span>
+                : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$stackPtr</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">bool</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_inForCondition">
+        inForCondition()
+        <a href="classes/PHPCSUtils-Utils-Context.html#method_inForCondition" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Context.php"><a href="files/phpcsutils-utils-context.html"><abbr title="PHPCSUtils/Utils/Context.php">Context.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">179</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Check whether an arbitrary token is in a for condition and if so, in which part:
+the first, second or third expression.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">inForCondition</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|false</span></code>
+
+        <section class="phpdocumentor-description"><p>Note: the semicolons separating the conditions are regarded as belonging with the
+expression before it.</p>
+</section>
+
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$phpcsFile</span>
+                : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$stackPtr</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">string|false</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>String <code class="prettyprint">'expr1'</code>, <code class="prettyprint">'expr2'</code> or <code class="prettyprint">'expr3'</code> when the token is within
+a <code class="prettyprint">for</code> condition.
+<code class="prettyprint">FALSE</code> in all other cases, including for parse errors.</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_inForeachCondition">
+        inForeachCondition()
+        <a href="classes/PHPCSUtils-Utils-Context.html#method_inForeachCondition" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Context.php"><a href="files/phpcsutils-utils-context.html"><abbr title="PHPCSUtils/Utils/Context.php">Context.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">127</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Check whether an arbitrary token is in a foreach condition and if so, in which part:
+before or after the &quot;as&quot;.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">inForeachCondition</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|false</span></code>
+
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$phpcsFile</span>
+                : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$stackPtr</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">string|false</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>String <code class="prettyprint">'beforeAs'</code>, <code class="prettyprint">'as'</code> or <code class="prettyprint">'afterAs'</code> when the token is within
+a <code class="prettyprint">foreach</code> condition.
+<code class="prettyprint">FALSE</code> in all other cases, including for parse errors.</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_inIsset">
+        inIsset()
+        <a href="classes/PHPCSUtils-Utils-Context.html#method_inIsset" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Context.php"><a href="files/phpcsutils-utils-context.html"><abbr title="PHPCSUtils/Utils/Context.php">Context.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">63</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Check whether an arbitrary token is within a call to isset().</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">inIsset</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+
+        <section class="phpdocumentor-description"><p><em>This method is a thin, descriptive wrapper around the <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOwner"><abbr title="\PHPCSUtils\Utils\Parentheses::getLastOwner()">Parentheses::getLastOwner()</abbr></a> method.
+For more complex/combined queries, it is recommended to call the <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOwner"><abbr title="\PHPCSUtils\Utils\Parentheses::getLastOwner()">Parentheses::getLastOwner()</abbr></a>
+method directly.</em></p>
+</section>
+
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$phpcsFile</span>
+                : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$stackPtr</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">bool</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_inUnset">
+        inUnset()
+        <a href="classes/PHPCSUtils-Utils-Context.html#method_inUnset" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Context.php"><a href="files/phpcsutils-utils-context.html"><abbr title="PHPCSUtils/Utils/Context.php">Context.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">82</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Check whether an arbitrary token is within a call to unset().</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">inUnset</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+
+        <section class="phpdocumentor-description"><p><em>This method is a thin, descriptive wrapper around the <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOwner"><abbr title="\PHPCSUtils\Utils\Parentheses::getLastOwner()">Parentheses::getLastOwner()</abbr></a> method.
+For more complex/combined queries, it is recommended to call the <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOwner"><abbr title="\PHPCSUtils\Utils\Parentheses::getLastOwner()">Parentheses::getLastOwner()</abbr></a>
+method directly.</em></p>
+</section>
+
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$phpcsFile</span>
+                : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$stackPtr</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">bool</span>
+            &mdash;
+        
+    
+</article>
+            </section>
+
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
+
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
+            </div>
+        </div>
+        <a href="classes/PHPCSUtils-Utils-Context.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+
+    </main>
+
+    <script>
+        cssVars({});
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
+</body>
+</html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-ControlStructures.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-ControlStructures.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-utils.html">Utils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,15 +118,22 @@
     ControlStructures
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ControlStructures.php"><a href="../files/phpcsutils-utils-controlstructures.html"><abbr title="PHPCSUtils/Utils/ControlStructures.php">ControlStructures.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ControlStructures.php"><a href="files/phpcsutils-utils-controlstructures.html"><abbr title="PHPCSUtils/Utils/ControlStructures.php">ControlStructures.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">23</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility functions for use when examining control structures.</p>
 
@@ -98,8 +149,9 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 
@@ -113,31 +165,31 @@
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-ControlStructures.html#method_getCaughtExceptions">getCaughtExceptions()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-ControlStructures.html#method_getCaughtExceptions">getCaughtExceptions()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Retrieve the exception(s) being caught in a CATCH condition.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-ControlStructures.html#method_getDeclareScopeOpenClose">getDeclareScopeOpenClose()</a>
+    <a href="classes/PHPCSUtils-Utils-ControlStructures.html#method_getDeclareScopeOpenClose">getDeclareScopeOpenClose()</a>
     <span>
-                        &nbsp;: array|false    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;|false    </span>
 </dt>
 <dd>Get the scope opener and closer for a DECLARE statement.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-ControlStructures.html#method_hasBody">hasBody()</a>
+    <a href="classes/PHPCSUtils-Utils-ControlStructures.html#method_hasBody">hasBody()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Check whether a control structure has a body.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-ControlStructures.html#method_isElseIf">isElseIf()</a>
+    <a href="classes/PHPCSUtils-Utils-ControlStructures.html#method_isElseIf">isElseIf()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Check whether an IF or ELSE token is part of an &quot;else if&quot;.</dd>
 
@@ -152,7 +204,7 @@
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-ControlStructures.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -162,19 +214,20 @@
 >
     <h4 class="phpdocumentor-element__name" id="method_getCaughtExceptions">
         getCaughtExceptions()
-        <a href="#method_getCaughtExceptions" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-ControlStructures.html#method_getCaughtExceptions" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ControlStructures.php"><a href="../files/phpcsutils-utils-controlstructures.html"><abbr title="PHPCSUtils/Utils/ControlStructures.php">ControlStructures.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ControlStructures.php"><a href="files/phpcsutils-utils-controlstructures.html"><abbr title="PHPCSUtils/Utils/ControlStructures.php">ControlStructures.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">372</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieve the exception(s) being caught in a CATCH condition.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getCaughtExceptions</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getCaughtExceptions</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -184,7 +237,8 @@
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -192,7 +246,8 @@
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
 
             </dd>
             </dl>
@@ -208,30 +263,35 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified <code class="prettyprint">$stackPtr</code> is not of
-type <code class="prettyprint">T_CATCH</code> or doesn't exist.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified <code class="prettyprint">$stackPtr</code> is not of
+type <code class="prettyprint">T_CATCH</code> or doesn't exist.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If no parenthesis opener or closer can be
-determined (parse error).</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If no parenthesis opener or closer can be
+determined (parse error).</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
             <section class="phpdocumentor-description"><p>Array with information about the caught Exception(s).
 The returned array will contain the following information for
@@ -240,7 +300,9 @@ each caught exception:</p>
   'type'           =&gt; string,  // The type declaration for the exception being caught.
   'type_token'     =&gt; integer, // The stack pointer to the start of the type declaration.
   'type_end_token' =&gt; integer, // The stack pointer to the end of the type declaration.
-)</code></pre></section>
+)
+</code></pre>
+</section>
 
     
 </article>
@@ -252,23 +314,25 @@ each caught exception:</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_getDeclareScopeOpenClose">
         getDeclareScopeOpenClose()
-        <a href="#method_getDeclareScopeOpenClose" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-ControlStructures.html#method_getDeclareScopeOpenClose" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ControlStructures.php"><a href="../files/phpcsutils-utils-controlstructures.html"><abbr title="PHPCSUtils/Utils/ControlStructures.php">ControlStructures.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ControlStructures.php"><a href="files/phpcsutils-utils-controlstructures.html"><abbr title="PHPCSUtils/Utils/ControlStructures.php">ControlStructures.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">235</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Get the scope opener and closer for a DECLARE statement.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getDeclareScopeOpenClose</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getDeclareScopeOpenClose</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span></code>
 
         <section class="phpdocumentor-description"><p>A <code class="prettyprint">declare</code> statement can be:</p>
 <ul>
-<li>applied to the rest of the file, like <code class="prettyprint">declare(ticks=1);</code></li>
+<li>applied to the rest of the file, like <code class="prettyprint">declare(ticks=1);</code>
+</li>
 <li>applied to a limited scope using curly braces;</li>
 <li>applied to a limited scope using the alternative control structure syntax.</li>
 </ul>
@@ -278,7 +342,8 @@ In the last case, due to a bug in the PHPCS Tokenizer, it won't have the scope o
 while it really should. This bug is fixed in PHPCS 3.5.4.</p>
 <p>In other words, if a sniff needs to support PHPCS &lt; 3.5.4 and needs to take the alternative
 control structure syntax into account, this method can be used to retrieve the
-scope opener/closer for the declare statement.</p></section>
+scope opener/closer for the declare statement.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -287,7 +352,8 @@ scope opener/closer for the declare statement.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -295,7 +361,8 @@ scope opener/closer for the declare statement.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
 
             </dd>
             </dl>
@@ -310,21 +377,22 @@ scope opener/closer for the declare statement.</p></section>
                     <span class="phpdocumentor-tag__name">link</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/squizlabs/PHP_CodeSniffer/pull/2843">https://github.com/squizlabs/PHP_CodeSniffer/pull/2843</a>
-                                            <section class="phpdocumentor-description"><p>PHPCS PR #2843</p></section>
-
-                </dd>
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/squizlabs/PHP_CodeSniffer/pull/2843"> <p>PHPCS PR #2843</p>
+ </a>
+                    
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array|false</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span>
             &mdash;
             <section class="phpdocumentor-description"><p>An array with the token pointers; or <code class="prettyprint">FALSE</code> if not a <code class="prettyprint">DECLARE</code> token
 or if the opener/closer could not be determined.
@@ -332,7 +400,9 @@ The format of the array return value is:</p>
 <pre class="prettyprint"><code class="language-php">array(
   'opener' =&gt; integer, // Stack pointer to the scope opener.
   'closer' =&gt; integer, // Stack pointer to the scope closer.
-)</code></pre></section>
+)
+</code></pre>
+</section>
 
     
 </article>
@@ -344,25 +414,28 @@ The format of the array return value is:</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_hasBody">
         hasBody()
-        <a href="#method_hasBody" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-ControlStructures.html#method_hasBody" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ControlStructures.php"><a href="../files/phpcsutils-utils-controlstructures.html"><abbr title="PHPCSUtils/Utils/ControlStructures.php">ControlStructures.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ControlStructures.php"><a href="files/phpcsutils-utils-controlstructures.html"><abbr title="PHPCSUtils/Utils/ControlStructures.php">ControlStructures.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">50</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Check whether a control structure has a body.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">hasBody</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$allowEmpty</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">true</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">hasBody</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$allowEmpty</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">true</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
         <section class="phpdocumentor-description"><p>Some control structures - <code class="prettyprint">while</code>, <code class="prettyprint">for</code> and <code class="prettyprint">declare</code> - can be declared without a body, like:</p>
-<pre class="prettyprint"><code class="language-php">while (++$i &lt; 10);</code></pre>
+<pre class="prettyprint"><code class="language-php">while (++$i &lt; 10);
+</code></pre>
 <p>All other control structures will always have a body, though the body may be empty, where &quot;empty&quot; means:
 no <em>code</em> is found in the body. If a control structure body only contains a comment, it will be
-regarded as empty.</p></section>
+regarded as empty.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -371,7 +444,8 @@ regarded as empty.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -379,7 +453,8 @@ regarded as empty.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -389,7 +464,8 @@ regarded as empty.</p></section>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Whether a control structure with an empty body should
 still be considered as having a body.
-Defaults to <code class="prettyprint">true</code>.</p></section>
+Defaults to <code class="prettyprint">true</code>.</p>
+</section>
 
             </dd>
             </dl>
@@ -405,8 +481,9 @@ Defaults to <code class="prettyprint">true</code>.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -414,7 +491,8 @@ Defaults to <code class="prettyprint">true</code>.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> when the control structure has a body, or in case <code class="prettyprint">$allowEmpty</code> is set to <code class="prettyprint">FALSE</code>:
 when it has a non-empty body.
-<code class="prettyprint">FALSE</code> in all other cases, including when a non-control structure token has been passed.</p></section>
+<code class="prettyprint">FALSE</code> in all other cases, including when a non-control structure token has been passed.</p>
+</section>
 
     
 </article>
@@ -426,19 +504,20 @@ when it has a non-empty body.
 >
     <h4 class="phpdocumentor-element__name" id="method_isElseIf">
         isElseIf()
-        <a href="#method_isElseIf" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-ControlStructures.html#method_isElseIf" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ControlStructures.php"><a href="../files/phpcsutils-utils-controlstructures.html"><abbr title="PHPCSUtils/Utils/ControlStructures.php">ControlStructures.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ControlStructures.php"><a href="files/phpcsutils-utils-controlstructures.html"><abbr title="PHPCSUtils/Utils/ControlStructures.php">ControlStructures.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">161</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Check whether an IF or ELSE token is part of an &quot;else if&quot;.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isElseIf</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isElseIf</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -448,7 +527,8 @@ when it has a non-empty body.
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -456,7 +536,8 @@ when it has a non-empty body.
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
 
             </dd>
             </dl>
@@ -472,8 +553,9 @@ when it has a non-empty body.
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -484,21 +566,92 @@ when it has a non-empty body.
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Utils-ControlStructures.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-ControlStructures.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-ControlStructures.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -131,7 +135,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ControlStructures.php"><a href="files/phpcsutils-utils-controlstructures.html"><abbr title="PHPCSUtils/Utils/ControlStructures.php">ControlStructures.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">23</span>
+    <span class="phpdocumentor-element-found-in__line">24</span>
 
     </aside>
 
@@ -151,6 +155,16 @@
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
                                                                                 
                                              
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Dropped support for PHPCS &lt; 3.7.1.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -219,7 +233,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ControlStructures.php"><a href="files/phpcsutils-utils-controlstructures.html"><abbr title="PHPCSUtils/Utils/ControlStructures.php">ControlStructures.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">372</span>
+    <span class="phpdocumentor-element-found-in__line">278</span>
 
     </aside>
 
@@ -266,6 +280,16 @@
                                                                                 
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 identifier name tokenization.</p>
+</section>
+
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
@@ -310,7 +334,7 @@ each caught exception:</p>
         class="phpdocumentor-element
             -method
             -public
-                                    -static                    "
+            -deprecated                        -static                    "
 >
     <h4 class="phpdocumentor-element__name" id="method_getDeclareScopeOpenClose">
         getDeclareScopeOpenClose()
@@ -319,13 +343,13 @@ each caught exception:</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ControlStructures.php"><a href="files/phpcsutils-utils-controlstructures.html"><abbr title="PHPCSUtils/Utils/ControlStructures.php">ControlStructures.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">235</span>
+    <span class="phpdocumentor-element-found-in__line">224</span>
 
     </aside>
 
         <p class="phpdocumentor-summary">Get the scope opener and closer for a DECLARE statement.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getDeclareScopeOpenClose</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span></code>
 
@@ -339,10 +363,7 @@ each caught exception:</p>
 <p>In the first case, the statement - correctly - won't have a scope opener/closer.
 In the second case, the statement will have the scope opener/closer indexes.
 In the last case, due to a bug in the PHPCS Tokenizer, it won't have the scope opener/closer indexes,
-while it really should. This bug is fixed in PHPCS 3.5.4.</p>
-<p>In other words, if a sniff needs to support PHPCS &lt; 3.5.4 and needs to take the alternative
-control structure syntax into account, this method can be used to retrieve the
-scope opener/closer for the declare statement.</p>
+while it really should. This bug was fixed in PHPCS 3.5.4.</p>
 </section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -389,6 +410,16 @@ scope opener/closer for the declare statement.</p>
                                                                                 
                                              
                                     </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Check the scope_opener/scope_closer instead.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -419,7 +450,7 @@ The format of the array return value is:</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ControlStructures.php"><a href="files/phpcsutils-utils-controlstructures.html"><abbr title="PHPCSUtils/Utils/ControlStructures.php">ControlStructures.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">50</span>
+    <span class="phpdocumentor-element-found-in__line">52</span>
 
     </aside>
 
@@ -484,6 +515,16 @@ Defaults to <code class="prettyprint">true</code>.</p>
                                                                                 
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 match control structures.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -509,7 +550,7 @@ when it has a non-empty body.
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ControlStructures.php"><a href="files/phpcsutils-utils-controlstructures.html"><abbr title="PHPCSUtils/Utils/ControlStructures.php">ControlStructures.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">161</span>
+    <span class="phpdocumentor-element-found-in__line">153</span>
 
     </aside>
 

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-FunctionDeclarations.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-FunctionDeclarations.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -156,6 +160,16 @@ inspired by respectively the <code class="prettyprint">getMethodProperties()</co
 and <code class="prettyprint">getMethodParameters()</code> methods in the PHPCS native
 <code class="prettyprint">PHP_CodeSniffer\Files\File</code> class.
 Also see <a href="classes/PHPCSUtils-BackCompat-BCFile.html"><abbr title="\PHPCSUtils\BackCompat\BCFile">BCFile</abbr></a>.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Dropped support for PHPCS &lt; 3.7.1.</p>
 </section>
 
                                     </dd>
@@ -489,7 +503,7 @@ and comparisons against this list should therefore always be done in a case-inse
         class="phpdocumentor-element
             -method
             -public
-                                    -static                    "
+            -deprecated                        -static                    "
 >
     <h4 class="phpdocumentor-element__name" id="method_getArrowFunctionOpenClose">
         getArrowFunctionOpenClose()
@@ -498,21 +512,19 @@ and comparisons against this list should therefore always be done in a case-inse
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">677</span>
+    <span class="phpdocumentor-element-found-in__line">695</span>
 
     </aside>
 
         <p class="phpdocumentor-summary">Retrieve the parenthesis opener, parenthesis closer, the scope opener and the scope closer
 for an arrow function.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getArrowFunctionOpenClose</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span></code>
 
         <section class="phpdocumentor-description"><p>Helper function for cross-version compatibility with both PHP as well as PHPCS.
-In PHPCS versions prior to PHPCS 3.5.3/3.5.4, the <code class="prettyprint">T_FN</code> token is not yet backfilled
-and does not have parenthesis opener/closer nor scope opener/closer indexes assigned
-in the <code class="prettyprint">$tokens</code> array.</p>
+As of PHPCS 3.5.6, this function is no longer be needed.</p>
 </section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -563,6 +575,16 @@ only two tokens which can be the arrow function keyword.</p>
                                                                                 
                                              
                                     </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the T_FN token constant instead.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -594,7 +616,7 @@ The format of the return value is:</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">155</span>
+    <span class="phpdocumentor-element-found-in__line">136</span>
 
     </aside>
 
@@ -698,7 +720,7 @@ the function is anonymous or in case of a parse error/live coding.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">401</span>
+    <span class="phpdocumentor-element-found-in__line">394</span>
 
     </aside>
 
@@ -714,6 +736,7 @@ the function is anonymous or in case of a parse error/live coding.</p>
   'name'                =&gt; '$var',  // The variable name.
   'token'               =&gt; integer, // The stack pointer to the variable name.
   'content'             =&gt; string,  // The full content of the variable definition.
+  'has_attributes'      =&gt; boolean, // Does the parameter have one or more attributes attached ?
   'pass_by_reference'   =&gt; boolean, // Is the variable passed by reference?
   'reference_token'     =&gt; integer, // The stack pointer to the reference operator
                                     // or FALSE if the param is not passed by reference.
@@ -725,7 +748,8 @@ the function is anonymous or in case of a parse error/live coding.</p>
                                     // or FALSE if there is no type hint.
   'type_hint_end_token' =&gt; integer, // The stack pointer to the end of the type hint
                                     // or FALSE if there is no type hint.
-  'nullable_type'       =&gt; boolean, // TRUE if the var type is nullable.
+  'nullable_type'       =&gt; boolean, // TRUE if the var type is preceded by the nullability
+                                    // operator.
   'comma_token'         =&gt; integer, // The stack pointer to the comma after the param
                                     // or FALSE if this is the last param.
 )
@@ -735,14 +759,21 @@ the function is anonymous or in case of a parse error/live coding.</p>
   'default_token'       =&gt; integer, // The stack pointer to the start of the default value.
   'default_equal_token' =&gt; integer, // The stack pointer to the equals sign.
 </code></pre>
+<p>Parameters declared using PHP 8 constructor property promotion, have these additional array indexes:</p>
+<pre class="prettyprint"><code class="language-php">  'property_visibility' =&gt; string,  // The property visibility as declared.
+  'visibility_token'    =&gt; integer, // The stack pointer to the visibility modifier token.
+  'property_readonly'   =&gt; bool,    // TRUE if the readonly keyword was found.
+  'readonly_token'      =&gt; integer, // The stack pointer to the readonly modifier token.
+</code></pre>
 <p>Main differences with the PHPCS version:</p>
 <ul>
 <li>Defensive coding against incorrect calls to this method.</li>
 <li>More efficient and more stable checking whether a <code class="prettyprint">T_USE</code> token is a closure use.</li>
 <li>More efficient and more stable looping of the default value.</li>
 <li>Clearer exception message when a non-closure use token was passed to the function.</li>
-<li>To allow for backward compatible handling of arrow functions, this method will also accept
-<code class="prettyprint">T_STRING</code> tokens and examine them to check if these are arrow functions.</li>
+<li>Support for PHP 8.0 identifier name tokens in parameter types, cross-version PHP &amp; PHPCS.</li>
+<li>Support for the PHP 8.2 <code class="prettyprint">true</code> type.</li>
+<li>The results of this function call are cached during a PHPCS run for faster response times.</li>
 </ul>
 </section>
 
@@ -809,7 +840,77 @@ to acquire the parameters for.</p>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
                                                                                 
-                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 7.4 arrow functions.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 union types.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 constructor property promotion.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 identifier name tokenization.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 parameter attributes.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.1 readonly keyword for constructor property promotion.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.1 intersection types.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.2 true type.</p>
 </section>
 
                                     </dd>
@@ -857,7 +958,7 @@ use token.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">207</span>
+    <span class="phpdocumentor-element-found-in__line">191</span>
 
     </aside>
 
@@ -879,9 +980,8 @@ parse errors or live coding.</li>
 </li>
 <li>Defensive coding against incorrect calls to this method.</li>
 <li>More efficient checking whether a function has a body.</li>
-<li>New <code class="prettyprint">&quot;return_type_end_token&quot;</code> (int|false) array index.</li>
-<li>To allow for backward compatible handling of arrow functions, this method will also accept
-<code class="prettyprint">T_STRING</code> tokens and examine them to check if these are arrow functions.</li>
+<li>Support for PHP 8.0 identifier name tokens in return types, cross-version PHP &amp; PHPCS.</li>
+<li>Support for the PHP 8.2 <code class="prettyprint">true</code> type.</li>
 </ul>
 </section>
 
@@ -948,7 +1048,7 @@ acquire the properties for.</p>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
                                                                                 
-                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 7.4 arrow functions.</p>
 </section>
 
                                     </dd>
@@ -959,6 +1059,36 @@ acquire the properties for.</p>
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
                                                                                 
                                                  <section class="phpdocumentor-description"><p>Added support for PHP 8.0 static return type.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 union types.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.1 intersection types.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.2 true type.</p>
 </section>
 
                                     </dd>
@@ -988,7 +1118,8 @@ The format of the return value is:</p>
                                        // or FALSE if there is no return type.
   'return_type_end_token' =&gt; integer,  // The stack pointer to the end of the return type
                                        // or FALSE if there is no return type.
-  'nullable_return_type'  =&gt; false,    // TRUE if the return type is nullable.
+  'nullable_return_type'  =&gt; false,    // TRUE if the return type is preceded
+                                       // by the nullability operator.
   'is_abstract'           =&gt; false,    // TRUE if the abstract keyword was found.
   'is_final'              =&gt; false,    // TRUE if the final keyword was found.
   'is_static'             =&gt; false,    // TRUE if the static keyword was found.
@@ -1003,7 +1134,7 @@ The format of the return value is:</p>
         class="phpdocumentor-element
             -method
             -public
-                                    -static                    "
+            -deprecated                        -static                    "
 >
     <h4 class="phpdocumentor-element__name" id="method_isArrowFunction">
         isArrowFunction()
@@ -1012,38 +1143,18 @@ The format of the return value is:</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">621</span>
+    <span class="phpdocumentor-element-found-in__line">643</span>
 
     </aside>
 
         <p class="phpdocumentor-summary">Check if an arbitrary token is the &quot;fn&quot; keyword for a PHP 7.4 arrow function.</p>
 
-    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <code class="phpdocumentor-code phpdocumentor-signature -deprecated">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isArrowFunction</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
-        <section class="phpdocumentor-description"><p>Helper function for cross-version compatibility with both PHP as well as PHPCS.</p>
-<ul>
-<li>PHP 7.4+ will tokenize most tokens with the content &quot;fn&quot; as <code class="prettyprint">T_FN</code>, even when it isn't an arrow function.</li>
-<li>PHPCS &lt; 3.5.3 will tokenize arrow functions keywords as <code class="prettyprint">T_STRING</code>.</li>
-<li>PHPCS 3.5.3/3.5.4 will tokenize the keyword differently depending on which PHP version is used
-and similar to PHP will tokenize most tokens with the content &quot;fn&quot; as <code class="prettyprint">T_FN</code>, even when it's not an
-arrow function.
-<blockquote>
-<p>Note: the tokens tokenized by PHPCS 3.5.3 - 3.5.4 as <code class="prettyprint">T_FN</code> are not 100% the same as those tokenized
-by PHP 7.4+ as <code class="prettyprint">T_FN</code>.</p>
-</blockquote>
-</li>
-</ul>
-<p>Either way, the <code class="prettyprint">T_FN</code> token is not a reliable search vector for finding or examining
-arrow functions, at least not until PHPCS 3.5.5.
-This function solves that and will give reliable results in the same way as this is now
-solved in PHPCS 3.5.5.</p>
-<blockquote>
-<p>Note: Bugs are still being found and reported about how PHPCS tokenizes the arrow functions.
-This method will keep up with upstream changes and backport them, in as far possible, to allow
-for sniffing arrow functions in PHPCS &lt; current.</p>
-</blockquote>
+        <section class="phpdocumentor-description"><p>Helper function for cross-version compatibility with both PHP as well as PHPCS.
+As of PHPCS 3.5.6, this function is no longer be needed.</p>
 </section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -1094,6 +1205,16 @@ tokens which can be the arrow function keyword.</p>
                                                                                 
                                              
                                     </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">deprecated</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Use the T_FN token constant instead.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -1118,7 +1239,7 @@ or in case of live coding/parse error.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">839</span>
+    <span class="phpdocumentor-element-found-in__line">743</span>
 
     </aside>
 
@@ -1217,7 +1338,7 @@ sniff.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">865</span>
+    <span class="phpdocumentor-element-found-in__line">769</span>
 
     </aside>
 
@@ -1286,7 +1407,7 @@ sniff.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">886</span>
+    <span class="phpdocumentor-element-found-in__line">790</span>
 
     </aside>
 
@@ -1376,7 +1497,7 @@ sniff.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">907</span>
+    <span class="phpdocumentor-element-found-in__line">811</span>
 
     </aside>
 
@@ -1445,7 +1566,7 @@ sniff.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">929</span>
+    <span class="phpdocumentor-element-found-in__line">833</span>
 
     </aside>
 
@@ -1536,7 +1657,7 @@ checking is done in the sniff.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">970</span>
+    <span class="phpdocumentor-element-found-in__line">874</span>
 
     </aside>
 
@@ -1606,7 +1727,7 @@ double underscore method names.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">993</span>
+    <span class="phpdocumentor-element-found-in__line">897</span>
 
     </aside>
 
@@ -1687,7 +1808,7 @@ sniff.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1015</span>
+    <span class="phpdocumentor-element-found-in__line">919</span>
 
     </aside>
 

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-FunctionDeclarations.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-FunctionDeclarations.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-utils.html">Utils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,15 +118,22 @@
     FunctionDeclarations
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="../files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">34</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility functions for use when examining function declaration statements.</p>
 
@@ -98,14 +149,16 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                        <section class="phpdocumentor-description"><p>The <code class="prettyprint">FunctionDeclarations::getProperties()</code> and the
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>The <code class="prettyprint">FunctionDeclarations::getProperties()</code> and the
 <code class="prettyprint">FunctionDeclarations::getParameters()</code> methods are based on and
 inspired by respectively the <code class="prettyprint">getMethodProperties()</code>
 and <code class="prettyprint">getMethodParameters()</code> methods in the PHPCS native
 <code class="prettyprint">PHP_CodeSniffer\Files\File</code> class.
-Also see {@see \PHPCSUtils\BackCompat\BCFile}.</p></section>
+Also see <a href="classes/PHPCSUtils-BackCompat-BCFile.html"><abbr title="\PHPCSUtils\BackCompat\BCFile">BCFile</abbr></a>.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
 
@@ -119,116 +172,116 @@ Also see {@see \PHPCSUtils\BackCompat\BCFile}.</p></section>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#property_magicFunctions">$magicFunctions</a>
+                    <dt class="phpdocumentor-table-of-contents__entry -property -public">
+    <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#property_magicFunctions">$magicFunctions</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>A list of all PHP magic functions.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#property_magicMethods">$magicMethods</a>
+    <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#property_magicMethods">$magicMethods</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>A list of all PHP magic methods.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#property_methodsDoubleUnderscore">$methodsDoubleUnderscore</a>
+    <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#property_methodsDoubleUnderscore">$methodsDoubleUnderscore</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>A list of all PHP native non-magic methods starting with a double underscore.</dd>
 
                 <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getArrowFunctionOpenClose">getArrowFunctionOpenClose()</a>
+    <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getArrowFunctionOpenClose">getArrowFunctionOpenClose()</a>
     <span>
-                        &nbsp;: array|false    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;|false    </span>
 </dt>
 <dd>Retrieve the parenthesis opener, parenthesis closer, the scope opener and the scope closer
 for an arrow function.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getName">getName()</a>
+    <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getName">getName()</a>
     <span>
-                        &nbsp;: string|null    </span>
+                                &nbsp;: string|null    </span>
 </dt>
 <dd>Returns the declaration name for a function.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getParameters">getParameters()</a>
+    <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getParameters">getParameters()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Retrieves the method parameters for the specified function token.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getProperties">getProperties()</a>
+    <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getProperties">getProperties()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Retrieves the visibility and implementation properties of a method.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isArrowFunction">isArrowFunction()</a>
+    <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isArrowFunction">isArrowFunction()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Check if an arbitrary token is the &quot;fn&quot; keyword for a PHP 7.4 arrow function.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicFunction">isMagicFunction()</a>
+    <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicFunction">isMagicFunction()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Checks if a given function is a PHP magic function.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicFunctionName">isMagicFunctionName()</a>
+    <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicFunctionName">isMagicFunctionName()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Verify if a given function name is the name of a PHP magic function.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicMethod">isMagicMethod()</a>
+    <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicMethod">isMagicMethod()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Checks if a given function is a PHP magic method.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicMethodName">isMagicMethodName()</a>
+    <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicMethodName">isMagicMethodName()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Verify if a given function name is the name of a PHP magic method.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isPHPDoubleUnderscoreMethod">isPHPDoubleUnderscoreMethod()</a>
+    <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isPHPDoubleUnderscoreMethod">isPHPDoubleUnderscoreMethod()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Checks if a given function is a non-magic PHP native double underscore method.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isPHPDoubleUnderscoreMethodName">isPHPDoubleUnderscoreMethodName()</a>
+    <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isPHPDoubleUnderscoreMethodName">isPHPDoubleUnderscoreMethodName()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Verify if a given function name is the name of a non-magic PHP native double underscore method.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isSpecialMethod">isSpecialMethod()</a>
+    <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isSpecialMethod">isSpecialMethod()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Checks if a given function is a magic method or a PHP native double underscore method.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isSpecialMethodName">isSpecialMethodName()</a>
+    <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isSpecialMethodName">isSpecialMethodName()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Verify if a given function name is the name of a magic method or a PHP native double underscore method.</dd>
 
@@ -242,7 +295,7 @@ for an arrow function.</dd>
     <section class="phpdocumentor-properties">
         <h3 class="phpdocumentor-elements__header" id="properties">
             Properties
-            <a href="#properties" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#properties" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="
@@ -253,27 +306,32 @@ for an arrow function.</dd>
 >
     <h4 class="phpdocumentor-element__name" id="property_magicFunctions">
         $magicFunctions
-        <a href="#property_magicFunctions" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#property_magicFunctions" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="../files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">49</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">A list of all PHP magic functions.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$magicFunctions</span>
      = <span class="phpdocumentor-signature__default-value">[&#039;__autoload&#039; =&gt; &#039;autoload&#039;]</span></code>
 
         <section class="phpdocumentor-description"><p>The array keys contain the function names. The values contain the name without the double underscore.</p>
 <p>The function names are listed in lowercase as these function names in PHP are case-insensitive
-and comparisons against this list should therefore always be done in a case-insensitive manner.</p></section>
+and comparisons against this list should therefore always be done in a case-insensitive manner.</p>
+</section>
+
+        <section class="phpdocumentor-description"><p><string> =&gt; <string></p>
+</section>
 
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -286,8 +344,9 @@ and comparisons against this list should therefore always be done in a case-inse
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -300,21 +359,22 @@ and comparisons against this list should therefore always be done in a case-inse
 >
     <h4 class="phpdocumentor-element__name" id="property_magicMethods">
         $magicMethods
-        <a href="#property_magicMethods" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#property_magicMethods" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="../files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">65</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">A list of all PHP magic methods.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$magicMethods</span>
      = <span class="phpdocumentor-signature__default-value">[
     &#039;__construct&#039; =&gt; &#039;construct&#039;,
@@ -340,7 +400,11 @@ and comparisons against this list should therefore always be done in a case-inse
 
         <section class="phpdocumentor-description"><p>The array keys contain the method names. The values contain the name without the double underscore.</p>
 <p>The method names are listed in lowercase as these method names in PHP are case-insensitive
-and comparisons against this list should therefore always be done in a case-insensitive manner.</p></section>
+and comparisons against this list should therefore always be done in a case-insensitive manner.</p>
+</section>
+
+        <section class="phpdocumentor-description"><p><string> =&gt; <string></p>
+</section>
 
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -353,8 +417,9 @@ and comparisons against this list should therefore always be done in a case-inse
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -367,21 +432,22 @@ and comparisons against this list should therefore always be done in a case-inse
 >
     <h4 class="phpdocumentor-element__name" id="property_methodsDoubleUnderscore">
         $methodsDoubleUnderscore
-        <a href="#property_methodsDoubleUnderscore" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#property_methodsDoubleUnderscore" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="../files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">100</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">A list of all PHP native non-magic methods starting with a double underscore.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$methodsDoubleUnderscore</span>
      = <span class="phpdocumentor-signature__default-value">[&#039;__dorequest&#039; =&gt; &#039;SOAPClient&#039;, &#039;__getcookies&#039; =&gt; &#039;SOAPClient&#039;, &#039;__getfunctions&#039; =&gt; &#039;SOAPClient&#039;, &#039;__getlastrequest&#039; =&gt; &#039;SOAPClient&#039;, &#039;__getlastrequestheaders&#039; =&gt; &#039;SOAPClient&#039;, &#039;__getlastresponse&#039; =&gt; &#039;SOAPClient&#039;, &#039;__getlastresponseheaders&#039; =&gt; &#039;SOAPClient&#039;, &#039;__gettypes&#039; =&gt; &#039;SOAPClient&#039;, &#039;__setcookie&#039; =&gt; &#039;SOAPClient&#039;, &#039;__setlocation&#039; =&gt; &#039;SOAPClient&#039;, &#039;__setsoapheaders&#039; =&gt; &#039;SOAPClient&#039;, &#039;__soapcall&#039; =&gt; &#039;SOAPClient&#039;]</span></code>
 
@@ -389,7 +455,11 @@ and comparisons against this list should therefore always be done in a case-inse
 <p>The array keys are the method names, the values the name of the PHP class containing
 the function.</p>
 <p>The method names are listed in lowercase as function names in PHP are case-insensitive
-and comparisons against this list should therefore always be done in a case-insensitive manner.</p></section>
+and comparisons against this list should therefore always be done in a case-insensitive manner.</p>
+</section>
+
+        <section class="phpdocumentor-description"><p><string> =&gt; <string></p>
+</section>
 
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -402,8 +472,9 @@ and comparisons against this list should therefore always be done in a case-inse
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -412,7 +483,7 @@ and comparisons against this list should therefore always be done in a case-inse
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -422,25 +493,27 @@ and comparisons against this list should therefore always be done in a case-inse
 >
     <h4 class="phpdocumentor-element__name" id="method_getArrowFunctionOpenClose">
         getArrowFunctionOpenClose()
-        <a href="#method_getArrowFunctionOpenClose" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getArrowFunctionOpenClose" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="../files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">677</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieve the parenthesis opener, parenthesis closer, the scope opener and the scope closer
 for an arrow function.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getArrowFunctionOpenClose</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getArrowFunctionOpenClose</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span></code>
 
         <section class="phpdocumentor-description"><p>Helper function for cross-version compatibility with both PHP as well as PHPCS.
 In PHPCS versions prior to PHPCS 3.5.3/3.5.4, the <code class="prettyprint">T_FN</code> token is not yet backfilled
 and does not have parenthesis opener/closer nor scope opener/closer indexes assigned
-in the <code class="prettyprint">$tokens</code> array.</p></section>
+in the <code class="prettyprint">$tokens</code> array.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -449,7 +522,8 @@ in the <code class="prettyprint">$tokens</code> array.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -459,7 +533,8 @@ in the <code class="prettyprint">$tokens</code> array.</p></section>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The token to retrieve the openers/closers for.
 Typically a <code class="prettyprint">T_FN</code> or <code class="prettyprint">T_STRING</code> token as those are the
-only two tokens which can be the arrow function keyword.</p></section>
+only two tokens which can be the arrow function keyword.</p>
+</section>
 
             </dd>
             </dl>
@@ -474,21 +549,24 @@ only two tokens which can be the arrow function keyword.</p></section>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isArrowFunction"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction()">FunctionDeclarations::isArrowFunction()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Related function.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isArrowFunction"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction()">FunctionDeclarations::isArrowFunction()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related function.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array|false</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span>
             &mdash;
             <section class="phpdocumentor-description"><p>An array with the token pointers or <code class="prettyprint">FALSE</code> if this is not an arrow function.
 The format of the return value is:</p>
@@ -497,7 +575,9 @@ The format of the return value is:</p>
   'parenthesis_closer' =&gt; integer, // Stack pointer to the parenthesis closer.
   'scope_opener'       =&gt; integer, // Stack pointer to the scope opener (arrow).
   'scope_closer'       =&gt; integer, // Stack pointer to the scope closer.
-)</code></pre></section>
+)
+</code></pre>
+</section>
 
     
 </article>
@@ -509,21 +589,23 @@ The format of the return value is:</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_getName">
         getName()
-        <a href="#method_getName" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getName" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="../files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">155</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Returns the declaration name for a function.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|null</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|null</span></code>
 
-        <section class="phpdocumentor-description"><p>Alias for the <a href="../classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getName">\PHPCSUtils\Utils\ObjectDeclarations::getName()</a> method.</p></section>
+        <section class="phpdocumentor-description"><p>Alias for the <a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getName"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations::getName()">ObjectDeclarations::getName()</abbr></a> method.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -532,7 +614,8 @@ The format of the return value is:</p>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -540,7 +623,8 @@ The format of the return value is:</p>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the function keyword token.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the function keyword token.</p>
+</section>
 
             </dd>
             </dl>
@@ -555,47 +639,49 @@ The format of the return value is:</p>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_getDeclarationName"><abbr title="\PHPCSUtils\BackCompat\BCFile::getDeclarationName()">BCFile::getDeclarationName()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Original function.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getDeclarationName"><abbr title="\PHPCSUtils\BackCompat\BCFile::getDeclarationName()">BCFile::getDeclarationName()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original function.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getName"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations::getName()">ObjectDeclarations::getName()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>PHPCSUtils native improved version.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getName"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations::getName()">ObjectDeclarations::getName()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>PHPCSUtils native improved version.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">codeCoverageIgnore</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified token is not of type
-<code class="prettyprint">T_FUNCTION</code>.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified token is not of type
+<code class="prettyprint">T_FUNCTION</code>.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string|null</span>
             &mdash;
             <section class="phpdocumentor-description"><p>The name of the function; or <code class="prettyprint">NULL</code> if the passed token doesn't exist,
-the function is anonymous or in case of a parse error/live coding.</p></section>
+the function is anonymous or in case of a parse error/live coding.</p>
+</section>
 
     
 </article>
@@ -607,19 +693,20 @@ the function is anonymous or in case of a parse error/live coding.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getParameters">
         getParameters()
-        <a href="#method_getParameters" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getParameters" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="../files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">401</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieves the method parameters for the specified function token.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getParameters</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getParameters</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Also supports passing in a <code class="prettyprint">T_USE</code> token for a closure use group.</p>
 <p>The returned array will contain the following information for each parameter:</p>
@@ -641,11 +728,13 @@ the function is anonymous or in case of a parse error/live coding.</p></section>
   'nullable_type'       =&gt; boolean, // TRUE if the var type is nullable.
   'comma_token'         =&gt; integer, // The stack pointer to the comma after the param
                                     // or FALSE if this is the last param.
-)</code></pre>
+)
+</code></pre>
 <p>Parameters with default values have the following additional array indexes:</p>
 <pre class="prettyprint"><code class="language-php">  'default'             =&gt; string,  // The full content of the default value.
   'default_token'       =&gt; integer, // The stack pointer to the start of the default value.
-  'default_equal_token' =&gt; integer, // The stack pointer to the equals sign.</code></pre>
+  'default_equal_token' =&gt; integer, // The stack pointer to the equals sign.
+</code></pre>
 <p>Main differences with the PHPCS version:</p>
 <ul>
 <li>Defensive coding against incorrect calls to this method.</li>
@@ -654,7 +743,8 @@ the function is anonymous or in case of a parse error/live coding.</p></section>
 <li>Clearer exception message when a non-closure use token was passed to the function.</li>
 <li>To allow for backward compatible handling of arrow functions, this method will also accept
 <code class="prettyprint">T_STRING</code> tokens and examine them to check if these are arrow functions.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -663,7 +753,8 @@ the function is anonymous or in case of a parse error/live coding.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -672,7 +763,8 @@ the function is anonymous or in case of a parse error/live coding.</p></section>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position in the stack of the function token
-to acquire the parameters for.</p></section>
+to acquire the parameters for.</p>
+</section>
 
             </dd>
             </dl>
@@ -688,55 +780,66 @@ to acquire the parameters for.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getMethodParameters()">File::getMethodParameters()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_getMethodParameters"><abbr title="\PHPCSUtils\BackCompat\BCFile::getMethodParameters()">BCFile::getMethodParameters()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getMethodParameters"><abbr title="\PHPCSUtils\BackCompat\BCFile::getMethodParameters()">BCFile::getMethodParameters()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                                        <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p></section>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified $stackPtr is not of
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified $stackPtr is not of
 type <code class="prettyprint">T_FUNCTION</code>, <code class="prettyprint">T_CLOSURE</code> or <code class="prettyprint">T_USE</code>,
-nor an arrow function.</p></section>
+nor an arrow function.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If a passed <code class="prettyprint">T_USE</code> token is not a closure
-use token.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If a passed <code class="prettyprint">T_USE</code> token is not a closure
+use token.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
         
     
@@ -749,34 +852,38 @@ use token.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getProperties">
         getProperties()
-        <a href="#method_getProperties" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getProperties" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="../files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">207</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieves the visibility and implementation properties of a method.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getProperties</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getProperties</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Main differences with the PHPCS version:</p>
 <ul>
 <li>Bugs fixed:
 <ul>
 <li>Handling of PHPCS annotations.</li>
-<li><code class="prettyprint">"has_body"</code> index could be set to <code class="prettyprint">true</code> for functions without body in the case of
+<li>
+<code class="prettyprint">&quot;has_body&quot;</code> index could be set to <code class="prettyprint">true</code> for functions without body in the case of
 parse errors or live coding.</li>
-</ul></li>
+</ul>
+</li>
 <li>Defensive coding against incorrect calls to this method.</li>
 <li>More efficient checking whether a function has a body.</li>
-<li>New <code class="prettyprint">"return_type_end_token"</code> (int|false) array index.</li>
+<li>New <code class="prettyprint">&quot;return_type_end_token&quot;</code> (int|false) array index.</li>
 <li>To allow for backward compatible handling of arrow functions, this method will also accept
 <code class="prettyprint">T_STRING</code> tokens and examine them to check if these are arrow functions.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -785,7 +892,8 @@ parse errors or live coding.</li>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -794,7 +902,8 @@ parse errors or live coding.</li>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position in the stack of the function token to
-acquire the properties for.</p></section>
+acquire the properties for.</p>
+</section>
 
             </dd>
             </dl>
@@ -810,53 +919,64 @@ acquire the properties for.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getMethodProperties()">File::getMethodProperties()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_getMethodProperties"><abbr title="\PHPCSUtils\BackCompat\BCFile::getMethodProperties()">BCFile::getMethodProperties()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getMethodProperties"><abbr title="\PHPCSUtils\BackCompat\BCFile::getMethodProperties()">BCFile::getMethodProperties()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                                        <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p></section>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                                        <section class="phpdocumentor-description"><p>Added support for PHP 8.0 static return type.</p></section>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 static return type.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified position is not a T_FUNCTION
-or T_CLOSURE token, nor an arrow function.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified position is not a T_FUNCTION
+or T_CLOSURE token, nor an arrow function.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
             <section class="phpdocumentor-description"><p>Array with information about a function declaration.
 The format of the return value is:</p>
@@ -873,7 +993,9 @@ The format of the return value is:</p>
   'is_final'              =&gt; false,    // TRUE if the final keyword was found.
   'is_static'             =&gt; false,    // TRUE if the static keyword was found.
   'has_body'              =&gt; false,    // TRUE if the method has a body
-);</code></pre></section>
+);
+</code></pre>
+</section>
 
     
 </article>
@@ -885,19 +1007,20 @@ The format of the return value is:</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_isArrowFunction">
         isArrowFunction()
-        <a href="#method_isArrowFunction" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isArrowFunction" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="../files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">621</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Check if an arbitrary token is the &quot;fn&quot; keyword for a PHP 7.4 arrow function.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isArrowFunction</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isArrowFunction</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
         <section class="phpdocumentor-description"><p>Helper function for cross-version compatibility with both PHP as well as PHPCS.</p>
 <ul>
@@ -909,7 +1032,8 @@ arrow function.
 <blockquote>
 <p>Note: the tokens tokenized by PHPCS 3.5.3 - 3.5.4 as <code class="prettyprint">T_FN</code> are not 100% the same as those tokenized
 by PHP 7.4+ as <code class="prettyprint">T_FN</code>.</p>
-</blockquote></li>
+</blockquote>
+</li>
 </ul>
 <p>Either way, the <code class="prettyprint">T_FN</code> token is not a reliable search vector for finding or examining
 arrow functions, at least not until PHPCS 3.5.5.
@@ -919,7 +1043,8 @@ solved in PHPCS 3.5.5.</p>
 <p>Note: Bugs are still being found and reported about how PHPCS tokenizes the arrow functions.
 This method will keep up with upstream changes and backport them, in as far possible, to allow
 for sniffing arrow functions in PHPCS &lt; current.</p>
-</blockquote></section>
+</blockquote>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -928,7 +1053,8 @@ for sniffing arrow functions in PHPCS &lt; current.</p>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -938,7 +1064,8 @@ for sniffing arrow functions in PHPCS &lt; current.</p>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The token to check. Typically a T_FN or
 T_STRING token as those are the only two
-tokens which can be the arrow function keyword.</p></section>
+tokens which can be the arrow function keyword.</p>
+</section>
 
             </dd>
             </dl>
@@ -953,24 +1080,28 @@ tokens which can be the arrow function keyword.</p></section>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getArrowFunctionOpenClose"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations::getArrowFunctionOpenClose()">FunctionDeclarations::getArrowFunctionOpenClose()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Related function.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getArrowFunctionOpenClose"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations::getArrowFunctionOpenClose()">FunctionDeclarations::getArrowFunctionOpenClose()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Related function.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">bool</span>
             &mdash;
             <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> if the token is the &quot;fn&quot; keyword for an arrow function. <code class="prettyprint">FALSE</code> when it's not
-or in case of live coding/parse error.</p></section>
+or in case of live coding/parse error.</p>
+</section>
 
     
 </article>
@@ -982,19 +1113,20 @@ or in case of live coding/parse error.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_isMagicFunction">
         isMagicFunction()
-        <a href="#method_isMagicFunction" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicFunction" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="../files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">839</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Checks if a given function is a PHP magic function.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isMagicFunction</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isMagicFunction</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -1004,7 +1136,8 @@ or in case of live coding/parse error.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1012,7 +1145,8 @@ or in case of live coding/parse error.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The <code class="prettyprint">T_FUNCTION</code> token to check.</p></section>
+                    <section class="phpdocumentor-description"><p>The <code class="prettyprint">T_FUNCTION</code> token to check.</p>
+</section>
 
             </dd>
             </dl>
@@ -1027,34 +1161,41 @@ or in case of live coding/parse error.</p></section>
                     <span class="phpdocumentor-tag__name">todo</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                                        <section class="phpdocumentor-description"><p>Add check for the function declaration being namespaced!</p></section>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Add check for the function declaration being namespaced!</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Utils\FunctionDeclaration::$magicFunctions">FunctionDeclaration::$magicFunctions</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>List of names of magic functions.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>List of names of magic functions.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Utils\FunctionDeclaration::isMagicFunctionName()">FunctionDeclaration::isMagicFunctionName()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>For when you already know the name of the
+                                        
+                                                 <section class="phpdocumentor-description"><p>For when you already know the name of the
 function and scope checking is done in the
-sniff.</p></section>
+sniff.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -1071,19 +1212,20 @@ sniff.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_isMagicFunctionName">
         isMagicFunctionName()
-        <a href="#method_isMagicFunctionName" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicFunctionName" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="../files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">865</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Verify if a given function name is the name of a PHP magic function.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isMagicFunctionName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isMagicFunctionName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -1093,7 +1235,8 @@ sniff.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The full function name.</p></section>
+                    <section class="phpdocumentor-description"><p>The full function name.</p>
+</section>
 
             </dd>
             </dl>
@@ -1109,16 +1252,19 @@ sniff.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Utils\FunctionDeclaration::$magicFunctions">FunctionDeclaration::$magicFunctions</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>List of names of magic functions.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>List of names of magic functions.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -1135,19 +1281,20 @@ sniff.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_isMagicMethod">
         isMagicMethod()
-        <a href="#method_isMagicMethod" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicMethod" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="../files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">886</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Checks if a given function is a PHP magic method.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isMagicMethod</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isMagicMethod</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -1157,7 +1304,8 @@ sniff.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1165,7 +1313,8 @@ sniff.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The <code class="prettyprint">T_FUNCTION</code> token to check.</p></section>
+                    <section class="phpdocumentor-description"><p>The <code class="prettyprint">T_FUNCTION</code> token to check.</p>
+</section>
 
             </dd>
             </dl>
@@ -1181,26 +1330,31 @@ sniff.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Utils\FunctionDeclaration::$magicMethods">FunctionDeclaration::$magicMethods</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>List of names of magic methods.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>List of names of magic methods.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Utils\FunctionDeclaration::isMagicMethodName()">FunctionDeclaration::isMagicMethodName()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>For when you already know the name of the
+                                        
+                                                 <section class="phpdocumentor-description"><p>For when you already know the name of the
 method and scope checking is done in the
-sniff.</p></section>
+sniff.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -1217,19 +1371,20 @@ sniff.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_isMagicMethodName">
         isMagicMethodName()
-        <a href="#method_isMagicMethodName" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicMethodName" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="../files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">907</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Verify if a given function name is the name of a PHP magic method.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isMagicMethodName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isMagicMethodName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -1239,7 +1394,8 @@ sniff.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The full function name.</p></section>
+                    <section class="phpdocumentor-description"><p>The full function name.</p>
+</section>
 
             </dd>
             </dl>
@@ -1255,16 +1411,19 @@ sniff.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Utils\FunctionDeclaration::$magicMethods">FunctionDeclaration::$magicMethods</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>List of names of magic methods.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>List of names of magic methods.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -1281,19 +1440,20 @@ sniff.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_isPHPDoubleUnderscoreMethod">
         isPHPDoubleUnderscoreMethod()
-        <a href="#method_isPHPDoubleUnderscoreMethod" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isPHPDoubleUnderscoreMethod" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="../files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">929</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Checks if a given function is a non-magic PHP native double underscore method.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isPHPDoubleUnderscoreMethod</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isPHPDoubleUnderscoreMethod</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -1303,7 +1463,8 @@ sniff.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1311,7 +1472,8 @@ sniff.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The <code class="prettyprint">T_FUNCTION</code> token to check.</p></section>
+                    <section class="phpdocumentor-description"><p>The <code class="prettyprint">T_FUNCTION</code> token to check.</p>
+</section>
 
             </dd>
             </dl>
@@ -1327,27 +1489,32 @@ sniff.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Utils\FunctionDeclaration::$methodsDoubleUnderscore">FunctionDeclaration::$methodsDoubleUnderscore</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>List of the PHP native non-magic
-double underscore method names.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>List of the PHP native non-magic
+double underscore method names.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Utils\FunctionDeclaration::isPHPDoubleUnderscoreMethodName()">FunctionDeclaration::isPHPDoubleUnderscoreMethodName()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>For when you already know the
+                                        
+                                                 <section class="phpdocumentor-description"><p>For when you already know the
 name of the method and scope
-checking is done in the sniff.</p></section>
+checking is done in the sniff.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -1364,19 +1531,20 @@ checking is done in the sniff.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_isPHPDoubleUnderscoreMethodName">
         isPHPDoubleUnderscoreMethodName()
-        <a href="#method_isPHPDoubleUnderscoreMethodName" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isPHPDoubleUnderscoreMethodName" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="../files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">970</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Verify if a given function name is the name of a non-magic PHP native double underscore method.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isPHPDoubleUnderscoreMethodName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isPHPDoubleUnderscoreMethodName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -1386,7 +1554,8 @@ checking is done in the sniff.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The full function name.</p></section>
+                    <section class="phpdocumentor-description"><p>The full function name.</p>
+</section>
 
             </dd>
             </dl>
@@ -1402,17 +1571,20 @@ checking is done in the sniff.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Utils\FunctionDeclaration::$methodsDoubleUnderscore">FunctionDeclaration::$methodsDoubleUnderscore</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>List of the PHP native non-magic
-double underscore method names.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>List of the PHP native non-magic
+double underscore method names.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -1429,22 +1601,22 @@ double underscore method names.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_isSpecialMethod">
         isSpecialMethod()
-        <a href="#method_isSpecialMethod" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isSpecialMethod" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="../files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">993</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Checks if a given function is a magic method or a PHP native double underscore method.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isSpecialMethod</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isSpecialMethod</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
-        <section class="phpdocumentor-description"><p>{@internal Not the most efficient way of checking this, but less efficient ways will get
-less reliable results or introduce a lot of code duplication.}</p></section>
+        <section class="phpdocumentor-description"></section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -1453,7 +1625,8 @@ less reliable results or introduce a lot of code duplication.}</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1461,7 +1634,8 @@ less reliable results or introduce a lot of code duplication.}</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The <code class="prettyprint">T_FUNCTION</code> token to check.</p></section>
+                    <section class="phpdocumentor-description"><p>The <code class="prettyprint">T_FUNCTION</code> token to check.</p>
+</section>
 
             </dd>
             </dl>
@@ -1477,18 +1651,21 @@ less reliable results or introduce a lot of code duplication.}</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Utils\FunctionDeclaration::isSpecialMethodName()">FunctionDeclaration::isSpecialMethodName()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>For when you already know the name of the
+                                        
+                                                 <section class="phpdocumentor-description"><p>For when you already know the name of the
 method and scope checking is done in the
-sniff.</p></section>
+sniff.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -1505,19 +1682,20 @@ sniff.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_isSpecialMethodName">
         isSpecialMethodName()
-        <a href="#method_isSpecialMethodName" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isSpecialMethodName" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="../files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/FunctionDeclarations.php"><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">1015</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Verify if a given function name is the name of a magic method or a PHP native double underscore method.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isSpecialMethodName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isSpecialMethodName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -1527,7 +1705,8 @@ sniff.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The full function name.</p></section>
+                    <section class="phpdocumentor-description"><p>The full function name.</p>
+</section>
 
             </dd>
             </dl>
@@ -1543,8 +1722,9 @@ sniff.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -1555,21 +1735,92 @@ sniff.</p></section>
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-GetTokensAsString.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-GetTokensAsString.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-utils.html">Utils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,21 +118,29 @@
     GetTokensAsString
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/GetTokensAsString.php"><a href="../files/phpcsutils-utils-gettokensasstring.html"><abbr title="PHPCSUtils/Utils/GetTokensAsString.php">GetTokensAsString.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/GetTokensAsString.php"><a href="files/phpcsutils-utils-gettokensasstring.html"><abbr title="PHPCSUtils/Utils/GetTokensAsString.php">GetTokensAsString.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">29</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility functions to retrieve the content of a set of tokens as a string.</p>
 
-    <section class="phpdocumentor-description"><p>In contrast to the PHPCS native \PHP_CodeSniffer\Files\File::getTokensAsString() method,
+    <section class="phpdocumentor-description"><p>In contrast to the PHPCS native <abbr title="\PHP_CodeSniffer\Files\File::getTokensAsString()">File::getTokensAsString()</abbr> method,
 which has <code class="prettyprint">$length</code> as the third parameter, all methods in this class expect a stack pointer to
-an <code class="prettyprint">$end</code> token (inclusive) as the third parameter.</p></section>
+an <code class="prettyprint">$end</code> token (inclusive) as the third parameter.</p>
+</section>
 
 
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -101,12 +153,14 @@ an <code class="prettyprint">$end</code> token (inclusive) as the third paramete
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                        <section class="phpdocumentor-description"><p>The principle of this class is loosely based on and inspired by the
-{@see \PHP_CodeSniffer\Files\File::getTokensAsString()} method in the
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>The principle of this class is loosely based on and inspired by the
+<abbr title="\PHP_CodeSniffer\Files\File::getTokensAsString()">File::getTokensAsString()</abbr> method in the
 PHPCS native <code class="prettyprint">File</code> class.
-Also see {@see \PHPCSUtils\BackCompat\BCFile::getTokensAsString()}.</p></section>
+Also see <a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getTokensAsString"><abbr title="\PHPCSUtils\BackCompat\BCFile::getTokensAsString()">BCFile::getTokensAsString()</abbr></a>.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
 
@@ -120,59 +174,59 @@ Also see {@see \PHPCSUtils\BackCompat\BCFile::getTokensAsString()}.</p></section
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-GetTokensAsString.html#method_compact">compact()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_compact">compact()</a>
     <span>
-                        &nbsp;: string    </span>
+                                &nbsp;: string    </span>
 </dt>
 <dd>Retrieve the content of the tokens from the specified start position in the token
 stack to the specified end position (inclusive) with all consecutive whitespace tokens - tabs,
 new lines, multiple spaces - replaced by a single space and optionally without comments.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-GetTokensAsString.html#method_noComments">noComments()</a>
+    <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_noComments">noComments()</a>
     <span>
-                        &nbsp;: string    </span>
+                                &nbsp;: string    </span>
 </dt>
 <dd>Retrieve the content of the tokens from the specified start position in the token
 stack to the specified end position (inclusive) without comments.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-GetTokensAsString.html#method_noEmpties">noEmpties()</a>
+    <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_noEmpties">noEmpties()</a>
     <span>
-                        &nbsp;: string    </span>
+                                &nbsp;: string    </span>
 </dt>
 <dd>Retrieve the code-tokens only content of the tokens from the specified start position
 in the token stack to the specified end position (inclusive) without whitespace or comments.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-GetTokensAsString.html#method_normal">normal()</a>
+    <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_normal">normal()</a>
     <span>
-                        &nbsp;: string    </span>
+                                &nbsp;: string    </span>
 </dt>
 <dd>Retrieve the tab-replaced content of the tokens from the specified start position in
 the token stack to the specified end position (inclusive).</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-GetTokensAsString.html#method_origContent">origContent()</a>
+    <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_origContent">origContent()</a>
     <span>
-                        &nbsp;: string    </span>
+                                &nbsp;: string    </span>
 </dt>
 <dd>Retrieve the original content of the tokens from the specified start position in
 the token stack to the specified end position (inclusive).</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-GetTokensAsString.html#method_tabReplaced">tabReplaced()</a>
+    <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_tabReplaced">tabReplaced()</a>
     <span>
-                        &nbsp;: string    </span>
+                                &nbsp;: string    </span>
 </dt>
 <dd>Retrieve the tab-replaced content of the tokens from the specified start position in
 the token stack to the specified end position (inclusive).</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -protected">
-    <a href="../classes/PHPCSUtils-Utils-GetTokensAsString.html#method_getString">getString()</a>
+    <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_getString">getString()</a>
     <span>
-                        &nbsp;: string    </span>
+                                &nbsp;: string    </span>
 </dt>
 <dd>Retrieve the content of the tokens from the specified start position in the token stack
 to the specified end position (inclusive).</dd>
@@ -188,7 +242,7 @@ to the specified end position (inclusive).</dd>
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -198,13 +252,14 @@ to the specified end position (inclusive).</dd>
 >
     <h4 class="phpdocumentor-element__name" id="method_compact">
         compact()
-        <a href="#method_compact" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_compact" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/GetTokensAsString.php"><a href="../files/phpcsutils-utils-gettokensasstring.html"><abbr title="PHPCSUtils/Utils/GetTokensAsString.php">GetTokensAsString.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/GetTokensAsString.php"><a href="files/phpcsutils-utils-gettokensasstring.html"><abbr title="PHPCSUtils/Utils/GetTokensAsString.php">GetTokensAsString.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">177</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieve the content of the tokens from the specified start position in the token
 stack to the specified end position (inclusive) with all consecutive whitespace tokens - tabs,
@@ -212,7 +267,7 @@ new lines, multiple spaces - replaced by a single space and optionally without c
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">compact</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stripComments</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">false</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">compact</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stripComments</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">false</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -222,7 +277,8 @@ new lines, multiple spaces - replaced by a single space and optionally without c
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -230,7 +286,8 @@ new lines, multiple spaces - replaced by a single space and optionally without c
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position to start from in the token stack.</p></section>
+                    <section class="phpdocumentor-description"><p>The position to start from in the token stack.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -238,7 +295,8 @@ new lines, multiple spaces - replaced by a single space and optionally without c
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position to end at in the token stack (inclusive).</p></section>
+                    <section class="phpdocumentor-description"><p>The position to end at in the token stack (inclusive).</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -247,7 +305,8 @@ new lines, multiple spaces - replaced by a single space and optionally without c
                  = <span class="phpdocumentor-signature__argument__default-value">false</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Whether comments should be stripped from the contents.
-Defaults to <code class="prettyprint">false</code>.</p></section>
+Defaults to <code class="prettyprint">false</code>.</p>
+</section>
 
             </dd>
             </dl>
@@ -263,30 +322,36 @@ Defaults to <code class="prettyprint">false</code>.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getTokensAsString()">File::getTokensAsString()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Loosely related function.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Loosely related function.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified start position does not exist.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified start position does not exist.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>The token contents with compacted whitespace and optionally stripped off comments.</p></section>
+            <section class="phpdocumentor-description"><p>The token contents with compacted whitespace and optionally stripped off comments.</p>
+</section>
 
     
 </article>
@@ -298,20 +363,21 @@ Defaults to <code class="prettyprint">false</code>.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_noComments">
         noComments()
-        <a href="#method_noComments" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_noComments" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/GetTokensAsString.php"><a href="../files/phpcsutils-utils-gettokensasstring.html"><abbr title="PHPCSUtils/Utils/GetTokensAsString.php">GetTokensAsString.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/GetTokensAsString.php"><a href="files/phpcsutils-utils-gettokensasstring.html"><abbr title="PHPCSUtils/Utils/GetTokensAsString.php">GetTokensAsString.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">129</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieve the content of the tokens from the specified start position in the token
 stack to the specified end position (inclusive) without comments.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">noComments</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">noComments</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -321,7 +387,8 @@ stack to the specified end position (inclusive) without comments.</p>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -329,7 +396,8 @@ stack to the specified end position (inclusive) without comments.</p>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position to start from in the token stack.</p></section>
+                    <section class="phpdocumentor-description"><p>The position to start from in the token stack.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -337,7 +405,8 @@ stack to the specified end position (inclusive) without comments.</p>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position to end at in the token stack (inclusive).</p></section>
+                    <section class="phpdocumentor-description"><p>The position to end at in the token stack (inclusive).</p>
+</section>
 
             </dd>
             </dl>
@@ -353,30 +422,36 @@ stack to the specified end position (inclusive) without comments.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getTokensAsString()">File::getTokensAsString()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Loosely related function.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Loosely related function.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified start position does not exist.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified start position does not exist.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>The token contents stripped off comments.</p></section>
+            <section class="phpdocumentor-description"><p>The token contents stripped off comments.</p>
+</section>
 
     
 </article>
@@ -388,23 +463,25 @@ stack to the specified end position (inclusive) without comments.</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_noEmpties">
         noEmpties()
-        <a href="#method_noEmpties" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_noEmpties" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/GetTokensAsString.php"><a href="../files/phpcsutils-utils-gettokensasstring.html"><abbr title="PHPCSUtils/Utils/GetTokensAsString.php">GetTokensAsString.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/GetTokensAsString.php"><a href="files/phpcsutils-utils-gettokensasstring.html"><abbr title="PHPCSUtils/Utils/GetTokensAsString.php">GetTokensAsString.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">153</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieve the code-tokens only content of the tokens from the specified start position
 in the token stack to the specified end position (inclusive) without whitespace or comments.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">noEmpties</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">noEmpties</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
         <section class="phpdocumentor-description"><p>This is, for instance, useful to retrieve a namespace name without stray whitespace or comments.
-Use this function selectively and with care!</p></section>
+Use this function selectively and with care!</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -413,7 +490,8 @@ Use this function selectively and with care!</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -421,7 +499,8 @@ Use this function selectively and with care!</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position to start from in the token stack.</p></section>
+                    <section class="phpdocumentor-description"><p>The position to start from in the token stack.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -429,7 +508,8 @@ Use this function selectively and with care!</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position to end at in the token stack (inclusive).</p></section>
+                    <section class="phpdocumentor-description"><p>The position to end at in the token stack (inclusive).</p>
+</section>
 
             </dd>
             </dl>
@@ -445,30 +525,36 @@ Use this function selectively and with care!</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getTokensAsString()">File::getTokensAsString()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Loosely related function.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Loosely related function.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified start position does not exist.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified start position does not exist.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>The token contents stripped off comments and whitespace.</p></section>
+            <section class="phpdocumentor-description"><p>The token contents stripped off comments and whitespace.</p>
+</section>
 
     
 </article>
@@ -480,26 +566,28 @@ Use this function selectively and with care!</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_normal">
         normal()
-        <a href="#method_normal" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_normal" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/GetTokensAsString.php"><a href="../files/phpcsutils-utils-gettokensasstring.html"><abbr title="PHPCSUtils/Utils/GetTokensAsString.php">GetTokensAsString.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/GetTokensAsString.php"><a href="files/phpcsutils-utils-gettokensasstring.html"><abbr title="PHPCSUtils/Utils/GetTokensAsString.php">GetTokensAsString.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">56</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieve the tab-replaced content of the tokens from the specified start position in
 the token stack to the specified end position (inclusive).</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">normal</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">normal</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
         <section class="phpdocumentor-description"><p>This is the default behaviour for PHPCS.</p>
 <p>If the <code class="prettyprint">tabWidth</code> is set, either via a (custom) ruleset, the config file or by passing it
 on the command-line, PHPCS will automatically replace tabs with spaces.
 The <code class="prettyprint">'content'</code> index key in the <code class="prettyprint">$tokens</code> array will contain the tab-replaced content.
-The <code class="prettyprint">'orig_content'</code> index key in the <code class="prettyprint">$tokens</code> array will contain the original content.</p></section>
+The <code class="prettyprint">'orig_content'</code> index key in the <code class="prettyprint">$tokens</code> array will contain the original content.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -508,7 +596,8 @@ The <code class="prettyprint">'orig_content'</code> index key in the <code class
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -516,7 +605,8 @@ The <code class="prettyprint">'orig_content'</code> index key in the <code class
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position to start from in the token stack.</p></section>
+                    <section class="phpdocumentor-description"><p>The position to start from in the token stack.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -524,7 +614,8 @@ The <code class="prettyprint">'orig_content'</code> index key in the <code class
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position to end at in the token stack (inclusive).</p></section>
+                    <section class="phpdocumentor-description"><p>The position to end at in the token stack (inclusive).</p>
+</section>
 
             </dd>
             </dl>
@@ -540,38 +631,46 @@ The <code class="prettyprint">'orig_content'</code> index key in the <code class
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getTokensAsString()">File::getTokensAsString()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Similar length-based function.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Similar length-based function.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_getTokensAsString"><abbr title="\PHPCSUtils\BackCompat\BCFile::getTokensAsString()">BCFile::getTokensAsString()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getTokensAsString"><abbr title="\PHPCSUtils\BackCompat\BCFile::getTokensAsString()">BCFile::getTokensAsString()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified start position does not exist.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified start position does not exist.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>The token contents.</p></section>
+            <section class="phpdocumentor-description"><p>The token contents.</p>
+</section>
 
     
 </article>
@@ -583,28 +682,30 @@ The <code class="prettyprint">'orig_content'</code> index key in the <code class
 >
     <h4 class="phpdocumentor-element__name" id="method_origContent">
         origContent()
-        <a href="#method_origContent" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_origContent" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/GetTokensAsString.php"><a href="../files/phpcsutils-utils-gettokensasstring.html"><abbr title="PHPCSUtils/Utils/GetTokensAsString.php">GetTokensAsString.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/GetTokensAsString.php"><a href="files/phpcsutils-utils-gettokensasstring.html"><abbr title="PHPCSUtils/Utils/GetTokensAsString.php">GetTokensAsString.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">108</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieve the original content of the tokens from the specified start position in
 the token stack to the specified end position (inclusive).</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">origContent</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">origContent</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
-        <section class="phpdocumentor-description"><p>In contrast to the <a href="../classes/PHPCSUtils-Utils-GetTokensAsString.html#method_normal">\PHPCSUtils\Utils\GetTokensAsString::normal()</a> method, this method will return
+        <section class="phpdocumentor-description"><p>In contrast to the <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_normal"><abbr title="\PHPCSUtils\Utils\GetTokensAsString::normal()">GetTokensAsString::normal()</abbr></a> method, this method will return
 the original token content for the specified tokens.
 That means that if the original content contained tabs, the return value of this function
 will also contain tabs.</p>
 <p>The same can be achieved in PHPCS since version 3.3.0, by calling the
-\PHP_CodeSniffer\Files\File::getTokensAsString() method and passing <code class="prettyprint">true</code> as the
-value for the <code class="prettyprint">$origContent</code> parameter.</p></section>
+<abbr title="\PHP_CodeSniffer\Files\File::getTokensAsString()">File::getTokensAsString()</abbr> method and passing <code class="prettyprint">true</code> as the
+value for the <code class="prettyprint">$origContent</code> parameter.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -613,7 +714,8 @@ value for the <code class="prettyprint">$origContent</code> parameter.</p></sect
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -621,7 +723,8 @@ value for the <code class="prettyprint">$origContent</code> parameter.</p></sect
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position to start from in the token stack.</p></section>
+                    <section class="phpdocumentor-description"><p>The position to start from in the token stack.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -629,7 +732,8 @@ value for the <code class="prettyprint">$origContent</code> parameter.</p></sect
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position to end at in the token stack (inclusive).</p></section>
+                    <section class="phpdocumentor-description"><p>The position to end at in the token stack (inclusive).</p>
+</section>
 
             </dd>
             </dl>
@@ -645,38 +749,46 @@ value for the <code class="prettyprint">$origContent</code> parameter.</p></sect
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getTokensAsString()">File::getTokensAsString()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Similar length-based function.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Similar length-based function.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_getTokensAsString"><abbr title="\PHPCSUtils\BackCompat\BCFile::getTokensAsString()">BCFile::getTokensAsString()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getTokensAsString"><abbr title="\PHPCSUtils\BackCompat\BCFile::getTokensAsString()">BCFile::getTokensAsString()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified start position does not exist.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified start position does not exist.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>The token contents.</p></section>
+            <section class="phpdocumentor-description"><p>The token contents.</p>
+</section>
 
     
 </article>
@@ -688,22 +800,24 @@ value for the <code class="prettyprint">$origContent</code> parameter.</p></sect
 >
     <h4 class="phpdocumentor-element__name" id="method_tabReplaced">
         tabReplaced()
-        <a href="#method_tabReplaced" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_tabReplaced" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/GetTokensAsString.php"><a href="../files/phpcsutils-utils-gettokensasstring.html"><abbr title="PHPCSUtils/Utils/GetTokensAsString.php">GetTokensAsString.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/GetTokensAsString.php"><a href="files/phpcsutils-utils-gettokensasstring.html"><abbr title="PHPCSUtils/Utils/GetTokensAsString.php">GetTokensAsString.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">77</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieve the tab-replaced content of the tokens from the specified start position in
 the token stack to the specified end position (inclusive).</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">tabReplaced</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">tabReplaced</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
-        <section class="phpdocumentor-description"><p>Alias for the <a href="../classes/PHPCSUtils-Utils-GetTokensAsString.html#method_normal">\PHPCSUtils\Utils\GetTokensAsString::normal()</a> method.</p></section>
+        <section class="phpdocumentor-description"><p>Alias for the <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_normal"><abbr title="\PHPCSUtils\Utils\GetTokensAsString::normal()">GetTokensAsString::normal()</abbr></a> method.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -712,7 +826,8 @@ the token stack to the specified end position (inclusive).</p>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -720,7 +835,8 @@ the token stack to the specified end position (inclusive).</p>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position to start from in the token stack.</p></section>
+                    <section class="phpdocumentor-description"><p>The position to start from in the token stack.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -728,7 +844,8 @@ the token stack to the specified end position (inclusive).</p>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position to end at in the token stack (inclusive).</p></section>
+                    <section class="phpdocumentor-description"><p>The position to end at in the token stack (inclusive).</p>
+</section>
 
             </dd>
             </dl>
@@ -744,22 +861,26 @@ the token stack to the specified end position (inclusive).</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified start position does not exist.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified start position does not exist.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>The token contents.</p></section>
+            <section class="phpdocumentor-description"><p>The token contents.</p>
+</section>
 
     
 </article>
@@ -771,20 +892,21 @@ the token stack to the specified end position (inclusive).</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_getString">
         getString()
-        <a href="#method_getString" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_getString" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/GetTokensAsString.php"><a href="../files/phpcsutils-utils-gettokensasstring.html"><abbr title="PHPCSUtils/Utils/GetTokensAsString.php">GetTokensAsString.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/GetTokensAsString.php"><a href="files/phpcsutils-utils-gettokensasstring.html"><abbr title="PHPCSUtils/Utils/GetTokensAsString.php">GetTokensAsString.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">205</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieve the content of the tokens from the specified start position in the token stack
 to the specified end position (inclusive).</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">protected</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getString</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$origContent</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">false</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stripComments</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">false</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stripWhitespace</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">false</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$compact</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">false</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getString</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$origContent</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">false</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stripComments</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">false</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stripWhitespace</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">false</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$compact</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">false</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -794,7 +916,8 @@ to the specified end position (inclusive).</p>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -802,7 +925,8 @@ to the specified end position (inclusive).</p>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position to start from in the token stack.</p></section>
+                    <section class="phpdocumentor-description"><p>The position to start from in the token stack.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -810,7 +934,8 @@ to the specified end position (inclusive).</p>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position to end at in the token stack (inclusive).</p></section>
+                    <section class="phpdocumentor-description"><p>The position to end at in the token stack (inclusive).</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -820,7 +945,8 @@ to the specified end position (inclusive).</p>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Whether the original content or the tab replaced
 content should be used.
-Defaults to <code class="prettyprint">false</code> (= tabs replaced with spaces).</p></section>
+Defaults to <code class="prettyprint">false</code> (= tabs replaced with spaces).</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -829,7 +955,8 @@ Defaults to <code class="prettyprint">false</code> (= tabs replaced with spaces)
                  = <span class="phpdocumentor-signature__argument__default-value">false</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Whether comments should be stripped from the contents.
-Defaults to <code class="prettyprint">false</code>.</p></section>
+Defaults to <code class="prettyprint">false</code>.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -838,7 +965,8 @@ Defaults to <code class="prettyprint">false</code>.</p></section>
                  = <span class="phpdocumentor-signature__argument__default-value">false</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Whether whitespace should be stripped from the contents.
-Defaults to <code class="prettyprint">false</code>.</p></section>
+Defaults to <code class="prettyprint">false</code>.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -847,7 +975,8 @@ Defaults to <code class="prettyprint">false</code>.</p></section>
                  = <span class="phpdocumentor-signature__argument__default-value">false</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Whether all consecutive whitespace tokens should be
-replaced with a single space. Defaults to <code class="prettyprint">false</code>.</p></section>
+replaced with a single space. Defaults to <code class="prettyprint">false</code>.</p>
+</section>
 
             </dd>
             </dl>
@@ -863,42 +992,117 @@ replaced with a single space. Defaults to <code class="prettyprint">false</code>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified start position does not exist.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified start position does not exist.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>The token contents.</p></section>
+            <section class="phpdocumentor-description"><p>The token contents.</p>
+</section>
 
     
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-GetTokensAsString.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-GetTokensAsString.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -479,7 +483,7 @@ in the token stack to the specified end position (inclusive) without whitespace 
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">noEmpties</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
-        <section class="phpdocumentor-description"><p>This is, for instance, useful to retrieve a namespace name without stray whitespace or comments.
+        <section class="phpdocumentor-description"><p>This is useful, for instance, to retrieve a namespace name without stray whitespace or comments.
 Use this function selectively and with care!</p>
 </section>
 
@@ -571,7 +575,7 @@ Use this function selectively and with care!</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/GetTokensAsString.php"><a href="files/phpcsutils-utils-gettokensasstring.html"><abbr title="PHPCSUtils/Utils/GetTokensAsString.php">GetTokensAsString.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">56</span>
+    <span class="phpdocumentor-element-found-in__line">48</span>
 
     </aside>
 
@@ -582,11 +586,7 @@ the token stack to the specified end position (inclusive).</p>
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">normal</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
-        <section class="phpdocumentor-description"><p>This is the default behaviour for PHPCS.</p>
-<p>If the <code class="prettyprint">tabWidth</code> is set, either via a (custom) ruleset, the config file or by passing it
-on the command-line, PHPCS will automatically replace tabs with spaces.
-The <code class="prettyprint">'content'</code> index key in the <code class="prettyprint">$tokens</code> array will contain the tab-replaced content.
-The <code class="prettyprint">'orig_content'</code> index key in the <code class="prettyprint">$tokens</code> array will contain the original content.</p>
+        <section class="phpdocumentor-description"><p>Alias for the <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_tabReplaced"><abbr title="\PHPCSUtils\Utils\GetTokensAsString::tabReplaced()">GetTokensAsString::tabReplaced()</abbr></a> method.</p>
 </section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -627,26 +627,6 @@ The <code class="prettyprint">'orig_content'</code> index key in the <code class
     </h5>
     <dl class="phpdocumentor-tag-list">
                                     <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">see</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getTokensAsString()">File::getTokensAsString()</abbr></span>
-                                        
-                                                 <section class="phpdocumentor-description"><p>Similar length-based function.</p>
-</section>
-
-                                    </dd>
-                            <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">see</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getTokensAsString"><abbr title="\PHPCSUtils\BackCompat\BCFile::getTokensAsString()">BCFile::getTokensAsString()</abbr></a></span>
-                                        
-                                                 <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p>
-</section>
-
-                                    </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
@@ -698,7 +678,7 @@ the token stack to the specified end position (inclusive).</p>
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">origContent</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
-        <section class="phpdocumentor-description"><p>In contrast to the <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_normal"><abbr title="\PHPCSUtils\Utils\GetTokensAsString::normal()">GetTokensAsString::normal()</abbr></a> method, this method will return
+        <section class="phpdocumentor-description"><p>In contrast to the <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_tabReplaced"><abbr title="\PHPCSUtils\Utils\GetTokensAsString::tabReplaced()">GetTokensAsString::tabReplaced()</abbr></a> method, this method will return
 the original token content for the specified tokens.
 That means that if the original content contained tabs, the return value of this function
 will also contain tabs.</p>
@@ -816,7 +796,11 @@ the token stack to the specified end position (inclusive).</p>
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">tabReplaced</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$start</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$end</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
-        <section class="phpdocumentor-description"><p>Alias for the <a href="classes/PHPCSUtils-Utils-GetTokensAsString.html#method_normal"><abbr title="\PHPCSUtils\Utils\GetTokensAsString::normal()">GetTokensAsString::normal()</abbr></a> method.</p>
+        <section class="phpdocumentor-description"><p>This is the default behaviour for PHPCS.</p>
+<p>If the <code class="prettyprint">tabWidth</code> is set, either via a (custom) ruleset, the config file or by passing it
+on the command-line, PHPCS will automatically replace tabs with spaces.
+The <code class="prettyprint">'content'</code> index key in the <code class="prettyprint">$tokens</code> array will contain the tab-replaced content.
+The <code class="prettyprint">'orig_content'</code> index key in the <code class="prettyprint">$tokens</code> array will contain the original content.</p>
 </section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -857,6 +841,26 @@ the token stack to the specified end position (inclusive).</p>
     </h5>
     <dl class="phpdocumentor-tag-list">
                                     <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">see</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getTokensAsString()">File::getTokensAsString()</abbr></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Similar length-based function.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">see</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getTokensAsString"><abbr title="\PHPCSUtils\BackCompat\BCFile::getTokensAsString()">BCFile::getTokensAsString()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Lists.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Lists.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -131,7 +135,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Lists.php"><a href="files/phpcsutils-utils-lists.html"><abbr title="PHPCSUtils/Utils/Lists.php">Lists.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">25</span>
+    <span class="phpdocumentor-element-found-in__line">27</span>
 
     </aside>
 
@@ -151,6 +155,16 @@
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
                                                                                 
                                              
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Dropped support for PHPCS &lt; 3.7.1.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -212,7 +226,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Lists.php"><a href="files/phpcsutils-utils-lists.html"><abbr title="PHPCSUtils/Utils/Lists.php">Lists.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">309</span>
+    <span class="phpdocumentor-element-found-in__line">203</span>
 
     </aside>
 
@@ -345,7 +359,7 @@ or an empty array if no assignments are made at all (fatal error in PHP &gt;= 7.
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Lists.php"><a href="files/phpcsutils-utils-lists.html"><abbr title="PHPCSUtils/Utils/Lists.php">Lists.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">198</span>
+    <span class="phpdocumentor-element-found-in__line">101</span>
 
     </aside>
 
@@ -441,7 +455,7 @@ The format of the array return value is:</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Lists.php"><a href="files/phpcsutils-utils-lists.html"><abbr title="PHPCSUtils/Utils/Lists.php">Lists.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">65</span>
+    <span class="phpdocumentor-element-found-in__line">67</span>
 
     </aside>
 

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Lists.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Lists.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-utils.html">Utils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,15 +118,22 @@
     Lists
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Lists.php"><a href="../files/phpcsutils-utils-lists.html"><abbr title="PHPCSUtils/Utils/Lists.php">Lists.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Lists.php"><a href="files/phpcsutils-utils-lists.html"><abbr title="PHPCSUtils/Utils/Lists.php">Lists.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">25</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility functions to retrieve information when working with lists.</p>
 
@@ -98,8 +149,9 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 
@@ -113,24 +165,24 @@
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Lists.html#method_getAssignments">getAssignments()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-Lists.html#method_getAssignments">getAssignments()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Retrieves information on the assignments made in the specified (long/short) list.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Lists.html#method_getOpenClose">getOpenClose()</a>
+    <a href="classes/PHPCSUtils-Utils-Lists.html#method_getOpenClose">getOpenClose()</a>
     <span>
-                        &nbsp;: array|false    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;|false    </span>
 </dt>
 <dd>Find the list opener and closer based on a T_LIST or T_OPEN_SHORT_ARRAY token.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Lists.html#method_isShortList">isShortList()</a>
+    <a href="classes/PHPCSUtils-Utils-Lists.html#method_isShortList">isShortList()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Determine whether a T_OPEN/CLOSE_SHORT_ARRAY token is a short list() construct.</dd>
 
@@ -145,7 +197,7 @@
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-Lists.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -155,19 +207,20 @@
 >
     <h4 class="phpdocumentor-element__name" id="method_getAssignments">
         getAssignments()
-        <a href="#method_getAssignments" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Lists.html#method_getAssignments" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Lists.php"><a href="../files/phpcsutils-utils-lists.html"><abbr title="PHPCSUtils/Utils/Lists.php">Lists.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Lists.php"><a href="files/phpcsutils-utils-lists.html"><abbr title="PHPCSUtils/Utils/Lists.php">Lists.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">309</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieves information on the assignments made in the specified (long/short) list.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getAssignments</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getAssignments</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>This method also accepts <code class="prettyprint">T_OPEN_SQUARE_BRACKET</code> tokens to allow it to be
 PHPCS cross-version compatible as the short array tokenizing has been plagued by
@@ -198,12 +251,15 @@ a number of bugs over time, which affects the short list determination.</p>
   'assign_by_reference'  =&gt; bool,         // Is the variable assigned by reference?
   'reference_token'      =&gt; int|false,    // The stack pointer to the reference operator;
                                           // or FALSE when not a reference assignment.
-)</code></pre>
+)
+</code></pre>
 <p>Assignments with keys will have the following additional array indexes set:</p>
 <pre class="prettyprint"><code class="language-php">  'key'                 =&gt; string, // The content of the key, cleaned of comments.
   'key_token'           =&gt; int,    // The stack pointer to the start of the key.
   'key_end_token'       =&gt; int,    // The stack pointer to the end of the key.
-  'double_arrow_token'  =&gt; int,    // The stack pointer to the double arrow.</code></pre></section>
+  'double_arrow_token'  =&gt; int,    // The stack pointer to the double arrow.
+</code></pre>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -212,7 +268,8 @@ a number of bugs over time, which affects the short list determination.</p>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -221,7 +278,8 @@ a number of bugs over time, which affects the short list determination.</p>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position in the stack of the function token
-to acquire the parameters for.</p></section>
+to acquire the parameters for.</p>
+</section>
 
             </dd>
             </dl>
@@ -237,34 +295,40 @@ to acquire the parameters for.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                                        <section class="phpdocumentor-description"><p>The returned value has been simplified with sensible defaults and always
-available keys.</p></section>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>The returned value has been simplified with sensible defaults and always
+available keys.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified $stackPtr is not of
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified $stackPtr is not of
 type T_LIST, T_OPEN_SHORT_ARRAY or
-T_OPEN_SQUARE_BRACKET.</p></section>
+T_OPEN_SQUARE_BRACKET.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
             <section class="phpdocumentor-description"><p>An array with information on each assignment made, including skipped assignments (empty),
-or an empty array if no assignments are made at all (fatal error in PHP &gt;= 7.0).</p></section>
+or an empty array if no assignments are made at all (fatal error in PHP &gt;= 7.0).</p>
+</section>
 
     
 </article>
@@ -276,23 +340,25 @@ or an empty array if no assignments are made at all (fatal error in PHP &gt;= 7.
 >
     <h4 class="phpdocumentor-element__name" id="method_getOpenClose">
         getOpenClose()
-        <a href="#method_getOpenClose" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Lists.html#method_getOpenClose" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Lists.php"><a href="../files/phpcsutils-utils-lists.html"><abbr title="PHPCSUtils/Utils/Lists.php">Lists.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Lists.php"><a href="files/phpcsutils-utils-lists.html"><abbr title="PHPCSUtils/Utils/Lists.php">Lists.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">198</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Find the list opener and closer based on a T_LIST or T_OPEN_SHORT_ARRAY token.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getOpenClose</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">true|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$isShortList</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getOpenClose</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">true|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$isShortList</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span></code>
 
         <section class="phpdocumentor-description"><p>This method also accepts <code class="prettyprint">T_OPEN_SQUARE_BRACKET</code> tokens to allow it to be
 PHPCS cross-version compatible as the short array tokenizing has been plagued by
-a number of bugs over time, which affects the short list determination.</p></section>
+a number of bugs over time, which affects the short list determination.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -301,7 +367,8 @@ a number of bugs over time, which affects the short list determination.</p></sec
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -310,7 +377,8 @@ a number of bugs over time, which affects the short list determination.</p></sec
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position of the T_LIST or T_OPEN_SHORT_ARRAY
-token in the stack.</p></section>
+token in the stack.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -323,7 +391,8 @@ tokens if it isn't necessary.
 Efficiency tweak for when this has already been established,
 i.e. when encountering a nested list while walking the
 tokens in a list.
-Use with care.</p></section>
+Use with care.</p>
+</section>
 
             </dd>
             </dl>
@@ -339,12 +408,13 @@ Use with care.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array|false</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span>
             &mdash;
             <section class="phpdocumentor-description"><p>An array with the token pointers; or <code class="prettyprint">FALSE</code> if this is not a (short) list
 token or if the opener/closer could not be determined.
@@ -352,7 +422,9 @@ The format of the array return value is:</p>
 <pre class="prettyprint"><code class="language-php">array(
   'opener' =&gt; integer, // Stack pointer to the list open bracket.
   'closer' =&gt; integer, // Stack pointer to the list close bracket.
-)</code></pre></section>
+)
+</code></pre>
+</section>
 
     
 </article>
@@ -364,23 +436,25 @@ The format of the array return value is:</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_isShortList">
         isShortList()
-        <a href="#method_isShortList" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Lists.html#method_isShortList" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Lists.php"><a href="../files/phpcsutils-utils-lists.html"><abbr title="PHPCSUtils/Utils/Lists.php">Lists.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Lists.php"><a href="files/phpcsutils-utils-lists.html"><abbr title="PHPCSUtils/Utils/Lists.php">Lists.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">65</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Determine whether a T_OPEN/CLOSE_SHORT_ARRAY token is a short list() construct.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isShortList</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isShortList</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
         <section class="phpdocumentor-description"><p>This method also accepts <code class="prettyprint">T_OPEN/CLOSE_SQUARE_BRACKET</code> tokens to allow it to be
 PHPCS cross-version compatible as the short array tokenizing has been plagued by
-a number of bugs over time, which affects the short list determination.</p></section>
+a number of bugs over time, which affects the short list determination.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -389,7 +463,8 @@ a number of bugs over time, which affects the short list determination.</p></sec
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -397,7 +472,8 @@ a number of bugs over time, which affects the short list determination.</p></sec
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the short array bracket token.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the short array bracket token.</p>
+</section>
 
             </dd>
             </dl>
@@ -413,8 +489,9 @@ a number of bugs over time, which affects the short list determination.</p></sec
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -422,27 +499,99 @@ a number of bugs over time, which affects the short list determination.</p></sec
             &mdash;
             <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> if the token passed is the open/close bracket of a short list.
 <code class="prettyprint">FALSE</code> if the token is a short array bracket or plain square bracket
-or not one of the accepted tokens.</p></section>
+or not one of the accepted tokens.</p>
+</section>
 
     
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Lists.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-MessageHelper.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-MessageHelper.html
@@ -1,0 +1,695 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+            <title>PHPCSUtils</title>
+    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
+                <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
+        <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
+    </head>
+<body id="top">
+    <header class="phpdocumentor-header phpdocumentor-section">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
+    <section data-search-form class="phpdocumentor-search">
+    <label>
+        <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
+        <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
+    </label>
+</section>
+
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
+
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
+                        </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
+
+                        </section>
+            
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
+    </section>
+
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
+    </section>
+</aside>
+
+            <div class="phpdocumentor-column -eight phpdocumentor-content">
+                    <ul class="phpdocumentor-breadcrumbs">
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
+    </ul>
+
+    <article class="phpdocumentor-element -class">
+        <h2 class="phpdocumentor-content__title">
+    MessageHelper
+
+    
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
+    
+    
+    </h2>
+
+        <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/MessageHelper.php"><a href="files/phpcsutils-utils-messagehelper.html"><abbr title="PHPCSUtils/Utils/MessageHelper.php">MessageHelper.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">20</span>
+
+    </aside>
+
+            <p class="phpdocumentor-summary">Helper functions for creating PHPCS error/warning messages.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+
+
+
+
+
+<h3 id="toc">
+    Table of Contents
+    <a href="#toc" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-MessageHelper.html#method_addFixableMessage">addFixableMessage()</a>
+    <span>
+                                &nbsp;: bool    </span>
+</dt>
+<dd>Add a PHPCS message to the output stack as either a fixable warning or a fixable error.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-MessageHelper.html#method_addMessage">addMessage()</a>
+    <span>
+                                &nbsp;: bool    </span>
+</dt>
+<dd>Add a PHPCS message to the output stack as either a warning or an error.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-MessageHelper.html#method_showEscapeChars">showEscapeChars()</a>
+    <span>
+                                &nbsp;: string    </span>
+</dt>
+<dd>Make the whitespace escape codes used in an arbitrary text string visible.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-MessageHelper.html#method_stringToErrorcode">stringToErrorcode()</a>
+    <span>
+                                &nbsp;: string    </span>
+</dt>
+<dd>Convert an arbitrary text string to an alphanumeric string with underscores.</dd>
+
+        </dl>
+
+
+
+        
+
+        
+
+            <section class="phpdocumentor-methods">
+        <h3 class="phpdocumentor-elements__header" id="methods">
+            Methods
+            <a href="classes/PHPCSUtils-Utils-MessageHelper.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
+        </h3>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_addFixableMessage">
+        addFixableMessage()
+        <a href="classes/PHPCSUtils-Utils-MessageHelper.html#method_addFixableMessage" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/MessageHelper.php"><a href="files/phpcsutils-utils-messagehelper.html"><abbr title="PHPCSUtils/Utils/MessageHelper.php">MessageHelper.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">79</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Add a PHPCS message to the output stack as either a fixable warning or a fixable error.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">addFixableMessage</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$message</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$isError</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">true</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$code</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">&#039;Found&#039;</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$data</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$severity</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$phpcsFile</span>
+                : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$message</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The message.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$stackPtr</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The position of the token
+the message relates to.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$isError</span>
+                : <span class="phpdocumentor-signature__argument__return-type">bool</span>
+                 = <span class="phpdocumentor-signature__argument__default-value">true</span>            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Whether to report the message as an
+'error' or 'warning'.
+Defaults to true (error).</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$code</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                 = <span class="phpdocumentor-signature__argument__default-value">&#039;Found&#039;</span>            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The error code for the message.
+Defaults to 'Found'.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$data</span>
+                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;</span>
+                 = <span class="phpdocumentor-signature__argument__default-value">[]</span>            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Optional input for the data replacements.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$severity</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Optional. Severity level. Defaults to 0 which will
+translate to the PHPCS default severity level.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">bool</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_addMessage">
+        addMessage()
+        <a href="classes/PHPCSUtils-Utils-MessageHelper.html#method_addMessage" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/MessageHelper.php"><a href="files/phpcsutils-utils-messagehelper.html"><abbr title="PHPCSUtils/Utils/MessageHelper.php">MessageHelper.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">43</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Add a PHPCS message to the output stack as either a warning or an error.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">addMessage</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$message</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$isError</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">true</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$code</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">&#039;Found&#039;</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$data</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$severity</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$phpcsFile</span>
+                : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$message</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The message.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$stackPtr</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The position of the token
+the message relates to.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$isError</span>
+                : <span class="phpdocumentor-signature__argument__return-type">bool</span>
+                 = <span class="phpdocumentor-signature__argument__default-value">true</span>            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Whether to report the message as an
+'error' or 'warning'.
+Defaults to true (error).</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$code</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                 = <span class="phpdocumentor-signature__argument__default-value">&#039;Found&#039;</span>            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The error code for the message.
+Defaults to 'Found'.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$data</span>
+                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;</span>
+                 = <span class="phpdocumentor-signature__argument__default-value">[]</span>            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Optional input for the data replacements.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$severity</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Optional. Severity level. Defaults to 0 which will
+translate to the PHPCS default severity level.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">bool</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_showEscapeChars">
+        showEscapeChars()
+        <a href="classes/PHPCSUtils-Utils-MessageHelper.html#method_showEscapeChars" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/MessageHelper.php"><a href="files/phpcsutils-utils-messagehelper.html"><abbr title="PHPCSUtils/Utils/MessageHelper.php">MessageHelper.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">138</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Make the whitespace escape codes used in an arbitrary text string visible.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">showEscapeChars</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$text</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+
+        <section class="phpdocumentor-description"><p>At times, it is useful to show a code snippet in an error message.
+If such a code snippet contains new lines and/or tab or space characters, those would be
+displayed as-is in the command-line report, often breaking the layout of the report
+or making the report harder to read.</p>
+<p>This method will convert these characters to their escape codes, making them visible in the
+display string without impacting the report layout.</p>
+</section>
+
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$text</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Arbitrary text string.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">see</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\Utils\GetTokensToString">GetTokensToString</abbr></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Methods to retrieve a multi-token code snippet.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">see</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                    <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Util\Common\prepareForOutput()">prepareForOutput()</abbr></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Similar PHPCS native method.</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">string</span>
+            &mdash;
+        
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_stringToErrorcode">
+        stringToErrorcode()
+        <a href="classes/PHPCSUtils-Utils-MessageHelper.html#method_stringToErrorcode" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/MessageHelper.php"><a href="files/phpcsutils-utils-messagehelper.html"><abbr title="PHPCSUtils/Utils/MessageHelper.php">MessageHelper.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">107</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Convert an arbitrary text string to an alphanumeric string with underscores.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">stringToErrorcode</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$text</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$strtolower</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">false</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+
+        <section class="phpdocumentor-description"><p>Pre-empt issues in XML and PHP when arbitrary strings are being used as error codes.</p>
+</section>
+
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$text</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Arbitrary text string intended to be used in an error code.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$strtolower</span>
+                : <span class="phpdocumentor-signature__argument__return-type">bool</span>
+                 = <span class="phpdocumentor-signature__argument__default-value">false</span>            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Whether or not to convert the text string to lowercase.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">string</span>
+            &mdash;
+        
+    
+</article>
+            </section>
+
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
+
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
+            </div>
+        </div>
+        <a href="classes/PHPCSUtils-Utils-MessageHelper.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+
+    </main>
+
+    <script>
+        cssVars({});
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
+</body>
+</html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Namespaces.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Namespaces.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-utils.html">Utils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,15 +118,22 @@
     Namespaces
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="../files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">31</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility functions for use when examining T_NAMESPACE tokens and to determine the
 namespace of arbitrary tokens.</p>
@@ -98,17 +149,18 @@ namespace of arbitrary tokens.</p>
                     <span class="phpdocumentor-tag__name">link</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.php.net/language.namespaces">https://www.php.net/language.namespaces</a>
-                                            <section class="phpdocumentor-description"><p>PHP Manual on namespaces.</p></section>
-
-                </dd>
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.php.net/language.namespaces"> <p>PHP Manual on namespaces.</p>
+ </a>
+                    
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 
@@ -122,45 +174,45 @@ namespace of arbitrary tokens.</p>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Namespaces.html#method_determineNamespace">determineNamespace()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-Namespaces.html#method_determineNamespace">determineNamespace()</a>
     <span>
-                        &nbsp;: string    </span>
+                                &nbsp;: string    </span>
 </dt>
 <dd>Determine the namespace name an arbitrary token lives in.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Namespaces.html#method_findNamespacePtr">findNamespacePtr()</a>
+    <a href="classes/PHPCSUtils-Utils-Namespaces.html#method_findNamespacePtr">findNamespacePtr()</a>
     <span>
-                        &nbsp;: int|false    </span>
+                                &nbsp;: int|false    </span>
 </dt>
 <dd>Determine the namespace an arbitrary token lives in.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Namespaces.html#method_getDeclaredName">getDeclaredName()</a>
+    <a href="classes/PHPCSUtils-Utils-Namespaces.html#method_getDeclaredName">getDeclaredName()</a>
     <span>
-                        &nbsp;: string|false    </span>
+                                &nbsp;: string|false    </span>
 </dt>
 <dd>Get the complete namespace name as declared.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Namespaces.html#method_getType">getType()</a>
+    <a href="classes/PHPCSUtils-Utils-Namespaces.html#method_getType">getType()</a>
     <span>
-                        &nbsp;: string    </span>
+                                &nbsp;: string    </span>
 </dt>
 <dd>Determine what a T_NAMESPACE token is used for.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Namespaces.html#method_isDeclaration">isDeclaration()</a>
+    <a href="classes/PHPCSUtils-Utils-Namespaces.html#method_isDeclaration">isDeclaration()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Determine whether a T_NAMESPACE token is the keyword for a namespace declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Namespaces.html#method_isOperator">isOperator()</a>
+    <a href="classes/PHPCSUtils-Utils-Namespaces.html#method_isOperator">isOperator()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Determine whether a T_NAMESPACE token is used as an operator.</dd>
 
@@ -175,7 +227,7 @@ namespace of arbitrary tokens.</p>
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-Namespaces.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -185,22 +237,24 @@ namespace of arbitrary tokens.</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_determineNamespace">
         determineNamespace()
-        <a href="#method_determineNamespace" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Namespaces.html#method_determineNamespace" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="../files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">365</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Determine the namespace name an arbitrary token lives in.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">determineNamespace</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">determineNamespace</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
         <section class="phpdocumentor-description"><p>Note: this method has no opinion on whether the token passed is actually <em>subject</em>
-to namespacing.</p></section>
+to namespacing.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -209,7 +263,8 @@ to namespacing.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -218,7 +273,8 @@ to namespacing.</p></section>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The token for which to determine
-the namespace.</p></section>
+the namespace.</p>
+</section>
 
             </dd>
             </dl>
@@ -234,15 +290,17 @@ the namespace.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string</span>
             &mdash;
             <section class="phpdocumentor-description"><p>Namespace name; or an empty string if the namespace couldn't be
-determined or when no namespace applies.</p></section>
+determined or when no namespace applies.</p>
+</section>
 
     
 </article>
@@ -254,19 +312,20 @@ determined or when no namespace applies.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_findNamespacePtr">
         findNamespacePtr()
-        <a href="#method_findNamespacePtr" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Namespaces.html#method_findNamespacePtr" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="../files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">229</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Determine the namespace an arbitrary token lives in.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">findNamespacePtr</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">findNamespacePtr</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
         <section class="phpdocumentor-description"><p>Take note:</p>
 <ol>
@@ -275,7 +334,8 @@ name is passed to this method, the result will be <code class="prettyprint">fals
 are not <em>within</em> a namespace.</li>
 <li>This method has no opinion on whether the token passed is actually <em>subject</em>
 to namespacing.</li>
-</ol></section>
+</ol>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -284,7 +344,8 @@ to namespacing.</li>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -293,7 +354,8 @@ to namespacing.</li>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The token for which to determine
-the namespace.</p></section>
+the namespace.</p>
+</section>
 
             </dd>
             </dl>
@@ -309,8 +371,9 @@ the namespace.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -318,7 +381,8 @@ the namespace.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p>Token pointer to the namespace keyword for the applicable namespace
 declaration; or <code class="prettyprint">FALSE</code> if it couldn't be determined or
-if no namespace applies.</p></section>
+if no namespace applies.</p>
+</section>
 
     
 </article>
@@ -330,22 +394,24 @@ if no namespace applies.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getDeclaredName">
         getDeclaredName()
-        <a href="#method_getDeclaredName" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Namespaces.html#method_getDeclaredName" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="../files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">176</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Get the complete namespace name as declared.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getDeclaredName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$clean</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">true</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getDeclaredName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$clean</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">true</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|false</span></code>
 
         <section class="phpdocumentor-description"><p>For hierarchical namespaces, the namespace name will be composed of several tokens,
-i.e. &quot;MyProject\Sub\Level&quot;, which will be returned together as one string.</p></section>
+i.e. &quot;MyProject\Sub\Level&quot;, which will be returned together as one string.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -354,7 +420,8 @@ i.e. &quot;MyProject\Sub\Level&quot;, which will be returned together as one str
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -362,7 +429,8 @@ i.e. &quot;MyProject\Sub\Level&quot;, which will be returned together as one str
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of a <code class="prettyprint">T_NAMESPACE</code> token.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of a <code class="prettyprint">T_NAMESPACE</code> token.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -372,7 +440,8 @@ i.e. &quot;MyProject\Sub\Level&quot;, which will be returned together as one str
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Optional. Whether to get the name stripped
 of potentially interlaced whitespace and/or
-comments. Defaults to <code class="prettyprint">true</code>.</p></section>
+comments. Defaults to <code class="prettyprint">true</code>.</p>
+</section>
 
             </dd>
             </dl>
@@ -388,8 +457,9 @@ comments. Defaults to <code class="prettyprint">true</code>.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -401,7 +471,8 @@ or when parse errors are encountered/during live coding.</p>
 <blockquote>
 <p>Note: The name can be an empty string for a valid global
 namespace declaration.</p>
-</blockquote></section>
+</blockquote>
+</section>
 
     
 </article>
@@ -413,19 +484,20 @@ namespace declaration.</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_getType">
         getType()
-        <a href="#method_getType" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Namespaces.html#method_getType" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="../files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">50</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Determine what a T_NAMESPACE token is used for.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getType</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getType</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -435,7 +507,8 @@ namespace declaration.</p>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -443,7 +516,8 @@ namespace declaration.</p>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_NAMESPACE</code> token.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_NAMESPACE</code> token.</p>
+</section>
 
             </dd>
             </dl>
@@ -459,17 +533,20 @@ namespace declaration.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified position is
-not a <code class="prettyprint">T_NAMESPACE</code> token.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified position is
+not a <code class="prettyprint">T_NAMESPACE</code> token.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -478,7 +555,8 @@ not a <code class="prettyprint">T_NAMESPACE</code> token.</p></section>
             <section class="phpdocumentor-description"><p>Either <code class="prettyprint">'declaration'</code>, <code class="prettyprint">'operator'</code> or an empty string.
 An empty string will be returned if it couldn't be
 reliably determined what the <code class="prettyprint">T_NAMESPACE</code> token is used for,
-which, in most cases, will mean the code contains a parse/fatal error.</p></section>
+which, in most cases, will mean the code contains a parse/fatal error.</p>
+</section>
 
     
 </article>
@@ -490,19 +568,20 @@ which, in most cases, will mean the code contains a parse/fatal error.</p></sect
 >
     <h4 class="phpdocumentor-element__name" id="method_isDeclaration">
         isDeclaration()
-        <a href="#method_isDeclaration" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Namespaces.html#method_isDeclaration" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="../files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">130</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Determine whether a T_NAMESPACE token is the keyword for a namespace declaration.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isDeclaration</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isDeclaration</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -512,7 +591,8 @@ which, in most cases, will mean the code contains a parse/fatal error.</p></sect
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -520,7 +600,8 @@ which, in most cases, will mean the code contains a parse/fatal error.</p></sect
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of a <code class="prettyprint">T_NAMESPACE</code> token.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of a <code class="prettyprint">T_NAMESPACE</code> token.</p>
+</section>
 
             </dd>
             </dl>
@@ -536,24 +617,28 @@ which, in most cases, will mean the code contains a parse/fatal error.</p></sect
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified position is
-not a <code class="prettyprint">T_NAMESPACE</code> token.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified position is
+not a <code class="prettyprint">T_NAMESPACE</code> token.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">bool</span>
             &mdash;
             <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> if the token passed is the keyword for a namespace declaration.
-<code class="prettyprint">FALSE</code> if not.</p></section>
+<code class="prettyprint">FALSE</code> if not.</p>
+</section>
 
     
 </article>
@@ -565,19 +650,20 @@ not a <code class="prettyprint">T_NAMESPACE</code> token.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_isOperator">
         isOperator()
-        <a href="#method_isOperator" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Namespaces.html#method_isOperator" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="../files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">151</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Determine whether a T_NAMESPACE token is used as an operator.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isOperator</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isOperator</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -587,7 +673,8 @@ not a <code class="prettyprint">T_NAMESPACE</code> token.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -595,7 +682,8 @@ not a <code class="prettyprint">T_NAMESPACE</code> token.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of a <code class="prettyprint">T_NAMESPACE</code> token.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of a <code class="prettyprint">T_NAMESPACE</code> token.</p>
+</section>
 
             </dd>
             </dl>
@@ -610,53 +698,128 @@ not a <code class="prettyprint">T_NAMESPACE</code> token.</p></section>
                     <span class="phpdocumentor-tag__name">link</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.php.net/language.namespaces.nsconstants">https://www.php.net/language.namespaces.nsconstants</a>
-                                            <section class="phpdocumentor-description"><p>PHP Manual about the use of the
-namespace keyword as an operator.</p></section>
-
-                </dd>
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.php.net/language.namespaces.nsconstants"> <p>PHP Manual about the use of the
+namespace keyword as an operator.</p>
+ </a>
+                    
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified position is
-not a <code class="prettyprint">T_NAMESPACE</code> token.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified position is
+not a <code class="prettyprint">T_NAMESPACE</code> token.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">bool</span>
             &mdash;
-            <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> if the namespace token passed is used as an operator. <code class="prettyprint">FALSE</code> if not.</p></section>
+            <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> if the namespace token passed is used as an operator. <code class="prettyprint">FALSE</code> if not.</p>
+</section>
 
     
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Namespaces.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Namespaces.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Namespaces.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -131,7 +135,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">32</span>
 
     </aside>
 
@@ -160,6 +164,16 @@ namespace of arbitrary tokens.</p>
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
                                                                                 
                                              
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Dropped support for PHPCS &lt; 3.7.1.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -242,7 +256,7 @@ namespace of arbitrary tokens.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">365</span>
+    <span class="phpdocumentor-element-found-in__line">377</span>
 
     </aside>
 
@@ -317,7 +331,7 @@ determined or when no namespace applies.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">229</span>
+    <span class="phpdocumentor-element-found-in__line">232</span>
 
     </aside>
 
@@ -399,7 +413,7 @@ if no namespace applies.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">176</span>
+    <span class="phpdocumentor-element-found-in__line">179</span>
 
     </aside>
 
@@ -489,7 +503,7 @@ namespace declaration.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">50</span>
+    <span class="phpdocumentor-element-found-in__line">52</span>
 
     </aside>
 
@@ -536,6 +550,16 @@ namespace declaration.</p>
                                                                                 
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 identifier name tokenization.</p>
+</section>
+
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
@@ -573,7 +597,7 @@ which, in most cases, will mean the code contains a parse/fatal error.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">130</span>
+    <span class="phpdocumentor-element-found-in__line">133</span>
 
     </aside>
 
@@ -655,7 +679,7 @@ not a <code class="prettyprint">T_NAMESPACE</code> token.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Namespaces.php"><a href="files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">151</span>
+    <span class="phpdocumentor-element-found-in__line">154</span>
 
     </aside>
 

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-NamingConventions.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-NamingConventions.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -131,7 +135,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/NamingConventions.php"><a href="files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">27</span>
+    <span class="phpdocumentor-element-found-in__line">28</span>
 
     </aside>
 
@@ -143,8 +147,9 @@
 <a href="https://www.php.net/language.namespaces.definition">namespace</a> names;</li>
 <li>
 <a href="https://www.php.net/language.oop5.basic">class</a>,
-<a href="https://www.php.net/language.oop5.traits">trait</a> and
-<a href="https://www.php.net/language.oop5.interfaces">interface</a> names;</li>
+<a href="https://www.php.net/language.oop5.traits">trait</a>,
+<a href="https://www.php.net/language.oop5.interfaces">interface</a> and
+<a href="https://www.php.net/language.types.enumerations">enum</a> names;</li>
 <li>
 <a href="https://www.php.net/functions.user-defined">function and method</a> names;</li>
 <li>
@@ -235,7 +240,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/NamingConventions.php"><a href="files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">55</span>
+    <span class="phpdocumentor-element-found-in__line">56</span>
 
     </aside>
 
@@ -277,7 +282,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/NamingConventions.php"><a href="files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">46</span>
+    <span class="phpdocumentor-element-found-in__line">47</span>
 
     </aside>
 
@@ -319,7 +324,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/NamingConventions.php"><a href="files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">37</span>
+    <span class="phpdocumentor-element-found-in__line">38</span>
 
     </aside>
 
@@ -374,7 +379,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/NamingConventions.php"><a href="files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">103</span>
+    <span class="phpdocumentor-element-found-in__line">104</span>
 
     </aside>
 
@@ -456,7 +461,7 @@ to verify that, if necessary.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/NamingConventions.php"><a href="files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">69</span>
 
     </aside>
 

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-NamingConventions.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-NamingConventions.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-utils.html">Utils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,28 +118,41 @@
     NamingConventions
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/NamingConventions.php"><a href="../files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/NamingConventions.php"><a href="files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">27</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility functions for working with identifier names.</p>
 
     <section class="phpdocumentor-description"><p>Identifier names in PHP are:</p>
 <ul>
-<li><a href="https://www.php.net/language.namespaces.definition">namespace</a> names;</li>
-<li><a href="https://www.php.net/language.oop5.basic">class</a>,
+<li>
+<a href="https://www.php.net/language.namespaces.definition">namespace</a> names;</li>
+<li>
+<a href="https://www.php.net/language.oop5.basic">class</a>,
 <a href="https://www.php.net/language.oop5.traits">trait</a> and
 <a href="https://www.php.net/language.oop5.interfaces">interface</a> names;</li>
-<li><a href="https://www.php.net/functions.user-defined">function and method</a> names;</li>
-<li><a href="https://www.php.net/language.variables.basics">variable</a> names;</li>
-<li><a href="https://www.php.net/language.constants">constant</a> names.</li>
-</ul></section>
+<li>
+<a href="https://www.php.net/functions.user-defined">function and method</a> names;</li>
+<li>
+<a href="https://www.php.net/language.variables.basics">variable</a> names;</li>
+<li>
+<a href="https://www.php.net/language.constants">constant</a> names.</li>
+</ul>
+</section>
 
 
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -108,8 +165,9 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 
@@ -124,37 +182,37 @@
 
 <dl class="phpdocumentor-table-of-contents">
             <dt class="phpdocumentor-table-of-contents__entry -constant -public">
-    <a href="../classes/PHPCSUtils-Utils-NamingConventions.html#constant_AZ_LOWER">AZ_LOWER</a>
+    <a href="classes/PHPCSUtils-Utils-NamingConventions.html#constant_AZ_LOWER">AZ_LOWER</a>
     <span>
-        &nbsp;= &#039;abcdefghijklmnopqrstuvwxyz&#039;                    </span>
+        &nbsp;= &#039;abcdefghijklmnopqrstuvwxyz&#039;                            </span>
 </dt>
 <dd>Lowercase a-z.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -constant -public">
-    <a href="../classes/PHPCSUtils-Utils-NamingConventions.html#constant_AZ_UPPER">AZ_UPPER</a>
+    <a href="classes/PHPCSUtils-Utils-NamingConventions.html#constant_AZ_UPPER">AZ_UPPER</a>
     <span>
-        &nbsp;= &#039;ABCDEFGHIJKLMNOPQRSTUVWXYZ&#039;                    </span>
+        &nbsp;= &#039;ABCDEFGHIJKLMNOPQRSTUVWXYZ&#039;                            </span>
 </dt>
 <dd>Uppercase A-Z.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -constant -public">
-    <a href="../classes/PHPCSUtils-Utils-NamingConventions.html#constant_PHP_LABEL_REGEX">PHP_LABEL_REGEX</a>
+    <a href="classes/PHPCSUtils-Utils-NamingConventions.html#constant_PHP_LABEL_REGEX">PHP_LABEL_REGEX</a>
     <span>
-        &nbsp;= &#039;`^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$`&#039;                    </span>
+        &nbsp;= &#039;`^[a-zA-Z_\\x80-\\xff][a-zA-Z0-9_\\x80-\\xff]*$`&#039;                            </span>
 </dt>
 <dd>Regular expression to check if a given identifier name is valid for use in PHP.</dd>
 
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-NamingConventions.html#method_isEqual">isEqual()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-NamingConventions.html#method_isEqual">isEqual()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Check if two arbitrary identifier names will be seen as the same in PHP.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-NamingConventions.html#method_isValidIdentifierName">isValidIdentifierName()</a>
+    <a href="classes/PHPCSUtils-Utils-NamingConventions.html#method_isValidIdentifierName">isValidIdentifierName()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Verify whether an arbitrary text string is valid as an identifier name in PHP.</dd>
 
@@ -166,25 +224,26 @@
     <section class="phpdocumentor-constants">
         <h3 class="phpdocumentor-elements__header" id="constants">
             Constants
-            <a href="#constants" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-NamingConventions.html#constants" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article class="phpdocumentor-element -constant -public ">
     <h4 class="phpdocumentor-element__name" id="constant_AZ_LOWER">
         AZ_LOWER
-        <a href="#constant_AZ_LOWER" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-NamingConventions.html#constant_AZ_LOWER" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
 
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/NamingConventions.php"><a href="../files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/NamingConventions.php"><a href="files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">55</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Lowercase a-z.</p>
 
     <code class="phpdocumentor-signature phpdocumentor-code ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__type">string</span>
+        <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">AZ_LOWER</span>
     = <span class="phpdocumentor-signature__default-value">&#039;abcdefghijklmnopqrstuvwxyz&#039;</span>
 </code>
@@ -192,6 +251,7 @@
 
     
     
+    
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
         <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
@@ -202,28 +262,30 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
                     <article class="phpdocumentor-element -constant -public ">
     <h4 class="phpdocumentor-element__name" id="constant_AZ_UPPER">
         AZ_UPPER
-        <a href="#constant_AZ_UPPER" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-NamingConventions.html#constant_AZ_UPPER" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
 
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/NamingConventions.php"><a href="../files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/NamingConventions.php"><a href="files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">46</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Uppercase A-Z.</p>
 
     <code class="phpdocumentor-signature phpdocumentor-code ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__type">string</span>
+        <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">AZ_UPPER</span>
     = <span class="phpdocumentor-signature__default-value">&#039;ABCDEFGHIJKLMNOPQRSTUVWXYZ&#039;</span>
 </code>
@@ -231,6 +293,7 @@
 
     
     
+    
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
         <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
@@ -241,33 +304,36 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
                     <article class="phpdocumentor-element -constant -public ">
     <h4 class="phpdocumentor-element__name" id="constant_PHP_LABEL_REGEX">
         PHP_LABEL_REGEX
-        <a href="#constant_PHP_LABEL_REGEX" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-NamingConventions.html#constant_PHP_LABEL_REGEX" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
 
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/NamingConventions.php"><a href="../files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/NamingConventions.php"><a href="files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">37</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Regular expression to check if a given identifier name is valid for use in PHP.</p>
 
     <code class="phpdocumentor-signature phpdocumentor-code ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__type">string</span>
+        <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">PHP_LABEL_REGEX</span>
-    = <span class="phpdocumentor-signature__default-value">&#039;`^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$`&#039;</span>
+    = <span class="phpdocumentor-signature__default-value">&#039;`^[a-zA-Z_\\x80-\\xff][a-zA-Z0-9_\\x80-\\xff]*$`&#039;</span>
 </code>
 
 
+    
     
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -280,8 +346,9 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -292,7 +359,7 @@
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-NamingConventions.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -302,19 +369,20 @@
 >
     <h4 class="phpdocumentor-element__name" id="method_isEqual">
         isEqual()
-        <a href="#method_isEqual" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-NamingConventions.html#method_isEqual" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/NamingConventions.php"><a href="../files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/NamingConventions.php"><a href="files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">103</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Check if two arbitrary identifier names will be seen as the same in PHP.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isEqual</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$nameA</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$nameB</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isEqual</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$nameA</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$nameB</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
         <section class="phpdocumentor-description"><p>This method should not be used for variable or constant names, but <em>should</em> be used
 when comparing namespace, class/trait/interface and function names.</p>
@@ -325,8 +393,9 @@ declared case-insensitive using the third parameter for
 Basically ASCII chars used are case-insensitive, but anything from 0x80 up is case-sensitive.</p>
 <p>This method takes this case-(in)sensitivity into account when comparing identifier names.</p>
 <p>Note: this method does not check whether the passed names would be valid for identifiers!
-The <a href="../classes/PHPCSUtils-Utils-NamingConventions.html#method_isValidIdentifierName">\PHPCSUtils\Utils\NamingConventions::isValidIdentifierName()</a> method should be used
-to verify that, if necessary.</p></section>
+The <a href="classes/PHPCSUtils-Utils-NamingConventions.html#method_isValidIdentifierName"><abbr title="\PHPCSUtils\Utils\NamingConventions::isValidIdentifierName()">NamingConventions::isValidIdentifierName()</abbr></a> method should be used
+to verify that, if necessary.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -335,7 +404,8 @@ to verify that, if necessary.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The first identifier name.</p></section>
+                    <section class="phpdocumentor-description"><p>The first identifier name.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -343,7 +413,8 @@ to verify that, if necessary.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The second identifier name.</p></section>
+                    <section class="phpdocumentor-description"><p>The second identifier name.</p>
+</section>
 
             </dd>
             </dl>
@@ -359,14 +430,16 @@ to verify that, if necessary.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">bool</span>
             &mdash;
-            <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> if these names would be considered the same in PHP; <code class="prettyprint">FALSE</code> otherwise.</p></section>
+            <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> if these names would be considered the same in PHP; <code class="prettyprint">FALSE</code> otherwise.</p>
+</section>
 
     
 </article>
@@ -378,19 +451,20 @@ to verify that, if necessary.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_isValidIdentifierName">
         isValidIdentifierName()
-        <a href="#method_isValidIdentifierName" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-NamingConventions.html#method_isValidIdentifierName" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/NamingConventions.php"><a href="../files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/NamingConventions.php"><a href="files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">68</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Verify whether an arbitrary text string is valid as an identifier name in PHP.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isValidIdentifierName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isValidIdentifierName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -404,7 +478,8 @@ to verify that, if necessary.</p></section>
 <blockquote>
 <p>Note: for variable names, the leading dollar sign - <code class="prettyprint">$</code> - needs to be
 removed prior to passing the name to this method.</p>
-</blockquote></section>
+</blockquote>
+</section>
 
             </dd>
             </dl>
@@ -420,8 +495,9 @@ removed prior to passing the name to this method.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -432,21 +508,92 @@ removed prior to passing the name to this method.</p>
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Utils-NamingConventions.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Numbers.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Numbers.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-utils.html">Utils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,15 +118,22 @@
     Numbers
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="../files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">35</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility functions for working with integer/float tokens.</p>
 
@@ -92,7 +143,8 @@ PHPCS backfills this since PHPCS 3.5.3/4.</p>
 with number tokens has suddenly become a challenge.</p>
 <p>The functions in this class have been put in place to ease that pain and it is
 <em>strongly</em> recommended to always use these functions when sniffing for and examining the
-contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettyprint">T_DNUMBER</code> tokens.</p></section>
+contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettyprint">T_DNUMBER</code> tokens.</p>
+</section>
 
 
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -104,17 +156,18 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
                     <span class="phpdocumentor-tag__name">link</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.php.net/migration74.new-features.php#migration74.new-features.core.numeric-literal-separator">https://www.php.net/migration74.new-features.php#migration74.new-features.core.numeric-literal-separator</a>
-                                            <section class="phpdocumentor-description"><p>PHP Manual on numeric literal separators.</p></section>
-
-                </dd>
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.php.net/migration74.new-features.php#migration74.new-features.core.numeric-literal-separator"> <p>PHP Manual on numeric literal separators.</p>
+ </a>
+                    
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 
@@ -129,21 +182,21 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
 
 <dl class="phpdocumentor-table-of-contents">
             <dt class="phpdocumentor-table-of-contents__entry -constant -public">
-    <a href="../classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_BINARY_INT">REGEX_BINARY_INT</a>
+    <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_BINARY_INT">REGEX_BINARY_INT</a>
     <span>
-        &nbsp;= &#039;`^0b[0-1]+$`iD&#039;                    </span>
+        &nbsp;= &#039;`^0b[0-1]+$`iD&#039;                            </span>
 </dt>
 <dd>Regex to determine whether the contents of an arbitrary string represents a binary integer.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -constant -public">
-    <a href="../classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_DECIMAL_INT">REGEX_DECIMAL_INT</a>
+    <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_DECIMAL_INT">REGEX_DECIMAL_INT</a>
     <span>
-        &nbsp;= &#039;`^(?:0|[1-9][0-9]*)$`D&#039;                    </span>
+        &nbsp;= &#039;`^(?:0|[1-9][0-9]*)$`D&#039;                            </span>
 </dt>
 <dd>Regex to determine whether the contents of an arbitrary string represents a decimal integer.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -constant -public">
-    <a href="../classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_FLOAT">REGEX_FLOAT</a>
+    <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_FLOAT">REGEX_FLOAT</a>
     <span>
         &nbsp;= &#039;`
         ^(?:
@@ -151,7 +204,7 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
                 (?:
                     (?P&lt;LNUM&gt;[0-9]+)
                 |
-                    (?P&lt;DNUM&gt;([0-9]*\.(?P&gt;LNUM)|(?P&gt;LNUM)\.[0-9]*))
+                    (?P&lt;DNUM&gt;([0-9]*\\.(?P&gt;LNUM)|(?P&gt;LNUM)\\.[0-9]*))
                 )
                 [e][+-]?(?P&gt;LNUM)
             )
@@ -160,91 +213,91 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
             |
             (?:0|[1-9][0-9]*)
         )$
-        `ixD&#039;                    </span>
+        `ixD&#039;                            </span>
 </dt>
 <dd>Regex to determine whether the contents of an arbitrary string represents a float.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -constant -public">
-    <a href="../classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_HEX_INT">REGEX_HEX_INT</a>
+    <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_HEX_INT">REGEX_HEX_INT</a>
     <span>
-        &nbsp;= &#039;`^0x[0-9A-F]+$`iD&#039;                    </span>
+        &nbsp;= &#039;`^0x[0-9A-F]+$`iD&#039;                            </span>
 </dt>
 <dd>Regex to determine whether the contents of an arbitrary string represents a hexidecimal integer.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -constant -public">
-    <a href="../classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_HEX_NUMLIT_STRING">REGEX_HEX_NUMLIT_STRING</a>
+    <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_HEX_NUMLIT_STRING">REGEX_HEX_NUMLIT_STRING</a>
     <span>
-        &nbsp;= &#039;`^((?&lt;!\.)_[0-9A-F]*)+$`iD&#039;                    </span>
+        &nbsp;= &#039;`^((?&lt;!\\.)_[0-9A-F]*)+$`iD&#039;                            </span>
 </dt>
 <dd>Regex to determine is a T_STRING following a T_[DL]NUMBER is part of a hexidecimal numeric literal sequence.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -constant -public">
-    <a href="../classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_NUMLIT_STRING">REGEX_NUMLIT_STRING</a>
+    <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_NUMLIT_STRING">REGEX_NUMLIT_STRING</a>
     <span>
-        &nbsp;= &#039;`^((?&lt;![\.e])_[0-9][0-9e\.]*)+$`iD&#039;                    </span>
+        &nbsp;= &#039;`^((?&lt;![\\.e])_[0-9][0-9e\\.]*)+$`iD&#039;                            </span>
 </dt>
 <dd>Regex to determine if a T_STRING following a T_[DL]NUMBER is part of a numeric literal sequence.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -constant -public">
-    <a href="../classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_OCTAL_INT">REGEX_OCTAL_INT</a>
+    <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_OCTAL_INT">REGEX_OCTAL_INT</a>
     <span>
-        &nbsp;= &#039;`^0[0-7]+$`D&#039;                    </span>
+        &nbsp;= &#039;`^0[0-7]+$`D&#039;                            </span>
 </dt>
 <dd>Regex to determine whether the contents of an arbitrary string represents an octal integer.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -constant -public">
-    <a href="../classes/PHPCSUtils-Utils-Numbers.html#constant_UNSUPPORTED_PHPCS_VERSION">UNSUPPORTED_PHPCS_VERSION</a>
+    <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_UNSUPPORTED_PHPCS_VERSION">UNSUPPORTED_PHPCS_VERSION</a>
     <span>
-        &nbsp;= &#039;3.5.3&#039;                    </span>
+        &nbsp;= &#039;3.5.3&#039;                            </span>
 </dt>
 <dd>PHPCS versions in which the backfill for PHP 7.4 numeric literal separators is broken.</dd>
 
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Numbers.html#method_getCompleteNumber">getCompleteNumber()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-Numbers.html#method_getCompleteNumber">getCompleteNumber()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Retrieve information about a number token in a cross-version compatible manner.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Numbers.html#method_getDecimalValue">getDecimalValue()</a>
+    <a href="classes/PHPCSUtils-Utils-Numbers.html#method_getDecimalValue">getDecimalValue()</a>
     <span>
-                        &nbsp;: string|false    </span>
+                                &nbsp;: string|false    </span>
 </dt>
 <dd>Get the decimal number value of a numeric string.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Numbers.html#method_isBinaryInt">isBinaryInt()</a>
+    <a href="classes/PHPCSUtils-Utils-Numbers.html#method_isBinaryInt">isBinaryInt()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Verify whether the contents of an arbitrary string represents a binary integer.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Numbers.html#method_isDecimalInt">isDecimalInt()</a>
+    <a href="classes/PHPCSUtils-Utils-Numbers.html#method_isDecimalInt">isDecimalInt()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Verify whether the contents of an arbitrary string represents a decimal integer.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Numbers.html#method_isFloat">isFloat()</a>
+    <a href="classes/PHPCSUtils-Utils-Numbers.html#method_isFloat">isFloat()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Verify whether the contents of an arbitrary string represents a floating point number.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Numbers.html#method_isHexidecimalInt">isHexidecimalInt()</a>
+    <a href="classes/PHPCSUtils-Utils-Numbers.html#method_isHexidecimalInt">isHexidecimalInt()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Verify whether the contents of an arbitrary string represents a hexidecimal integer.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Numbers.html#method_isOctalInt">isOctalInt()</a>
+    <a href="classes/PHPCSUtils-Utils-Numbers.html#method_isOctalInt">isOctalInt()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Verify whether the contents of an arbitrary string represents an octal integer.</dd>
 
@@ -256,25 +309,26 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
     <section class="phpdocumentor-constants">
         <h3 class="phpdocumentor-elements__header" id="constants">
             Constants
-            <a href="#constants" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-Numbers.html#constants" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article class="phpdocumentor-element -constant -public ">
     <h4 class="phpdocumentor-element__name" id="constant_REGEX_BINARY_INT">
         REGEX_BINARY_INT
-        <a href="#constant_REGEX_BINARY_INT" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_BINARY_INT" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
 
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="../files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">63</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Regex to determine whether the contents of an arbitrary string represents a binary integer.</p>
 
     <code class="phpdocumentor-signature phpdocumentor-code ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__type">string</span>
+        <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">REGEX_BINARY_INT</span>
     = <span class="phpdocumentor-signature__default-value">&#039;`^0b[0-1]+$`iD&#039;</span>
 </code>
@@ -282,6 +336,7 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
 
     
     
+    
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
         <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
@@ -292,28 +347,30 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
                     <article class="phpdocumentor-element -constant -public ">
     <h4 class="phpdocumentor-element__name" id="constant_REGEX_DECIMAL_INT">
         REGEX_DECIMAL_INT
-        <a href="#constant_REGEX_DECIMAL_INT" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_DECIMAL_INT" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
 
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="../files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">45</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Regex to determine whether the contents of an arbitrary string represents a decimal integer.</p>
 
     <code class="phpdocumentor-signature phpdocumentor-code ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__type">string</span>
+        <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">REGEX_DECIMAL_INT</span>
     = <span class="phpdocumentor-signature__default-value">&#039;`^(?:0|[1-9][0-9]*)$`D&#039;</span>
 </code>
@@ -321,6 +378,7 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
 
     
     
+    
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
         <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
@@ -331,28 +389,30 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
                     <article class="phpdocumentor-element -constant -public ">
     <h4 class="phpdocumentor-element__name" id="constant_REGEX_FLOAT">
         REGEX_FLOAT
-        <a href="#constant_REGEX_FLOAT" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_FLOAT" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
 
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="../files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">83</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Regex to determine whether the contents of an arbitrary string represents a float.</p>
 
     <code class="phpdocumentor-signature phpdocumentor-code ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__type">string</span>
+        <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">REGEX_FLOAT</span>
     = <span class="phpdocumentor-signature__default-value">&#039;`
         ^(?:
@@ -360,7 +420,7 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
                 (?:
                     (?P&lt;LNUM&gt;[0-9]+)
                 |
-                    (?P&lt;DNUM&gt;([0-9]*\.(?P&gt;LNUM)|(?P&gt;LNUM)\.[0-9]*))
+                    (?P&lt;DNUM&gt;([0-9]*\\.(?P&gt;LNUM)|(?P&gt;LNUM)\\.[0-9]*))
                 )
                 [e][+-]?(?P&gt;LNUM)
             )
@@ -375,6 +435,7 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
 
     
     
+    
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
         <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
@@ -384,37 +445,39 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
                     <span class="phpdocumentor-tag__name">link</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.php.net/language.types.float">https://www.php.net/language.types.float</a>
-                                            <section class="phpdocumentor-description"><p>PHP Manual on floats</p></section>
-
-                </dd>
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.php.net/language.types.float"> <p>PHP Manual on floats</p>
+ </a>
+                    
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
                     <article class="phpdocumentor-element -constant -public ">
     <h4 class="phpdocumentor-element__name" id="constant_REGEX_HEX_INT">
         REGEX_HEX_INT
-        <a href="#constant_REGEX_HEX_INT" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_HEX_INT" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
 
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="../files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">72</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Regex to determine whether the contents of an arbitrary string represents a hexidecimal integer.</p>
 
     <code class="phpdocumentor-signature phpdocumentor-code ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__type">string</span>
+        <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">REGEX_HEX_INT</span>
     = <span class="phpdocumentor-signature__default-value">&#039;`^0x[0-9A-F]+$`iD&#039;</span>
 </code>
@@ -422,6 +485,7 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
 
     
     
+    
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
         <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
@@ -432,35 +496,39 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
                     <article class="phpdocumentor-element -constant -public ">
     <h4 class="phpdocumentor-element__name" id="constant_REGEX_HEX_NUMLIT_STRING">
         REGEX_HEX_NUMLIT_STRING
-        <a href="#constant_REGEX_HEX_NUMLIT_STRING" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_HEX_NUMLIT_STRING" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
 
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="../files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">120</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Regex to determine is a T_STRING following a T_[DL]NUMBER is part of a hexidecimal numeric literal sequence.</p>
 
     <code class="phpdocumentor-signature phpdocumentor-code ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__type">string</span>
+        <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">REGEX_HEX_NUMLIT_STRING</span>
-    = <span class="phpdocumentor-signature__default-value">&#039;`^((?&lt;!\.)_[0-9A-F]*)+$`iD&#039;</span>
+    = <span class="phpdocumentor-signature__default-value">&#039;`^((?&lt;!\\.)_[0-9A-F]*)+$`iD&#039;</span>
 </code>
 
 
-        <section class="phpdocumentor-description"><p>Cross-version compatibility helper for PHP 7.4 numeric literals with underscore separators.</p></section>
+        <section class="phpdocumentor-description"><p>Cross-version compatibility helper for PHP 7.4 numeric literals with underscore separators.</p>
+</section>
 
+    
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -472,35 +540,39 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
                     <article class="phpdocumentor-element -constant -public ">
     <h4 class="phpdocumentor-element__name" id="constant_REGEX_NUMLIT_STRING">
         REGEX_NUMLIT_STRING
-        <a href="#constant_REGEX_NUMLIT_STRING" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_NUMLIT_STRING" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
 
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="../files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">109</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Regex to determine if a T_STRING following a T_[DL]NUMBER is part of a numeric literal sequence.</p>
 
     <code class="phpdocumentor-signature phpdocumentor-code ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__type">string</span>
+        <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">REGEX_NUMLIT_STRING</span>
-    = <span class="phpdocumentor-signature__default-value">&#039;`^((?&lt;![\.e])_[0-9][0-9e\.]*)+$`iD&#039;</span>
+    = <span class="phpdocumentor-signature__default-value">&#039;`^((?&lt;![\\.e])_[0-9][0-9e\\.]*)+$`iD&#039;</span>
 </code>
 
 
-        <section class="phpdocumentor-description"><p>Cross-version compatibility helper for PHP 7.4 numeric literals with underscore separators.</p></section>
+        <section class="phpdocumentor-description"><p>Cross-version compatibility helper for PHP 7.4 numeric literals with underscore separators.</p>
+</section>
 
+    
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
@@ -512,28 +584,30 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
                     <article class="phpdocumentor-element -constant -public ">
     <h4 class="phpdocumentor-element__name" id="constant_REGEX_OCTAL_INT">
         REGEX_OCTAL_INT
-        <a href="#constant_REGEX_OCTAL_INT" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_OCTAL_INT" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
 
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="../files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">54</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Regex to determine whether the contents of an arbitrary string represents an octal integer.</p>
 
     <code class="phpdocumentor-signature phpdocumentor-code ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__type">string</span>
+        <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">REGEX_OCTAL_INT</span>
     = <span class="phpdocumentor-signature__default-value">&#039;`^0[0-7]+$`D&#039;</span>
 </code>
@@ -541,6 +615,7 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
 
     
     
+    
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
         <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
@@ -551,28 +626,30 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
                     <article class="phpdocumentor-element -constant -public ">
     <h4 class="phpdocumentor-element__name" id="constant_UNSUPPORTED_PHPCS_VERSION">
         UNSUPPORTED_PHPCS_VERSION
-        <a href="#constant_UNSUPPORTED_PHPCS_VERSION" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_UNSUPPORTED_PHPCS_VERSION" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
 
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="../files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">131</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">PHPCS versions in which the backfill for PHP 7.4 numeric literal separators is broken.</p>
 
     <code class="phpdocumentor-signature phpdocumentor-code ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__type">string</span>
+        <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">UNSUPPORTED_PHPCS_VERSION</span>
     = <span class="phpdocumentor-signature__default-value">&#039;3.5.3&#039;</span>
 </code>
@@ -580,6 +657,7 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
 
     
     
+    
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
         <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
@@ -590,17 +668,20 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                                        <section class="phpdocumentor-description"><p>Changed from a property to a class constant.
-Changed from an array to a string.</p></section>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Changed from a property to a class constant.
+Changed from an array to a string.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
 </article>
@@ -611,7 +692,7 @@ Changed from an array to a string.</p></section>
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-Numbers.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -621,19 +702,20 @@ Changed from an array to a string.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getCompleteNumber">
         getCompleteNumber()
-        <a href="#method_getCompleteNumber" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Numbers.html#method_getCompleteNumber" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="../files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">194</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieve information about a number token in a cross-version compatible manner.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getCompleteNumber</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getCompleteNumber</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Helper function to deal with numeric literals, potentially with underscore separators.</p>
 <p>PHP &lt; 7.4 does not tokenize numeric literals containing underscores correctly.
@@ -642,7 +724,8 @@ implementation. A fix for this broken backfill is included in PHPCS 3.5.4.</p>
 <p>Either way, this function can be used with all PHPCS/PHP combinations and will, if necessary,
 provide a backfill for PHPCS/PHP combinations where PHP 7.4 numbers with underscore separators
 are tokenized incorrectly - with the exception of PHPCS 3.5.3 as the buggyness of the original
-backfill implementation makes it impossible to provide reliable results.</p></section>
+backfill implementation makes it impossible to provide reliable results.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -651,7 +734,8 @@ backfill implementation makes it impossible to provide reliable results.</p></se
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -659,7 +743,8 @@ backfill implementation makes it impossible to provide reliable results.</p></se
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of a T_LNUMBER or T_DNUMBER token.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of a T_LNUMBER or T_DNUMBER token.</p>
+</section>
 
             </dd>
             </dl>
@@ -674,47 +759,52 @@ backfill implementation makes it impossible to provide reliable results.</p></se
                     <span class="phpdocumentor-tag__name">link</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/squizlabs/PHP_CodeSniffer/issues/2546">https://github.com/squizlabs/PHP_CodeSniffer/issues/2546</a>
-                                            <section class="phpdocumentor-description"><p>PHPCS issue #2546</p></section>
-
-                </dd>
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/squizlabs/PHP_CodeSniffer/issues/2546"> <p>PHPCS issue #2546</p>
+ </a>
+                    
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">link</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/squizlabs/PHP_CodeSniffer/pull/2771">https://github.com/squizlabs/PHP_CodeSniffer/pull/2771</a>
-                                            <section class="phpdocumentor-description"><p>PHPCS PR #2771</p></section>
-
-                </dd>
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/squizlabs/PHP_CodeSniffer/pull/2771"> <p>PHPCS PR #2771</p>
+ </a>
+                    
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified token is not of type
-<code class="prettyprint">T_LNUMBER</code> or <code class="prettyprint">T_DNUMBER</code>.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified token is not of type
+<code class="prettyprint">T_LNUMBER</code> or <code class="prettyprint">T_DNUMBER</code>.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If this function is called in combination
-with an unsupported PHPCS version.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If this function is called in combination
+with an unsupported PHPCS version.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
             <section class="phpdocumentor-description"><p>An array with information about the number.
 The format of the array return value is:</p>
@@ -733,7 +823,9 @@ The format of the array return value is:</p>
                             // This will be the same as the original
                             // stackPtr if it is not a PHP 7.4 number
                             // with underscores.
-)</code></pre></section>
+)
+</code></pre>
+</section>
 
     
 </article>
@@ -745,21 +837,23 @@ The format of the array return value is:</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_getDecimalValue">
         getDecimalValue()
-        <a href="#method_getDecimalValue" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Numbers.html#method_getDecimalValue" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="../files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">342</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Get the decimal number value of a numeric string.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getDecimalValue</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getDecimalValue</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|false</span></code>
 
-        <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators in numbers into account.</p></section>
+        <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators in numbers into account.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -768,7 +862,8 @@ The format of the array return value is:</p>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>Arbitrary token content string.</p></section>
+                    <section class="phpdocumentor-description"><p>Arbitrary token content string.</p>
+</section>
 
             </dd>
             </dl>
@@ -784,8 +879,9 @@ The format of the array return value is:</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -796,7 +892,8 @@ was not a numeric string.</p>
 <blockquote>
 <p>Note: floating point numbers with exponent will not be expanded,
 but returned as-is.</p>
-</blockquote></section>
+</blockquote>
+</section>
 
     
 </article>
@@ -808,21 +905,23 @@ but returned as-is.</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_isBinaryInt">
         isBinaryInt()
-        <a href="#method_isBinaryInt" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Numbers.html#method_isBinaryInt" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="../files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">437</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Verify whether the contents of an arbitrary string represents a binary integer.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isBinaryInt</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isBinaryInt</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
-        <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators in numbers into account.</p></section>
+        <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators in numbers into account.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -831,7 +930,8 @@ but returned as-is.</p>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>Arbitrary string.</p></section>
+                    <section class="phpdocumentor-description"><p>Arbitrary string.</p>
+</section>
 
             </dd>
             </dl>
@@ -847,8 +947,9 @@ but returned as-is.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -865,21 +966,23 @@ but returned as-is.</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_isDecimalInt">
         isDecimalInt()
-        <a href="#method_isDecimalInt" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Numbers.html#method_isDecimalInt" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="../files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">391</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Verify whether the contents of an arbitrary string represents a decimal integer.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isDecimalInt</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isDecimalInt</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
-        <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators in numbers into account.</p></section>
+        <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators in numbers into account.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -888,7 +991,8 @@ but returned as-is.</p>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>Arbitrary string.</p></section>
+                    <section class="phpdocumentor-description"><p>Arbitrary string.</p>
+</section>
 
             </dd>
             </dl>
@@ -904,8 +1008,9 @@ but returned as-is.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -922,21 +1027,23 @@ but returned as-is.</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_isFloat">
         isFloat()
-        <a href="#method_isFloat" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Numbers.html#method_isFloat" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="../files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">483</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Verify whether the contents of an arbitrary string represents a floating point number.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isFloat</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isFloat</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
-        <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators in numbers into account.</p></section>
+        <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators in numbers into account.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -945,7 +1052,8 @@ but returned as-is.</p>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>Arbitrary string.</p></section>
+                    <section class="phpdocumentor-description"><p>Arbitrary string.</p>
+</section>
 
             </dd>
             </dl>
@@ -961,8 +1069,9 @@ but returned as-is.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -979,21 +1088,23 @@ but returned as-is.</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_isHexidecimalInt">
         isHexidecimalInt()
-        <a href="#method_isHexidecimalInt" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Numbers.html#method_isHexidecimalInt" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="../files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">414</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Verify whether the contents of an arbitrary string represents a hexidecimal integer.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isHexidecimalInt</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isHexidecimalInt</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
-        <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators in numbers into account.</p></section>
+        <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators in numbers into account.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -1002,7 +1113,8 @@ but returned as-is.</p>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>Arbitrary string.</p></section>
+                    <section class="phpdocumentor-description"><p>Arbitrary string.</p>
+</section>
 
             </dd>
             </dl>
@@ -1018,8 +1130,9 @@ but returned as-is.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -1036,21 +1149,23 @@ but returned as-is.</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_isOctalInt">
         isOctalInt()
-        <a href="#method_isOctalInt" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Numbers.html#method_isOctalInt" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="../files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">460</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Verify whether the contents of an arbitrary string represents an octal integer.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isOctalInt</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isOctalInt</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
-        <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators in numbers into account.</p></section>
+        <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators in numbers into account.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -1059,7 +1174,8 @@ but returned as-is.</p>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>Arbitrary string.</p></section>
+                    <section class="phpdocumentor-description"><p>Arbitrary string.</p>
+</section>
 
             </dd>
             </dl>
@@ -1075,8 +1191,9 @@ but returned as-is.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -1087,21 +1204,92 @@ but returned as-is.</p>
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Numbers.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Numbers.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Numbers.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -131,18 +135,16 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">35</span>
+    <span class="phpdocumentor-element-found-in__line">38</span>
 
     </aside>
 
             <p class="phpdocumentor-summary">Utility functions for working with integer/float tokens.</p>
 
-    <section class="phpdocumentor-description"><p>PHP 7.4 introduced numeric literal separators which break number tokenization in older PHP versions.
-PHPCS backfills this since PHPCS 3.5.3/4.</p>
-<p>In other words, if an external standard intends to support PHPCS &lt; 3.5.4 and PHP &lt; 7.4, working
-with number tokens has suddenly become a challenge.</p>
-<p>The functions in this class have been put in place to ease that pain and it is
-<em>strongly</em> recommended to always use these functions when sniffing for and examining the
+    <section class="phpdocumentor-description"><p>PHP 7.4 introduced numeric literal separators. PHPCS backfills this since PHPCS 3.5.3/4.
+PHP 8.1 introduced an explicit octal notation. This is backfilled in PHPCS since PHPCS 3.7.0.</p>
+<p>While there are currently no unsupported numeric syntaxes, the methods in this class
+can still be useful for external standards which need to examine the
 contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettyprint">T_DNUMBER</code> tokens.</p>
 </section>
 
@@ -160,6 +162,14 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
  </a>
                     
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.octal-literal-prefix"> <p>PHP Manual on the introduction of the integer octal literal prefix.</p>
+ </a>
+                    
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
@@ -167,6 +177,37 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
                                                                                 
                                              
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Dropped support for PHPCS &lt; 3.7.1.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Removed the following class constants:</p>
+<ul>
+<li>
+<code class="prettyprint">Numbers::REGEX_NUMLIT_STRING</code>
+</li>
+<li>
+<code class="prettyprint">Numbers::REGEX_HEX_NUMLIT_STRING</code>
+</li>
+<li>
+<code class="prettyprint">Numbers::UNSUPPORTED_PHPCS_VERSION</code>
+</li>
+</ul>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -225,39 +266,18 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
 <dd>Regex to determine whether the contents of an arbitrary string represents a hexidecimal integer.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -constant -public">
-    <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_HEX_NUMLIT_STRING">REGEX_HEX_NUMLIT_STRING</a>
-    <span>
-        &nbsp;= &#039;`^((?&lt;!\\.)_[0-9A-F]*)+$`iD&#039;                            </span>
-</dt>
-<dd>Regex to determine is a T_STRING following a T_[DL]NUMBER is part of a hexidecimal numeric literal sequence.</dd>
-
-            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
-    <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_NUMLIT_STRING">REGEX_NUMLIT_STRING</a>
-    <span>
-        &nbsp;= &#039;`^((?&lt;![\\.e])_[0-9][0-9e\\.]*)+$`iD&#039;                            </span>
-</dt>
-<dd>Regex to determine if a T_STRING following a T_[DL]NUMBER is part of a numeric literal sequence.</dd>
-
-            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
     <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_OCTAL_INT">REGEX_OCTAL_INT</a>
     <span>
-        &nbsp;= &#039;`^0[0-7]+$`D&#039;                            </span>
+        &nbsp;= &#039;`^0[o]?[0-7]+$`iD&#039;                            </span>
 </dt>
 <dd>Regex to determine whether the contents of an arbitrary string represents an octal integer.</dd>
-
-            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
-    <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_UNSUPPORTED_PHPCS_VERSION">UNSUPPORTED_PHPCS_VERSION</a>
-    <span>
-        &nbsp;= &#039;3.5.3&#039;                            </span>
-</dt>
-<dd>PHPCS versions in which the backfill for PHP 7.4 numeric literal separators is broken.</dd>
 
                         <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Utils-Numbers.html#method_getCompleteNumber">getCompleteNumber()</a>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
-<dd>Retrieve information about a number token in a cross-version compatible manner.</dd>
+<dd>Retrieve information about a number token.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Utils-Numbers.html#method_getDecimalValue">getDecimalValue()</a>
@@ -320,7 +340,7 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">63</span>
+    <span class="phpdocumentor-element-found-in__line">66</span>
 
     </aside>
 
@@ -362,7 +382,7 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">45</span>
+    <span class="phpdocumentor-element-found-in__line">48</span>
 
     </aside>
 
@@ -404,7 +424,7 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">83</span>
+    <span class="phpdocumentor-element-found-in__line">86</span>
 
     </aside>
 
@@ -469,7 +489,7 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">72</span>
+    <span class="phpdocumentor-element-found-in__line">75</span>
 
     </aside>
 
@@ -503,94 +523,6 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
 
 </article>
                     <article class="phpdocumentor-element -constant -public ">
-    <h4 class="phpdocumentor-element__name" id="constant_REGEX_HEX_NUMLIT_STRING">
-        REGEX_HEX_NUMLIT_STRING
-        <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_HEX_NUMLIT_STRING" class="headerlink"><i class="fas fa-link"></i></a>
-    </h4>
-
-    <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
-    :
-    <span class="phpdocumentor-element-found-in__line">120</span>
-
-    </aside>
-
-        <p class="phpdocumentor-summary">Regex to determine is a T_STRING following a T_[DL]NUMBER is part of a hexidecimal numeric literal sequence.</p>
-
-    <code class="phpdocumentor-signature phpdocumentor-code ">
-    <span class="phpdocumentor-signature__visibility">public</span>
-        <span class="phpdocumentor-signature__type">string</span>
-    <span class="phpdocumentor-signature__name">REGEX_HEX_NUMLIT_STRING</span>
-    = <span class="phpdocumentor-signature__default-value">&#039;`^((?&lt;!\\.)_[0-9A-F]*)+$`iD&#039;</span>
-</code>
-
-
-        <section class="phpdocumentor-description"><p>Cross-version compatibility helper for PHP 7.4 numeric literals with underscore separators.</p>
-</section>
-
-    
-    
-    <h5 class="phpdocumentor-tag-list__heading" id="tags">
-        Tags
-        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
-    </h5>
-    <dl class="phpdocumentor-tag-list">
-                                    <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                
-                                             
-                                    </dd>
-                        </dl>
-
-</article>
-                    <article class="phpdocumentor-element -constant -public ">
-    <h4 class="phpdocumentor-element__name" id="constant_REGEX_NUMLIT_STRING">
-        REGEX_NUMLIT_STRING
-        <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_NUMLIT_STRING" class="headerlink"><i class="fas fa-link"></i></a>
-    </h4>
-
-    <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
-    :
-    <span class="phpdocumentor-element-found-in__line">109</span>
-
-    </aside>
-
-        <p class="phpdocumentor-summary">Regex to determine if a T_STRING following a T_[DL]NUMBER is part of a numeric literal sequence.</p>
-
-    <code class="phpdocumentor-signature phpdocumentor-code ">
-    <span class="phpdocumentor-signature__visibility">public</span>
-        <span class="phpdocumentor-signature__type">string</span>
-    <span class="phpdocumentor-signature__name">REGEX_NUMLIT_STRING</span>
-    = <span class="phpdocumentor-signature__default-value">&#039;`^((?&lt;![\\.e])_[0-9][0-9e\\.]*)+$`iD&#039;</span>
-</code>
-
-
-        <section class="phpdocumentor-description"><p>Cross-version compatibility helper for PHP 7.4 numeric literals with underscore separators.</p>
-</section>
-
-    
-    
-    <h5 class="phpdocumentor-tag-list__heading" id="tags">
-        Tags
-        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
-    </h5>
-    <dl class="phpdocumentor-tag-list">
-                                    <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                
-                                             
-                                    </dd>
-                        </dl>
-
-</article>
-                    <article class="phpdocumentor-element -constant -public ">
     <h4 class="phpdocumentor-element__name" id="constant_REGEX_OCTAL_INT">
         REGEX_OCTAL_INT
         <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_OCTAL_INT" class="headerlink"><i class="fas fa-link"></i></a>
@@ -599,7 +531,7 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">54</span>
+    <span class="phpdocumentor-element-found-in__line">57</span>
 
     </aside>
 
@@ -609,7 +541,7 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
     <span class="phpdocumentor-signature__visibility">public</span>
         <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">REGEX_OCTAL_INT</span>
-    = <span class="phpdocumentor-signature__default-value">&#039;`^0[0-7]+$`D&#039;</span>
+    = <span class="phpdocumentor-signature__default-value">&#039;`^0[o]?[0-7]+$`iD&#039;</span>
 </code>
 
 
@@ -628,59 +560,6 @@ contents of <code class="prettyprint">T_LNUMBER</code> or <code class="prettypri
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
                                                                                 
                                              
-                                    </dd>
-                        </dl>
-
-</article>
-                    <article class="phpdocumentor-element -constant -public ">
-    <h4 class="phpdocumentor-element__name" id="constant_UNSUPPORTED_PHPCS_VERSION">
-        UNSUPPORTED_PHPCS_VERSION
-        <a href="classes/PHPCSUtils-Utils-Numbers.html#constant_UNSUPPORTED_PHPCS_VERSION" class="headerlink"><i class="fas fa-link"></i></a>
-    </h4>
-
-    <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
-    :
-    <span class="phpdocumentor-element-found-in__line">131</span>
-
-    </aside>
-
-        <p class="phpdocumentor-summary">PHPCS versions in which the backfill for PHP 7.4 numeric literal separators is broken.</p>
-
-    <code class="phpdocumentor-signature phpdocumentor-code ">
-    <span class="phpdocumentor-signature__visibility">public</span>
-        <span class="phpdocumentor-signature__type">string</span>
-    <span class="phpdocumentor-signature__name">UNSUPPORTED_PHPCS_VERSION</span>
-    = <span class="phpdocumentor-signature__default-value">&#039;3.5.3&#039;</span>
-</code>
-
-
-    
-    
-    
-    <h5 class="phpdocumentor-tag-list__heading" id="tags">
-        Tags
-        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
-    </h5>
-    <dl class="phpdocumentor-tag-list">
-                                    <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                
-                                             
-                                    </dd>
-                            <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">since</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                            <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                
-                                                 <section class="phpdocumentor-description"><p>Changed from a property to a class constant.
-Changed from an array to a string.</p>
-</section>
-
                                     </dd>
                         </dl>
 
@@ -707,24 +586,18 @@ Changed from an array to a string.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">194</span>
+    <span class="phpdocumentor-element-found-in__line">136</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Retrieve information about a number token in a cross-version compatible manner.</p>
+        <p class="phpdocumentor-summary">Retrieve information about a number token.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getCompleteNumber</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Helper function to deal with numeric literals, potentially with underscore separators.</p>
-<p>PHP &lt; 7.4 does not tokenize numeric literals containing underscores correctly.
-As of PHPCS 3.5.3, PHPCS contains a backfill, but this backfill was buggy in the initial
-implementation. A fix for this broken backfill is included in PHPCS 3.5.4.</p>
-<p>Either way, this function can be used with all PHPCS/PHP combinations and will, if necessary,
-provide a backfill for PHPCS/PHP combinations where PHP 7.4 numbers with underscore separators
-are tokenized incorrectly - with the exception of PHPCS 3.5.3 as the buggyness of the original
-backfill implementation makes it impossible to provide reliable results.</p>
+        <section class="phpdocumentor-description"><p>Helper function to deal with numeric literals, potentially with underscore separators
+and/or explicit octal notation.</p>
 </section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -756,22 +629,6 @@ backfill implementation makes it impossible to provide reliable results.</p>
     </h5>
     <dl class="phpdocumentor-tag-list">
                                     <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">link</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/squizlabs/PHP_CodeSniffer/issues/2546"> <p>PHPCS issue #2546</p>
- </a>
-                    
-                                    </dd>
-                            <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">link</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/squizlabs/PHP_CodeSniffer/pull/2771"> <p>PHPCS PR #2771</p>
- </a>
-                    
-                                    </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
@@ -790,17 +647,6 @@ backfill implementation makes it impossible to provide reliable results.</p>
 </section>
 
                                     </dd>
-                            <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">throws</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                            
-                                                 <section class="phpdocumentor-description"><p>If this function is called in combination
-with an unsupported PHPCS version.</p>
-</section>
-
-                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -809,10 +655,8 @@ with an unsupported PHPCS version.</p>
             <section class="phpdocumentor-description"><p>An array with information about the number.
 The format of the array return value is:</p>
 <pre class="prettyprint"><code class="language-php">array(
-  'orig_content' =&gt; string, // The (potentially concatenated) original
-                            // content of the tokens;
-  'content'      =&gt; string, // The (potentially concatenated) content,
-                            // underscore(s) removed;
+  'orig_content' =&gt; string, // The original content of the token(s);
+  'content'      =&gt; string, // The content, underscore(s) removed;
   'code'         =&gt; int,    // The token code of the number, either
                             // T_LNUMBER or T_DNUMBER.
   'type'         =&gt; string, // The token type, either 'T_LNUMBER'
@@ -820,9 +664,9 @@ The format of the array return value is:</p>
   'decimal'      =&gt; string, // The decimal value of the number;
   'last_token'   =&gt; int,    // The stackPtr to the last token which was
                             // part of the number.
-                            // This will be the same as the original
-                            // stackPtr if it is not a PHP 7.4 number
-                            // with underscores.
+                            // At this time, this will be always be the original
+                            // stackPtr. This may change in the future if
+                            // new numeric syntaxes would be added to PHP.
 )
 </code></pre>
 </section>
@@ -842,7 +686,7 @@ The format of the array return value is:</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">342</span>
+    <span class="phpdocumentor-element-found-in__line">175</span>
 
     </aside>
 
@@ -850,19 +694,21 @@ The format of the array return value is:</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getDecimalValue</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getDecimalValue</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$textString</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|false</span></code>
 
-        <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators in numbers into account.</p>
+        <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators and explicit octal literals in numbers into account.</p>
 </section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
-                <span class="phpdocumentor-signature__argument__name">$string</span>
+                <span class="phpdocumentor-signature__argument__name">$textString</span>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>Arbitrary token content string.</p>
+                    <section class="phpdocumentor-description"><p>Arbitrary text string.
+This text string should be the (combined) token content of
+one or more tokens which together represent a number in PHP.</p>
 </section>
 
             </dd>
@@ -910,7 +756,7 @@ but returned as-is.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">437</span>
+    <span class="phpdocumentor-element-found-in__line">270</span>
 
     </aside>
 
@@ -918,7 +764,7 @@ but returned as-is.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isBinaryInt</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isBinaryInt</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$textString</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
         <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators in numbers into account.</p>
 </section>
@@ -926,7 +772,7 @@ but returned as-is.</p>
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
-                <span class="phpdocumentor-signature__argument__name">$string</span>
+                <span class="phpdocumentor-signature__argument__name">$textString</span>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
@@ -971,7 +817,7 @@ but returned as-is.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">391</span>
+    <span class="phpdocumentor-element-found-in__line">224</span>
 
     </aside>
 
@@ -979,7 +825,7 @@ but returned as-is.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isDecimalInt</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isDecimalInt</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$textString</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
         <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators in numbers into account.</p>
 </section>
@@ -987,7 +833,7 @@ but returned as-is.</p>
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
-                <span class="phpdocumentor-signature__argument__name">$string</span>
+                <span class="phpdocumentor-signature__argument__name">$textString</span>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
@@ -1032,7 +878,7 @@ but returned as-is.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">483</span>
+    <span class="phpdocumentor-element-found-in__line">316</span>
 
     </aside>
 
@@ -1040,7 +886,7 @@ but returned as-is.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isFloat</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isFloat</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$textString</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
         <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators in numbers into account.</p>
 </section>
@@ -1048,7 +894,7 @@ but returned as-is.</p>
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
-                <span class="phpdocumentor-signature__argument__name">$string</span>
+                <span class="phpdocumentor-signature__argument__name">$textString</span>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
@@ -1093,7 +939,7 @@ but returned as-is.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">414</span>
+    <span class="phpdocumentor-element-found-in__line">247</span>
 
     </aside>
 
@@ -1101,7 +947,7 @@ but returned as-is.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isHexidecimalInt</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isHexidecimalInt</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$textString</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
         <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators in numbers into account.</p>
 </section>
@@ -1109,7 +955,7 @@ but returned as-is.</p>
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
-                <span class="phpdocumentor-signature__argument__name">$string</span>
+                <span class="phpdocumentor-signature__argument__name">$textString</span>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
@@ -1154,7 +1000,7 @@ but returned as-is.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Numbers.php"><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">460</span>
+    <span class="phpdocumentor-element-found-in__line">293</span>
 
     </aside>
 
@@ -1162,15 +1008,15 @@ but returned as-is.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isOctalInt</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isOctalInt</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$textString</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
-        <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators in numbers into account.</p>
+        <section class="phpdocumentor-description"><p>Takes PHP 7.4 numeric literal separators and explicit octal literals in numbers into account.</p>
 </section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
-                <span class="phpdocumentor-signature__argument__name">$string</span>
+                <span class="phpdocumentor-signature__argument__name">$textString</span>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-ObjectDeclarations.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-ObjectDeclarations.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-utils.html">Utils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,15 +118,22 @@
     ObjectDeclarations
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ObjectDeclarations.php"><a href="../files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ObjectDeclarations.php"><a href="files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">29</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility functions for use when examining object declaration statements.</p>
 
@@ -98,14 +149,16 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                        <section class="phpdocumentor-description"><p>The <code class="prettyprint">ObjectDeclarations::get(Declaration)Name()</code>,
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>The <code class="prettyprint">ObjectDeclarations::get(Declaration)Name()</code>,
 <code class="prettyprint">ObjectDeclarations::getClassProperties()</code>, <code class="prettyprint">ObjectDeclarations::findExtendedClassName()</code>
 and <code class="prettyprint">ObjectDeclarations::findImplementedInterfaceNames()</code> methods are based on and
 inspired by the methods of the same name in the PHPCS native
 <code class="prettyprint">PHP_CodeSniffer\Files\File</code> class.
-Also see {@see \PHPCSUtils\BackCompat\BCFile}.</p></section>
+Also see <a href="classes/PHPCSUtils-BackCompat-BCFile.html"><abbr title="\PHPCSUtils\BackCompat\BCFile">BCFile</abbr></a>.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
 
@@ -119,38 +172,38 @@ Also see {@see \PHPCSUtils\BackCompat\BCFile}.</p></section>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findExtendedClassName">findExtendedClassName()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findExtendedClassName">findExtendedClassName()</a>
     <span>
-                        &nbsp;: string|false    </span>
+                                &nbsp;: string|false    </span>
 </dt>
 <dd>Retrieves the name of the class that the specified class extends.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findExtendedInterfaceNames">findExtendedInterfaceNames()</a>
+    <a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findExtendedInterfaceNames">findExtendedInterfaceNames()</a>
     <span>
-                        &nbsp;: array|false    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;|false    </span>
 </dt>
 <dd>Retrieves the names of the interfaces that the specified interface extends.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findImplementedInterfaceNames">findImplementedInterfaceNames()</a>
+    <a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findImplementedInterfaceNames">findImplementedInterfaceNames()</a>
     <span>
-                        &nbsp;: array|false    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;|false    </span>
 </dt>
 <dd>Retrieves the names of the interfaces that the specified class implements.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getClassProperties">getClassProperties()</a>
+    <a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getClassProperties">getClassProperties()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Retrieves the implementation properties of a class.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getName">getName()</a>
+    <a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getName">getName()</a>
     <span>
-                        &nbsp;: string|null    </span>
+                                &nbsp;: string|null    </span>
 </dt>
 <dd>Retrieves the declaration name for classes, interfaces, traits, and functions.</dd>
 
@@ -165,7 +218,7 @@ Also see {@see \PHPCSUtils\BackCompat\BCFile}.</p></section>
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -175,22 +228,23 @@ Also see {@see \PHPCSUtils\BackCompat\BCFile}.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_findExtendedClassName">
         findExtendedClassName()
-        <a href="#method_findExtendedClassName" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findExtendedClassName" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ObjectDeclarations.php"><a href="../files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ObjectDeclarations.php"><a href="files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">245</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieves the name of the class that the specified class extends.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">findExtendedClassName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">findExtendedClassName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|false</span></code>
 
         <section class="phpdocumentor-description"><p>Works for classes, anonymous classes and interfaces, though it is strongly recommended
-to use the <a href="../classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findExtendedInterfaceNames">\PHPCSUtils\Utils\ObjectDeclarations::findExtendedInterfaceNames()</a>
+to use the <a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findExtendedInterfaceNames"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations::findExtendedInterfaceNames()">ObjectDeclarations::findExtendedInterfaceNames()</abbr></a>
 method to examine interfaces instead. Interfaces can extend multiple parent interfaces,
 and that use-case is not handled by this method.</p>
 <p>Main differences with the PHPCS version:</p>
@@ -199,10 +253,12 @@ and that use-case is not handled by this method.</p>
 <ul>
 <li>Handling of PHPCS annotations.</li>
 <li>Handling of comments.</li>
-</ul></li>
+</ul>
+</li>
 <li>Improved handling of parse errors.</li>
 <li>The returned name will be clean of superfluous whitespace and/or comments.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -211,7 +267,8 @@ and that use-case is not handled by this method.</p>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -219,7 +276,8 @@ and that use-case is not handled by this method.</p>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The stack position of the class or interface.</p></section>
+                    <section class="phpdocumentor-description"><p>The stack position of the class or interface.</p>
+</section>
 
             </dd>
             </dl>
@@ -235,40 +293,48 @@ and that use-case is not handled by this method.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::findExtendedClassName()">File::findExtendedClassName()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_findExtendedClassName"><abbr title="\PHPCSUtils\BackCompat\BCFile::findExtendedClassName()">BCFile::findExtendedClassName()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Cross-version compatible version of
-the original.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_findExtendedClassName"><abbr title="\PHPCSUtils\BackCompat\BCFile::findExtendedClassName()">BCFile::findExtendedClassName()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Cross-version compatible version of
+the original.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findExtendedInterfaceNames"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations::findExtendedInterfaceNames()">ObjectDeclarations::findExtendedInterfaceNames()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Similar method for extended interfaces.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findExtendedInterfaceNames"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations::findExtendedInterfaceNames()">ObjectDeclarations::findExtendedInterfaceNames()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Similar method for extended interfaces.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string|false</span>
             &mdash;
             <section class="phpdocumentor-description"><p>The extended class name or <code class="prettyprint">FALSE</code> on error or if there
-is no extended class name.</p></section>
+is no extended class name.</p>
+</section>
 
     
 </article>
@@ -280,19 +346,20 @@ is no extended class name.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_findExtendedInterfaceNames">
         findExtendedInterfaceNames()
-        <a href="#method_findExtendedInterfaceNames" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findExtendedInterfaceNames" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ObjectDeclarations.php"><a href="../files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ObjectDeclarations.php"><a href="files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">296</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieves the names of the interfaces that the specified interface extends.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">findExtendedInterfaceNames</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">findExtendedInterfaceNames</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -302,7 +369,8 @@ is no extended class name.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -310,7 +378,8 @@ is no extended class name.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The stack position of the interface keyword.</p></section>
+                    <section class="phpdocumentor-description"><p>The stack position of the interface keyword.</p>
+</section>
 
             </dd>
             </dl>
@@ -325,24 +394,28 @@ is no extended class name.</p></section>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findExtendedClassName"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations::findExtendedClassName()">ObjectDeclarations::findExtendedClassName()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Similar method for extended classes.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findExtendedClassName"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations::findExtendedClassName()">ObjectDeclarations::findExtendedClassName()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Similar method for extended classes.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array|false</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span>
             &mdash;
             <section class="phpdocumentor-description"><p>Array with names of the extended interfaces or <code class="prettyprint">FALSE</code> on
-error or if there are no extended interface names.</p></section>
+error or if there are no extended interface names.</p>
+</section>
 
     
 </article>
@@ -354,19 +427,20 @@ error or if there are no extended interface names.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_findImplementedInterfaceNames">
         findImplementedInterfaceNames()
-        <a href="#method_findImplementedInterfaceNames" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findImplementedInterfaceNames" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ObjectDeclarations.php"><a href="../files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ObjectDeclarations.php"><a href="files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">278</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieves the names of the interfaces that the specified class implements.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">findImplementedInterfaceNames</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">findImplementedInterfaceNames</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span></code>
 
         <section class="phpdocumentor-description"><p>Main differences with the PHPCS version:</p>
 <ul>
@@ -374,10 +448,12 @@ error or if there are no extended interface names.</p></section>
 <ul>
 <li>Handling of PHPCS annotations.</li>
 <li>Handling of comments.</li>
-</ul></li>
+</ul>
+</li>
 <li>Improved handling of parse errors.</li>
 <li>The returned name(s) will be clean of superfluous whitespace and/or comments.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -386,7 +462,8 @@ error or if there are no extended interface names.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -394,7 +471,8 @@ error or if there are no extended interface names.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The stack position of the class.</p></section>
+                    <section class="phpdocumentor-description"><p>The stack position of the class.</p>
+</section>
 
             </dd>
             </dl>
@@ -410,32 +488,38 @@ error or if there are no extended interface names.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::findImplementedInterfaceNames()">File::findImplementedInterfaceNames()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_findImplementedInterfaceNames"><abbr title="\PHPCSUtils\BackCompat\BCFile::findImplementedInterfaceNames()">BCFile::findImplementedInterfaceNames()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Cross-version compatible version of
-the original.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_findImplementedInterfaceNames"><abbr title="\PHPCSUtils\BackCompat\BCFile::findImplementedInterfaceNames()">BCFile::findImplementedInterfaceNames()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Cross-version compatible version of
+the original.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array|false</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span>
             &mdash;
             <section class="phpdocumentor-description"><p>Array with names of the implemented interfaces or <code class="prettyprint">FALSE</code> on
-error or if there are no implemented interface names.</p></section>
+error or if there are no implemented interface names.</p>
+</section>
 
     
 </article>
@@ -447,19 +531,20 @@ error or if there are no implemented interface names.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getClassProperties">
         getClassProperties()
-        <a href="#method_getClassProperties" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getClassProperties" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ObjectDeclarations.php"><a href="../files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ObjectDeclarations.php"><a href="files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">184</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieves the implementation properties of a class.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getClassProperties</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getClassProperties</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Main differences with the PHPCS version:</p>
 <ul>
@@ -468,9 +553,11 @@ error or if there are no implemented interface names.</p></section>
 <li>Handling of PHPCS annotations.</li>
 <li>Handling of unorthodox docblock placement.</li>
 <li>A class cannot both be abstract as well as final, so this utility should not allow for that.</li>
-</ul></li>
+</ul>
+</li>
 <li>Defensive coding against incorrect calls to this method.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -479,7 +566,8 @@ error or if there are no implemented interface names.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -488,7 +576,8 @@ error or if there are no implemented interface names.</p></section>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position in the stack of the <code class="prettyprint">T_CLASS</code>
-token to acquire the properties for.</p></section>
+token to acquire the properties for.</p>
+</section>
 
             </dd>
             </dl>
@@ -504,44 +593,53 @@ token to acquire the properties for.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getClassProperties()">File::getClassProperties()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_getClassProperties"><abbr title="\PHPCSUtils\BackCompat\BCFile::getClassProperties()">BCFile::getClassProperties()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getClassProperties"><abbr title="\PHPCSUtils\BackCompat\BCFile::getClassProperties()">BCFile::getClassProperties()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified position is not a
-<code class="prettyprint">T_CLASS</code> token.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified position is not a
+<code class="prettyprint">T_CLASS</code> token.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
             <section class="phpdocumentor-description"><p>Array with implementation properties of a class.
 The format of the return value is:</p>
 <pre class="prettyprint"><code class="language-php">array(
   'is_abstract' =&gt; false, // TRUE if the abstract keyword was found.
   'is_final'    =&gt; false, // TRUE if the final keyword was found.
-);</code></pre></section>
+);
+</code></pre>
+</section>
 
     
 </article>
@@ -553,19 +651,20 @@ The format of the return value is:</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_getName">
         getName()
-        <a href="#method_getName" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getName" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ObjectDeclarations.php"><a href="../files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ObjectDeclarations.php"><a href="files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">68</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieves the declaration name for classes, interfaces, traits, and functions.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|null</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string|null</span></code>
 
         <section class="phpdocumentor-description"><p>Main differences with the PHPCS version:</p>
 <ul>
@@ -584,7 +683,8 @@ be returned or <code class="prettyprint">null</code> in case of no name (parse e
 <li>For ES6 classes in combination with PHPCS 2.x, passing a <code class="prettyprint">T_STRING</code> token to
 this method will be accepted for JS files.</li>
 <li>Support for JS ES6 method syntax has not been back-filled for PHPCS &lt; 3.0.0.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -593,7 +693,8 @@ this method will be accepted for JS files.</li>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -603,7 +704,8 @@ this method will be accepted for JS files.</li>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position of the declaration token
 which declared the class, interface,
-trait, or function.</p></section>
+trait, or function.</p>
+</section>
 
             </dd>
             </dl>
@@ -619,33 +721,40 @@ trait, or function.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getDeclarationName()">File::getDeclarationName()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_getDeclarationName"><abbr title="\PHPCSUtils\BackCompat\BCFile::getDeclarationName()">BCFile::getDeclarationName()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getDeclarationName"><abbr title="\PHPCSUtils\BackCompat\BCFile::getDeclarationName()">BCFile::getDeclarationName()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified token is not of type
-<code class="prettyprint">T_FUNCTION</code>, <code class="prettyprint">T_CLASS</code>, <code class="prettyprint">T_TRAIT</code>, or <code class="prettyprint">T_INTERFACE</code>.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified token is not of type
+<code class="prettyprint">T_FUNCTION</code>, <code class="prettyprint">T_CLASS</code>, <code class="prettyprint">T_TRAIT</code>, or <code class="prettyprint">T_INTERFACE</code>.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -653,27 +762,99 @@ trait, or function.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p>The name of the class, interface, trait, or function;
 or <code class="prettyprint">NULL</code> if the passed token doesn't exist, the function or
-class is anonymous or in case of a parse error/live coding.</p></section>
+class is anonymous or in case of a parse error/live coding.</p>
+</section>
 
     
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-ObjectDeclarations.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-ObjectDeclarations.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -131,7 +135,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ObjectDeclarations.php"><a href="files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">29</span>
+    <span class="phpdocumentor-element-found-in__line">30</span>
 
     </aside>
 
@@ -156,6 +160,16 @@ and <code class="prettyprint">ObjectDeclarations::findImplementedInterfaceNames(
 inspired by the methods of the same name in the PHPCS native
 <code class="prettyprint">PHP_CodeSniffer\Files\File</code> class.
 Also see <a href="classes/PHPCSUtils-BackCompat-BCFile.html"><abbr title="\PHPCSUtils\BackCompat\BCFile">BCFile</abbr></a>.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Dropped support for PHPCS &lt; 3.7.1.</p>
 </section>
 
                                     </dd>
@@ -191,7 +205,7 @@ Also see <a href="classes/PHPCSUtils-BackCompat-BCFile.html"><abbr title="\PHPCS
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;|false    </span>
 </dt>
-<dd>Retrieves the names of the interfaces that the specified class implements.</dd>
+<dd>Retrieves the names of the interfaces that the specified class or enum implements.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getClassProperties">getClassProperties()</a>
@@ -205,7 +219,7 @@ Also see <a href="classes/PHPCSUtils-BackCompat-BCFile.html"><abbr title="\PHPCS
     <span>
                                 &nbsp;: string|null    </span>
 </dt>
-<dd>Retrieves the declaration name for classes, interfaces, traits, and functions.</dd>
+<dd>Retrieves the declaration name for classes, interfaces, traits, enums and functions.</dd>
 
         </dl>
 
@@ -233,7 +247,7 @@ Also see <a href="classes/PHPCSUtils-BackCompat-BCFile.html"><abbr title="\PHPCS
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ObjectDeclarations.php"><a href="files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">245</span>
+    <span class="phpdocumentor-element-found-in__line">234</span>
 
     </aside>
 
@@ -253,10 +267,12 @@ and that use-case is not handled by this method.</p>
 <ul>
 <li>Handling of PHPCS annotations.</li>
 <li>Handling of comments.</li>
+<li>Handling of the namespace keyword used as operator.</li>
 </ul>
 </li>
 <li>Improved handling of parse errors.</li>
 <li>The returned name will be clean of superfluous whitespace and/or comments.</li>
+<li>Support for PHP 8.0 tokenization of identifier/namespaced names, cross-version PHP &amp; PHPCS.</li>
 </ul>
 </section>
 
@@ -351,7 +367,7 @@ is no extended class name.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ObjectDeclarations.php"><a href="files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">296</span>
+    <span class="phpdocumentor-element-found-in__line">288</span>
 
     </aside>
 
@@ -432,11 +448,11 @@ error or if there are no extended interface names.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ObjectDeclarations.php"><a href="files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">278</span>
+    <span class="phpdocumentor-element-found-in__line">270</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Retrieves the names of the interfaces that the specified class implements.</p>
+        <p class="phpdocumentor-summary">Retrieves the names of the interfaces that the specified class or enum implements.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
@@ -448,10 +464,12 @@ error or if there are no extended interface names.</p>
 <ul>
 <li>Handling of PHPCS annotations.</li>
 <li>Handling of comments.</li>
+<li>Handling of the namespace keyword used as operator.</li>
 </ul>
 </li>
 <li>Improved handling of parse errors.</li>
 <li>The returned name(s) will be clean of superfluous whitespace and/or comments.</li>
+<li>Support for PHP 8.0 tokenization of identifier/namespaced names, cross-version PHP &amp; PHPCS.</li>
 </ul>
 </section>
 
@@ -471,7 +489,7 @@ error or if there are no extended interface names.</p>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The stack position of the class.</p>
+                    <section class="phpdocumentor-description"><p>The stack position of the class or enum token.</p>
 </section>
 
             </dd>
@@ -512,6 +530,16 @@ the original.</p>
                                                                                 
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.1 enums.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -536,7 +564,7 @@ error or if there are no implemented interface names.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ObjectDeclarations.php"><a href="files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">184</span>
+    <span class="phpdocumentor-element-found-in__line">166</span>
 
     </aside>
 
@@ -552,10 +580,10 @@ error or if there are no implemented interface names.</p>
 <ul>
 <li>Handling of PHPCS annotations.</li>
 <li>Handling of unorthodox docblock placement.</li>
-<li>A class cannot both be abstract as well as final, so this utility should not allow for that.</li>
 </ul>
 </li>
 <li>Defensive coding against incorrect calls to this method.</li>
+<li>Support for PHP 8.2 readonly classes.</li>
 </ul>
 </section>
 
@@ -616,6 +644,16 @@ token to acquire the properties for.</p>
                                                                                 
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for the PHP 8.2 readonly keyword.</p>
+</section>
+
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
@@ -637,6 +675,7 @@ The format of the return value is:</p>
 <pre class="prettyprint"><code class="language-php">array(
   'is_abstract' =&gt; false, // TRUE if the abstract keyword was found.
   'is_final'    =&gt; false, // TRUE if the final keyword was found.
+  'is_readonly' =&gt; false, // TRUE if the readonly keyword was found.
 );
 </code></pre>
 </section>
@@ -656,11 +695,11 @@ The format of the return value is:</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/ObjectDeclarations.php"><a href="files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">68</span>
+    <span class="phpdocumentor-element-found-in__line">66</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Retrieves the declaration name for classes, interfaces, traits, and functions.</p>
+        <p class="phpdocumentor-summary">Retrieves the declaration name for classes, interfaces, traits, enums and functions.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
@@ -677,12 +716,6 @@ to return the name of the <em>next</em> construct, a partial name and/or the nam
 being extended/interface being implemented.
 Using this version of the utility method, either the complete name (invalid or not) will
 be returned or <code class="prettyprint">null</code> in case of no name (parse error).</li>
-</ul>
-<p>Note:</p>
-<ul>
-<li>For ES6 classes in combination with PHPCS 2.x, passing a <code class="prettyprint">T_STRING</code> token to
-this method will be accepted for JS files.</li>
-<li>Support for JS ES6 method syntax has not been back-filled for PHPCS &lt; 3.0.0.</li>
 </ul>
 </section>
 
@@ -704,7 +737,7 @@ this method will be accepted for JS files.</li>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position of the declaration token
 which declared the class, interface,
-trait, or function.</p>
+trait, enum or function.</p>
 </section>
 
             </dd>
@@ -744,6 +777,16 @@ trait, or function.</p>
                                                                                 
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.1 enums.</p>
+</section>
+
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
@@ -751,7 +794,8 @@ trait, or function.</p>
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
                                                             
                                                  <section class="phpdocumentor-description"><p>If the specified token is not of type
-<code class="prettyprint">T_FUNCTION</code>, <code class="prettyprint">T_CLASS</code>, <code class="prettyprint">T_TRAIT</code>, or <code class="prettyprint">T_INTERFACE</code>.</p>
+<code class="prettyprint">T_FUNCTION</code>, <code class="prettyprint">T_CLASS</code>, <code class="prettyprint">T_ANON_CLASS</code>,
+<code class="prettyprint">T_CLOSURE</code>, <code class="prettyprint">T_TRAIT</code>, <code class="prettyprint">T_ENUM</code> or <code class="prettyprint">T_INTERFACE</code>.</p>
 </section>
 
                                     </dd>
@@ -760,7 +804,7 @@ trait, or function.</p>
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string|null</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>The name of the class, interface, trait, or function;
+            <section class="phpdocumentor-description"><p>The name of the class, interface, trait, enum, or function;
 or <code class="prettyprint">NULL</code> if the passed token doesn't exist, the function or
 class is anonymous or in case of a parse error/live coding.</p>
 </section>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Operators.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Operators.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-utils.html">Utils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,15 +118,22 @@
     Operators
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Operators.php"><a href="../files/phpcsutils-utils-operators.html"><abbr title="PHPCSUtils/Utils/Operators.php">Operators.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Operators.php"><a href="files/phpcsutils-utils-operators.html"><abbr title="PHPCSUtils/Utils/Operators.php">Operators.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">31</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility functions for use when working with operators.</p>
 
@@ -97,22 +148,24 @@
                     <span class="phpdocumentor-tag__name">link</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.php.net/language.operators">https://www.php.net/language.operators</a>
-                                            <section class="phpdocumentor-description"><p>PHP manual on operators.</p></section>
-
-                </dd>
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.php.net/language.operators"> <p>PHP manual on operators.</p>
+ </a>
+                    
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                        <section class="phpdocumentor-description"><p>The <code class="prettyprint">isReference()</code> method is based on and inspired by
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>The <code class="prettyprint">isReference()</code> method is based on and inspired by
 the method of the same name in the PHPCS native <code class="prettyprint">File</code> class.
-Also see {@see \PHPCSUtils\BackCompat\BCFile}.
+Also see <a href="classes/PHPCSUtils-BackCompat-BCFile.html"><abbr title="\PHPCSUtils\BackCompat\BCFile">BCFile</abbr></a>.
 The <code class="prettyprint">isUnaryPlusMinus()</code> method is, in part, inspired by the
-<code class="prettyprint">Squiz.WhiteSpace.OperatorSpacing</code> sniff.</p></section>
+<code class="prettyprint">Squiz.WhiteSpace.OperatorSpacing</code> sniff.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
 
@@ -126,24 +179,24 @@ The <code class="prettyprint">isUnaryPlusMinus()</code> method is, in part, insp
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Operators.html#method_isReference">isReference()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-Operators.html#method_isReference">isReference()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Determine if the passed token is a reference operator.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Operators.html#method_isShortTernary">isShortTernary()</a>
+    <a href="classes/PHPCSUtils-Utils-Operators.html#method_isShortTernary">isShortTernary()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Determine whether a ternary is a short ternary/elvis operator, i.e. without &quot;middle&quot;.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Operators.html#method_isUnaryPlusMinus">isUnaryPlusMinus()</a>
+    <a href="classes/PHPCSUtils-Utils-Operators.html#method_isUnaryPlusMinus">isUnaryPlusMinus()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Determine whether a T_MINUS/T_PLUS token is a unary operator.</dd>
 
@@ -158,7 +211,7 @@ The <code class="prettyprint">isUnaryPlusMinus()</code> method is, in part, insp
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-Operators.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -168,25 +221,27 @@ The <code class="prettyprint">isUnaryPlusMinus()</code> method is, in part, insp
 >
     <h4 class="phpdocumentor-element__name" id="method_isReference">
         isReference()
-        <a href="#method_isReference" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Operators.html#method_isReference" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Operators.php"><a href="../files/phpcsutils-utils-operators.html"><abbr title="PHPCSUtils/Utils/Operators.php">Operators.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Operators.php"><a href="files/phpcsutils-utils-operators.html"><abbr title="PHPCSUtils/Utils/Operators.php">Operators.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">77</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Determine if the passed token is a reference operator.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isReference</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isReference</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
         <section class="phpdocumentor-description"><p>Main differences with the PHPCS version:</p>
 <ul>
 <li>Defensive coding against incorrect calls to this method.</li>
 <li>Improved handling of select tokenizer errors involving short lists/short arrays.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -195,7 +250,8 @@ The <code class="prettyprint">isUnaryPlusMinus()</code> method is, in part, insp
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -203,7 +259,8 @@ The <code class="prettyprint">isUnaryPlusMinus()</code> method is, in part, insp
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_BITWISE_AND</code> token.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_BITWISE_AND</code> token.</p>
+</section>
 
             </dd>
             </dl>
@@ -219,39 +276,47 @@ The <code class="prettyprint">isUnaryPlusMinus()</code> method is, in part, insp
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::isReference()">File::isReference()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_isReference"><abbr title="\PHPCSUtils\BackCompat\BCFile::isReference()">BCFile::isReference()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_isReference"><abbr title="\PHPCSUtils\BackCompat\BCFile::isReference()">BCFile::isReference()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                                        <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p></section>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">bool</span>
             &mdash;
             <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> if the specified token position represents a reference.
-<code class="prettyprint">FALSE</code> if the token represents a bitwise operator.</p></section>
+<code class="prettyprint">FALSE</code> if the token represents a bitwise operator.</p>
+</section>
 
     
 </article>
@@ -263,19 +328,20 @@ The <code class="prettyprint">isUnaryPlusMinus()</code> method is, in part, insp
 >
     <h4 class="phpdocumentor-element__name" id="method_isShortTernary">
         isShortTernary()
-        <a href="#method_isShortTernary" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Operators.html#method_isShortTernary" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Operators.php"><a href="../files/phpcsutils-utils-operators.html"><abbr title="PHPCSUtils/Utils/Operators.php">Operators.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Operators.php"><a href="files/phpcsutils-utils-operators.html"><abbr title="PHPCSUtils/Utils/Operators.php">Operators.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">244</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Determine whether a ternary is a short ternary/elvis operator, i.e. without &quot;middle&quot;.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isShortTernary</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isShortTernary</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -285,7 +351,8 @@ The <code class="prettyprint">isUnaryPlusMinus()</code> method is, in part, insp
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -294,7 +361,8 @@ The <code class="prettyprint">isUnaryPlusMinus()</code> method is, in part, insp
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position of the ternary then/else
-operator in the stack.</p></section>
+operator in the stack.</p>
+</section>
 
             </dd>
             </dl>
@@ -310,14 +378,16 @@ operator in the stack.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">bool</span>
             &mdash;
-            <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> if short ternary; or <code class="prettyprint">FALSE</code> otherwise.</p></section>
+            <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> if short ternary; or <code class="prettyprint">FALSE</code> otherwise.</p>
+</section>
 
     
 </article>
@@ -329,19 +399,20 @@ operator in the stack.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_isUnaryPlusMinus">
         isUnaryPlusMinus()
-        <a href="#method_isUnaryPlusMinus" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Operators.html#method_isUnaryPlusMinus" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Operators.php"><a href="../files/phpcsutils-utils-operators.html"><abbr title="PHPCSUtils/Utils/Operators.php">Operators.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Operators.php"><a href="files/phpcsutils-utils-operators.html"><abbr title="PHPCSUtils/Utils/Operators.php">Operators.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">185</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Determine whether a T_MINUS/T_PLUS token is a unary operator.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isUnaryPlusMinus</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isUnaryPlusMinus</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -351,7 +422,8 @@ operator in the stack.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -359,7 +431,8 @@ operator in the stack.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the plus/minus token.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the plus/minus token.</p>
+</section>
 
             </dd>
             </dl>
@@ -375,8 +448,9 @@ operator in the stack.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -384,27 +458,99 @@ operator in the stack.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> if the token passed is a unary operator.
 <code class="prettyprint">FALSE</code> otherwise, i.e. if the token is an arithmetic operator,
-or if the token is not a <code class="prettyprint">T_PLUS</code>/<code class="prettyprint">T_MINUS</code> token.</p></section>
+or if the token is not a <code class="prettyprint">T_PLUS</code>/<code class="prettyprint">T_MINUS</code> token.</p>
+</section>
 
     
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Operators.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Operators.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Operators.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -166,6 +170,16 @@ The <code class="prettyprint">isUnaryPlusMinus()</code> method is, in part, insp
 </section>
 
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Dropped support for PHPCS &lt; 3.7.1.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
 
@@ -226,7 +240,7 @@ The <code class="prettyprint">isUnaryPlusMinus()</code> method is, in part, insp
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Operators.php"><a href="files/phpcsutils-utils-operators.html"><abbr title="PHPCSUtils/Utils/Operators.php">Operators.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">77</span>
+    <span class="phpdocumentor-element-found-in__line">82</span>
 
     </aside>
 
@@ -239,7 +253,6 @@ The <code class="prettyprint">isUnaryPlusMinus()</code> method is, in part, insp
         <section class="phpdocumentor-description"><p>Main differences with the PHPCS version:</p>
 <ul>
 <li>Defensive coding against incorrect calls to this method.</li>
-<li>Improved handling of select tokenizer errors involving short lists/short arrays.</li>
 </ul>
 </section>
 
@@ -305,7 +318,17 @@ The <code class="prettyprint">isUnaryPlusMinus()</code> method is, in part, insp
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
                                                                                 
-                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 7.4 arrow functions.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 identifier name tokenization.</p>
 </section>
 
                                     </dd>
@@ -333,7 +356,7 @@ The <code class="prettyprint">isUnaryPlusMinus()</code> method is, in part, insp
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Operators.php"><a href="files/phpcsutils-utils-operators.html"><abbr title="PHPCSUtils/Utils/Operators.php">Operators.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">244</span>
+    <span class="phpdocumentor-element-found-in__line">231</span>
 
     </aside>
 
@@ -404,7 +427,7 @@ operator in the stack.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Operators.php"><a href="files/phpcsutils-utils-operators.html"><abbr title="PHPCSUtils/Utils/Operators.php">Operators.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">185</span>
+    <span class="phpdocumentor-element-found-in__line">180</span>
 
     </aside>
 

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Orthography.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Orthography.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -289,7 +293,7 @@ Source: https://en.wikipedia.org/wiki/Orthography</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isFirstCharCapitalized</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isFirstCharCapitalized</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$textString</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
         <section class="phpdocumentor-description"><p>Letter characters which do not have a concept of lower/uppercase will
 be accepted as correctly capitalized.</p>
@@ -298,7 +302,7 @@ be accepted as correctly capitalized.</p>
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
-                <span class="phpdocumentor-signature__argument__name">$string</span>
+                <span class="phpdocumentor-signature__argument__name">$textString</span>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
@@ -360,13 +364,13 @@ which doesn't have a concept of capitalization.
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isFirstCharLowercase</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isFirstCharLowercase</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$textString</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
-                <span class="phpdocumentor-signature__argument__name">$string</span>
+                <span class="phpdocumentor-signature__argument__name">$textString</span>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
@@ -428,13 +432,13 @@ capitalization and for non-letter characters.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isLastCharPunctuation</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$allowedChars</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">self::TERMINAL_POINTS</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isLastCharPunctuation</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$textString</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$allowedChars</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">self::TERMINAL_POINTS</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
-                <span class="phpdocumentor-signature__argument__name">$string</span>
+                <span class="phpdocumentor-signature__argument__name">$textString</span>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Orthography.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Orthography.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-utils.html">Utils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,23 +118,31 @@
     Orthography
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Orthography.php"><a href="../files/phpcsutils-utils-orthography.html"><abbr title="PHPCSUtils/Utils/Orthography.php">Orthography.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Orthography.php"><a href="files/phpcsutils-utils-orthography.html"><abbr title="PHPCSUtils/Utils/Orthography.php">Orthography.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">24</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility functions for checking the orthography of arbitrary text strings.</p>
 
     <section class="phpdocumentor-description"><blockquote>
 <p>An orthography is a set of conventions for writing a language. It includes norms of spelling,
 hyphenation, capitalization, word breaks, emphasis, and punctuation.
-Source: <a href="https://en.wikipedia.org/wiki/Orthography">https://en.wikipedia.org/wiki/Orthography</a></p>
-</blockquote></section>
+Source: https://en.wikipedia.org/wiki/Orthography</p>
+</blockquote>
+</section>
 
 
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -103,8 +155,9 @@ Source: <a href="https://en.wikipedia.org/wiki/Orthography">https://en.wikipedia
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 
@@ -119,30 +172,30 @@ Source: <a href="https://en.wikipedia.org/wiki/Orthography">https://en.wikipedia
 
 <dl class="phpdocumentor-table-of-contents">
             <dt class="phpdocumentor-table-of-contents__entry -constant -public">
-    <a href="../classes/PHPCSUtils-Utils-Orthography.html#constant_TERMINAL_POINTS">TERMINAL_POINTS</a>
+    <a href="classes/PHPCSUtils-Utils-Orthography.html#constant_TERMINAL_POINTS">TERMINAL_POINTS</a>
     <span>
-        &nbsp;= &#039;.?!&#039;                    </span>
+        &nbsp;= &#039;.?!&#039;                            </span>
 </dt>
 <dd>Characters which are considered terminal points for a sentence.</dd>
 
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Orthography.html#method_isFirstCharCapitalized">isFirstCharCapitalized()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-Orthography.html#method_isFirstCharCapitalized">isFirstCharCapitalized()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Check if the first character of an arbitrary text string is a capital letter.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Orthography.html#method_isFirstCharLowercase">isFirstCharLowercase()</a>
+    <a href="classes/PHPCSUtils-Utils-Orthography.html#method_isFirstCharLowercase">isFirstCharLowercase()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Check if the first character of an arbitrary text string is a lowercase letter.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Orthography.html#method_isLastCharPunctuation">isLastCharPunctuation()</a>
+    <a href="classes/PHPCSUtils-Utils-Orthography.html#method_isLastCharPunctuation">isLastCharPunctuation()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Check if the last character of an arbitrary text string is a valid punctuation character.</dd>
 
@@ -154,30 +207,32 @@ Source: <a href="https://en.wikipedia.org/wiki/Orthography">https://en.wikipedia
     <section class="phpdocumentor-constants">
         <h3 class="phpdocumentor-elements__header" id="constants">
             Constants
-            <a href="#constants" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-Orthography.html#constants" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article class="phpdocumentor-element -constant -public ">
     <h4 class="phpdocumentor-element__name" id="constant_TERMINAL_POINTS">
         TERMINAL_POINTS
-        <a href="#constant_TERMINAL_POINTS" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Orthography.html#constant_TERMINAL_POINTS" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
 
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Orthography.php"><a href="../files/phpcsutils-utils-orthography.html"><abbr title="PHPCSUtils/Utils/Orthography.php">Orthography.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Orthography.php"><a href="files/phpcsutils-utils-orthography.html"><abbr title="PHPCSUtils/Utils/Orthography.php">Orthography.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">36</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Characters which are considered terminal points for a sentence.</p>
 
     <code class="phpdocumentor-signature phpdocumentor-code ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__type">string</span>
+        <span class="phpdocumentor-signature__type">string</span>
     <span class="phpdocumentor-signature__name">TERMINAL_POINTS</span>
     = <span class="phpdocumentor-signature__default-value">&#039;.?!&#039;</span>
 </code>
 
 
+    
     
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -189,17 +244,18 @@ Source: <a href="https://en.wikipedia.org/wiki/Orthography">https://en.wikipedia
                     <span class="phpdocumentor-tag__name">link</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.thepunctuationguide.com/terminal-points.html">https://www.thepunctuationguide.com/terminal-points.html</a>
-                                            <section class="phpdocumentor-description"><p>Punctuation guide on terminal points.</p></section>
-
-                </dd>
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.thepunctuationguide.com/terminal-points.html"> <p>Punctuation guide on terminal points.</p>
+ </a>
+                    
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 </article>
@@ -210,7 +266,7 @@ Source: <a href="https://en.wikipedia.org/wiki/Orthography">https://en.wikipedia
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-Orthography.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -220,22 +276,24 @@ Source: <a href="https://en.wikipedia.org/wiki/Orthography">https://en.wikipedia
 >
     <h4 class="phpdocumentor-element__name" id="method_isFirstCharCapitalized">
         isFirstCharCapitalized()
-        <a href="#method_isFirstCharCapitalized" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Orthography.html#method_isFirstCharCapitalized" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Orthography.php"><a href="../files/phpcsutils-utils-orthography.html"><abbr title="PHPCSUtils/Utils/Orthography.php">Orthography.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Orthography.php"><a href="files/phpcsutils-utils-orthography.html"><abbr title="PHPCSUtils/Utils/Orthography.php">Orthography.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">57</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Check if the first character of an arbitrary text string is a capital letter.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isFirstCharCapitalized</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isFirstCharCapitalized</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
         <section class="phpdocumentor-description"><p>Letter characters which do not have a concept of lower/uppercase will
-be accepted as correctly capitalized.</p></section>
+be accepted as correctly capitalized.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -249,7 +307,8 @@ This can be the contents of a text string token,
 but also, for instance, a comment text.
 Potential text delimiter quotes should be stripped
 off a text string before passing it to this method.
-Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.</p></section>
+Also see: <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_stripQuotes"><abbr title="\PHPCSUtils\Utils\TextStrings::stripQuotes()">TextStrings::stripQuotes()</abbr></a>.</p>
+</section>
 
             </dd>
             </dl>
@@ -265,8 +324,9 @@ Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -274,7 +334,8 @@ Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> when the first character is a capital letter or a letter
 which doesn't have a concept of capitalization.
-<code class="prettyprint">FALSE</code> otherwise, including for non-letter characters.</p></section>
+<code class="prettyprint">FALSE</code> otherwise, including for non-letter characters.</p>
+</section>
 
     
 </article>
@@ -286,19 +347,20 @@ which doesn't have a concept of capitalization.
 >
     <h4 class="phpdocumentor-element__name" id="method_isFirstCharLowercase">
         isFirstCharLowercase()
-        <a href="#method_isFirstCharLowercase" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Orthography.html#method_isFirstCharLowercase" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Orthography.php"><a href="../files/phpcsutils-utils-orthography.html"><abbr title="PHPCSUtils/Utils/Orthography.php">Orthography.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Orthography.php"><a href="files/phpcsutils-utils-orthography.html"><abbr title="PHPCSUtils/Utils/Orthography.php">Orthography.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">79</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Check if the first character of an arbitrary text string is a lowercase letter.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isFirstCharLowercase</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isFirstCharLowercase</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -313,7 +375,8 @@ This can be the contents of a text string token,
 but also, for instance, a comment text.
 Potential text delimiter quotes should be stripped
 off a text string before passing it to this method.
-Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.</p></section>
+Also see: <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_stripQuotes"><abbr title="\PHPCSUtils\Utils\TextStrings::stripQuotes()">TextStrings::stripQuotes()</abbr></a>.</p>
+</section>
 
             </dd>
             </dl>
@@ -329,8 +392,9 @@ Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -338,7 +402,8 @@ Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> when the first character is a lowercase letter.
 <code class="prettyprint">FALSE</code> otherwise, including for letters which don't have a concept of
-capitalization and for non-letter characters.</p></section>
+capitalization and for non-letter characters.</p>
+</section>
 
     
 </article>
@@ -350,19 +415,20 @@ capitalization and for non-letter characters.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_isLastCharPunctuation">
         isLastCharPunctuation()
-        <a href="#method_isLastCharPunctuation" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Orthography.html#method_isLastCharPunctuation" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Orthography.php"><a href="../files/phpcsutils-utils-orthography.html"><abbr title="PHPCSUtils/Utils/Orthography.php">Orthography.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Orthography.php"><a href="files/phpcsutils-utils-orthography.html"><abbr title="PHPCSUtils/Utils/Orthography.php">Orthography.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">103</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Check if the last character of an arbitrary text string is a valid punctuation character.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isLastCharPunctuation</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$allowedChars</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">self::TERMINAL_POINTS</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isLastCharPunctuation</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$allowedChars</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">self::TERMINAL_POINTS</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -377,7 +443,8 @@ This can be the contents of a text string token,
 but also, for instance, a comment text.
 Potential text delimiter quotes should be stripped
 off a text string before passing it to this method.
-Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.</p></section>
+Also see: <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_stripQuotes"><abbr title="\PHPCSUtils\Utils\TextStrings::stripQuotes()">TextStrings::stripQuotes()</abbr></a>.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -388,7 +455,8 @@ Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.</p></section>
                     <section class="phpdocumentor-description"><p>Characters which are considered valid punctuation
 to end the text string.
 Defaults to <code class="prettyprint">'.?!'</code>, i.e. a full stop, question mark
-or exclamation mark.</p></section>
+or exclamation mark.</p>
+</section>
 
             </dd>
             </dl>
@@ -404,8 +472,9 @@ or exclamation mark.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -416,21 +485,92 @@ or exclamation mark.</p></section>
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Orthography.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Parentheses.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Parentheses.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-utils.html">Utils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,15 +118,22 @@
     Parentheses
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="../files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">25</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility functions for use when examining parenthesis tokens and arbitrary tokens wrapped in
 parentheses.</p>
@@ -99,8 +150,9 @@ parentheses.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 
@@ -114,88 +166,88 @@ parentheses.</p>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Parentheses.html#method_firstOwnerIn">firstOwnerIn()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_firstOwnerIn">firstOwnerIn()</a>
     <span>
-                        &nbsp;: int|false    </span>
+                                &nbsp;: int|false    </span>
 </dt>
 <dd>Check whether the owner of a outermost wrapping set of parentheses of an arbitrary token
 is within a limited set of acceptable token types.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstCloser">getFirstCloser()</a>
+    <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstCloser">getFirstCloser()</a>
     <span>
-                        &nbsp;: int|false    </span>
+                                &nbsp;: int|false    </span>
 </dt>
 <dd>Retrieve the position of the closer to the first (outer) set of parentheses an arbitrary
 token is wrapped in, where the parentheses owner is within the set of valid owners.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstOpener">getFirstOpener()</a>
+    <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstOpener">getFirstOpener()</a>
     <span>
-                        &nbsp;: int|false    </span>
+                                &nbsp;: int|false    </span>
 </dt>
 <dd>Retrieve the position of the opener to the first (outer) set of parentheses an arbitrary
 token is wrapped in, where the parentheses owner is within the set of valid owners.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstOwner">getFirstOwner()</a>
+    <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstOwner">getFirstOwner()</a>
     <span>
-                        &nbsp;: int|false    </span>
+                                &nbsp;: int|false    </span>
 </dt>
 <dd>Retrieve the position of the parentheses owner to the first (outer) set of parentheses an
 arbitrary token is wrapped in, where the parentheses owner is within the set of valid owners.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Parentheses.html#method_getLastCloser">getLastCloser()</a>
+    <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getLastCloser">getLastCloser()</a>
     <span>
-                        &nbsp;: int|false    </span>
+                                &nbsp;: int|false    </span>
 </dt>
 <dd>Retrieve the position of the closer to the last (inner) set of parentheses an arbitrary
 token is wrapped in, where the parentheses owner is within the set of valid owners.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOpener">getLastOpener()</a>
+    <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOpener">getLastOpener()</a>
     <span>
-                        &nbsp;: int|false    </span>
+                                &nbsp;: int|false    </span>
 </dt>
 <dd>Retrieve the position of the opener to the last (inner) set of parentheses an arbitrary
 token is wrapped in, where the parentheses owner is within the set of valid owners.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOwner">getLastOwner()</a>
+    <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOwner">getLastOwner()</a>
     <span>
-                        &nbsp;: int|false    </span>
+                                &nbsp;: int|false    </span>
 </dt>
 <dd>Retrieve the position of the parentheses owner to the last (inner) set of parentheses an
 arbitrary token is wrapped in where the parentheses owner is within the set of valid owners.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Parentheses.html#method_getOwner">getOwner()</a>
+    <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getOwner">getOwner()</a>
     <span>
-                        &nbsp;: int|false    </span>
+                                &nbsp;: int|false    </span>
 </dt>
 <dd>Get the pointer to the parentheses owner of an open/close parenthesis.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Parentheses.html#method_hasOwner">hasOwner()</a>
+    <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_hasOwner">hasOwner()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Check whether the passed token is nested within parentheses owned by one of the valid owners.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Parentheses.html#method_isOwnerIn">isOwnerIn()</a>
+    <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_isOwnerIn">isOwnerIn()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Check whether the parenthesis owner of an open/close parenthesis is within a limited
 set of valid owners.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Parentheses.html#method_lastOwnerIn">lastOwnerIn()</a>
+    <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_lastOwnerIn">lastOwnerIn()</a>
     <span>
-                        &nbsp;: int|false    </span>
+                                &nbsp;: int|false    </span>
 </dt>
 <dd>Check whether the owner of a innermost wrapping set of parentheses of an arbitrary token
 is within a limited set of acceptable token types.</dd>
@@ -211,7 +263,7 @@ is within a limited set of acceptable token types.</dd>
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-Parentheses.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -221,20 +273,21 @@ is within a limited set of acceptable token types.</dd>
 >
     <h4 class="phpdocumentor-element__name" id="method_firstOwnerIn">
         firstOwnerIn()
-        <a href="#method_firstOwnerIn" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_firstOwnerIn" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="../files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">327</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Check whether the owner of a outermost wrapping set of parentheses of an arbitrary token
 is within a limited set of acceptable token types.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">firstOwnerIn</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">firstOwnerIn</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -244,7 +297,8 @@ is within a limited set of acceptable token types.</p>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -253,16 +307,18 @@ is within a limited set of acceptable token types.</p>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position in the stack of the
-token to verify.</p></section>
+token to verify.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$validOwners</span>
-                : <span class="phpdocumentor-signature__argument__return-type">int|string|array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Array of token constants for the owners
-which should be considered valid.</p></section>
+which should be considered valid.</p>
+</section>
 
             </dd>
             </dl>
@@ -278,8 +334,9 @@ which should be considered valid.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -288,7 +345,8 @@ which should be considered valid.</p></section>
             <section class="phpdocumentor-description"><p>Integer stack pointer to the valid parentheses owner; or <code class="prettyprint">FALSE</code> if
 the token was not wrapped in parentheses or if the outermost set
 of parentheses in which the token is wrapped does not have an owner
-within the set of owners considered valid.</p></section>
+within the set of owners considered valid.</p>
+</section>
 
     
 </article>
@@ -300,23 +358,25 @@ within the set of owners considered valid.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getFirstCloser">
         getFirstCloser()
-        <a href="#method_getFirstCloser" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstCloser" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="../files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">191</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieve the position of the closer to the first (outer) set of parentheses an arbitrary
 token is wrapped in, where the parentheses owner is within the set of valid owners.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getFirstCloser</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getFirstCloser</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
         <section class="phpdocumentor-description"><p>If no <code class="prettyprint">$validOwners</code> are specified, the closer to the first set of parentheses surrounding
-the token will be returned.</p></section>
+the token will be returned.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -325,7 +385,8 @@ the token will be returned.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -333,16 +394,18 @@ the token will be returned.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$validOwners</span>
-                : <span class="phpdocumentor-signature__argument__return-type">int|string|array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;</span>
                  = <span class="phpdocumentor-signature__argument__default-value">[]</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Array of token constants for the owners
-which should be considered valid.</p></section>
+which should be considered valid.</p>
+</section>
 
             </dd>
             </dl>
@@ -358,8 +421,9 @@ which should be considered valid.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -367,7 +431,8 @@ which should be considered valid.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p>Integer stack pointer to the parentheses closer; or <code class="prettyprint">FALSE</code> if the token
 does not have parentheses owned by any of the valid owners or if
-the token is not nested in parentheses at all.</p></section>
+the token is not nested in parentheses at all.</p>
+</section>
 
     
 </article>
@@ -379,23 +444,25 @@ the token is not nested in parentheses at all.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getFirstOpener">
         getFirstOpener()
-        <a href="#method_getFirstOpener" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstOpener" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="../files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">168</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieve the position of the opener to the first (outer) set of parentheses an arbitrary
 token is wrapped in, where the parentheses owner is within the set of valid owners.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getFirstOpener</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getFirstOpener</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
         <section class="phpdocumentor-description"><p>If no <code class="prettyprint">$validOwners</code> are specified, the opener to the first set of parentheses surrounding
-the token will be returned.</p></section>
+the token will be returned.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -404,7 +471,8 @@ the token will be returned.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -412,16 +480,18 @@ the token will be returned.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$validOwners</span>
-                : <span class="phpdocumentor-signature__argument__return-type">int|string|array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;</span>
                  = <span class="phpdocumentor-signature__argument__default-value">[]</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Array of token constants for the owners
-which should be considered valid.</p></section>
+which should be considered valid.</p>
+</section>
 
             </dd>
             </dl>
@@ -437,8 +507,9 @@ which should be considered valid.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -446,7 +517,8 @@ which should be considered valid.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p>Integer stack pointer to the parentheses opener; or <code class="prettyprint">FALSE</code> if the token
 does not have parentheses owned by any of the valid owners or if
-the token is not nested in parentheses at all.</p></section>
+the token is not nested in parentheses at all.</p>
+</section>
 
     
 </article>
@@ -458,23 +530,25 @@ the token is not nested in parentheses at all.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getFirstOwner">
         getFirstOwner()
-        <a href="#method_getFirstOwner" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstOwner" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="../files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">220</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieve the position of the parentheses owner to the first (outer) set of parentheses an
 arbitrary token is wrapped in, where the parentheses owner is within the set of valid owners.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getFirstOwner</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getFirstOwner</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
         <section class="phpdocumentor-description"><p>If no <code class="prettyprint">$validOwners</code> are specified, the owner to the first set of parentheses surrounding
-the token will be returned or <code class="prettyprint">false</code> if the first set of parentheses does not have an owner.</p></section>
+the token will be returned or <code class="prettyprint">false</code> if the first set of parentheses does not have an owner.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -483,7 +557,8 @@ the token will be returned or <code class="prettyprint">false</code> if the firs
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -491,16 +566,18 @@ the token will be returned or <code class="prettyprint">false</code> if the firs
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$validOwners</span>
-                : <span class="phpdocumentor-signature__argument__return-type">int|string|array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;</span>
                  = <span class="phpdocumentor-signature__argument__default-value">[]</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Array of token constants for the owners
-which should be considered valid.</p></section>
+which should be considered valid.</p>
+</section>
 
             </dd>
             </dl>
@@ -516,8 +593,9 @@ which should be considered valid.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -525,7 +603,8 @@ which should be considered valid.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p>Integer stack pointer to the parentheses owner; or <code class="prettyprint">FALSE</code> if the token
 does not have parentheses owned by any of the valid owners or if
-the token is not nested in parentheses at all.</p></section>
+the token is not nested in parentheses at all.</p>
+</section>
 
     
 </article>
@@ -537,23 +616,25 @@ the token is not nested in parentheses at all.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getLastCloser">
         getLastCloser()
-        <a href="#method_getLastCloser" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getLastCloser" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="../files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">271</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieve the position of the closer to the last (inner) set of parentheses an arbitrary
 token is wrapped in, where the parentheses owner is within the set of valid owners.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getLastCloser</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getLastCloser</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
         <section class="phpdocumentor-description"><p>If no <code class="prettyprint">$validOwners</code> are specified, the closer to the last set of parentheses surrounding
-the token will be returned.</p></section>
+the token will be returned.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -562,7 +643,8 @@ the token will be returned.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -570,16 +652,18 @@ the token will be returned.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$validOwners</span>
-                : <span class="phpdocumentor-signature__argument__return-type">int|string|array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;</span>
                  = <span class="phpdocumentor-signature__argument__default-value">[]</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Array of token constants for the owners
-which should be considered valid.</p></section>
+which should be considered valid.</p>
+</section>
 
             </dd>
             </dl>
@@ -595,8 +679,9 @@ which should be considered valid.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -604,7 +689,8 @@ which should be considered valid.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p>Integer stack pointer to the parentheses closer; or <code class="prettyprint">FALSE</code> if the token
 does not have parentheses owned by any of the valid owners or if
-the token is not nested in parentheses at all.</p></section>
+the token is not nested in parentheses at all.</p>
+</section>
 
     
 </article>
@@ -616,23 +702,25 @@ the token is not nested in parentheses at all.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getLastOpener">
         getLastOpener()
-        <a href="#method_getLastOpener" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOpener" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="../files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">248</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieve the position of the opener to the last (inner) set of parentheses an arbitrary
 token is wrapped in, where the parentheses owner is within the set of valid owners.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getLastOpener</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getLastOpener</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
         <section class="phpdocumentor-description"><p>If no <code class="prettyprint">$validOwners</code> are specified, the opener to the last set of parentheses surrounding
-the token will be returned.</p></section>
+the token will be returned.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -641,7 +729,8 @@ the token will be returned.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -649,16 +738,18 @@ the token will be returned.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$validOwners</span>
-                : <span class="phpdocumentor-signature__argument__return-type">int|string|array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;</span>
                  = <span class="phpdocumentor-signature__argument__default-value">[]</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Array of token constants for the owners
-which should be considered valid.</p></section>
+which should be considered valid.</p>
+</section>
 
             </dd>
             </dl>
@@ -674,8 +765,9 @@ which should be considered valid.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -683,7 +775,8 @@ which should be considered valid.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p>Integer stack pointer to the parentheses opener; or <code class="prettyprint">FALSE</code> if the token
 does not have parentheses owned by any of the valid owners or if
-the token is not nested in parentheses at all.</p></section>
+the token is not nested in parentheses at all.</p>
+</section>
 
     
 </article>
@@ -695,23 +788,25 @@ the token is not nested in parentheses at all.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getLastOwner">
         getLastOwner()
-        <a href="#method_getLastOwner" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOwner" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="../files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">300</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieve the position of the parentheses owner to the last (inner) set of parentheses an
 arbitrary token is wrapped in where the parentheses owner is within the set of valid owners.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getLastOwner</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getLastOwner</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
         <section class="phpdocumentor-description"><p>If no <code class="prettyprint">$validOwners</code> are specified, the owner to the last set of parentheses surrounding
-the token will be returned or <code class="prettyprint">false</code> if the last set of parentheses does not have an owner.</p></section>
+the token will be returned or <code class="prettyprint">false</code> if the last set of parentheses does not have an owner.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -720,7 +815,8 @@ the token will be returned or <code class="prettyprint">false</code> if the last
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -728,16 +824,18 @@ the token will be returned or <code class="prettyprint">false</code> if the last
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$validOwners</span>
-                : <span class="phpdocumentor-signature__argument__return-type">int|string|array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;</span>
                  = <span class="phpdocumentor-signature__argument__default-value">[]</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Array of token constants for the owners
-which should be considered valid.</p></section>
+which should be considered valid.</p>
+</section>
 
             </dd>
             </dl>
@@ -753,8 +851,9 @@ which should be considered valid.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -762,7 +861,8 @@ which should be considered valid.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p>Integer stack pointer to the parentheses owner; or <code class="prettyprint">FALSE</code> if the token
 does not have parentheses owned by any of the valid owners or if
-the token is not nested in parentheses at all.</p></section>
+the token is not nested in parentheses at all.</p>
+</section>
 
     
 </article>
@@ -774,19 +874,20 @@ the token is not nested in parentheses at all.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getOwner">
         getOwner()
-        <a href="#method_getOwner" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getOwner" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="../files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">41</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Get the pointer to the parentheses owner of an open/close parenthesis.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getOwner</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getOwner</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -796,7 +897,8 @@ the token is not nested in parentheses at all.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -804,7 +906,8 @@ the token is not nested in parentheses at all.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of <code class="prettyprint">T_OPEN/CLOSE_PARENTHESIS</code> token.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of <code class="prettyprint">T_OPEN/CLOSE_PARENTHESIS</code> token.</p>
+</section>
 
             </dd>
             </dl>
@@ -820,16 +923,19 @@ the token is not nested in parentheses at all.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                                        <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p></section>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -837,7 +943,8 @@ the token is not nested in parentheses at all.</p></section>
             &mdash;
             <section class="phpdocumentor-description"><p>Integer stack pointer to the parentheses owner; or <code class="prettyprint">FALSE</code> if the
 parenthesis does not have a (direct) owner or if the token passed
-was not a parenthesis.</p></section>
+was not a parenthesis.</p>
+</section>
 
     
 </article>
@@ -849,19 +956,20 @@ was not a parenthesis.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_hasOwner">
         hasOwner()
-        <a href="#method_hasOwner" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_hasOwner" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="../files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">145</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Check whether the passed token is nested within parentheses owned by one of the valid owners.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">hasOwner</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">hasOwner</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -871,7 +979,8 @@ was not a parenthesis.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -879,16 +988,18 @@ was not a parenthesis.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the token we are checking.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$validOwners</span>
-                : <span class="phpdocumentor-signature__argument__return-type">int|string|array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Array of token constants for the owners
-which should be considered valid.</p></section>
+which should be considered valid.</p>
+</section>
 
             </dd>
             </dl>
@@ -904,8 +1015,9 @@ which should be considered valid.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -922,20 +1034,21 @@ which should be considered valid.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_isOwnerIn">
         isOwnerIn()
-        <a href="#method_isOwnerIn" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_isOwnerIn" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="../files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">103</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Check whether the parenthesis owner of an open/close parenthesis is within a limited
 set of valid owners.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isOwnerIn</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isOwnerIn</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -945,7 +1058,8 @@ set of valid owners.</p>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -953,16 +1067,18 @@ set of valid owners.</p>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of <code class="prettyprint">T_OPEN/CLOSE_PARENTHESIS</code> token.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of <code class="prettyprint">T_OPEN/CLOSE_PARENTHESIS</code> token.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$validOwners</span>
-                : <span class="phpdocumentor-signature__argument__return-type">int|string|array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Array of token constants for the owners
-which should be considered valid.</p></section>
+which should be considered valid.</p>
+</section>
 
             </dd>
             </dl>
@@ -978,23 +1094,27 @@ which should be considered valid.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
-                                                                                                        <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p></section>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">bool</span>
             &mdash;
             <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> if the owner is within the list of <code class="prettyprint">$validOwners</code>; <code class="prettyprint">FALSE</code> if not and
-if the parenthesis does not have a (direct) owner.</p></section>
+if the parenthesis does not have a (direct) owner.</p>
+</section>
 
     
 </article>
@@ -1006,20 +1126,21 @@ if the parenthesis does not have a (direct) owner.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_lastOwnerIn">
         lastOwnerIn()
-        <a href="#method_lastOwnerIn" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_lastOwnerIn" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="../files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">355</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Check whether the owner of a innermost wrapping set of parentheses of an arbitrary token
 is within a limited set of acceptable token types.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">lastOwnerIn</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">lastOwnerIn</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -1029,7 +1150,8 @@ is within a limited set of acceptable token types.</p>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -1038,16 +1160,18 @@ is within a limited set of acceptable token types.</p>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position in the stack of the
-token to verify.</p></section>
+token to verify.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$validOwners</span>
-                : <span class="phpdocumentor-signature__argument__return-type">int|string|array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Array of token constants for the owners
-which should be considered valid.</p></section>
+which should be considered valid.</p>
+</section>
 
             </dd>
             </dl>
@@ -1063,8 +1187,9 @@ which should be considered valid.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -1073,27 +1198,99 @@ which should be considered valid.</p></section>
             <section class="phpdocumentor-description"><p>Integer stack pointer to the valid parentheses owner; or <code class="prettyprint">FALSE</code> if
 the token was not wrapped in parentheses or if the innermost set
 of parentheses in which the token is wrapped does not have an owner
-within the set of owners considered valid.</p></section>
+within the set of owners considered valid.</p>
+</section>
 
     
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Parentheses.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Parentheses.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Parentheses.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -131,13 +135,16 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">25</span>
+    <span class="phpdocumentor-element-found-in__line">28</span>
 
     </aside>
 
-            <p class="phpdocumentor-summary">Utility functions for use when examining parenthesis tokens and arbitrary tokens wrapped in
-parentheses.</p>
+            <p class="phpdocumentor-summary">Utility functions for use when examining parenthesis tokens and arbitrary tokens wrapped
+in parentheses.</p>
 
+    <section class="phpdocumentor-description"><p>In contrast to PHPCS natively, <code class="prettyprint">isset()</code>, <code class="prettyprint">unset()</code>, <code class="prettyprint">empty()</code>, <code class="prettyprint">exit()</code>, <code class="prettyprint">die()</code> and <code class="prettyprint">eval()</code>
+will be considered parentheses owners by the functions in this class.</p>
+</section>
 
 
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -152,6 +159,27 @@ parentheses.</p>
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
                                                                                 
                                              
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for <code class="prettyprint">isset()</code>, <code class="prettyprint">unset()</code>, <code class="prettyprint">empty()</code>, <code class="prettyprint">exit()</code>, <code class="prettyprint">die()</code>
+and <code class="prettyprint">eval()</code> as parentheses owners to all applicable functions.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Dropped support for PHPCS &lt; 3.7.1.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -171,7 +199,7 @@ parentheses.</p>
     <span>
                                 &nbsp;: int|false    </span>
 </dt>
-<dd>Check whether the owner of a outermost wrapping set of parentheses of an arbitrary token
+<dd>Check whether the owner of the outermost wrapping set of parentheses of an arbitrary token
 is within a limited set of acceptable token types.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
@@ -179,55 +207,55 @@ is within a limited set of acceptable token types.</dd>
     <span>
                                 &nbsp;: int|false    </span>
 </dt>
-<dd>Retrieve the position of the closer to the first (outer) set of parentheses an arbitrary
-token is wrapped in, where the parentheses owner is within the set of valid owners.</dd>
+<dd>Retrieve the stack pointer to the parentheses closer of the first (outer) set of parentheses
+an arbitrary token is wrapped in.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstOpener">getFirstOpener()</a>
     <span>
                                 &nbsp;: int|false    </span>
 </dt>
-<dd>Retrieve the position of the opener to the first (outer) set of parentheses an arbitrary
-token is wrapped in, where the parentheses owner is within the set of valid owners.</dd>
+<dd>Retrieve the stack pointer to the parentheses opener of the first (outer) set of parentheses
+an arbitrary token is wrapped in.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstOwner">getFirstOwner()</a>
     <span>
                                 &nbsp;: int|false    </span>
 </dt>
-<dd>Retrieve the position of the parentheses owner to the first (outer) set of parentheses an
-arbitrary token is wrapped in, where the parentheses owner is within the set of valid owners.</dd>
+<dd>Retrieve the stack pointer to the parentheses owner of the first (outer) set of parentheses
+an arbitrary token is wrapped in.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getLastCloser">getLastCloser()</a>
     <span>
                                 &nbsp;: int|false    </span>
 </dt>
-<dd>Retrieve the position of the closer to the last (inner) set of parentheses an arbitrary
-token is wrapped in, where the parentheses owner is within the set of valid owners.</dd>
+<dd>Retrieve the stack pointer to the parentheses closer of the last (inner) set of parentheses
+an arbitrary token is wrapped in.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOpener">getLastOpener()</a>
     <span>
                                 &nbsp;: int|false    </span>
 </dt>
-<dd>Retrieve the position of the opener to the last (inner) set of parentheses an arbitrary
-token is wrapped in, where the parentheses owner is within the set of valid owners.</dd>
+<dd>Retrieve the stack pointer to the parentheses opener of the last (inner) set of parentheses
+an arbitrary token is wrapped in.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOwner">getLastOwner()</a>
     <span>
                                 &nbsp;: int|false    </span>
 </dt>
-<dd>Retrieve the position of the parentheses owner to the last (inner) set of parentheses an
-arbitrary token is wrapped in where the parentheses owner is within the set of valid owners.</dd>
+<dd>Retrieve the stack pointer to the parentheses owner of the last (inner) set of parentheses
+an arbitrary token is wrapped in.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_getOwner">getOwner()</a>
     <span>
                                 &nbsp;: int|false    </span>
 </dt>
-<dd>Get the pointer to the parentheses owner of an open/close parenthesis.</dd>
+<dd>Get the stack pointer to the parentheses owner of an open/close parenthesis.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Utils-Parentheses.html#method_hasOwner">hasOwner()</a>
@@ -249,7 +277,7 @@ set of valid owners.</dd>
     <span>
                                 &nbsp;: int|false    </span>
 </dt>
-<dd>Check whether the owner of a innermost wrapping set of parentheses of an arbitrary token
+<dd>Check whether the owner of the innermost wrapping set of parentheses of an arbitrary token
 is within a limited set of acceptable token types.</dd>
 
         </dl>
@@ -278,11 +306,11 @@ is within a limited set of acceptable token types.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">327</span>
+    <span class="phpdocumentor-element-found-in__line">324</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Check whether the owner of a outermost wrapping set of parentheses of an arbitrary token
+        <p class="phpdocumentor-summary">Check whether the owner of the outermost wrapping set of parentheses of an arbitrary token
 is within a limited set of acceptable token types.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
@@ -363,19 +391,20 @@ within the set of owners considered valid.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">191</span>
+    <span class="phpdocumentor-element-found-in__line">184</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Retrieve the position of the closer to the first (outer) set of parentheses an arbitrary
-token is wrapped in, where the parentheses owner is within the set of valid owners.</p>
+        <p class="phpdocumentor-summary">Retrieve the stack pointer to the parentheses closer of the first (outer) set of parentheses
+an arbitrary token is wrapped in.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getFirstCloser</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
-        <section class="phpdocumentor-description"><p>If no <code class="prettyprint">$validOwners</code> are specified, the closer to the first set of parentheses surrounding
-the token will be returned.</p>
+        <section class="phpdocumentor-description"><p>If the optional <code class="prettyprint">$validOwners</code> parameter is passed, the stack pointer to the closer to
+the first set of parentheses, which has an owner which is in the list of valid owners,
+will be returned. This may be a nested set of parentheses.</p>
 </section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -449,19 +478,20 @@ the token is not nested in parentheses at all.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">168</span>
+    <span class="phpdocumentor-element-found-in__line">160</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Retrieve the position of the opener to the first (outer) set of parentheses an arbitrary
-token is wrapped in, where the parentheses owner is within the set of valid owners.</p>
+        <p class="phpdocumentor-summary">Retrieve the stack pointer to the parentheses opener of the first (outer) set of parentheses
+an arbitrary token is wrapped in.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getFirstOpener</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
-        <section class="phpdocumentor-description"><p>If no <code class="prettyprint">$validOwners</code> are specified, the opener to the first set of parentheses surrounding
-the token will be returned.</p>
+        <section class="phpdocumentor-description"><p>If the optional <code class="prettyprint">$validOwners</code> parameter is passed, the stack pointer to the opener to
+the first set of parentheses, which has an owner which is in the list of valid owners,
+will be returned. This may be a nested set of parentheses.</p>
 </section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -535,19 +565,20 @@ the token is not nested in parentheses at all.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">220</span>
+    <span class="phpdocumentor-element-found-in__line">214</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Retrieve the position of the parentheses owner to the first (outer) set of parentheses an
-arbitrary token is wrapped in, where the parentheses owner is within the set of valid owners.</p>
+        <p class="phpdocumentor-summary">Retrieve the stack pointer to the parentheses owner of the first (outer) set of parentheses
+an arbitrary token is wrapped in.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getFirstOwner</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
-        <section class="phpdocumentor-description"><p>If no <code class="prettyprint">$validOwners</code> are specified, the owner to the first set of parentheses surrounding
-the token will be returned or <code class="prettyprint">false</code> if the first set of parentheses does not have an owner.</p>
+        <section class="phpdocumentor-description"><p>If the optional <code class="prettyprint">$validOwners</code> parameter is passed, the stack pointer to the owner of
+the first set of parentheses, which has an owner which is in the list of valid owners,
+will be returned. This may be a nested set of parentheses.</p>
 </section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -621,19 +652,20 @@ the token is not nested in parentheses at all.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">271</span>
+    <span class="phpdocumentor-element-found-in__line">267</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Retrieve the position of the closer to the last (inner) set of parentheses an arbitrary
-token is wrapped in, where the parentheses owner is within the set of valid owners.</p>
+        <p class="phpdocumentor-summary">Retrieve the stack pointer to the parentheses closer of the last (inner) set of parentheses
+an arbitrary token is wrapped in.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getLastCloser</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
-        <section class="phpdocumentor-description"><p>If no <code class="prettyprint">$validOwners</code> are specified, the closer to the last set of parentheses surrounding
-the token will be returned.</p>
+        <section class="phpdocumentor-description"><p>If the optional <code class="prettyprint">$validOwners</code> parameter is passed, the stack pointer to the closer to
+the last set of parentheses, which has an owner which is in the list of valid owners,
+will be returned. This may be a set of parentheses higher up.</p>
 </section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -707,19 +739,20 @@ the token is not nested in parentheses at all.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">248</span>
+    <span class="phpdocumentor-element-found-in__line">243</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Retrieve the position of the opener to the last (inner) set of parentheses an arbitrary
-token is wrapped in, where the parentheses owner is within the set of valid owners.</p>
+        <p class="phpdocumentor-summary">Retrieve the stack pointer to the parentheses opener of the last (inner) set of parentheses
+an arbitrary token is wrapped in.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getLastOpener</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
-        <section class="phpdocumentor-description"><p>If no <code class="prettyprint">$validOwners</code> are specified, the opener to the last set of parentheses surrounding
-the token will be returned.</p>
+        <section class="phpdocumentor-description"><p>If the optional <code class="prettyprint">$validOwners</code> parameter is passed, the stack pointer to the opener to
+the last set of parentheses, which has an owner which is in the list of valid owners,
+will be returned. This may be a set of parentheses higher up.</p>
 </section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -793,19 +826,20 @@ the token is not nested in parentheses at all.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">300</span>
+    <span class="phpdocumentor-element-found-in__line">297</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Retrieve the position of the parentheses owner to the last (inner) set of parentheses an
-arbitrary token is wrapped in where the parentheses owner is within the set of valid owners.</p>
+        <p class="phpdocumentor-summary">Retrieve the stack pointer to the parentheses owner of the last (inner) set of parentheses
+an arbitrary token is wrapped in.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
             <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getLastOwner</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validOwners</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
-        <section class="phpdocumentor-description"><p>If no <code class="prettyprint">$validOwners</code> are specified, the owner to the last set of parentheses surrounding
-the token will be returned or <code class="prettyprint">false</code> if the last set of parentheses does not have an owner.</p>
+        <section class="phpdocumentor-description"><p>If the optional <code class="prettyprint">$validOwners</code> parameter is passed, the stack pointer to the owner of
+the last set of parentheses, which has an owner which is in the list of valid owners,
+will be returned. This may be a set of parentheses higher up.</p>
 </section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -879,11 +913,11 @@ the token is not nested in parentheses at all.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">41</span>
+    <span class="phpdocumentor-element-found-in__line">63</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Get the pointer to the parentheses owner of an open/close parenthesis.</p>
+        <p class="phpdocumentor-summary">Get the stack pointer to the parentheses owner of an open/close parenthesis.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
@@ -932,7 +966,7 @@ the token is not nested in parentheses at all.</p>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
                                                                                 
-                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 7.4 arrow functions.</p>
 </section>
 
                                     </dd>
@@ -961,7 +995,7 @@ was not a parenthesis.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">145</span>
+    <span class="phpdocumentor-element-found-in__line">136</span>
 
     </aside>
 
@@ -1039,7 +1073,7 @@ which should be considered valid.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">103</span>
+    <span class="phpdocumentor-element-found-in__line">111</span>
 
     </aside>
 
@@ -1103,7 +1137,7 @@ which should be considered valid.</p>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha2</span>
                                                                                 
-                                                 <section class="phpdocumentor-description"><p>Added BC support for PHP 7.4 arrow functions.</p>
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 7.4 arrow functions.</p>
 </section>
 
                                     </dd>
@@ -1131,11 +1165,11 @@ if the parenthesis does not have a (direct) owner.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Parentheses.php"><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">355</span>
+    <span class="phpdocumentor-element-found-in__line">352</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Check whether the owner of a innermost wrapping set of parentheses of an arbitrary token
+        <p class="phpdocumentor-summary">Check whether the owner of the innermost wrapping set of parentheses of an arbitrary token
 is within a limited set of acceptable token types.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-PassedParameters.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-PassedParameters.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-utils.html">Utils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,15 +118,22 @@
     PassedParameters
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/PassedParameters.php"><a href="../files/phpcsutils-utils-passedparameters.html"><abbr title="PHPCSUtils/Utils/PassedParameters.php">PassedParameters.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/PassedParameters.php"><a href="files/phpcsutils-utils-passedparameters.html"><abbr title="PHPCSUtils/Utils/PassedParameters.php">PassedParameters.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">25</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility functions to retrieve information about parameters passed to function calls,
 array declarations, isset and unset constructs.</p>
@@ -99,8 +150,9 @@ array declarations, isset and unset constructs.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 
@@ -114,31 +166,31 @@ array declarations, isset and unset constructs.</p>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameter">getParameter()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameter">getParameter()</a>
     <span>
-                        &nbsp;: array|false    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;|false    </span>
 </dt>
 <dd>Get information on a specific parameter passed.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameterCount">getParameterCount()</a>
+    <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameterCount">getParameterCount()</a>
     <span>
-                        &nbsp;: int    </span>
+                                &nbsp;: int    </span>
 </dt>
 <dd>Count the number of parameters which have been passed.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameters">getParameters()</a>
+    <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameters">getParameters()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Get information on all parameters passed.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-PassedParameters.html#method_hasParameters">hasParameters()</a>
+    <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_hasParameters">hasParameters()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Checks if any parameters have been passed.</dd>
 
@@ -153,7 +205,7 @@ array declarations, isset and unset constructs.</p>
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-PassedParameters.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -163,21 +215,23 @@ array declarations, isset and unset constructs.</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_getParameter">
         getParameter()
-        <a href="#method_getParameter" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameter" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/PassedParameters.php"><a href="../files/phpcsutils-utils-passedparameters.html"><abbr title="PHPCSUtils/Utils/PassedParameters.php">PassedParameters.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/PassedParameters.php"><a href="files/phpcsutils-utils-passedparameters.html"><abbr title="PHPCSUtils/Utils/PassedParameters.php">PassedParameters.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">303</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Get information on a specific parameter passed.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getParameter</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$paramOffset</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getParameter</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$paramOffset</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span></code>
 
-        <section class="phpdocumentor-description"><p>See <a href="../classes/PHPCSUtils-Utils-PassedParameters.html#method_hasParameters">\PHPCSUtils\Utils\PassedParameters::hasParameters()</a> for information on the supported constructs.</p></section>
+        <section class="phpdocumentor-description"><p>See <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_hasParameters"><abbr title="\PHPCSUtils\Utils\PassedParameters::hasParameters()">PassedParameters::hasParameters()</abbr></a> for information on the supported constructs.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -186,7 +240,8 @@ array declarations, isset and unset constructs.</p>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -195,7 +250,8 @@ array declarations, isset and unset constructs.</p>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_STRING</code>, <code class="prettyprint">T_VARIABLE</code>, <code class="prettyprint">T_ARRAY</code>,
-<code class="prettyprint">T_OPEN_SHORT_ARRAY</code>, <code class="prettyprint">T_ISSET</code> or <code class="prettyprint">T_UNSET</code> token.</p></section>
+<code class="prettyprint">T_OPEN_SHORT_ARRAY</code>, <code class="prettyprint">T_ISSET</code> or <code class="prettyprint">T_UNSET</code> token.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -203,7 +259,8 @@ array declarations, isset and unset constructs.</p>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The 1-based index position of the parameter to retrieve.</p></section>
+                    <section class="phpdocumentor-description"><p>The 1-based index position of the parameter to retrieve.</p>
+</section>
 
             </dd>
             </dl>
@@ -219,21 +276,24 @@ array declarations, isset and unset constructs.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the token passed is not one of the
-accepted types or doesn't exist.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the token passed is not one of the
+accepted types or doesn't exist.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array|false</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span>
             &mdash;
             <section class="phpdocumentor-description"><p>Array with information on the parameter/array item at the specified offset.
 Or <code class="prettyprint">FALSE</code> if the specified parameter/array item is not found.
@@ -243,7 +303,9 @@ The format of the return value is:</p>
   'end'   =&gt; int,    // The stack pointer to the last token in the parameter/array item.
   'raw'   =&gt; string, // A string with the contents of all tokens between `start` and `end`.
   'clean' =&gt; string, // Same as `raw`, but all comment tokens have been stripped out.
-)</code></pre></section>
+)
+</code></pre>
+</section>
 
     
 </article>
@@ -255,21 +317,23 @@ The format of the return value is:</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_getParameterCount">
         getParameterCount()
-        <a href="#method_getParameterCount" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameterCount" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/PassedParameters.php"><a href="../files/phpcsutils-utils-passedparameters.html"><abbr title="PHPCSUtils/Utils/PassedParameters.php">PassedParameters.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/PassedParameters.php"><a href="files/phpcsutils-utils-passedparameters.html"><abbr title="PHPCSUtils/Utils/PassedParameters.php">PassedParameters.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">330</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Count the number of parameters which have been passed.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getParameterCount</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getParameterCount</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int</span></code>
 
-        <section class="phpdocumentor-description"><p>See <a href="../classes/PHPCSUtils-Utils-PassedParameters.html#method_hasParameters">\PHPCSUtils\Utils\PassedParameters::hasParameters()</a> for information on the supported constructs.</p></section>
+        <section class="phpdocumentor-description"><p>See <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_hasParameters"><abbr title="\PHPCSUtils\Utils\PassedParameters::hasParameters()">PassedParameters::hasParameters()</abbr></a> for information on the supported constructs.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -278,7 +342,8 @@ The format of the return value is:</p>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -287,7 +352,8 @@ The format of the return value is:</p>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_STRING</code>, <code class="prettyprint">T_VARIABLE</code>, <code class="prettyprint">T_ARRAY</code>,
-<code class="prettyprint">T_OPEN_SHORT_ARRAY</code>, <code class="prettyprint">T_ISSET</code> or <code class="prettyprint">T_UNSET</code> token.</p></section>
+<code class="prettyprint">T_OPEN_SHORT_ARRAY</code>, <code class="prettyprint">T_ISSET</code> or <code class="prettyprint">T_UNSET</code> token.</p>
+</section>
 
             </dd>
             </dl>
@@ -303,17 +369,20 @@ The format of the return value is:</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the token passed is not one of the
-accepted types or doesn't exist.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the token passed is not one of the
+accepted types or doesn't exist.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -330,21 +399,23 @@ accepted types or doesn't exist.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_getParameters">
         getParameters()
-        <a href="#method_getParameters" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameters" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/PassedParameters.php"><a href="../files/phpcsutils-utils-passedparameters.html"><abbr title="PHPCSUtils/Utils/PassedParameters.php">PassedParameters.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/PassedParameters.php"><a href="files/phpcsutils-utils-passedparameters.html"><abbr title="PHPCSUtils/Utils/PassedParameters.php">PassedParameters.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">181</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Get information on all parameters passed.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getParameters</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getParameters</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>See <a href="../classes/PHPCSUtils-Utils-PassedParameters.html#method_hasParameters">\PHPCSUtils\Utils\PassedParameters::hasParameters()</a> for information on the supported constructs.</p></section>
+        <section class="phpdocumentor-description"><p>See <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_hasParameters"><abbr title="\PHPCSUtils\Utils\PassedParameters::hasParameters()">PassedParameters::hasParameters()</abbr></a> for information on the supported constructs.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -353,7 +424,8 @@ accepted types or doesn't exist.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -362,7 +434,8 @@ accepted types or doesn't exist.</p></section>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_STRING</code>, <code class="prettyprint">T_VARIABLE</code>, <code class="prettyprint">T_ARRAY</code>,
-<code class="prettyprint">T_OPEN_SHORT_ARRAY</code>, <code class="prettyprint">T_ISSET</code>, or <code class="prettyprint">T_UNSET</code> token.</p></section>
+<code class="prettyprint">T_OPEN_SHORT_ARRAY</code>, <code class="prettyprint">T_ISSET</code>, or <code class="prettyprint">T_UNSET</code> token.</p>
+</section>
 
             </dd>
             </dl>
@@ -378,21 +451,24 @@ accepted types or doesn't exist.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the token passed is not one of the
-accepted types or doesn't exist.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the token passed is not one of the
+accepted types or doesn't exist.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
             <section class="phpdocumentor-description"><p>A multi-dimentional array information on each parameter/array item.
 The information gathered about each parameter/array item is in the following format:</p>
@@ -401,9 +477,11 @@ The information gathered about each parameter/array item is in the following for
   'end'   =&gt; int,    // The stack pointer to the last token in the parameter/array item.
   'raw'   =&gt; string, // A string with the contents of all tokens between `start` and `end`.
   'clean' =&gt; string, // Same as `raw`, but all comment tokens have been stripped out.
-)</code></pre>
+)
+</code></pre>
 <p><em>Note: The array starts at index 1.</em>
-If no parameters/array items are found, an empty array will be returned.</p></section>
+If no parameters/array items are found, an empty array will be returned.</p>
+</section>
 
     
 </article>
@@ -415,19 +493,20 @@ If no parameters/array items are found, an empty array will be returned.</p></se
 >
     <h4 class="phpdocumentor-element__name" id="method_hasParameters">
         hasParameters()
-        <a href="#method_hasParameters" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_hasParameters" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/PassedParameters.php"><a href="../files/phpcsutils-utils-passedparameters.html"><abbr title="PHPCSUtils/Utils/PassedParameters.php">PassedParameters.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/PassedParameters.php"><a href="files/phpcsutils-utils-passedparameters.html"><abbr title="PHPCSUtils/Utils/PassedParameters.php">PassedParameters.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">88</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Checks if any parameters have been passed.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">hasParameters</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">hasParameters</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
         <section class="phpdocumentor-description"><ul>
 <li>If passed a <code class="prettyprint">T_STRING</code> or <code class="prettyprint">T_VARIABLE</code> stack pointer, it will treat it as a function call.
@@ -439,7 +518,8 @@ function call when used like <code class="prettyprint">new self()</code>.</li>
 whether the array has values or is empty.</li>
 <li>If passed a <code class="prettyprint">T_ISSET</code> or <code class="prettyprint">T_UNSET</code> stack pointer, it will detect whether those
 language constructs have &quot;parameters&quot;.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -448,7 +528,8 @@ language constructs have &quot;parameters&quot;.</li>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -457,7 +538,8 @@ language constructs have &quot;parameters&quot;.</li>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_STRING</code>, <code class="prettyprint">T_VARIABLE</code>, <code class="prettyprint">T_ARRAY</code>,
-<code class="prettyprint">T_OPEN_SHORT_ARRAY</code>, <code class="prettyprint">T_ISSET</code>, or <code class="prettyprint">T_UNSET</code> token.</p></section>
+<code class="prettyprint">T_OPEN_SHORT_ARRAY</code>, <code class="prettyprint">T_ISSET</code>, or <code class="prettyprint">T_UNSET</code> token.</p>
+</section>
 
             </dd>
             </dl>
@@ -473,17 +555,20 @@ language constructs have &quot;parameters&quot;.</li>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the token passed is not one of the
-accepted types or doesn't exist.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the token passed is not one of the
+accepted types or doesn't exist.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -494,21 +579,92 @@ accepted types or doesn't exist.</p></section>
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Utils-PassedParameters.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-PassedParameters.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-PassedParameters.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -131,12 +135,12 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/PassedParameters.php"><a href="files/phpcsutils-utils-passedparameters.html"><abbr title="PHPCSUtils/Utils/PassedParameters.php">PassedParameters.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">25</span>
+    <span class="phpdocumentor-element-found-in__line">28</span>
 
     </aside>
 
             <p class="phpdocumentor-summary">Utility functions to retrieve information about parameters passed to function calls,
-array declarations, isset and unset constructs.</p>
+class instantiations, array declarations, isset and unset constructs.</p>
 
 
 
@@ -152,6 +156,16 @@ array declarations, isset and unset constructs.</p>
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
                                                                                 
                                              
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Dropped support for PHPCS &lt; 3.7.1.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -179,6 +193,13 @@ array declarations, isset and unset constructs.</p>
                                 &nbsp;: int    </span>
 </dt>
 <dd>Count the number of parameters which have been passed.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameterFromStack">getParameterFromStack()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;|false    </span>
+</dt>
+<dd>Get information on a specific function call parameter passed.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameters">getParameters()</a>
@@ -220,7 +241,7 @@ array declarations, isset and unset constructs.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/PassedParameters.php"><a href="files/phpcsutils-utils-passedparameters.html"><abbr title="PHPCSUtils/Utils/PassedParameters.php">PassedParameters.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">303</span>
+    <span class="phpdocumentor-element-found-in__line">398</span>
 
     </aside>
 
@@ -228,7 +249,7 @@ array declarations, isset and unset constructs.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getParameter</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$paramOffset</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getParameter</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$paramOffset</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|array&lt;string|int, string&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$paramNames</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">[]</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span></code>
 
         <section class="phpdocumentor-description"><p>See <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_hasParameters"><abbr title="\PHPCSUtils\Utils\PassedParameters::hasParameters()">PassedParameters::hasParameters()</abbr></a> for information on the supported constructs.</p>
 </section>
@@ -249,8 +270,8 @@ array declarations, isset and unset constructs.</p>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_STRING</code>, <code class="prettyprint">T_VARIABLE</code>, <code class="prettyprint">T_ARRAY</code>,
-<code class="prettyprint">T_OPEN_SHORT_ARRAY</code>, <code class="prettyprint">T_ISSET</code> or <code class="prettyprint">T_UNSET</code> token.</p>
+                    <section class="phpdocumentor-description"><p>The position of function call name,
+language construct or array open token.</p>
 </section>
 
             </dd>
@@ -263,6 +284,26 @@ array declarations, isset and unset constructs.</p>
 </section>
 
             </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$paramNames</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string|array&lt;string|int, string&gt;</span>
+                 = <span class="phpdocumentor-signature__argument__default-value">[]</span>            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Optional. Either the name of the target parameter
+to retrieve as a string or an array of names for the
+same target parameter.
+Only relevant for function calls.
+An arrays of names is supported to allow for functions
+for which the parameter names have undergone name
+changes over time.
+When specified, the name will take precedence over the
+offset.
+For PHP 8 support, it is STRONGLY recommended to
+always pass both the offset as well as the parameter
+name when examining function calls.</p>
+</section>
+
+            </dd>
             </dl>
 
     
@@ -272,12 +313,33 @@ array declarations, isset and unset constructs.</p>
     </h5>
     <dl class="phpdocumentor-tag-list">
                                     <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">see</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameterFromStack"><abbr title="\PHPCSUtils\Utils\PassedParameters::getParameterFromStack()">PassedParameters::getParameterFromStack()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>For when the parameter stack of a function call is
+already retrieved.</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
                                                                                 
                                              
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the <code class="prettyprint">$paramNames</code> parameter.</p>
+</section>
+
                                     </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
@@ -290,21 +352,27 @@ accepted types or doesn't exist.</p>
 </section>
 
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">throws</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If a function call parameter is requested and
+the <code class="prettyprint">$paramName</code> parameter is not passed.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>Array with information on the parameter/array item at the specified offset.
+            <section class="phpdocumentor-description"><p>Array with information on the parameter/array item at the specified offset,
+or with the specified name.
 Or <code class="prettyprint">FALSE</code> if the specified parameter/array item is not found.
-The format of the return value is:</p>
-<pre class="prettyprint"><code class="language-php">array(
-  'start' =&gt; int,    // The stack pointer to the first token in the parameter/array item.
-  'end'   =&gt; int,    // The stack pointer to the last token in the parameter/array item.
-  'raw'   =&gt; string, // A string with the contents of all tokens between `start` and `end`.
-  'clean' =&gt; string, // Same as `raw`, but all comment tokens have been stripped out.
-)
-</code></pre>
+See <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameters"><abbr title="\PHPCSUtils\Utils\PassedParameters::getParameters()">PassedParameters::getParameters()</abbr></a> for the format of the returned
+(single-dimensional) array.</p>
 </section>
 
     
@@ -322,7 +390,7 @@ The format of the return value is:</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/PassedParameters.php"><a href="files/phpcsutils-utils-passedparameters.html"><abbr title="PHPCSUtils/Utils/PassedParameters.php">PassedParameters.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">330</span>
+    <span class="phpdocumentor-element-found-in__line">441</span>
 
     </aside>
 
@@ -351,8 +419,8 @@ The format of the return value is:</p>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_STRING</code>, <code class="prettyprint">T_VARIABLE</code>, <code class="prettyprint">T_ARRAY</code>,
-<code class="prettyprint">T_OPEN_SHORT_ARRAY</code>, <code class="prettyprint">T_ISSET</code> or <code class="prettyprint">T_UNSET</code> token.</p>
+                    <section class="phpdocumentor-description"><p>The position of function call name,
+language construct or array open token.</p>
 </section>
 
             </dd>
@@ -397,6 +465,111 @@ accepted types or doesn't exist.</p>
             -public
                                     -static                    "
 >
+    <h4 class="phpdocumentor-element__name" id="method_getParameterFromStack">
+        getParameterFromStack()
+        <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameterFromStack" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/PassedParameters.php"><a href="files/phpcsutils-utils-passedparameters.html"><abbr title="PHPCSUtils/Utils/PassedParameters.php">PassedParameters.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">480</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Get information on a specific function call parameter passed.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getParameterFromStack</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$parameters</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$paramOffset</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|array&lt;string|int, string&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$paramNames</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span></code>
+
+        <section class="phpdocumentor-description"><p>This is an efficiency method to correctly handle positional versus named parameters
+for function calls when multiple parameters need to be examined.</p>
+<p>See <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_hasParameters"><abbr title="\PHPCSUtils\Utils\PassedParameters::hasParameters()">PassedParameters::hasParameters()</abbr></a> for information on the supported constructs.</p>
+</section>
+
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$parameters</span>
+                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The output of a previous call to <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameters"><abbr title="\PHPCSUtils\Utils\PassedParameters::getParameters()">PassedParameters::getParameters()</abbr></a>.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$paramOffset</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The 1-based index position of the parameter to retrieve.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$paramNames</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string|array&lt;string|int, string&gt;</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Either the name of the target parameter to retrieve
+as a string or an array of names for the same target parameter.
+An array of names is supported to allow for functions
+for which the parameter names have undergone name
+changes over time.
+The name will take precedence over the offset.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">throws</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the <code class="prettyprint">$paramNames</code> parameter is not passed
+and the requested parameter was not passed
+as a positional parameter in the function call
+being examined.</p>
+</section>
+
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;|false</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>Array with information on the parameter at the specified offset,
+or with the specified name.
+Or <code class="prettyprint">FALSE</code> if the specified parameter is not found.
+See <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameters"><abbr title="\PHPCSUtils\Utils\PassedParameters::getParameters()">PassedParameters::getParameters()</abbr></a> for the format of the returned
+(single-dimensional) array.</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
     <h4 class="phpdocumentor-element__name" id="method_getParameters">
         getParameters()
         <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameters" class="headerlink"><i class="fas fa-link"></i></a>
@@ -404,7 +577,7 @@ accepted types or doesn't exist.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/PassedParameters.php"><a href="files/phpcsutils-utils-passedparameters.html"><abbr title="PHPCSUtils/Utils/PassedParameters.php">PassedParameters.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">181</span>
+    <span class="phpdocumentor-element-found-in__line">205</span>
 
     </aside>
 
@@ -412,7 +585,7 @@ accepted types or doesn't exist.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getParameters</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getParameters</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$limit</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">true|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$isShortArray</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>See <a href="classes/PHPCSUtils-Utils-PassedParameters.html#method_hasParameters"><abbr title="\PHPCSUtils\Utils\PassedParameters::hasParameters()">PassedParameters::hasParameters()</abbr></a> for information on the supported constructs.</p>
 </section>
@@ -433,8 +606,32 @@ accepted types or doesn't exist.</p>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_STRING</code>, <code class="prettyprint">T_VARIABLE</code>, <code class="prettyprint">T_ARRAY</code>,
-<code class="prettyprint">T_OPEN_SHORT_ARRAY</code>, <code class="prettyprint">T_ISSET</code>, or <code class="prettyprint">T_UNSET</code> token.</p>
+                    <section class="phpdocumentor-description"><p>The position of function call name,
+language construct or array open token.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$limit</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Optional. Limit the parameter retrieval to the first #
+parameters/array entries.
+Use with care on function calls, as this can break
+support for named parameters!</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$isShortArray</span>
+                : <span class="phpdocumentor-signature__argument__return-type">true|null</span>
+                 = <span class="phpdocumentor-signature__argument__default-value">null</span>            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Optional. Short-circuit the short array check for
+<code class="prettyprint">T_OPEN_SHORT_ARRAY</code> tokens if it isn't necessary.
+Efficiency tweak for when this has already been established,
+Use with EXTREME care.</p>
 </section>
 
             </dd>
@@ -454,6 +651,28 @@ accepted types or doesn't exist.</p>
                                                                                 
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the <code class="prettyprint">$limit</code> and <code class="prettyprint">$isShortArray</code> parameters.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 function calls with named arguments by introducing
+the <code class="prettyprint">'name'</code> and <code class="prettyprint">'name_token'</code> index keys as well as using the name
+as the index for the top-level array for named parameters.</p>
+</section>
+
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
@@ -470,7 +689,7 @@ accepted types or doesn't exist.</p>
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>A multi-dimentional array information on each parameter/array item.
+            <section class="phpdocumentor-description"><p>A multi-dimentional array with information on each parameter/array item.
 The information gathered about each parameter/array item is in the following format:</p>
 <pre class="prettyprint"><code class="language-php">1 =&gt; array(
   'start' =&gt; int,    // The stack pointer to the first token in the parameter/array item.
@@ -479,7 +698,18 @@ The information gathered about each parameter/array item is in the following for
   'clean' =&gt; string, // Same as `raw`, but all comment tokens have been stripped out.
 )
 </code></pre>
-<p><em>Note: The array starts at index 1.</em>
+<p>If a named parameter is encountered in a function call, the top-level index will not be
+the parameter <em>position</em>, but the <em>parameter name</em> and the array will include two extra keys:</p>
+<pre class="prettyprint"><code class="language-php">'parameter_name' =&gt; array(
+  'name'       =&gt; string, // The parameter name (without the colon).
+  'name_token' =&gt; int,    // The stack pointer to the parameter name token.
+  ...
+)
+</code></pre>
+<p>The <code class="prettyprint">'start'</code>, <code class="prettyprint">'end'</code>, <code class="prettyprint">'raw'</code> and <code class="prettyprint">'clean'</code> indexes will always contain just and only
+information on the parameter value.
+<em>Note: The array starts at index 1 for positional parameters.</em>
+<em>The key for named parameters will be the parameter name.</em>
 If no parameters/array items are found, an empty array will be returned.</p>
 </section>
 
@@ -498,7 +728,7 @@ If no parameters/array items are found, an empty array will be returned.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/PassedParameters.php"><a href="files/phpcsutils-utils-passedparameters.html"><abbr title="PHPCSUtils/Utils/PassedParameters.php">PassedParameters.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">88</span>
+    <span class="phpdocumentor-element-found-in__line">85</span>
 
     </aside>
 
@@ -506,16 +736,21 @@ If no parameters/array items are found, an empty array will be returned.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">hasParameters</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">hasParameters</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">true|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$isShortArray</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
         <section class="phpdocumentor-description"><ul>
-<li>If passed a <code class="prettyprint">T_STRING</code> or <code class="prettyprint">T_VARIABLE</code> stack pointer, it will treat it as a function call.
+<li>If passed a <code class="prettyprint">T_STRING</code>, <code class="prettyprint">T_NAME_FULLY_QUALIFIED</code>, <code class="prettyprint">T_NAME_RELATIVE</code>, <code class="prettyprint">T_NAME_QUALIFIED</code>
+or <code class="prettyprint">T_VARIABLE</code> stack pointer, it will treat it as a function call.
 If a <code class="prettyprint">T_STRING</code> or <code class="prettyprint">T_VARIABLE</code> which is <em>not</em> a function call is passed, the behaviour is
 undetermined.</li>
-<li>If passed a <code class="prettyprint">T_SELF</code> or <code class="prettyprint">T_STATIC</code> stack pointer, it will accept it as a
-function call when used like <code class="prettyprint">new self()</code>.</li>
+<li>If passed a <code class="prettyprint">T_ANON_CLASS</code> stack pointer, it will accept it as a class instantiation.</li>
+<li>If passed a <code class="prettyprint">T_SELF</code>, <code class="prettyprint">T_STATIC</code> or <code class="prettyprint">T_PARENT</code> stack pointer, it will accept it as a
+class instantiation function call when used like <code class="prettyprint">new self()</code>.</li>
 <li>If passed a <code class="prettyprint">T_ARRAY</code> or <code class="prettyprint">T_OPEN_SHORT_ARRAY</code> stack pointer, it will detect
-whether the array has values or is empty.</li>
+whether the array has values or is empty.
+For purposes of backward-compatibility with older PHPCS versions, <code class="prettyprint">T_OPEN_SQUARE_BRACKET</code>
+tokens will also be accepted and will be checked whether they are in reality
+a short array opener.</li>
 <li>If passed a <code class="prettyprint">T_ISSET</code> or <code class="prettyprint">T_UNSET</code> stack pointer, it will detect whether those
 language constructs have &quot;parameters&quot;.</li>
 </ul>
@@ -537,8 +772,20 @@ language constructs have &quot;parameters&quot;.</li>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_STRING</code>, <code class="prettyprint">T_VARIABLE</code>, <code class="prettyprint">T_ARRAY</code>,
-<code class="prettyprint">T_OPEN_SHORT_ARRAY</code>, <code class="prettyprint">T_ISSET</code>, or <code class="prettyprint">T_UNSET</code> token.</p>
+                    <section class="phpdocumentor-description"><p>The position of function call name,
+language construct or array open token.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$isShortArray</span>
+                : <span class="phpdocumentor-signature__argument__return-type">true|null</span>
+                 = <span class="phpdocumentor-signature__argument__default-value">null</span>            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Optional. Short-circuit the short array check for
+<code class="prettyprint">T_OPEN_SHORT_ARRAY</code> tokens if it isn't necessary.
+Efficiency tweak for when this has already been established,
+Use with EXTREME care.</p>
 </section>
 
             </dd>
@@ -557,6 +804,37 @@ language constructs have &quot;parameters&quot;.</li>
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
                                                                                 
                                              
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added the <code class="prettyprint">$isShortArray</code> parameter.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 identifier name tokenization.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added defensive coding against PHP 8.1 first class callables
+being passed as if they were function calls.</p>
+</section>
+
                                     </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Scopes.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Scopes.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -170,14 +174,14 @@
     <span>
                                 &nbsp;: bool    </span>
 </dt>
-<dd>Check whether a T_CONST token is a class/interface constant declaration.</dd>
+<dd>Check whether a T_CONST token is a class/interface/trait/enum constant declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Utils-Scopes.html#method_isOOMethod">isOOMethod()</a>
     <span>
                                 &nbsp;: bool    </span>
 </dt>
-<dd>Check whether a T_FUNCTION token is a class/interface/trait method declaration.</dd>
+<dd>Check whether a T_FUNCTION token is a class/interface/trait/enum method declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Utils-Scopes.html#method_isOOProperty">isOOProperty()</a>
@@ -220,11 +224,11 @@ acceptable tokens.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Scopes.php"><a href="files/phpcsutils-utils-scopes.html"><abbr title="PHPCSUtils/Utils/Scopes.php">Scopes.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">69</span>
+    <span class="phpdocumentor-element-found-in__line">71</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Check whether a T_CONST token is a class/interface constant declaration.</p>
+        <p class="phpdocumentor-summary">Check whether a T_CONST token is a class/interface/trait/enum constant declaration.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
@@ -268,6 +272,26 @@ acceptable tokens.</dd>
                                                                                 
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.1 enums.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.2 constants in traits.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -289,11 +313,11 @@ acceptable tokens.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Scopes.php"><a href="files/phpcsutils-utils-scopes.html"><abbr title="PHPCSUtils/Utils/Scopes.php">Scopes.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">129</span>
+    <span class="phpdocumentor-element-found-in__line">132</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Check whether a T_FUNCTION token is a class/interface/trait method declaration.</p>
+        <p class="phpdocumentor-summary">Check whether a T_FUNCTION token is a class/interface/trait/enum method declaration.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
@@ -337,6 +361,16 @@ acceptable tokens.</dd>
                                                                                 
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.1 enums.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -358,7 +392,7 @@ acceptable tokens.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Scopes.php"><a href="files/phpcsutils-utils-scopes.html"><abbr title="PHPCSUtils/Utils/Scopes.php">Scopes.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">95</span>
+    <span class="phpdocumentor-element-found-in__line">97</span>
 
     </aside>
 

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Scopes.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Scopes.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-utils.html">Utils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,15 +118,22 @@
     Scopes
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Scopes.php"><a href="../files/phpcsutils-utils-scopes.html"><abbr title="PHPCSUtils/Utils/Scopes.php">Scopes.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Scopes.php"><a href="files/phpcsutils-utils-scopes.html"><abbr title="PHPCSUtils/Utils/Scopes.php">Scopes.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">24</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility functions for use when examining token scopes.</p>
 
@@ -98,8 +149,9 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 
@@ -113,31 +165,31 @@
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Scopes.html#method_isOOConstant">isOOConstant()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-Scopes.html#method_isOOConstant">isOOConstant()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Check whether a T_CONST token is a class/interface constant declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Scopes.html#method_isOOMethod">isOOMethod()</a>
+    <a href="classes/PHPCSUtils-Utils-Scopes.html#method_isOOMethod">isOOMethod()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Check whether a T_FUNCTION token is a class/interface/trait method declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Scopes.html#method_isOOProperty">isOOProperty()</a>
+    <a href="classes/PHPCSUtils-Utils-Scopes.html#method_isOOProperty">isOOProperty()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Check whether a T_VARIABLE token is a class/trait property declaration.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Scopes.html#method_validDirectScope">validDirectScope()</a>
+    <a href="classes/PHPCSUtils-Utils-Scopes.html#method_validDirectScope">validDirectScope()</a>
     <span>
-                        &nbsp;: int|false    </span>
+                                &nbsp;: int|false    </span>
 </dt>
 <dd>Check whether the direct wrapping scope of a token is within a limited set of
 acceptable tokens.</dd>
@@ -153,7 +205,7 @@ acceptable tokens.</dd>
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-Scopes.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -163,19 +215,20 @@ acceptable tokens.</dd>
 >
     <h4 class="phpdocumentor-element__name" id="method_isOOConstant">
         isOOConstant()
-        <a href="#method_isOOConstant" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Scopes.html#method_isOOConstant" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Scopes.php"><a href="../files/phpcsutils-utils-scopes.html"><abbr title="PHPCSUtils/Utils/Scopes.php">Scopes.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Scopes.php"><a href="files/phpcsutils-utils-scopes.html"><abbr title="PHPCSUtils/Utils/Scopes.php">Scopes.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">69</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Check whether a T_CONST token is a class/interface constant declaration.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isOOConstant</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isOOConstant</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -185,7 +238,8 @@ acceptable tokens.</dd>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -194,7 +248,8 @@ acceptable tokens.</dd>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position in the stack of the
-<code class="prettyprint">T_CONST</code> token to verify.</p></section>
+<code class="prettyprint">T_CONST</code> token to verify.</p>
+</section>
 
             </dd>
             </dl>
@@ -210,8 +265,9 @@ acceptable tokens.</dd>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -228,19 +284,20 @@ acceptable tokens.</dd>
 >
     <h4 class="phpdocumentor-element__name" id="method_isOOMethod">
         isOOMethod()
-        <a href="#method_isOOMethod" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Scopes.html#method_isOOMethod" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Scopes.php"><a href="../files/phpcsutils-utils-scopes.html"><abbr title="PHPCSUtils/Utils/Scopes.php">Scopes.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Scopes.php"><a href="files/phpcsutils-utils-scopes.html"><abbr title="PHPCSUtils/Utils/Scopes.php">Scopes.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">129</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Check whether a T_FUNCTION token is a class/interface/trait method declaration.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isOOMethod</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isOOMethod</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -250,7 +307,8 @@ acceptable tokens.</dd>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -259,7 +317,8 @@ acceptable tokens.</dd>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position in the stack of the
-<code class="prettyprint">T_FUNCTION</code> token to verify.</p></section>
+<code class="prettyprint">T_FUNCTION</code> token to verify.</p>
+</section>
 
             </dd>
             </dl>
@@ -275,8 +334,9 @@ acceptable tokens.</dd>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -293,19 +353,20 @@ acceptable tokens.</dd>
 >
     <h4 class="phpdocumentor-element__name" id="method_isOOProperty">
         isOOProperty()
-        <a href="#method_isOOProperty" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Scopes.html#method_isOOProperty" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Scopes.php"><a href="../files/phpcsutils-utils-scopes.html"><abbr title="PHPCSUtils/Utils/Scopes.php">Scopes.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Scopes.php"><a href="files/phpcsutils-utils-scopes.html"><abbr title="PHPCSUtils/Utils/Scopes.php">Scopes.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">95</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Check whether a T_VARIABLE token is a class/trait property declaration.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isOOProperty</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isOOProperty</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -315,7 +376,8 @@ acceptable tokens.</dd>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -324,7 +386,8 @@ acceptable tokens.</dd>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position in the stack of the
-<code class="prettyprint">T_VARIABLE</code> token to verify.</p></section>
+<code class="prettyprint">T_VARIABLE</code> token to verify.</p>
+</section>
 
             </dd>
             </dl>
@@ -340,8 +403,9 @@ acceptable tokens.</dd>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -358,20 +422,21 @@ acceptable tokens.</dd>
 >
     <h4 class="phpdocumentor-element__name" id="method_validDirectScope">
         validDirectScope()
-        <a href="#method_validDirectScope" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Scopes.html#method_validDirectScope" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Scopes.php"><a href="../files/phpcsutils-utils-scopes.html"><abbr title="PHPCSUtils/Utils/Scopes.php">Scopes.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Scopes.php"><a href="files/phpcsutils-utils-scopes.html"><abbr title="PHPCSUtils/Utils/Scopes.php">Scopes.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">42</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Check whether the direct wrapping scope of a token is within a limited set of
 acceptable tokens.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">validDirectScope</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validScopes</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">validDirectScope</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$validScopes</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int|false</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -381,7 +446,8 @@ acceptable tokens.</p>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -390,16 +456,18 @@ acceptable tokens.</p>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position in the stack of the
-token to verify.</p></section>
+token to verify.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$validScopes</span>
-                : <span class="phpdocumentor-signature__argument__return-type">int|string|array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int|string|array&lt;string|int, mixed&gt;</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Array of token constants representing
-the scopes considered valid.</p></section>
+the scopes considered valid.</p>
+</section>
 
             </dd>
             </dl>
@@ -415,35 +483,108 @@ the scopes considered valid.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">int|false</span>
             &mdash;
             <section class="phpdocumentor-description"><p>Integer stack pointer to the valid direct scope; or <code class="prettyprint">FALSE</code> if
-no valid direct scope was found.</p></section>
+no valid direct scope was found.</p>
+</section>
 
     
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Scopes.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-TextStrings.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-TextStrings.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -131,7 +135,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/TextStrings.php"><a href="files/phpcsutils-utils-textstrings.html"><abbr title="PHPCSUtils/Utils/TextStrings.php">TextStrings.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">22</span>
+    <span class="phpdocumentor-element-found-in__line">27</span>
 
     </aside>
 
@@ -152,6 +156,16 @@
                                                                                 
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Dropped support for PHPCS &lt; 3.7.1.</p>
+</section>
+
+                                    </dd>
                         </dl>
 
 
@@ -165,6 +179,20 @@
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
+            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
+    <a href="classes/PHPCSUtils-Utils-TextStrings.html#constant_START_OF_EMBED">START_OF_EMBED</a>
+    <span>
+        &nbsp;= &#039;`(?&lt;!\\\\)(\\\\{2})*(\\{\\$|\\$\\{|\\$(?=[a-zA-Z_\\x7f-\\xff]))`&#039;                            </span>
+</dt>
+<dd>Regex to match the start of an embedded variable/expression.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
+    <a href="classes/PHPCSUtils-Utils-TextStrings.html#constant_TYPE1_EMBED_AFTER_DOLLAR">TYPE1_EMBED_AFTER_DOLLAR</a>
+    <span>
+        &nbsp;= &#039;`(?P&lt;varname&gt;[a-zA-Z_\\x7f-\\xff][a-zA-Z0-9_\\x7f-\\xff]*)(?:\\??-&gt;(?P&gt;varname)|\\[[^\\]\&#039;&quot;\\s]+\\])?`&#039;                            </span>
+</dt>
+<dd>Regex to match a &quot;type 1&quot; - directly embedded - variable without the dollar sign.</dd>
+
                         <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_getCompleteTextString">getCompleteTextString()</a>
     <span>
@@ -173,17 +201,111 @@
 <dd>Get the complete contents of a - potentially multi-line - text string.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_getEmbeds">getEmbeds()</a>
+    <span>
+                                &nbsp;: array&lt;int, string&gt;    </span>
+</dt>
+<dd>Get the embedded variables/expressions from an arbitrary string.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_getEndOfCompleteTextString">getEndOfCompleteTextString()</a>
+    <span>
+                                &nbsp;: int    </span>
+</dt>
+<dd>Get the stack pointer to the end of a - potentially multi-line - text string.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_getStripEmbeds">getStripEmbeds()</a>
+    <span>
+                                &nbsp;: array&lt;string, mixed&gt;    </span>
+</dt>
+<dd>Split an arbitrary text string into embedded variables/expressions and remaining text.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_stripEmbeds">stripEmbeds()</a>
+    <span>
+                                &nbsp;: string    </span>
+</dt>
+<dd>Strip embedded variables/expressions from an arbitrary string.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_stripQuotes">stripQuotes()</a>
     <span>
                                 &nbsp;: string    </span>
 </dt>
-<dd>Strip text delimiter quotes from an arbitrary string.</dd>
+<dd>Strip text delimiter quotes from an arbitrary text string.</dd>
 
         </dl>
 
 
 
         
+    <section class="phpdocumentor-constants">
+        <h3 class="phpdocumentor-elements__header" id="constants">
+            Constants
+            <a href="classes/PHPCSUtils-Utils-TextStrings.html#constants" class="headerlink"><i class="fas fa-link"></i></a>
+        </h3>
+                    <article class="phpdocumentor-element -constant -public ">
+    <h4 class="phpdocumentor-element__name" id="constant_START_OF_EMBED">
+        START_OF_EMBED
+        <a href="classes/PHPCSUtils-Utils-TextStrings.html#constant_START_OF_EMBED" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/TextStrings.php"><a href="files/phpcsutils-utils-textstrings.html"><abbr title="PHPCSUtils/Utils/TextStrings.php">TextStrings.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">37</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Regex to match the start of an embedded variable/expression.</p>
+
+    <code class="phpdocumentor-signature phpdocumentor-code ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+        <span class="phpdocumentor-signature__type">string</span>
+    <span class="phpdocumentor-signature__name">START_OF_EMBED</span>
+    = <span class="phpdocumentor-signature__default-value">&#039;`(?&lt;!\\\\)(\\\\{2})*(\\{\\$|\\$\\{|\\$(?=[a-zA-Z_\\x7f-\\xff]))`&#039;</span>
+</code>
+
+
+        <section class="phpdocumentor-description"><p>Prevents matching escaped variables/expressions.</p>
+</section>
+
+    
+    
+
+</article>
+                    <article class="phpdocumentor-element -constant -public ">
+    <h4 class="phpdocumentor-element__name" id="constant_TYPE1_EMBED_AFTER_DOLLAR">
+        TYPE1_EMBED_AFTER_DOLLAR
+        <a href="classes/PHPCSUtils-Utils-TextStrings.html#constant_TYPE1_EMBED_AFTER_DOLLAR" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/TextStrings.php"><a href="files/phpcsutils-utils-textstrings.html"><abbr title="PHPCSUtils/Utils/TextStrings.php">TextStrings.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">46</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Regex to match a &quot;type 1&quot; - directly embedded - variable without the dollar sign.</p>
+
+    <code class="phpdocumentor-signature phpdocumentor-code ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+        <span class="phpdocumentor-signature__type">string</span>
+    <span class="phpdocumentor-signature__name">TYPE1_EMBED_AFTER_DOLLAR</span>
+    = <span class="phpdocumentor-signature__default-value">&#039;`(?P&lt;varname&gt;[a-zA-Z_\\x7f-\\xff][a-zA-Z0-9_\\x7f-\\xff]*)(?:\\??-&gt;(?P&gt;varname)|\\[[^\\]\&#039;&quot;\\s]+\\])?`&#039;</span>
+</code>
+
+
+        <section class="phpdocumentor-description"><p>Allows for array access and property access in as far as supported (single level).</p>
+</section>
+
+    
+    
+
+</article>
+            </section>
 
         
 
@@ -205,7 +327,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/TextStrings.php"><a href="files/phpcsutils-utils-textstrings.html"><abbr title="PHPCSUtils/Utils/TextStrings.php">TextStrings.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">53</span>
+    <span class="phpdocumentor-element-found-in__line">77</span>
 
     </aside>
 
@@ -299,7 +421,338 @@ token in a text string.</p>
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>The complete text string.</p>
+            <section class="phpdocumentor-description"><p>The contents of the complete text string.</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_getEmbeds">
+        getEmbeds()
+        <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_getEmbeds" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/TextStrings.php"><a href="files/phpcsutils-utils-textstrings.html"><abbr title="PHPCSUtils/Utils/TextStrings.php">TextStrings.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">205</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Get the embedded variables/expressions from an arbitrary string.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getEmbeds</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$text</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;int, string&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Note: this function gets the complete variables/expressions <em>as they are embedded</em>,
+i.e. including potential curly brace wrappers, array access, method calls etc.</p>
+</section>
+
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$text</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The contents of a T_DOUBLE_QUOTED_STRING or T_HEREDOC token.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;int, string&gt;</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>Array of encountered variable names/expressions with the offset at which
+the variable/expression was found in the string, as the key.</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_getEndOfCompleteTextString">
+        getEndOfCompleteTextString()
+        <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_getEndOfCompleteTextString" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/TextStrings.php"><a href="files/phpcsutils-utils-textstrings.html"><abbr title="PHPCSUtils/Utils/TextStrings.php">TextStrings.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">123</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Get the stack pointer to the end of a - potentially multi-line - text string.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getEndOfCompleteTextString</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">int</span></code>
+
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$phpcsFile</span>
+                : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$stackPtr</span>
+                : <span class="phpdocumentor-signature__argument__return-type">int</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Pointer to the first text string token
+of a - potentially multi-line - text string
+or to a Nowdoc/Heredoc opener.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">see</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-TextStrings.html#method_getCompleteTextString"><abbr title="\PHPCSUtils\Utils\TextStrings::getCompleteTextString()">TextStrings::getCompleteTextString()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Retrieve the contents of a complete - potentially
+multi-line - text string.</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">throws</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified position is not a
+valid text string token.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">throws</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified token is not the <em>first</em>
+token in a text string.</p>
+</section>
+
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">int</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>Stack pointer to the last token in the text string.</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_getStripEmbeds">
+        getStripEmbeds()
+        <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_getStripEmbeds" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/TextStrings.php"><a href="files/phpcsutils-utils-textstrings.html"><abbr title="PHPCSUtils/Utils/TextStrings.php">TextStrings.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">258</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Split an arbitrary text string into embedded variables/expressions and remaining text.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getStripEmbeds</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$text</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>PHP contains four types of embedding syntaxes:</p>
+<ol>
+<li>Directly embedding variables (&quot;$foo&quot;);</li>
+<li>Braces outside the variable (&quot;{$foo}&quot;);</li>
+<li>Braces after the dollar sign (&quot;${foo}&quot;);</li>
+<li>Variable variables (&quot;${expr}&quot;, equivalent to (string) ${expr}).</li>
+</ol>
+<p>Type 3 and 4 are deprecated as of PHP 8.2 and will be removed in PHP 9.0.</p>
+<p>This method handles all types of embeds, including recognition of whether an embed is escaped or not.</p>
+</section>
+
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$text</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The contents of a T_DOUBLE_QUOTED_STRING or T_HEREDOC token.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://www.php.net/language.types.string#language.types.string.parsing"> <p>PHP Manual on string parsing</p>
+ </a>
+                    
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation"> <p>PHP RFC on deprecating select
+string interpolation syntaxes</p>
+ </a>
+                    
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string, mixed&gt;</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>Array containing two values:</p>
+<ol>
+<li>An array containing a string representation of each embed encountered.
+The keys in this array are the integer offset within the original string
+where the embed was found.</li>
+<li>The textual contents, embeds stripped out of it.
+The format of the array return value is:</li>
+</ol>
+<pre class="prettyprint"><code class="language-php">array(
+  'embeds'    =&gt; array&lt;int, string&gt;,
+  'remaining' =&gt; string,
+)
+</code></pre>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
+    <h4 class="phpdocumentor-element__name" id="method_stripEmbeds">
+        stripEmbeds()
+        <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_stripEmbeds" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/TextStrings.php"><a href="files/phpcsutils-utils-textstrings.html"><abbr title="PHPCSUtils/Utils/TextStrings.php">TextStrings.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">219</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Strip embedded variables/expressions from an arbitrary string.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">stripEmbeds</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$text</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+
+    
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$text</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The contents of a T_DOUBLE_QUOTED_STRING or T_HEREDOC token.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">string</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>String without variables/expressions in it.</p>
 </section>
 
     
@@ -317,31 +770,31 @@ token in a text string.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/TextStrings.php"><a href="files/phpcsutils-utils-textstrings.html"><abbr title="PHPCSUtils/Utils/TextStrings.php">TextStrings.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">129</span>
+    <span class="phpdocumentor-element-found-in__line">187</span>
 
     </aside>
 
-        <p class="phpdocumentor-summary">Strip text delimiter quotes from an arbitrary string.</p>
+        <p class="phpdocumentor-summary">Strip text delimiter quotes from an arbitrary text string.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">stripQuotes</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">stripQuotes</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$textString</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
-        <section class="phpdocumentor-description"><p>Intended for use with the &quot;contents&quot; of a <code class="prettyprint">T_CONSTANT_ENCAPSED_STRING</code> / <code class="prettyprint">T_DOUBLE_QUOTED_STRING</code>.</p>
+        <section class="phpdocumentor-description"><p>Intended for use with the &quot;content&quot; of a <code class="prettyprint">T_CONSTANT_ENCAPSED_STRING</code> / <code class="prettyprint">T_DOUBLE_QUOTED_STRING</code>.</p>
 <ul>
 <li>Prevents stripping mis-matched quotes.</li>
-<li>Prevents stripping quotes from the textual content of the string.</li>
+<li>Prevents stripping quotes from the textual content of the text string.</li>
 </ul>
 </section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
-                <span class="phpdocumentor-signature__argument__name">$string</span>
+                <span class="phpdocumentor-signature__argument__name">$textString</span>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The raw string.</p>
+                    <section class="phpdocumentor-description"><p>The raw text string.</p>
 </section>
 
             </dd>
@@ -366,7 +819,7 @@ token in a text string.</p>
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>String without quotes around it.</p>
+            <section class="phpdocumentor-description"><p>Text string without quotes around it.</p>
 </section>
 
     

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-TextStrings.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-TextStrings.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-utils.html">Utils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,15 +118,22 @@
     TextStrings
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/TextStrings.php"><a href="../files/phpcsutils-utils-textstrings.html"><abbr title="PHPCSUtils/Utils/TextStrings.php">TextStrings.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/TextStrings.php"><a href="files/phpcsutils-utils-textstrings.html"><abbr title="PHPCSUtils/Utils/TextStrings.php">TextStrings.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">22</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility functions for working with text string tokens.</p>
 
@@ -98,8 +149,9 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 
@@ -113,17 +165,17 @@
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-TextStrings.html#method_getCompleteTextString">getCompleteTextString()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_getCompleteTextString">getCompleteTextString()</a>
     <span>
-                        &nbsp;: string    </span>
+                                &nbsp;: string    </span>
 </dt>
 <dd>Get the complete contents of a - potentially multi-line - text string.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-TextStrings.html#method_stripQuotes">stripQuotes()</a>
+    <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_stripQuotes">stripQuotes()</a>
     <span>
-                        &nbsp;: string    </span>
+                                &nbsp;: string    </span>
 </dt>
 <dd>Strip text delimiter quotes from an arbitrary string.</dd>
 
@@ -138,7 +190,7 @@
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-TextStrings.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -148,26 +200,28 @@
 >
     <h4 class="phpdocumentor-element__name" id="method_getCompleteTextString">
         getCompleteTextString()
-        <a href="#method_getCompleteTextString" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_getCompleteTextString" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/TextStrings.php"><a href="../files/phpcsutils-utils-textstrings.html"><abbr title="PHPCSUtils/Utils/TextStrings.php">TextStrings.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/TextStrings.php"><a href="files/phpcsutils-utils-textstrings.html"><abbr title="PHPCSUtils/Utils/TextStrings.php">TextStrings.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">53</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Get the complete contents of a - potentially multi-line - text string.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getCompleteTextString</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stripQuotes</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">true</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getCompleteTextString</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">bool&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stripQuotes</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">true</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
         <section class="phpdocumentor-description"><p>PHPCS tokenizes multi-line text strings with a single token for each line.
 This method can be used to retrieve the text string as it would be received and
 processed in PHP itself.</p>
 <p>This method is particularly useful for sniffs which examine the contents of text strings,
 where the content matching might result in false positives/false negatives if the text
-were to be examined line by line.</p></section>
+were to be examined line by line.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -176,7 +230,8 @@ were to be examined line by line.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -186,7 +241,8 @@ were to be examined line by line.</p></section>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Pointer to the first text string token
 of a - potentially multi-line - text string
-or to a Nowdoc/Heredoc opener.</p></section>
+or to a Nowdoc/Heredoc opener.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -196,7 +252,8 @@ or to a Nowdoc/Heredoc opener.</p></section>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>Optional. Whether to strip text delimiter
 quotes off the resulting text string.
-Defaults to <code class="prettyprint">true</code>.</p></section>
+Defaults to <code class="prettyprint">true</code>.</p>
+</section>
 
             </dd>
             </dl>
@@ -212,32 +269,38 @@ Defaults to <code class="prettyprint">true</code>.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified position is not a
-valid text string token.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified position is not a
+valid text string token.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified token is not the <em>first</em>
-token in a text string.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified token is not the <em>first</em>
+token in a text string.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>The complete text string.</p></section>
+            <section class="phpdocumentor-description"><p>The complete text string.</p>
+</section>
 
     
 </article>
@@ -249,25 +312,27 @@ token in a text string.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_stripQuotes">
         stripQuotes()
-        <a href="#method_stripQuotes" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_stripQuotes" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/TextStrings.php"><a href="../files/phpcsutils-utils-textstrings.html"><abbr title="PHPCSUtils/Utils/TextStrings.php">TextStrings.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/TextStrings.php"><a href="files/phpcsutils-utils-textstrings.html"><abbr title="PHPCSUtils/Utils/TextStrings.php">TextStrings.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">129</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Strip text delimiter quotes from an arbitrary string.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">stripQuotes</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">stripQuotes</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$string</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
         <section class="phpdocumentor-description"><p>Intended for use with the &quot;contents&quot; of a <code class="prettyprint">T_CONSTANT_ENCAPSED_STRING</code> / <code class="prettyprint">T_DOUBLE_QUOTED_STRING</code>.</p>
 <ul>
 <li>Prevents stripping mis-matched quotes.</li>
 <li>Prevents stripping quotes from the textual content of the string.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -276,7 +341,8 @@ token in a text string.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The raw string.</p></section>
+                    <section class="phpdocumentor-description"><p>The raw string.</p>
+</section>
 
             </dd>
             </dl>
@@ -292,34 +358,107 @@ token in a text string.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">string</span>
             &mdash;
-            <section class="phpdocumentor-description"><p>String without quotes around it.</p></section>
+            <section class="phpdocumentor-description"><p>String without quotes around it.</p>
+</section>
 
     
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Utils-TextStrings.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-UseStatements.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-UseStatements.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-utils.html">Utils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,15 +118,22 @@
     UseStatements
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="../files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">25</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility functions for examining use statements.</p>
 
@@ -98,8 +149,9 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
 
@@ -113,46 +165,46 @@
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                    <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-UseStatements.html#method_getType">getType()</a>
+                        <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_getType">getType()</a>
     <span>
-                        &nbsp;: string    </span>
+                                &nbsp;: string    </span>
 </dt>
 <dd>Determine what a T_USE token is used for.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-UseStatements.html#method_isClosureUse">isClosureUse()</a>
+    <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_isClosureUse">isClosureUse()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Determine whether a T_USE token represents a closure use statement.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-UseStatements.html#method_isImportUse">isImportUse()</a>
+    <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_isImportUse">isImportUse()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Determine whether a T_USE token represents a class/function/constant import use statement.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-UseStatements.html#method_isTraitUse">isTraitUse()</a>
+    <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_isTraitUse">isTraitUse()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Determine whether a T_USE token represents a trait use statement.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-UseStatements.html#method_splitAndMergeImportUseStatement">splitAndMergeImportUseStatement()</a>
+    <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_splitAndMergeImportUseStatement">splitAndMergeImportUseStatement()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Split an import use statement into individual imports and merge it with an array of previously
 seen import use statements.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-UseStatements.html#method_splitImportUseStatement">splitImportUseStatement()</a>
+    <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_splitImportUseStatement">splitImportUseStatement()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Split an import use statement into individual imports.</dd>
 
@@ -167,7 +219,7 @@ seen import use statements.</dd>
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-UseStatements.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -177,19 +229,20 @@ seen import use statements.</dd>
 >
     <h4 class="phpdocumentor-element__name" id="method_getType">
         getType()
-        <a href="#method_getType" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_getType" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="../files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">45</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Determine what a T_USE token is used for.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getType</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getType</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">string</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -199,7 +252,8 @@ seen import use statements.</dd>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -207,7 +261,8 @@ seen import use statements.</dd>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_USE</code> token.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_USE</code> token.</p>
+</section>
 
             </dd>
             </dl>
@@ -223,17 +278,20 @@ seen import use statements.</dd>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified position is not a
-<code class="prettyprint">T_USE</code> token.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified position is not a
+<code class="prettyprint">T_USE</code> token.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -243,7 +301,8 @@ seen import use statements.</dd>
 An empty string will be returned if the token is used in an
 invalid context or if it couldn't be reliably determined what
 the <code class="prettyprint">T_USE</code> token is used for. An empty string being returned will
-normally mean the code being examined contains a parse error.</p></section>
+normally mean the code being examined contains a parse error.</p>
+</section>
 
     
 </article>
@@ -255,19 +314,20 @@ normally mean the code being examined contains a parse error.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_isClosureUse">
         isClosureUse()
-        <a href="#method_isClosureUse" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_isClosureUse" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="../files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">99</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Determine whether a T_USE token represents a closure use statement.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isClosureUse</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isClosureUse</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -277,7 +337,8 @@ normally mean the code being examined contains a parse error.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -285,7 +346,8 @@ normally mean the code being examined contains a parse error.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_USE</code> token.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_USE</code> token.</p>
+</section>
 
             </dd>
             </dl>
@@ -301,24 +363,28 @@ normally mean the code being examined contains a parse error.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified position is not a
-<code class="prettyprint">T_USE</code> token.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified position is not a
+<code class="prettyprint">T_USE</code> token.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">bool</span>
             &mdash;
             <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> if the token passed is a closure use statement.
-<code class="prettyprint">FALSE</code> if it's not.</p></section>
+<code class="prettyprint">FALSE</code> if it's not.</p>
+</section>
 
     
 </article>
@@ -330,19 +396,20 @@ normally mean the code being examined contains a parse error.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_isImportUse">
         isImportUse()
-        <a href="#method_isImportUse" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_isImportUse" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="../files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">118</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Determine whether a T_USE token represents a class/function/constant import use statement.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isImportUse</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isImportUse</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -352,7 +419,8 @@ normally mean the code being examined contains a parse error.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -360,7 +428,8 @@ normally mean the code being examined contains a parse error.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_USE</code> token.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_USE</code> token.</p>
+</section>
 
             </dd>
             </dl>
@@ -376,24 +445,28 @@ normally mean the code being examined contains a parse error.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified position is not a
-<code class="prettyprint">T_USE</code> token.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified position is not a
+<code class="prettyprint">T_USE</code> token.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">bool</span>
             &mdash;
             <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> if the token passed is an import use statement.
-<code class="prettyprint">FALSE</code> if it's not.</p></section>
+<code class="prettyprint">FALSE</code> if it's not.</p>
+</section>
 
     
 </article>
@@ -405,19 +478,20 @@ normally mean the code being examined contains a parse error.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_isTraitUse">
         isTraitUse()
-        <a href="#method_isTraitUse" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_isTraitUse" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="../files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">137</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Determine whether a T_USE token represents a trait use statement.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isTraitUse</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isTraitUse</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -427,7 +501,8 @@ normally mean the code being examined contains a parse error.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -435,7 +510,8 @@ normally mean the code being examined contains a parse error.</p></section>
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_USE</code> token.</p></section>
+                    <section class="phpdocumentor-description"><p>The position of the <code class="prettyprint">T_USE</code> token.</p>
+</section>
 
             </dd>
             </dl>
@@ -451,24 +527,28 @@ normally mean the code being examined contains a parse error.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified position is not a
-<code class="prettyprint">T_USE</code> token.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified position is not a
+<code class="prettyprint">T_USE</code> token.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
     <span class="phpdocumentor-signature__response_type">bool</span>
             &mdash;
             <section class="phpdocumentor-description"><p><code class="prettyprint">TRUE</code> if the token passed is a trait use statement.
-<code class="prettyprint">FALSE</code> if it's not.</p></section>
+<code class="prettyprint">FALSE</code> if it's not.</p>
+</section>
 
     
 </article>
@@ -480,25 +560,27 @@ normally mean the code being examined contains a parse error.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="method_splitAndMergeImportUseStatement">
         splitAndMergeImportUseStatement()
-        <a href="#method_splitAndMergeImportUseStatement" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_splitAndMergeImportUseStatement" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="../files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">386</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Split an import use statement into individual imports and merge it with an array of previously
 seen import use statements.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">splitAndMergeImportUseStatement</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">array&nbsp;</span><span class="phpdocumentor-signature__argument__name">$previousUseStatements</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">splitAndMergeImportUseStatement</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$previousUseStatements</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Beware: this method should only be used to combine the import use statements found in <em>one</em> file.
 Do NOT combine the statements of multiple files as the result will be inaccurate and unreliable.</p>
-<p>In most cases when tempted to use this method, the \PHPCSUtils\AbstractSniffs\AbstractFileContextSniff
-(upcoming) should be used instead.</p></section>
+<p>In most cases when tempted to use this method, the <abbr title="\PHPCSUtils\AbstractSniffs\AbstractFileContextSniff">AbstractFileContextSniff</abbr>
+(upcoming) should be used instead.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -507,7 +589,8 @@ Do NOT combine the statements of multiple files as the result will be inaccurate
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -515,20 +598,22 @@ Do NOT combine the statements of multiple files as the result will be inaccurate
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position in the stack of the <code class="prettyprint">T_USE</code> token.</p></section>
+                    <section class="phpdocumentor-description"><p>The position in the stack of the <code class="prettyprint">T_USE</code> token.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$previousUseStatements</span>
-                : <span class="phpdocumentor-signature__argument__return-type">array</span>
+                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The import <code class="prettyprint">use</code> statements collected so far.
 This should be either the output of a
 previous call to this method or the output of
 an earlier call to the
-{@see \PHPCSUtils\Utils\UseStatements::splitImportUseStatement()}
-method.</p></section>
+<a href="classes/PHPCSUtils-Utils-UseStatements.html#method_splitImportUseStatement"><abbr title="\PHPCSUtils\Utils\UseStatements::splitImportUseStatement()">UseStatements::splitImportUseStatement()</abbr></a>
+method.</p>
+</section>
 
             </dd>
             </dl>
@@ -544,30 +629,34 @@ method.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHPCSUtils\AbstractSniffs\AbstractFileContextSniff">AbstractFileContextSniff</abbr></span>
-                                                            
-                </dd>
+                                        
+                                             
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-UseStatements.html#method_splitImportUseStatement"><abbr title="\PHPCSUtils\Utils\UseStatements::splitImportUseStatement()">UseStatements::splitImportUseStatement()</abbr></a></span>
-                                                            
-                </dd>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-UseStatements.html#method_splitImportUseStatement"><abbr title="\PHPCSUtils\Utils\UseStatements::splitImportUseStatement()">UseStatements::splitImportUseStatement()</abbr></a></span>
+                                        
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0-alpha3</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
             <section class="phpdocumentor-description"><p>A multi-level array containing information about the current <code class="prettyprint">use</code> statement combined with
 the previously collected <code class="prettyprint">use</code> statement information.
-See {@see \PHPCSUtils\Utils\UseStatements::splitImportUseStatement()} for more details about the array format.</p></section>
+See <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_splitImportUseStatement"><abbr title="\PHPCSUtils\Utils\UseStatements::splitImportUseStatement()">UseStatements::splitImportUseStatement()</abbr></a> for more details about the array format.</p>
+</section>
 
     
 </article>
@@ -579,21 +668,23 @@ See {@see \PHPCSUtils\Utils\UseStatements::splitImportUseStatement()} for more d
 >
     <h4 class="phpdocumentor-element__name" id="method_splitImportUseStatement">
         splitImportUseStatement()
-        <a href="#method_splitImportUseStatement" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_splitImportUseStatement" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="../files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">183</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Split an import use statement into individual imports.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">splitImportUseStatement</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">splitImportUseStatement</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
-        <section class="phpdocumentor-description"><p>Handles single import, multi-import and group-import use statements.</p></section>
+        <section class="phpdocumentor-description"><p>Handles single import, multi-import and group-import use statements.</p>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -602,7 +693,8 @@ See {@see \PHPCSUtils\Utils\UseStatements::splitImportUseStatement()} for more d
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -610,7 +702,8 @@ See {@see \PHPCSUtils\Utils\UseStatements::splitImportUseStatement()} for more d
                 : <span class="phpdocumentor-signature__argument__return-type">int</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The position in the stack of the <code class="prettyprint">T_USE</code> token.</p></section>
+                    <section class="phpdocumentor-description"><p>The position in the stack of the <code class="prettyprint">T_USE</code> token.</p>
+</section>
 
             </dd>
             </dl>
@@ -626,30 +719,35 @@ See {@see \PHPCSUtils\Utils\UseStatements::splitImportUseStatement()} for more d
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified position is not a
-<code class="prettyprint">T_USE</code> token.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified position is not a
+<code class="prettyprint">T_USE</code> token.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the <code class="prettyprint">T_USE</code> token is not for an import
-use statement.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the <code class="prettyprint">T_USE</code> token is not for an import
+use statement.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
             <section class="phpdocumentor-description"><p>A multi-level array containing information about the use statement.
 The first level is <code class="prettyprint">'name'</code>, <code class="prettyprint">'function'</code> and <code class="prettyprint">'const'</code>. These keys will always exist.
@@ -661,7 +759,8 @@ in this use statement for a particular category.</p>
 <pre class="prettyprint"><code class="language-php">use function Vendor\Package\{
     LevelA\Name as Alias,
     LevelB\Another_Name,
-};</code></pre>
+};
+</code></pre>
 <p>the return value would look like this:</p>
 <pre class="prettyprint"><code class="language-php">array(
   'name'     =&gt; array(),
@@ -670,27 +769,100 @@ in this use statement for a particular category.</p>
     'Another_Name' =&gt; 'Vendor\Package\LevelB\Another_Name',
   ),
   'const'    =&gt; array(),
-)</code></pre></section>
+)
+</code></pre>
+</section>
 
     
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Utils-UseStatements.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-UseStatements.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-UseStatements.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -131,7 +135,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">25</span>
+    <span class="phpdocumentor-element-found-in__line">26</span>
 
     </aside>
 
@@ -151,6 +155,16 @@
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
                                                                                 
                                              
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Dropped support for PHPCS &lt; 3.7.1.</p>
+</section>
+
                                     </dd>
                         </dl>
 
@@ -194,6 +208,13 @@
 <dd>Determine whether a T_USE token represents a trait use statement.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
+    <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_mergeImportUseStatements">mergeImportUseStatements()</a>
+    <span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
+</dt>
+<dd>Merge two import use statement arrays.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -method -public">
     <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_splitAndMergeImportUseStatement">splitAndMergeImportUseStatement()</a>
     <span>
                                 &nbsp;: array&lt;string|int, mixed&gt;    </span>
@@ -234,7 +255,7 @@ seen import use statements.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">45</span>
+    <span class="phpdocumentor-element-found-in__line">46</span>
 
     </aside>
 
@@ -319,7 +340,7 @@ normally mean the code being examined contains a parse error.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">99</span>
+    <span class="phpdocumentor-element-found-in__line">107</span>
 
     </aside>
 
@@ -401,7 +422,7 @@ normally mean the code being examined contains a parse error.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">118</span>
+    <span class="phpdocumentor-element-found-in__line">126</span>
 
     </aside>
 
@@ -483,7 +504,7 @@ normally mean the code being examined contains a parse error.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">137</span>
+    <span class="phpdocumentor-element-found-in__line">145</span>
 
     </aside>
 
@@ -558,6 +579,98 @@ normally mean the code being examined contains a parse error.</p>
             -public
                                     -static                    "
 >
+    <h4 class="phpdocumentor-element__name" id="method_mergeImportUseStatements">
+        mergeImportUseStatements()
+        <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_mergeImportUseStatements" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">413</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Merge two import use statement arrays.</p>
+
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">mergeImportUseStatements</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$previousUseStatements</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;&nbsp;</span><span class="phpdocumentor-signature__argument__name">$currentUseStatement</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
+
+        <section class="phpdocumentor-description"><p>Beware: this method should only be used to combine the import use statements found in <em>one</em> file.
+Do NOT combine the statements of multiple files as the result will be inaccurate and unreliable.</p>
+</section>
+
+        <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
+    <dl class="phpdocumentor-argument-list">
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$previousUseStatements</span>
+                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The import <code class="prettyprint">use</code> statements collected so far.
+This should be either the output of a
+previous call to this method or the output of
+an earlier call to the
+<a href="classes/PHPCSUtils-Utils-UseStatements.html#method_splitImportUseStatement"><abbr title="\PHPCSUtils\Utils\UseStatements::splitImportUseStatement()">UseStatements::splitImportUseStatement()</abbr></a>
+method.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$currentUseStatement</span>
+                : <span class="phpdocumentor-signature__argument__return-type">array&lt;string|int, mixed&gt;</span>
+                            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>The parsed import <code class="prettyprint">use</code> statements to merge with
+the previously collected use statements.
+This should be the output of a call to the
+<a href="classes/PHPCSUtils-Utils-UseStatements.html#method_splitImportUseStatement"><abbr title="\PHPCSUtils\Utils\UseStatements::splitImportUseStatement()">UseStatements::splitImportUseStatement()</abbr></a>
+method.</p>
+</section>
+
+            </dd>
+            </dl>
+
+    
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">see</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-UseStatements.html#method_splitImportUseStatement"><abbr title="\PHPCSUtils\Utils\UseStatements::splitImportUseStatement()">UseStatements::splitImportUseStatement()</abbr></a></span>
+                                        
+                                             
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
+            &mdash;
+            <section class="phpdocumentor-description"><p>A multi-level array containing information about the current <code class="prettyprint">use</code> statement combined with
+the previously collected <code class="prettyprint">use</code> statement information.
+See <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_splitImportUseStatement"><abbr title="\PHPCSUtils\Utils\UseStatements::splitImportUseStatement()">UseStatements::splitImportUseStatement()</abbr></a> for more details about the array format.</p>
+</section>
+
+    
+</article>
+                    <article
+        class="phpdocumentor-element
+            -method
+            -public
+                                    -static                    "
+>
     <h4 class="phpdocumentor-element__name" id="method_splitAndMergeImportUseStatement">
         splitAndMergeImportUseStatement()
         <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_splitAndMergeImportUseStatement" class="headerlink"><i class="fas fa-link"></i></a>
@@ -565,7 +678,7 @@ normally mean the code being examined contains a parse error.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">386</span>
+    <span class="phpdocumentor-element-found-in__line">375</span>
 
     </aside>
 
@@ -640,6 +753,14 @@ method.</p>
                                         
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">see</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-UseStatements.html#method_mergeImportUseStatements"><abbr title="\PHPCSUtils\Utils\UseStatements::mergeImportUseStatements()">UseStatements::mergeImportUseStatements()</abbr></a></span>
+                                        
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
@@ -673,7 +794,7 @@ See <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_splitImportUseSt
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/UseStatements.php"><a href="files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">183</span>
+    <span class="phpdocumentor-element-found-in__line">192</span>
 
     </aside>
 
@@ -721,6 +842,16 @@ See <a href="classes/PHPCSUtils-Utils-UseStatements.html#method_splitImportUseSt
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
                                                                                 
                                              
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 identifier name tokenization.</p>
+</section>
+
                                     </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Variables.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Variables.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -131,7 +135,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Variables.php"><a href="files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">27</span>
+    <span class="phpdocumentor-element-found-in__line">28</span>
 
     </aside>
 
@@ -153,6 +157,16 @@
                                                  <section class="phpdocumentor-description"><p>The <code class="prettyprint">Variables::getMemberProperties()</code> method is based on and inspired by
 the method of the same name in the PHPCS native <code class="prettyprint">PHP_CodeSniffer\Files\File</code> class.
 Also see <a href="classes/PHPCSUtils-BackCompat-BCFile.html"><abbr title="\PHPCSUtils\BackCompat\BCFile">BCFile</abbr></a>.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Dropped support for PHPCS &lt; 3.7.1.</p>
 </section>
 
                                     </dd>
@@ -232,7 +246,7 @@ Also see <a href="classes/PHPCSUtils-BackCompat-BCFile.html"><abbr title="\PHPCS
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Variables.php"><a href="files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">45</span>
+    <span class="phpdocumentor-element-found-in__line">46</span>
 
     </aside>
 
@@ -285,20 +299,20 @@ to be used with array index keys as well. Think: <code class="prettyprint">'_GET
     </h5>
     <dl class="phpdocumentor-tag-list">
                                     <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://php.net/reserved.variables"> <p>PHP Manual on reserved variables</p>
+ </a>
+                    
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
                                                                                 
                                              
-                                    </dd>
-                                                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">link</span>
-                </dt>
-                <dd class="phpdocumentor-tag-list__definition">
-                                                                                                        <a class="phpdocumentor-tag-link" href="http://php.net/reserved.variables"> <p>PHP Manual on reserved variables</p>
- </a>
-                    
                                     </dd>
                         </dl>
 
@@ -323,7 +337,7 @@ to be used with array index keys as well. Think: <code class="prettyprint">'_GET
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Variables.php"><a href="files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">114</span>
+    <span class="phpdocumentor-element-found-in__line">124</span>
 
     </aside>
 
@@ -339,6 +353,8 @@ to be used with array index keys as well. Think: <code class="prettyprint">'_GET
 This will now throw the same <em>&quot;$stackPtr is not a class member var&quot;</em> runtime exception as
 other non-property variables passed to the method.</li>
 <li>Defensive coding against incorrect calls to this method.</li>
+<li>Support PHP 8.0 identifier name tokens in property types, cross-version PHP &amp; PHPCS.</li>
+<li>Support for the PHP 8.2 <code class="prettyprint">true</code> type.</li>
 </ul>
 </section>
 
@@ -399,6 +415,56 @@ to acquire the properties for.</p>
                                                                                 
                                              
                                     </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.0 union types.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>No longer gets confused by PHP 8.0 property attributes.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.1 readonly properties.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.1 intersection types.</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0-alpha4</span>
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Added support for PHP 8.2 true type.</p>
+</section>
+
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
@@ -432,12 +498,14 @@ The format of the return value is:</p>
   'scope'           =&gt; string,  // Public, private, or protected.
   'scope_specified' =&gt; boolean, // TRUE if the scope was explicitly specified.
   'is_static'       =&gt; boolean, // TRUE if the static keyword was found.
+  'is_readonly'     =&gt; boolean, // TRUE if the readonly keyword was found.
   'type'            =&gt; string,  // The type of the var (empty if no type specified).
   'type_token'      =&gt; integer, // The stack pointer to the start of the type
                                 // or FALSE if there is no type.
   'type_end_token'  =&gt; integer, // The stack pointer to the end of the type
                                 // or FALSE if there is no type.
-  'nullable_type'   =&gt; boolean, // TRUE if the type is nullable.
+  'nullable_type'   =&gt; boolean, // TRUE if the type is preceded by the
+                                // nullability operator.
 );
 </code></pre>
 </section>
@@ -457,7 +525,7 @@ The format of the return value is:</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Variables.php"><a href="files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">228</span>
+    <span class="phpdocumentor-element-found-in__line">247</span>
 
     </aside>
 
@@ -533,7 +601,7 @@ Also see: <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_stripQuotes"
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Variables.php"><a href="files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">253</span>
+    <span class="phpdocumentor-element-found-in__line">272</span>
 
     </aside>
 
@@ -611,7 +679,7 @@ is not an array index key; or when it is, but is not an index to the
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Variables.php"><a href="files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">306</span>
+    <span class="phpdocumentor-element-found-in__line">325</span>
 
     </aside>
 

--- a/docs/phpdoc/classes/PHPCSUtils-Utils-Variables.html
+++ b/docs/phpdoc/classes/PHPCSUtils-Utils-Variables.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils-utils.html">Utils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils-utils.html">Utils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -class">
@@ -74,15 +118,22 @@
     Variables
 
     
+            <div class="phpdocumentor-element__package">
+            in package
+            <ul class="phpdocumentor-breadcrumbs">
+                                    <li class="phpdocumentor-breadcrumb"><a href="packages/PHPCSUtils.html">PHPCSUtils</a></li>
+                            </ul>
+        </div>
     
     
     </h2>
 
         <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Variables.php"><a href="../files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Variables.php"><a href="files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">27</span>
-</aside>
+
+    </aside>
 
             <p class="phpdocumentor-summary">Utility functions for use when examining variables.</p>
 
@@ -98,11 +149,13 @@
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                        <section class="phpdocumentor-description"><p>The <code class="prettyprint">Variables::getMemberProperties()</code> method is based on and inspired by
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>The <code class="prettyprint">Variables::getMemberProperties()</code> method is based on and inspired by
 the method of the same name in the PHPCS native <code class="prettyprint">PHP_CodeSniffer\Files\File</code> class.
-Also see {@see \PHPCSUtils\BackCompat\BCFile}.</p></section>
+Also see <a href="classes/PHPCSUtils-BackCompat-BCFile.html"><abbr title="\PHPCSUtils\BackCompat\BCFile">BCFile</abbr></a>.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
 
@@ -116,38 +169,38 @@ Also see {@see \PHPCSUtils\BackCompat\BCFile}.</p></section>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-                <dt class="phpdocumentor-table-of-contents__entry -property -public">
-    <a href="../classes/PHPCSUtils-Utils-Variables.html#property_phpReservedVars">$phpReservedVars</a>
+                    <dt class="phpdocumentor-table-of-contents__entry -property -public">
+    <a href="classes/PHPCSUtils-Utils-Variables.html#property_phpReservedVars">$phpReservedVars</a>
     <span>
-                &nbsp;: array            </span>
+                        &nbsp;: array&lt;string|int, mixed&gt;            </span>
 </dt>
 <dd>List of PHP Reserved variables.</dd>
 
                 <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Variables.html#method_getMemberProperties">getMemberProperties()</a>
+    <a href="classes/PHPCSUtils-Utils-Variables.html#method_getMemberProperties">getMemberProperties()</a>
     <span>
-                        &nbsp;: array    </span>
+                                &nbsp;: array&lt;string|int, mixed&gt;    </span>
 </dt>
 <dd>Retrieve the visibility and implementation properties of a class member variable.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Variables.html#method_isPHPReservedVarName">isPHPReservedVarName()</a>
+    <a href="classes/PHPCSUtils-Utils-Variables.html#method_isPHPReservedVarName">isPHPReservedVarName()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Verify if a given variable name is the name of a PHP reserved variable.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Variables.html#method_isSuperglobal">isSuperglobal()</a>
+    <a href="classes/PHPCSUtils-Utils-Variables.html#method_isSuperglobal">isSuperglobal()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Verify if a given variable or array key token points to a PHP superglobal.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -method -public">
-    <a href="../classes/PHPCSUtils-Utils-Variables.html#method_isSuperglobalName">isSuperglobalName()</a>
+    <a href="classes/PHPCSUtils-Utils-Variables.html#method_isSuperglobalName">isSuperglobalName()</a>
     <span>
-                        &nbsp;: bool    </span>
+                                &nbsp;: bool    </span>
 </dt>
 <dd>Verify if a given variable name is the name of a PHP superglobal.</dd>
 
@@ -161,7 +214,7 @@ Also see {@see \PHPCSUtils\BackCompat\BCFile}.</p></section>
     <section class="phpdocumentor-properties">
         <h3 class="phpdocumentor-elements__header" id="properties">
             Properties
-            <a href="#properties" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-Variables.html#properties" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="
@@ -172,21 +225,22 @@ Also see {@see \PHPCSUtils\BackCompat\BCFile}.</p></section>
 >
     <h4 class="phpdocumentor-element__name" id="property_phpReservedVars">
         $phpReservedVars
-        <a href="#property_phpReservedVars" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Variables.html#property_phpReservedVars" class="headerlink"><i class="fas fa-link"></i></a>
         <span class="phpdocumentor-element__modifiers">
                                 </span>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Variables.php"><a href="../files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Variables.php"><a href="files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">45</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">List of PHP Reserved variables.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array</span>
+    <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__type">array&lt;string|int, mixed&gt;</span>
     <span class="phpdocumentor-signature__name">$phpReservedVars</span>
      = <span class="phpdocumentor-signature__default-value">[
     &#039;_SERVER&#039; =&gt; true,
@@ -218,7 +272,11 @@ Also see {@see \PHPCSUtils\BackCompat\BCFile}.</p></section>
         <section class="phpdocumentor-description"><p>The array keys are the variable names without the leading dollar sign, the values indicate
 whether the variable is a superglobal or not.</p>
 <p>The variables names are set without the leading dollar sign to allow this array
-to be used with array index keys as well. Think: <code class="prettyprint">'_GET'</code> in <code class="prettyprint">$GLOBALS['_GET']</code>.}</p></section>
+to be used with array index keys as well. Think: <code class="prettyprint">'_GET'</code> in <code class="prettyprint">$GLOBALS['_GET']</code>.}</p>
+</section>
+
+        <section class="phpdocumentor-description"><p><string> =&gt; <bool></p>
+</section>
 
     
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
@@ -231,16 +289,17 @@ to be used with array index keys as well. Think: <code class="prettyprint">'_GET
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">link</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                                        <a class="phpdocumentor-tag-link" href="http://php.net/reserved.variables">http://php.net/reserved.variables</a>
-                                            <section class="phpdocumentor-description"><p>PHP Manual on reserved variables</p></section>
-
-                </dd>
+                                                                                                        <a class="phpdocumentor-tag-link" href="http://php.net/reserved.variables"> <p>PHP Manual on reserved variables</p>
+ </a>
+                    
+                                    </dd>
                         </dl>
 
 </article>
@@ -249,7 +308,7 @@ to be used with array index keys as well. Think: <code class="prettyprint">'_GET
             <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            <a href="classes/PHPCSUtils-Utils-Variables.html#methods" class="headerlink"><i class="fas fa-link"></i></a>
         </h3>
                     <article
         class="phpdocumentor-element
@@ -259,19 +318,20 @@ to be used with array index keys as well. Think: <code class="prettyprint">'_GET
 >
     <h4 class="phpdocumentor-element__name" id="method_getMemberProperties">
         getMemberProperties()
-        <a href="#method_getMemberProperties" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Variables.html#method_getMemberProperties" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Variables.php"><a href="../files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Variables.php"><a href="files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">114</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Retrieve the visibility and implementation properties of a class member variable.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">getMemberProperties</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">getMemberProperties</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span></code>
 
         <section class="phpdocumentor-description"><p>Main differences with the PHPCS version:</p>
 <ul>
@@ -279,7 +339,8 @@ to be used with array index keys as well. Think: <code class="prettyprint">'_GET
 This will now throw the same <em>&quot;$stackPtr is not a class member var&quot;</em> runtime exception as
 other non-property variables passed to the method.</li>
 <li>Defensive coding against incorrect calls to this method.</li>
-</ul></section>
+</ul>
+</section>
 
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
     <dl class="phpdocumentor-argument-list">
@@ -288,7 +349,8 @@ other non-property variables passed to the method.</li>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file being scanned.</p></section>
+                    <section class="phpdocumentor-description"><p>The file being scanned.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -297,7 +359,8 @@ other non-property variables passed to the method.</li>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position in the stack of the <code class="prettyprint">T_VARIABLE</code> token
-to acquire the properties for.</p></section>
+to acquire the properties for.</p>
+</section>
 
             </dd>
             </dl>
@@ -313,46 +376,55 @@ to acquire the properties for.</p></section>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                                     <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Files\File::getMemberProperties()">File::getMemberProperties()</abbr></span>
-                                                                <section class="phpdocumentor-description"><p>Original source.</p></section>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Original source.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-BackCompat-BCFile.html#method_getMemberProperties"><abbr title="\PHPCSUtils\BackCompat\BCFile::getMemberProperties()">BCFile::getMemberProperties()</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-BackCompat-BCFile.html#method_getMemberProperties"><abbr title="\PHPCSUtils\BackCompat\BCFile::getMemberProperties()">BCFile::getMemberProperties()</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>Cross-version compatible version of the original.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified position is not a
-<code class="prettyprint">T_VARIABLE</code> token.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified position is not a
+<code class="prettyprint">T_VARIABLE</code> token.</p>
+</section>
 
-                </dd>
+                                    </dd>
                             <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">throws</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                                                 <span class="phpdocumentor-tag-link"><abbr title="\PHP_CodeSniffer\Exceptions\RuntimeException">RuntimeException</abbr></span>
-                                                                                    <section class="phpdocumentor-description"><p>If the specified position is not a
-class member variable.</p></section>
+                                                            
+                                                 <section class="phpdocumentor-description"><p>If the specified position is not a
+class member variable.</p>
+</section>
 
-                </dd>
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">array</span>
+    <span class="phpdocumentor-signature__response_type">array&lt;string|int, mixed&gt;</span>
             &mdash;
             <section class="phpdocumentor-description"><p>Array with information about the class member variable.
 The format of the return value is:</p>
@@ -366,7 +438,9 @@ The format of the return value is:</p>
   'type_end_token'  =&gt; integer, // The stack pointer to the end of the type
                                 // or FALSE if there is no type.
   'nullable_type'   =&gt; boolean, // TRUE if the type is nullable.
-);</code></pre></section>
+);
+</code></pre>
+</section>
 
     
 </article>
@@ -378,19 +452,20 @@ The format of the return value is:</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_isPHPReservedVarName">
         isPHPReservedVarName()
-        <a href="#method_isPHPReservedVarName" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Variables.html#method_isPHPReservedVarName" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Variables.php"><a href="../files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Variables.php"><a href="files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">228</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Verify if a given variable name is the name of a PHP reserved variable.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isPHPReservedVarName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isPHPReservedVarName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -406,8 +481,9 @@ This allows for passing an array key variable name, such as
 <blockquote>
 <p>Note: when passing an array key, string quotes are expected
 to have been stripped already.
-Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.</p>
-</blockquote></section>
+Also see: <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_stripQuotes"><abbr title="\PHPCSUtils\Utils\TextStrings::stripQuotes()">TextStrings::stripQuotes()</abbr></a>.</p>
+</blockquote>
+</section>
 
             </dd>
             </dl>
@@ -422,17 +498,20 @@ Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.</p>
                     <span class="phpdocumentor-tag__name">see</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
-                                                                                    <span class="phpdocumentor-tag-link"><a href="../classes/PHPCSUtils-Utils-Variables.html#property_phpReservedVars"><abbr title="\PHPCSUtils\Utils\Variables::$phpReservedVars">Variables::$phpReservedVars</abbr></a></span>
-                                                                <section class="phpdocumentor-description"><p>List of variables names reserved by PHP.</p></section>
+                                                                                    <span class="phpdocumentor-tag-link"><a href="classes/PHPCSUtils-Utils-Variables.html#property_phpReservedVars"><abbr title="\PHPCSUtils\Utils\Variables::$phpReservedVars">Variables::$phpReservedVars</abbr></a></span>
+                                        
+                                                 <section class="phpdocumentor-description"><p>List of variables names reserved by PHP.</p>
+</section>
 
-                </dd>
+                                    </dd>
                                                 <dt class="phpdocumentor-tag-list__entry">
                     <span class="phpdocumentor-tag__name">since</span>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -449,19 +528,20 @@ Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.</p>
 >
     <h4 class="phpdocumentor-element__name" id="method_isSuperglobal">
         isSuperglobal()
-        <a href="#method_isSuperglobal" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Variables.html#method_isSuperglobal" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Variables.php"><a href="../files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Variables.php"><a href="files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">253</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Verify if a given variable or array key token points to a PHP superglobal.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isSuperglobal</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isSuperglobal</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$phpcsFile</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">int&nbsp;</span><span class="phpdocumentor-signature__argument__name">$stackPtr</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -471,7 +551,8 @@ Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.</p>
                 : <span class="phpdocumentor-signature__argument__return-type"><abbr title="\PHP_CodeSniffer\Files\File">File</abbr></span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>The file where this token was found.</p></section>
+                    <section class="phpdocumentor-description"><p>The file where this token was found.</p>
+</section>
 
             </dd>
                     <dt class="phpdocumentor-argument-list__entry">
@@ -481,7 +562,8 @@ Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.</p>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The position in the stack of a <code class="prettyprint">T_VARIABLE</code>
 token or of the <code class="prettyprint">T_CONSTANT_ENCAPSED_STRING</code>
-array key to a variable in <code class="prettyprint">$GLOBALS</code>.</p></section>
+array key to a variable in <code class="prettyprint">$GLOBALS</code>.</p>
+</section>
 
             </dd>
             </dl>
@@ -497,8 +579,9 @@ array key to a variable in <code class="prettyprint">$GLOBALS</code>.</p></secti
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -510,7 +593,8 @@ array key to a variable in <code class="prettyprint">$GLOBALS</code>.</p></secti
 been passed, when a <code class="prettyprint">T_CONSTANT_ENCAPSED_STRING</code> has been passed which
 is not an array index key; or when it is, but is not an index to the
 <code class="prettyprint">$GLOBALS</code> variable.</p>
-</blockquote></section>
+</blockquote>
+</section>
 
     
 </article>
@@ -522,19 +606,20 @@ is not an array index key; or when it is, but is not an index to the
 >
     <h4 class="phpdocumentor-element__name" id="method_isSuperglobalName">
         isSuperglobalName()
-        <a href="#method_isSuperglobalName" class="headerlink"><i class="fas fa-link"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Variables.html#method_isSuperglobalName" class="headerlink"><i class="fas fa-link"></i></a>
     </h4>
     <aside class="phpdocumentor-element-found-in">
-    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Variables.php"><a href="../files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></abbr>
+    <abbr class="phpdocumentor-element-found-in__file" title="PHPCSUtils/Utils/Variables.php"><a href="files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></abbr>
     :
     <span class="phpdocumentor-element-found-in__line">306</span>
-</aside>
+
+    </aside>
 
         <p class="phpdocumentor-summary">Verify if a given variable name is the name of a PHP superglobal.</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>    <span class="phpdocumentor-signature__name">isSuperglobalName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">isSuperglobalName</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$name</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">bool</span></code>
 
     
         <h5 class="phpdocumentor-argument-list__heading">Parameters</h5>
@@ -550,8 +635,9 @@ This allows for passing an array key variable name, such as
 <blockquote>
 <p>Note: when passing an array key, string quotes are expected
 to have been stripped already.
-Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.</p>
-</blockquote></section>
+Also see: <a href="classes/PHPCSUtils-Utils-TextStrings.html#method_stripQuotes"><abbr title="\PHPCSUtils\Utils\TextStrings::stripQuotes()">TextStrings::stripQuotes()</abbr></a>.</p>
+</blockquote>
+</section>
 
             </dd>
             </dl>
@@ -567,8 +653,9 @@ Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.</p>
                 </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                                             <span class="phpdocumentor-tag-link">1.0.0</span>
-                                                                                                    
-                </dd>
+                                                                                
+                                             
+                                    </dd>
                         </dl>
 
         <h5 class="phpdocumentor-return-value__heading">Return values</h5>
@@ -579,21 +666,92 @@ Also see: {@see \PHPCSUtils\Utils\TextStrings::stripQuotes()}.</p>
 </article>
             </section>
 
-    </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+        
+    <script type="text/javascript">
+        function loadExternalCodeSnippets(line) {
+            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
+                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
+                var language = 'php';
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                var code = document.createElement('code');
+                code.className = 'language-' + language;
+
+                pre.textContent = '';
+
+                pre.setAttribute('data-line', line)
+                code.textContent = 'Loading…';
+
+                pre.appendChild(code);
+
+                var xhr = new XMLHttpRequest();
+
+                xhr.open('GET', src, true);
+
+                xhr.onreadystatechange = function () {
+                    if (xhr.readyState == 4) {
+
+                        if (xhr.status < 400 && xhr.responseText) {
+                            code.textContent = xhr.responseText;
+
+                            Prism.highlightElement(code);
+                        }
+                        else if (xhr.status >= 400) {
+                            code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                        }
+                        else {
+                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
+                        }
+                    }
+                };
+
+                xhr.send(null);
+            });
+        }
+
+        var modals = document.querySelectorAll("[data-modal]");
+
+        modals.forEach(function (trigger) {
+            trigger.addEventListener("click", function (event) {
+                //event.preventDefault();
+                const modal = document.getElementById(trigger.dataset.modal);
+                modal.classList.add("phpdocumentor-modal__open");
+                loadExternalCodeSnippets(trigger.dataset.line)
+                const exits = modal.querySelectorAll("[data-exit-button]");
+                exits.forEach(function (exit) {
+                    exit.addEventListener("click", function (event) {
+                        event.preventDefault();
+                        modal.classList.remove("phpdocumentor-modal__open");
+                    });
+                });
+            });
+        });
+    </script>
+
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="classes/PHPCSUtils-Utils-Variables.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/css/base.css
+++ b/docs/phpdoc/css/base.css
@@ -3,6 +3,7 @@
     /* Typography */
     --font-primary: 'Source Sans Pro', Helvetica, Arial, sans-serif;
     --font-secondary: 'Source Sans Pro', Helvetica, Arial, sans-serif;
+    --font-monospace: 'Source Code Pro', monospace;
     --line-height--primary: 1.6;
     --letter-spacing--primary: .05rem;
     --text-base-size: 1em;
@@ -20,26 +21,29 @@
     --text-xxxxxl: calc(var(--text-base-size) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio));
 
     /* Colors */
-    --primary-color: hsl(96, 57%, 60%);
-    --primary-color-darken: hsl(96, 57%, 40%);
-    --primary-color-darker: hsl(96, 57%, 20%);
-    --primary-color-lighten: hsl(96, 57%, 80%);
-    --primary-color-lighter: hsl(96, 57%, 97%);
+    --primary-color-hue: 96;
+    --primary-color-saturation: 57%;
+    --primary-color: hsl(var(--primary-color-hue), var(--primary-color-saturation), 60%);
+    --primary-color-darken: hsl(var(--primary-color-hue), var(--primary-color-saturation), 40%);
+    --primary-color-darker: hsl(var(--primary-color-hue), var(--primary-color-saturation), 20%);
+    --primary-color-darkest: hsl(var(--primary-color-hue), var(--primary-color-saturation), 10%);
+    --primary-color-lighten: hsl(var(--primary-color-hue), var(--primary-color-saturation), 80%);
+    --primary-color-lighter: hsl(var(--primary-color-hue), var(--primary-color-saturation), 99%);
     --dark-gray: #d1d1d1;
     --light-gray: #f0f0f0;
 
-    --text-color: #4b3b40;
+    --text-color: var(--primary-color-darkest);
 
     --header-height: var(--spacing-xxxxl);
     --header-bg-color: var(--primary-color);
-    --code-background-color: #f7faf5;
-    --code-border-color: #d6e7cb;
+    --code-background-color: var(--primary-color-lighter);
+    --code-border-color: --primary-color-lighten;
     --button-border-color: var(--primary-color-darken);
     --button-color: transparent;
     --button-color-primary: var(--primary-color);
     --button-text-color: #555;
     --button-text-color-primary: white;
-    --popover-background-color: hsla(96, 57%, 95%, 0.9);
+    --popover-background-color: rgba(255, 255, 255, 0.75);
     --link-color-primary: var(--primary-color-darken);
     --link-hover-color-primary: var(--primary-color-darker);
     --form-field-border-color: var(--dark-gray);
@@ -80,6 +84,7 @@ body {
     font-size: var(--text-md);
     letter-spacing: var(--letter-spacing--primary);
     line-height: var(--line-height--primary);
+    width: 100%;
 }
 
 .phpdocumentor h1,
@@ -104,7 +109,6 @@ body {
     font-size: var(--text-xxxl);
     letter-spacing: var(--letter-spacing--primary);
     line-height: 1.25;
-    margin-top: 0;
 }
 
 .phpdocumentor h3 {
@@ -166,6 +170,17 @@ body {
 .phpdocumentor figure {
     margin-bottom: var(--spacing-md);
 }
+
+.phpdocumentor figcaption {
+    text-align: center;
+    font-style: italic;
+    font-size: 80%;
+}
+
+.phpdocumentor-uml-diagram svg {
+    max-width: 100%;
+    height: auto !important;
+}
 .phpdocumentor-line {
     border-top: 1px solid #E1E1E1;
     border-width: 0;
@@ -185,12 +200,6 @@ body {
     .phpdocumentor-section {
         padding: 0;
         width: 95%;
-    }
-}
-
-@media (min-width: 1000px) {
-    .phpdocumentor-section {
-        width: 85%;
     }
 }
 .phpdocumentor-column {
@@ -431,20 +440,25 @@ input[type="checkbox"].phpdocumentor-field,
 input[type="radio"].phpdocumentor-field {
     display: inline;
 }
+.phpdocumentor-column ul,
 div.phpdocumentor-list > ul,
 ul.phpdocumentor-list {
-    list-style: circle inside;
+    list-style: circle;
 }
 
+.phpdocumentor-column ol,
+div.phpdocumentor-list > ol,
 ol.phpdocumentor-list {
-    list-style: decimal inside;
+    list-style: decimal;
 }
 
+
+.phpdocumentor-column ul,
 div.phpdocumentor-list > ul,
 ol.phpdocumentor-list,
 ul.phpdocumentor-list {
     margin-top: 0;
-    padding-left: 0;
+    padding-left: 1rem;
     margin-bottom: var(--spacing-md);
 }
 
@@ -452,6 +466,7 @@ dl {
     margin-bottom: var(--spacing-md);
 }
 
+.phpdocumentor-column ul ul,
 div.phpdocumentor-list > ul ul,
 ul.phpdocumentor-list ul.phpdocumentor-list,
 ul.phpdocumentor-list ol.phpdocumentor-list,
@@ -461,7 +476,16 @@ ol.phpdocumentor-list ul.phpdocumentor-list {
     margin: var(--spacing-xs) 0 var(--spacing-xs) calc(var(--spacing-xs) * 2);
 }
 
-li.phpdocumentor-list {
+.phpdocumentor-column ul li,
+.phpdocumentor-list li {
+    padding-bottom: var(--spacing-xs);
+}
+
+.phpdocumentor dl dt {
+    margin-bottom: var(--spacing-xs);
+}
+
+.phpdocumentor dl dd {
     margin-bottom: var(--spacing-md);
 }
 .phpdocumentor pre {
@@ -469,6 +493,7 @@ li.phpdocumentor-list {
 }
 
 .phpdocumentor-code {
+    font-family: var(--font-monospace);
     background: var(--code-background-color);
     border: 1px solid var(--code-border-color);
     border-radius: var(--border-radius-base-size);
@@ -478,9 +503,26 @@ li.phpdocumentor-list {
     box-sizing: border-box;
 }
 
+.phpdocumentor-code.-dark {
+    background: var(--primary-color-darkest);
+    color: var(--light-gray);
+    box-shadow: 0 2px 3px var(--dark-gray);
+}
+
 pre > .phpdocumentor-code {
     display: block;
     white-space: pre;
+}
+.phpdocumentor blockquote {
+    border-left: 4px solid var(--primary-color-darken);
+    margin: var(--spacing-md) 0;
+    padding: var(--spacing-xs) var(--spacing-sm);
+    color: var(--primary-color-darker);
+    font-style: italic;
+}
+
+.phpdocumentor blockquote p:last-of-type {
+    margin-bottom: 0;
 }
 .phpdocumentor table {
     margin-bottom: var(--spacing-md);
@@ -506,11 +548,51 @@ td.phpdocumentor-cell:last-child {
 .phpdocumentor-header {
     display: flex;
     flex-direction: row;
-    align-items: center;
+    align-items: stretch;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    height: auto;
+    padding: var(--spacing-md) var(--spacing-md);
 }
 
-.phpdocumentor-header > * {
-    height: var(--header-height);
+.phpdocumentor-header__menu-button {
+    position: absolute;
+    top: -100%;
+    left: -100%;
+}
+
+.phpdocumentor-header__menu-icon {
+    font-size: 2rem;
+    color: var(--primary-color);
+}
+
+.phpdocumentor-header__menu-button:checked ~ .phpdocumentor-topnav {
+    max-height: 250px;
+    padding-top: var(--spacing-md);
+}
+
+@media (min-width: 1000px) {
+    .phpdocumentor-header {
+        flex-direction: row;
+        padding: var(--spacing-lg) var(--spacing-lg);
+        min-height: var(--header-height);
+    }
+
+    .phpdocumentor-header__menu-icon {
+        display: none;
+    }
+}
+
+@media (min-width: 1000px) {
+    .phpdocumentor-header {
+        padding-top: 0;
+        padding-bottom: 0;
+    }
+}
+@media (min-width: 1200px) {
+    .phpdocumentor-header {
+        padding: 0;
+    }
 }
 .phpdocumentor-title {
     box-sizing: border-box;
@@ -518,16 +600,19 @@ td.phpdocumentor-cell:last-child {
     font-size: var(--text-xxl);
     letter-spacing: .05rem;
     font-weight: normal;
-    width: 30.6666666667%;
+    width: auto;
     margin: 0;
-    border-right: var(--sidebar-border-color) solid 1px;
     display: flex;
     align-items: center;
 }
 
+.phpdocumentor-title.-without-divider {
+    border: none;
+}
+
 .phpdocumentor-title__link {
     transition: all .3s ease-out;
-    display: block;
+    display: flex;
     color: var(--title-text-color);
     text-decoration: none;
     font-weight: normal;
@@ -539,6 +624,17 @@ td.phpdocumentor-cell:last-child {
 .phpdocumentor-title__link:hover {
     transform: perspective(15rem) translateX(.5rem);
     font-weight: 600;
+}
+
+@media (min-width: 1000px) {
+    .phpdocumentor-title {
+        width: 30.6666666667%;
+        border-right: var(--sidebar-border-color) solid 1px;
+    }
+
+    .phpdocumentor-title__link {
+        transform-origin: left;
+    }
 }
 
 @media (min-width: 1000px) {
@@ -554,32 +650,36 @@ td.phpdocumentor-cell:last-child {
 }
 .phpdocumentor-topnav {
     display: flex;
-    flex: 1;
-    margin-left: 4%;
     align-items: center;
+    margin: 0;
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.2s ease-out;
+    flex-basis: 100%;
 }
 
 .phpdocumentor-topnav__menu {
-    display: inline-block;
+    text-align: right;
     list-style: none;
     margin: 0;
     padding: 0;
     flex: 1;
-}
-
-.phpdocumentor-topnav__menu.-social {
-    margin-left: auto;
-    flex: 0 auto;
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: center;
 }
 
 .phpdocumentor-topnav__menu-item {
-    display: inline;
     margin: 0;
-    padding: 0 var(--spacing-lg) 0 0;
+    width: 100%;
+    display: inline-block;
+    text-align: center;
+    padding: var(--spacing-sm) 0
 }
 
-.phpdocumentor-topnav__menu-item:last-of-type {
-    padding: 0;
+.phpdocumentor-topnav__menu-item.-social {
+    width: auto;
+    padding: var(--spacing-sm)
 }
 
 .phpdocumentor-topnav__menu-item a {
@@ -596,14 +696,38 @@ td.phpdocumentor-cell:last-child {
     transform: perspective(15rem) translateY(.1rem);
     border-bottom: 1px dotted var(--text-color);
 }
+
+@media (min-width: 1000px) {
+    .phpdocumentor-topnav {
+        max-height: none;
+        overflow: visible;
+        flex-basis: auto;
+    }
+
+    .phpdocumentor-topnav__menu {
+        display: flex;
+        flex-flow: row wrap;
+        justify-content: flex-end;
+    }
+
+    .phpdocumentor-topnav__menu-item,
+    .phpdocumentor-topnav__menu-item.-social {
+        width: auto;
+        display: inline;
+        text-align: right;
+        padding: 0 0 0 var(--spacing-md)
+    }
+}
 .phpdocumentor-sidebar {
-    border-right: var(--sidebar-border-color) solid 1px;
+    margin: 0;
+    overflow: hidden;
+    max-height: 0;
 }
 
 .phpdocumentor .phpdocumentor-sidebar .phpdocumentor-list {
-    padding-top: var(--spacing-xs);
-    padding-left: var(--spacing-md);
+    padding: var(--spacing-xs) var(--spacing-md);
     list-style: none;
+    margin: 0;
 }
 
 .phpdocumentor .phpdocumentor-sidebar li {
@@ -623,7 +747,8 @@ td.phpdocumentor-cell:last-child {
     transition: padding-left .4s ease-out;
 }
 
-.phpdocumentor .phpdocumentor-sidebar a:hover {
+.phpdocumentor .phpdocumentor-sidebar a:hover,
+.phpdocumentor .phpdocumentor-sidebar a.-active {
     padding-left: 5px;
     font-weight: 600;
 }
@@ -653,14 +778,73 @@ td.phpdocumentor-cell:last-child {
     color: var(--text-color);
     font-weight: normal;
 }
+
+@media (min-width: 550px) {
+    .phpdocumentor-sidebar {
+        border-right: var(--sidebar-border-color) solid 1px;
+    }
+}
+
+.phpdocumentor-sidebar__menu-button {
+    position: absolute;
+    top: -100%;
+    left: -100%;
+}
+
+.phpdocumentor-sidebar__menu-icon {
+    font-size: var(--text-md);
+    font-weight: 600;
+    background: var(--primary-color);
+    color: white;
+    margin: 0 0 var(--spacing-lg);
+    display: block;
+    padding: var(--spacing-sm);
+    text-align: center;
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: .15rem;
+}
+
+.phpdocumentor-sidebar__menu-button:checked ~ .phpdocumentor-sidebar {
+    max-height: 100%;
+    padding-top: var(--spacing-md);
+}
+
+@media (min-width: 550px) {
+    .phpdocumentor-sidebar {
+        overflow: visible;
+        max-height: 100%;
+    }
+
+    .phpdocumentor-sidebar__menu-icon {
+        display: none;
+    }
+}
 .phpdocumentor-admonition {
     border: 1px solid var(--admonition-border-color);
     border-radius: var(--border-radius-base-size);
-    padding: var(--spacing-sm) var(--spacing-md);
+    border-color: var(--primary-color-lighten);
+    background-color: var(--primary-color-lighter);
+    padding: var(--spacing-lg);
+    margin: var(--spacing-lg) 0;
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
 }
 
-.phpdocumentor-admonition--success {
+.phpdocumentor-admonition p:last-of-type {
+    margin-bottom: 0;
+}
+
+.phpdocumentor-admonition--success,
+.phpdocumentor-admonition.-success {
     border-color: var(--admonition-success-color);
+}
+
+.phpdocumentor-admonition__icon {
+    margin-right: var(--spacing-md);
+    color: var(--primary-color);
+    max-width: 3rem;
 }
 .phpdocumentor ul.phpdocumentor-breadcrumbs {
     font-size: var(--text-md);
@@ -702,28 +886,29 @@ td.phpdocumentor-cell:last-child {
     display: none; /** disable by default for non-js flow */
     opacity: .3; /** white-out default for loading indication */
     transition: opacity .3s, background .3s;
+    margin: var(--spacing-sm) 0;
+    flex: 1;
+    min-width: 100%;
 }
-.phpdocumentor-search:before {
-    content: '';
-    background: transparent;
-    left: calc(-1 * var(--spacing-md));
-    height: 100%;
-    position: absolute;
-    right: -15px;
-    z-index: -1;
-    opacity: 0;
-    transition: opacity .3s, background .3s;
+
+.phpdocumentor-search label {
+    display: flex;
+    align-items: center;
+    flex: 1;
+}
+
+.phpdocumentor-search__icon {
+    color: var(--primary-color);
+    margin-right: var(--spacing-sm);
+    width: 1rem;
+    height: 1rem;
 }
 
 .phpdocumentor-search--enabled {
-    display: block;
+    display: flex;
 }
 
 .phpdocumentor-search--active {
-    opacity: 1;
-}
-.phpdocumentor-search--has-results:before {
-    background: var(--popover-background-color);
     opacity: 1;
 }
 
@@ -731,7 +916,190 @@ td.phpdocumentor-cell:last-child {
     background-color: lightgray;
 }
 
+.phpdocumentor-search__field:focus,
+.phpdocumentor-search__field {
+    margin-bottom: 0;
+    border: 0;
+    border-bottom: 2px solid var(--primary-color);
+    padding: 0;
+    border-radius: 0;
+    flex: 1;
+}
+
+@media (min-width: 1000px) {
+    .phpdocumentor-search {
+        min-width: auto;
+        max-width: 20rem;
+        margin: 0 0 0 auto;
+    }
+}
+.phpdocumentor-content {
+    position: relative;
+}
+
+.phpdocumentor-search-results {
+    backdrop-filter: blur(5px);
+    background: var(--popover-background-color);
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 0;
+    opacity: 1;
+    pointer-events: all;
+
+    transition: opacity .3s, background .3s;
+}
+
+.phpdocumentor-search-results--hidden {
+    background: transparent;
+    backdrop-filter: blur(0);
+    opacity: 0;
+    pointer-events: none;
+}
+
+.phpdocumentor-search-results__dialog {
+    width: 100%;
+    background: white;
+    max-height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.phpdocumentor-search-results__body {
+    overflow: auto;
+}
+
+.phpdocumentor-search-results__header {
+    padding: var(--spacing-lg);
+    display: flex;
+    justify-content: space-between;
+    background: var(--primary-color-darken);
+    color: white;
+    align-items: center;
+}
+
+.phpdocumentor-search-results__close {
+    font-size: var(--text-xl);
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+}
+
+.phpdocumentor  .phpdocumentor-search-results__title {
+    font-size: var(--text-xl);
+    margin-bottom: 0;
+}
+
+.phpdocumentor-search-results__entries {
+    list-style: none;
+    padding: 0 var(--spacing-lg);
+    margin: 0;
+}
+
+.phpdocumentor-search-results__entry {
+    border-bottom: 1px solid var(--table-separator-color);
+    padding: var(--spacing-sm) 0;
+    text-align: left;
+}
+
+.phpdocumentor-search-results__entry a {
+    display: block;
+}
+
+.phpdocumentor-search-results__entry small {
+    margin-top: var(--spacing-xs);
+    margin-bottom: var(--spacing-md);
+    color: var(--primary-color-darker);
+    display: block;
+    word-break: break-word;
+}
+
+.phpdocumentor-search-results__entry h3 {
+    font-size: var(--text-lg);
+    margin: 0;
+}
+
+@media (min-width: 550px) {
+    .phpdocumentor-search-results {
+        padding: 0 var(--spacing-lg);
+    }
+
+    .phpdocumentor-search-results__entry h3 {
+        font-size: var(--text-xxl);
+    }
+
+    .phpdocumentor-search-results__dialog {
+        margin: var(--spacing-xl) auto;
+        max-width: 40rem;
+        background: white;
+        border: 1px solid silver;
+        box-shadow: 0 2px 5px silver;
+        max-height: 40rem;
+        border-radius: 3px;
+    }
+}
+.phpdocumentor-modal {
+    position: fixed;
+    width: 100vw;
+    height: 100vh;
+    opacity: 0;
+    visibility: hidden;
+    transition: all 0.3s ease;
+    top: 0;
+    left: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.phpdocumentor-modal__open {
+    visibility: visible;
+    opacity: 1;
+    transition-delay: 0s;
+}
+
+.phpdocumentor-modal-bg {
+    position: absolute;
+    background: gray;
+    opacity: 50%;
+    width: 100%;
+    height: 100%;
+}
+
+.phpdocumentor-modal-container {
+    border-radius: 1em;
+    background: #fff;
+    position: relative;
+    padding: 2em;
+    box-sizing: border-box;
+    max-width:100vw;
+}
+
+.phpdocumentor-modal__close {
+    position: absolute;
+    right: 0.75em;
+    top: 0.75em;
+    outline: none;
+    appearance: none;
+    color: var(--primary-color);
+    background: none;
+    border: 0px;
+    font-weight: bold;
+    cursor: pointer;
+}
+
 /* Used for screen readers and such */
 .visually-hidden {
     display: none;
+}
+
+.float-right {
+    float: right;
+}
+
+.float-left {
+    float: left;
 }

--- a/docs/phpdoc/css/normalize.css
+++ b/docs/phpdoc/css/normalize.css
@@ -230,7 +230,7 @@ code,
 kbd,
 pre,
 samp {
-    font-family: monospace, monospace;
+    font-family: var(--font-monospace);
     font-size: 1em;
 }
 

--- a/docs/phpdoc/css/template.css
+++ b/docs/phpdoc/css/template.css
@@ -142,59 +142,13 @@
     content: 'P'
 }
 
+.phpdocumentor-table-of-contents .phpdocumentor-table-of-contents__entry.-enum:before {
+    content: 'E'
+}
+
 .phpdocumentor-table-of-contents dd {
     font-style: italic;
     margin-left: 2rem;
-}
-.phpdocumentor-content {
-    position: relative;
-}
-
-.phpdocumentor-search-results {
-    backdrop-filter: blur(5px);
-    background: var(--popover-background-color);
-    min-height: 100%;
-    left: calc(var(--spacing-lg) * -1);
-    position: absolute;
-    right: calc(var(--spacing-lg) * -1);
-    top: 0;
-    padding: 0 var(--spacing-lg);
-    opacity: 1;
-    pointer-events: all;
-
-    transition: opacity .3s, background .3s;
-}
-
-.phpdocumentor-search-results--hidden {
-    background: transparent;
-    backdrop-filter: blur(0);
-    opacity: 0;
-    pointer-events: none;
-}
-
-.phpdocumentor-search-results__entries {
-    list-style: none;
-    padding: 0;
-}
-
-.phpdocumentor-search-results__entry {
-    border-bottom: 1px solid var(--table-separator-color);
-    padding: var(--spacing-sm) var(--spacing-md);
-    text-align: left;
-}
-
-.phpdocumentor-search-results__entry a {
-    display: block;
-}
-
-.phpdocumentor-search-results__entry small {
-    margin-top: var(--spacing-xs);
-    margin-bottom: var(--spacing-md);
-    color: var(--primary-color-darker);
-    display: block;
-}
-.phpdocumentor-search-results__entry h3 {
-    margin: 0;
 }
 .phpdocumentor-element-found-in {
     position: absolute;
@@ -202,6 +156,25 @@
     right: 0;
     font-size: var(--text-sm);
     color: gray;
+}
+
+.phpdocumentor-element-found-in .phpdocumentor-element-found-in__source {
+    flex: 0 1 auto;
+    display: inline-flex;
+}
+
+.phpdocumentor-element-found-in .phpdocumentor-element-found-in__source:after {
+    width: 1.25rem;
+    height: 1.25rem;
+    line-height: 1.25rem;
+    background: transparent url('data:image/svg+xml;utf8,<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="gray"><path d="M5.854 4.854a.5.5 0 1 0-.708-.708l-3.5 3.5a.5.5 0 0 0 0 .708l3.5 3.5a.5.5 0 0 0 .708-.708L2.707 8l3.147-3.146zm4.292 0a.5.5 0 0 1 .708-.708l3.5 3.5a.5.5 0 0 1 0 .708l-3.5 3.5a.5.5 0 0 1-.708-.708L13.293 8l-3.147-3.146z" stroke="gray" stroke-width="1.4"/></svg>') no-repeat center center;
+    content: '';
+    left: 0;
+    border-radius: 50%;
+    font-weight: 600;
+    text-align: center;
+    font-size: .75rem;
+    margin-top: .2rem;
 }
 .phpdocumentor-class-graph {
     width: 100%; height: 600px; border:1px solid black; overflow: hidden

--- a/docs/phpdoc/files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html
+++ b/docs/phpdoc/files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">AbstractArrayDeclarationSniff.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html"><abbr title="\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff">AbstractArrayDeclarationSniff</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html"><abbr title="\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff">AbstractArrayDeclarationSniff</abbr></a></dt>
         <dd>Abstract sniff to easily examine all parts of an array declaration.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html
+++ b/docs/phpdoc/files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-autoload.html
+++ b/docs/phpdoc/files/phpcsutils-autoload.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,30 +114,231 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">phpcsutils-autoload.php</h2>
 
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+    <section class="phpdocumentor-description"><p>Autoloader for the PHPCSUtils files.
+Also provides PHPCS cross-version class aliases.</p>
+<ul>
+<li>
+<p>If an external standard only supports PHPCS &gt;= 3.1.0 and uses the PHPCS
+native unit test framework, this file does not need to be included.</p>
+</li>
+<li>
+<p>When PHPCS 2.x support is desired, include the <code class="prettyprint">&quot;PHPCS23Utils&quot;</code> standard
+in the ruleset of the external standard and this file will be included
+automatically.
+Including this file will allow PHPCSUtils to work in both PHPCS 2.x
+as well as PHPCS 3.x.</p>
+</li>
+<li>
+<p>If an external standard uses its own unit test setup, this file should
+be included from the unit test bootstrap file.</p>
+</li>
+<li>
+<p>If an external standard uses the PHPCSUtils <a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html"><abbr title="\PHPCSUtils\TestUtils\UtilityMethodTestCase">UtilityMethodTestCase</abbr></a>
+class to test their own utility methods, this file should be included from
+the unit test bootstrap file.</p>
+</li>
+</ul>
+</section>
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">since</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                            <span class="phpdocumentor-tag-link">1.0.0</span>
+                                                                                
+                                             
+                                    </dd>
+                        </dl>
+
+
+
+
+
+
+<h3 id="toc">
+    Table of Contents
+    <a href="#toc" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
+    <a href="namespaces/default.html#constant_PHPCSUTILS_AUTOLOAD">PHPCSUTILS_AUTOLOAD</a>
+    <span>
+        &nbsp;= \true                            </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
+    <a href="namespaces/default.html#constant_PHPCSUTILS_PHPCS_ALIASES_SET">PHPCSUTILS_PHPCS_ALIASES_SET</a>
+    <span>
+        &nbsp;= \true                            </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
+    <a href="namespaces/default.html#constant_PHPCSUTILS_PHPUNIT_ALIASES_SET">PHPCSUTILS_PHPUNIT_ALIASES_SET</a>
+    <span>
+        &nbsp;= \true                            </span>
+</dt>
+<dd></dd>
+
+                    </dl>
+
+
+
         
+    <section class="phpdocumentor-constants">
+        <h3 class="phpdocumentor-elements__header" id="constants">
+            Constants
+            <a href="files/phpcsutils-autoload.html#constants" class="headerlink"><i class="fas fa-link"></i></a>
+        </h3>
+                    <article class="phpdocumentor-element -constant -public ">
+    <h4 class="phpdocumentor-element__name" id="constant_PHPCSUTILS_AUTOLOAD">
+        PHPCSUTILS_AUTOLOAD
+        <a href="namespaces/default.html#constant_PHPCSUTILS_AUTOLOAD" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="phpcsutils-autoload.php"><a href="files/phpcsutils-autoload.html"><abbr title="phpcsutils-autoload.php">phpcsutils-autoload.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">52</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-signature phpdocumentor-code ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+        <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__name">PHPCSUTILS_AUTOLOAD</span>
+    = <span class="phpdocumentor-signature__default-value">\true</span>
+</code>
 
 
+        <section class="phpdocumentor-description"></section>
+
+        <section class="phpdocumentor-description"></section>
+
+    
+
+</article>
+                    <article class="phpdocumentor-element -constant -public ">
+    <h4 class="phpdocumentor-element__name" id="constant_PHPCSUTILS_PHPCS_ALIASES_SET">
+        PHPCSUTILS_PHPCS_ALIASES_SET
+        <a href="namespaces/default.html#constant_PHPCSUTILS_PHPCS_ALIASES_SET" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="phpcsutils-autoload.php"><a href="files/phpcsutils-autoload.html"><abbr title="phpcsutils-autoload.php">phpcsutils-autoload.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">98</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-signature phpdocumentor-code ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+        <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__name">PHPCSUTILS_PHPCS_ALIASES_SET</span>
+    = <span class="phpdocumentor-signature__default-value">\true</span>
+</code>
 
 
+        <section class="phpdocumentor-description"></section>
 
-        
+        <section class="phpdocumentor-description"></section>
+
+    
+
+</article>
+                    <article class="phpdocumentor-element -constant -public ">
+    <h4 class="phpdocumentor-element__name" id="constant_PHPCSUTILS_PHPUNIT_ALIASES_SET">
+        PHPCSUTILS_PHPUNIT_ALIASES_SET
+        <a href="namespaces/default.html#constant_PHPCSUTILS_PHPUNIT_ALIASES_SET" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="phpcsutils-autoload.php"><a href="files/phpcsutils-autoload.html"><abbr title="phpcsutils-autoload.php">phpcsutils-autoload.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">119</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-signature phpdocumentor-code ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+        <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__name">PHPCSUTILS_PHPUNIT_ALIASES_SET</span>
+    = <span class="phpdocumentor-signature__default-value">\true</span>
+</code>
+
+
+        <section class="phpdocumentor-description"></section>
+
+        <section class="phpdocumentor-description"></section>
+
+    
+
+</article>
+            </section>
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-autoload.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-autoload.html
+++ b/docs/phpdoc/files/phpcsutils-autoload.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-backcompat-bcfile.html
+++ b/docs/phpdoc/files/phpcsutils-backcompat-bcfile.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,206 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">BCFile.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> <p>The methods in this class are imported from the PHP_CodeSniffer project.
+Note: this is not a one-on-one import of the <code class="prettyprint">File</code> class!</p>
+<p>Copyright of the original code in this class as per the import:</p>
+ </a>
+                    
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">author</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Greg Sherwood <a href="mailto:gsherwood@squiz.net">gsherwood@squiz.net</a></p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">author</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Jaroslav Hanslík <a href="mailto:kukulich@kukulich.cz">kukulich@kukulich.cz</a></p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">author</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>jdavis <a href="mailto:jdavis@bamboohr.com">jdavis@bamboohr.com</a></p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">author</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Klaus Purer <a href="mailto:klaus.purer@gmail.com">klaus.purer@gmail.com</a></p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">author</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Juliette Reinders Folmer <a href="mailto:jrf@phpcodesniffer.info">jrf@phpcodesniffer.info</a></p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">author</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Nick Wilde <a href="mailto:nick@briarmoon.ca">nick@briarmoon.ca</a></p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">author</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Martin Hujer <a href="mailto:mhujer@gmail.com">mhujer@gmail.com</a></p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">author</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Chris Wilkinson <a href="mailto:c.wilkinson@elifesciences.org">c.wilkinson@elifesciences.org</a></p>
+<p>With documentation contributions from:</p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">author</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Pascal Borreli <a href="mailto:pascal@borreli.com">pascal@borreli.com</a></p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">author</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Diogo Oliveira de Melo <a href="mailto:dmelo87@gmail.com">dmelo87@gmail.com</a></p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">author</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Stefano Kowalke <a href="mailto:blueduck@gmx.net">blueduck@gmx.net</a></p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">author</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>George Mponos <a href="mailto:gmponos@gmail.com">gmponos@gmail.com</a></p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">author</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Tyson Andre <a href="mailto:tysonandre775@hotmail.com">tysonandre775@hotmail.com</a></p>
+</section>
+
+                                    </dd>
+                            <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">author</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>Klaus Purer <a href="mailto:klaus.purer@protonmail.ch">klaus.purer@protonmail.ch</a></p>
+</section>
+
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-BackCompat-BCFile.html"><abbr title="\PHPCSUtils\BackCompat\BCFile">BCFile</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-BackCompat-BCFile.html"><abbr title="\PHPCSUtils\BackCompat\BCFile">BCFile</abbr></a></dt>
         <dd>PHPCS native utility functions.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +322,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-backcompat-bcfile.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-backcompat-bcfile.html
+++ b/docs/phpdoc/files/phpcsutils-backcompat-bcfile.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-backcompat-bctokens.html
+++ b/docs/phpdoc/files/phpcsutils-backcompat-bctokens.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">BCTokens.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-BackCompat-BCTokens.html"><abbr title="\PHPCSUtils\BackCompat\BCTokens">BCTokens</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-BackCompat-BCTokens.html"><abbr title="\PHPCSUtils\BackCompat\BCTokens">BCTokens</abbr></a></dt>
         <dd>Token arrays related utility methods.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-backcompat-bctokens.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-backcompat-bctokens.html
+++ b/docs/phpdoc/files/phpcsutils-backcompat-bctokens.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-backcompat-helper.html
+++ b/docs/phpdoc/files/phpcsutils-backcompat-helper.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">Helper.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-BackCompat-Helper.html"><abbr title="\PHPCSUtils\BackCompat\Helper">Helper</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-BackCompat-Helper.html"><abbr title="\PHPCSUtils\BackCompat\Helper">Helper</abbr></a></dt>
         <dd>Utility methods to retrieve (configuration) information from PHP_CodeSniffer.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-backcompat-helper.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-backcompat-helper.html
+++ b/docs/phpdoc/files/phpcsutils-backcompat-helper.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-exceptions-invalidtokenarray.html
+++ b/docs/phpdoc/files/phpcsutils-exceptions-invalidtokenarray.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+            <title>PHPCSUtils</title>
+    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
+                <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
+        <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
+    </head>
+<body id="top">
+    <header class="phpdocumentor-header phpdocumentor-section">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
+    <section data-search-form class="phpdocumentor-search">
+    <label>
+        <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
+        <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
+    </label>
+</section>
+
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
+
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
+                        </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
+
+                        </section>
+            
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
+    </section>
+
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
+    </section>
+</aside>
+
+            <div class="phpdocumentor-column -eight phpdocumentor-content">
+                    <ul class="phpdocumentor-breadcrumbs">
+    </ul>
+
+    <article class="phpdocumentor-element -file">
+        <h2 class="phpdocumentor-content__title">InvalidTokenArray.php</h2>
+
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
+
+<h3 id="interfaces_class_traits">
+    Interfaces, Classes, Traits and Enums
+    <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+    
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Exceptions-InvalidTokenArray.html"><abbr title="\PHPCSUtils\Exceptions\InvalidTokenArray">InvalidTokenArray</abbr></a></dt>
+        <dd>Exception thrown when an non-existent token array is requested.</dd>
+    
+    
+    </dl>
+
+
+
+
+
+        
+
+        
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
+            </div>
+        </div>
+        <a href="files/phpcsutils-exceptions-invalidtokenarray.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+
+    </main>
+
+    <script>
+        cssVars({});
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
+</body>
+</html>

--- a/docs/phpdoc/files/phpcsutils-exceptions-testfilenotfound.html
+++ b/docs/phpdoc/files/phpcsutils-exceptions-testfilenotfound.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+            <title>PHPCSUtils</title>
+    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
+                <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
+        <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
+    </head>
+<body id="top">
+    <header class="phpdocumentor-header phpdocumentor-section">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
+    <section data-search-form class="phpdocumentor-search">
+    <label>
+        <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
+        <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
+    </label>
+</section>
+
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
+
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
+                        </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
+
+                        </section>
+            
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
+    </section>
+
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
+    </section>
+</aside>
+
+            <div class="phpdocumentor-column -eight phpdocumentor-content">
+                    <ul class="phpdocumentor-breadcrumbs">
+    </ul>
+
+    <article class="phpdocumentor-element -file">
+        <h2 class="phpdocumentor-content__title">TestFileNotFound.php</h2>
+
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
+
+<h3 id="interfaces_class_traits">
+    Interfaces, Classes, Traits and Enums
+    <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+    
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Exceptions-TestFileNotFound.html"><abbr title="\PHPCSUtils\Exceptions\TestFileNotFound">TestFileNotFound</abbr></a></dt>
+        <dd>Exception thrown when the UtilityMethodTestCase::getTargetToken() method is run without a
+tokenized test case file being available.</dd>
+    
+    
+    </dl>
+
+
+
+
+
+        
+
+        
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
+            </div>
+        </div>
+        <a href="files/phpcsutils-exceptions-testfilenotfound.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+
+    </main>
+
+    <script>
+        cssVars({});
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
+</body>
+</html>

--- a/docs/phpdoc/files/phpcsutils-exceptions-testmarkernotfound.html
+++ b/docs/phpdoc/files/phpcsutils-exceptions-testmarkernotfound.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+            <title>PHPCSUtils</title>
+    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
+                <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
+        <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
+    </head>
+<body id="top">
+    <header class="phpdocumentor-header phpdocumentor-section">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
+    <section data-search-form class="phpdocumentor-search">
+    <label>
+        <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
+        <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
+    </label>
+</section>
+
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
+
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
+                        </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
+
+                        </section>
+            
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
+    </section>
+
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
+    </section>
+</aside>
+
+            <div class="phpdocumentor-column -eight phpdocumentor-content">
+                    <ul class="phpdocumentor-breadcrumbs">
+    </ul>
+
+    <article class="phpdocumentor-element -file">
+        <h2 class="phpdocumentor-content__title">TestMarkerNotFound.php</h2>
+
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
+
+<h3 id="interfaces_class_traits">
+    Interfaces, Classes, Traits and Enums
+    <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+    
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Exceptions-TestMarkerNotFound.html"><abbr title="\PHPCSUtils\Exceptions\TestMarkerNotFound">TestMarkerNotFound</abbr></a></dt>
+        <dd>Exception thrown when a delimiter comment can not be found in a test case file.</dd>
+    
+    
+    </dl>
+
+
+
+
+
+        
+
+        
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
+            </div>
+        </div>
+        <a href="files/phpcsutils-exceptions-testmarkernotfound.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+
+    </main>
+
+    <script>
+        cssVars({});
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
+</body>
+</html>

--- a/docs/phpdoc/files/phpcsutils-exceptions-testtargetnotfound.html
+++ b/docs/phpdoc/files/phpcsutils-exceptions-testtargetnotfound.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+            <title>PHPCSUtils</title>
+    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
+                <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
+        <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
+    </head>
+<body id="top">
+    <header class="phpdocumentor-header phpdocumentor-section">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
+    <section data-search-form class="phpdocumentor-search">
+    <label>
+        <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
+        <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
+    </label>
+</section>
+
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
+
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
+                        </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
+
+                        </section>
+            
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
+    </section>
+
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
+    </section>
+</aside>
+
+            <div class="phpdocumentor-column -eight phpdocumentor-content">
+                    <ul class="phpdocumentor-breadcrumbs">
+    </ul>
+
+    <article class="phpdocumentor-element -file">
+        <h2 class="phpdocumentor-content__title">TestTargetNotFound.php</h2>
+
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
+
+<h3 id="interfaces_class_traits">
+    Interfaces, Classes, Traits and Enums
+    <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+    
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Exceptions-TestTargetNotFound.html"><abbr title="\PHPCSUtils\Exceptions\TestTargetNotFound">TestTargetNotFound</abbr></a></dt>
+        <dd>Exception thrown when a test target token can not be found in a test case file.</dd>
+    
+    
+    </dl>
+
+
+
+
+
+        
+
+        
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
+            </div>
+        </div>
+        <a href="files/phpcsutils-exceptions-testtargetnotfound.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+
+    </main>
+
+    <script>
+        cssVars({});
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
+</body>
+</html>

--- a/docs/phpdoc/files/phpcsutils-fixers-spacesfixer.html
+++ b/docs/phpdoc/files/phpcsutils-fixers-spacesfixer.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">SpacesFixer.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Fixers-SpacesFixer.html"><abbr title="\PHPCSUtils\Fixers\SpacesFixer">SpacesFixer</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Fixers-SpacesFixer.html"><abbr title="\PHPCSUtils\Fixers\SpacesFixer">SpacesFixer</abbr></a></dt>
         <dd>Utility to check and, if necessary, fix the whitespace between two tokens.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-fixers-spacesfixer.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-fixers-spacesfixer.html
+++ b/docs/phpdoc/files/phpcsutils-fixers-spacesfixer.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-testutils-utilitymethodtestcase.html
+++ b/docs/phpdoc/files/phpcsutils-testutils-utilitymethodtestcase.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">UtilityMethodTestCase.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html"><abbr title="\PHPCSUtils\TestUtils\UtilityMethodTestCase">UtilityMethodTestCase</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html"><abbr title="\PHPCSUtils\TestUtils\UtilityMethodTestCase">UtilityMethodTestCase</abbr></a></dt>
         <dd>Base class for use when testing utility methods for PHP_CodeSniffer.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-testutils-utilitymethodtestcase.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-testutils-utilitymethodtestcase.html
+++ b/docs/phpdoc/files/phpcsutils-testutils-utilitymethodtestcase.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-tokens-collections.html
+++ b/docs/phpdoc/files/phpcsutils-tokens-collections.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">Collections.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Tokens-Collections.html"><abbr title="\PHPCSUtils\Tokens\Collections">Collections</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Tokens-Collections.html"><abbr title="\PHPCSUtils\Tokens\Collections">Collections</abbr></a></dt>
         <dd>Collections of related tokens as often used and needed for sniffs.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-tokens-collections.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-tokens-collections.html
+++ b/docs/phpdoc/files/phpcsutils-tokens-collections.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-tokens-tokenhelper.html
+++ b/docs/phpdoc/files/phpcsutils-tokens-tokenhelper.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+            <title>PHPCSUtils</title>
+    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
+                <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
+        <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
+    </head>
+<body id="top">
+    <header class="phpdocumentor-header phpdocumentor-section">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
+    <section data-search-form class="phpdocumentor-search">
+    <label>
+        <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
+        <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
+    </label>
+</section>
+
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
+
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
+                        </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
+
+                        </section>
+            
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
+    </section>
+
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
+    </section>
+</aside>
+
+            <div class="phpdocumentor-column -eight phpdocumentor-content">
+                    <ul class="phpdocumentor-breadcrumbs">
+    </ul>
+
+    <article class="phpdocumentor-element -file">
+        <h2 class="phpdocumentor-content__title">TokenHelper.php</h2>
+
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
+
+<h3 id="interfaces_class_traits">
+    Interfaces, Classes, Traits and Enums
+    <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+    
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Tokens-TokenHelper.html"><abbr title="\PHPCSUtils\Tokens\TokenHelper">TokenHelper</abbr></a></dt>
+        <dd>Helpers for working with tokens.</dd>
+    
+    
+    </dl>
+
+
+
+
+
+        
+
+        
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
+            </div>
+        </div>
+        <a href="files/phpcsutils-tokens-tokenhelper.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+
+    </main>
+
+    <script>
+        cssVars({});
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
+</body>
+</html>

--- a/docs/phpdoc/files/phpcsutils-utils-arrays.html
+++ b/docs/phpdoc/files/phpcsutils-utils-arrays.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">Arrays.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Arrays.html"><abbr title="\PHPCSUtils\Utils\Arrays">Arrays</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Arrays.html"><abbr title="\PHPCSUtils\Utils\Arrays">Arrays</abbr></a></dt>
         <dd>Utility functions for use when examining arrays.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-utils-arrays.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-utils-arrays.html
+++ b/docs/phpdoc/files/phpcsutils-utils-arrays.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-utils-conditions.html
+++ b/docs/phpdoc/files/phpcsutils-utils-conditions.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">Conditions.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Conditions.html"><abbr title="\PHPCSUtils\Utils\Conditions">Conditions</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Conditions.html"><abbr title="\PHPCSUtils\Utils\Conditions">Conditions</abbr></a></dt>
         <dd>Utility functions for use when examining token conditions.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-utils-conditions.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-utils-conditions.html
+++ b/docs/phpdoc/files/phpcsutils-utils-conditions.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-utils-context.html
+++ b/docs/phpdoc/files/phpcsutils-utils-context.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+            <title>PHPCSUtils</title>
+    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
+                <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
+        <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
+    </head>
+<body id="top">
+    <header class="phpdocumentor-header phpdocumentor-section">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
+    <section data-search-form class="phpdocumentor-search">
+    <label>
+        <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
+        <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
+    </label>
+</section>
+
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
+
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
+                        </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
+
+                        </section>
+            
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
+    </section>
+
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
+    </section>
+</aside>
+
+            <div class="phpdocumentor-column -eight phpdocumentor-content">
+                    <ul class="phpdocumentor-breadcrumbs">
+    </ul>
+
+    <article class="phpdocumentor-element -file">
+        <h2 class="phpdocumentor-content__title">Context.php</h2>
+
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
+
+<h3 id="interfaces_class_traits">
+    Interfaces, Classes, Traits and Enums
+    <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+    
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Context.html"><abbr title="\PHPCSUtils\Utils\Context">Context</abbr></a></dt>
+        <dd>Utility functions for examining in which context a certain token is used.</dd>
+    
+    
+    </dl>
+
+
+
+
+
+        
+
+        
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
+            </div>
+        </div>
+        <a href="files/phpcsutils-utils-context.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+
+    </main>
+
+    <script>
+        cssVars({});
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
+</body>
+</html>

--- a/docs/phpdoc/files/phpcsutils-utils-controlstructures.html
+++ b/docs/phpdoc/files/phpcsutils-utils-controlstructures.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">ControlStructures.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-ControlStructures.html"><abbr title="\PHPCSUtils\Utils\ControlStructures">ControlStructures</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-ControlStructures.html"><abbr title="\PHPCSUtils\Utils\ControlStructures">ControlStructures</abbr></a></dt>
         <dd>Utility functions for use when examining control structures.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-utils-controlstructures.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-utils-controlstructures.html
+++ b/docs/phpdoc/files/phpcsutils-utils-controlstructures.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-utils-functiondeclarations.html
+++ b/docs/phpdoc/files/phpcsutils-utils-functiondeclarations.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">FunctionDeclarations.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations">FunctionDeclarations</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations">FunctionDeclarations</abbr></a></dt>
         <dd>Utility functions for use when examining function declaration statements.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-utils-functiondeclarations.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-utils-functiondeclarations.html
+++ b/docs/phpdoc/files/phpcsutils-utils-functiondeclarations.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-utils-gettokensasstring.html
+++ b/docs/phpdoc/files/phpcsutils-utils-gettokensasstring.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">GetTokensAsString.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-GetTokensAsString.html"><abbr title="\PHPCSUtils\Utils\GetTokensAsString">GetTokensAsString</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-GetTokensAsString.html"><abbr title="\PHPCSUtils\Utils\GetTokensAsString">GetTokensAsString</abbr></a></dt>
         <dd>Utility functions to retrieve the content of a set of tokens as a string.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-utils-gettokensasstring.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-utils-gettokensasstring.html
+++ b/docs/phpdoc/files/phpcsutils-utils-gettokensasstring.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-utils-lists.html
+++ b/docs/phpdoc/files/phpcsutils-utils-lists.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">Lists.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Lists.html"><abbr title="\PHPCSUtils\Utils\Lists">Lists</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Lists.html"><abbr title="\PHPCSUtils\Utils\Lists">Lists</abbr></a></dt>
         <dd>Utility functions to retrieve information when working with lists.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-utils-lists.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-utils-lists.html
+++ b/docs/phpdoc/files/phpcsutils-utils-lists.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-utils-messagehelper.html
+++ b/docs/phpdoc/files/phpcsutils-utils-messagehelper.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+            <title>PHPCSUtils</title>
+    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
+                <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
+        <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
+    </head>
+<body id="top">
+    <header class="phpdocumentor-header phpdocumentor-section">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
+    <section data-search-form class="phpdocumentor-search">
+    <label>
+        <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
+        <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
+    </label>
+</section>
+
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
+
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
+                        </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
+
+                        </section>
+            
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
+    </section>
+
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
+    </section>
+</aside>
+
+            <div class="phpdocumentor-column -eight phpdocumentor-content">
+                    <ul class="phpdocumentor-breadcrumbs">
+    </ul>
+
+    <article class="phpdocumentor-element -file">
+        <h2 class="phpdocumentor-content__title">MessageHelper.php</h2>
+
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
+
+<h3 id="interfaces_class_traits">
+    Interfaces, Classes, Traits and Enums
+    <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+    
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-MessageHelper.html"><abbr title="\PHPCSUtils\Utils\MessageHelper">MessageHelper</abbr></a></dt>
+        <dd>Helper functions for creating PHPCS error/warning messages.</dd>
+    
+    
+    </dl>
+
+
+
+
+
+        
+
+        
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
+            </div>
+        </div>
+        <a href="files/phpcsutils-utils-messagehelper.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+
+    </main>
+
+    <script>
+        cssVars({});
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
+</body>
+</html>

--- a/docs/phpdoc/files/phpcsutils-utils-namespaces.html
+++ b/docs/phpdoc/files/phpcsutils-utils-namespaces.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,20 +114,59 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">Namespaces.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Namespaces.html"><abbr title="\PHPCSUtils\Utils\Namespaces">Namespaces</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Namespaces.html"><abbr title="\PHPCSUtils\Utils\Namespaces">Namespaces</abbr></a></dt>
         <dd>Utility functions for use when examining T_NAMESPACE tokens and to determine the
 namespace of arbitrary tokens.</dd>
     
+    
     </dl>
+
 
 
 
@@ -92,20 +175,29 @@ namespace of arbitrary tokens.</dd>
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-utils-namespaces.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-utils-namespaces.html
+++ b/docs/phpdoc/files/phpcsutils-utils-namespaces.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-utils-namingconventions.html
+++ b/docs/phpdoc/files/phpcsutils-utils-namingconventions.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">NamingConventions.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-NamingConventions.html"><abbr title="\PHPCSUtils\Utils\NamingConventions">NamingConventions</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-NamingConventions.html"><abbr title="\PHPCSUtils\Utils\NamingConventions">NamingConventions</abbr></a></dt>
         <dd>Utility functions for working with identifier names.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-utils-namingconventions.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-utils-namingconventions.html
+++ b/docs/phpdoc/files/phpcsutils-utils-namingconventions.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-utils-numbers.html
+++ b/docs/phpdoc/files/phpcsutils-utils-numbers.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">Numbers.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Numbers.html"><abbr title="\PHPCSUtils\Utils\Numbers">Numbers</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Numbers.html"><abbr title="\PHPCSUtils\Utils\Numbers">Numbers</abbr></a></dt>
         <dd>Utility functions for working with integer/float tokens.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-utils-numbers.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-utils-numbers.html
+++ b/docs/phpdoc/files/phpcsutils-utils-numbers.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-utils-objectdeclarations.html
+++ b/docs/phpdoc/files/phpcsutils-utils-objectdeclarations.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">ObjectDeclarations.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-ObjectDeclarations.html"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations">ObjectDeclarations</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations">ObjectDeclarations</abbr></a></dt>
         <dd>Utility functions for use when examining object declaration statements.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-utils-objectdeclarations.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-utils-objectdeclarations.html
+++ b/docs/phpdoc/files/phpcsutils-utils-objectdeclarations.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-utils-operators.html
+++ b/docs/phpdoc/files/phpcsutils-utils-operators.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">Operators.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Operators.html"><abbr title="\PHPCSUtils\Utils\Operators">Operators</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Operators.html"><abbr title="\PHPCSUtils\Utils\Operators">Operators</abbr></a></dt>
         <dd>Utility functions for use when working with operators.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-utils-operators.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-utils-operators.html
+++ b/docs/phpdoc/files/phpcsutils-utils-operators.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-utils-orthography.html
+++ b/docs/phpdoc/files/phpcsutils-utils-orthography.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">Orthography.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Orthography.html"><abbr title="\PHPCSUtils\Utils\Orthography">Orthography</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Orthography.html"><abbr title="\PHPCSUtils\Utils\Orthography">Orthography</abbr></a></dt>
         <dd>Utility functions for checking the orthography of arbitrary text strings.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-utils-orthography.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-utils-orthography.html
+++ b/docs/phpdoc/files/phpcsutils-utils-orthography.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-utils-parentheses.html
+++ b/docs/phpdoc/files/phpcsutils-utils-parentheses.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,20 +114,59 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">Parentheses.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Parentheses.html"><abbr title="\PHPCSUtils\Utils\Parentheses">Parentheses</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Parentheses.html"><abbr title="\PHPCSUtils\Utils\Parentheses">Parentheses</abbr></a></dt>
         <dd>Utility functions for use when examining parenthesis tokens and arbitrary tokens wrapped in
 parentheses.</dd>
     
+    
     </dl>
+
 
 
 
@@ -92,20 +175,29 @@ parentheses.</dd>
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-utils-parentheses.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-utils-parentheses.html
+++ b/docs/phpdoc/files/phpcsutils-utils-parentheses.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -161,8 +165,8 @@
 <dl class="phpdocumentor-table-of-contents">
     
             <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Parentheses.html"><abbr title="\PHPCSUtils\Utils\Parentheses">Parentheses</abbr></a></dt>
-        <dd>Utility functions for use when examining parenthesis tokens and arbitrary tokens wrapped in
-parentheses.</dd>
+        <dd>Utility functions for use when examining parenthesis tokens and arbitrary tokens wrapped
+in parentheses.</dd>
     
     
     </dl>

--- a/docs/phpdoc/files/phpcsutils-utils-passedparameters.html
+++ b/docs/phpdoc/files/phpcsutils-utils-passedparameters.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -162,7 +166,7 @@
     
             <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-PassedParameters.html"><abbr title="\PHPCSUtils\Utils\PassedParameters">PassedParameters</abbr></a></dt>
         <dd>Utility functions to retrieve information about parameters passed to function calls,
-array declarations, isset and unset constructs.</dd>
+class instantiations, array declarations, isset and unset constructs.</dd>
     
     
     </dl>

--- a/docs/phpdoc/files/phpcsutils-utils-passedparameters.html
+++ b/docs/phpdoc/files/phpcsutils-utils-passedparameters.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,20 +114,59 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">PassedParameters.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-PassedParameters.html"><abbr title="\PHPCSUtils\Utils\PassedParameters">PassedParameters</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-PassedParameters.html"><abbr title="\PHPCSUtils\Utils\PassedParameters">PassedParameters</abbr></a></dt>
         <dd>Utility functions to retrieve information about parameters passed to function calls,
 array declarations, isset and unset constructs.</dd>
     
+    
     </dl>
+
 
 
 
@@ -92,20 +175,29 @@ array declarations, isset and unset constructs.</dd>
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-utils-passedparameters.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-utils-scopes.html
+++ b/docs/phpdoc/files/phpcsutils-utils-scopes.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-utils-scopes.html
+++ b/docs/phpdoc/files/phpcsutils-utils-scopes.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">Scopes.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Scopes.html"><abbr title="\PHPCSUtils\Utils\Scopes">Scopes</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Scopes.html"><abbr title="\PHPCSUtils\Utils\Scopes">Scopes</abbr></a></dt>
         <dd>Utility functions for use when examining token scopes.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-utils-scopes.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-utils-textstrings.html
+++ b/docs/phpdoc/files/phpcsutils-utils-textstrings.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">TextStrings.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-TextStrings.html"><abbr title="\PHPCSUtils\Utils\TextStrings">TextStrings</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-TextStrings.html"><abbr title="\PHPCSUtils\Utils\TextStrings">TextStrings</abbr></a></dt>
         <dd>Utility functions for working with text string tokens.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-utils-textstrings.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-utils-textstrings.html
+++ b/docs/phpdoc/files/phpcsutils-utils-textstrings.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-utils-usestatements.html
+++ b/docs/phpdoc/files/phpcsutils-utils-usestatements.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">UseStatements.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-UseStatements.html"><abbr title="\PHPCSUtils\Utils\UseStatements">UseStatements</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-UseStatements.html"><abbr title="\PHPCSUtils\Utils\UseStatements">UseStatements</abbr></a></dt>
         <dd>Utility functions for examining use statements.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-utils-usestatements.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-utils-usestatements.html
+++ b/docs/phpdoc/files/phpcsutils-utils-usestatements.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/files/phpcsutils-utils-variables.html
+++ b/docs/phpdoc/files/phpcsutils-utils-variables.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -70,19 +114,58 @@
     <article class="phpdocumentor-element -file">
         <h2 class="phpdocumentor-content__title">Variables.php</h2>
 
-        
+            <p class="phpdocumentor-summary">PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.</p>
+
+
+
+    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+        Tags
+        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+    </h5>
+    <dl class="phpdocumentor-tag-list">
+                                    <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">copyright</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>2019-2020 PHPCSUtils Contributors</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">license</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                
+                                                 <section class="phpdocumentor-description"><p>https://opensource.org/licenses/LGPL-3.0 LGPL3</p>
+</section>
+
+                                    </dd>
+                                                <dt class="phpdocumentor-tag-list__entry">
+                    <span class="phpdocumentor-tag__name">link</span>
+                </dt>
+                <dd class="phpdocumentor-tag-list__definition">
+                                                                                                        <a class="phpdocumentor-tag-link" href="https://github.com/PHPCSStandards/PHPCSUtils"> https://github.com/PHPCSStandards/PHPCSUtils </a>
+                    
+                                    </dd>
+                        </dl>
+
+
+
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Variables.html"><abbr title="\PHPCSUtils\Utils\Variables">Variables</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Variables.html"><abbr title="\PHPCSUtils\Utils\Variables">Variables</abbr></a></dt>
         <dd>Utility functions for use when examining variables.</dd>
     
+    
     </dl>
+
 
 
 
@@ -91,20 +174,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="files/phpcsutils-utils-variables.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/files/phpcsutils-utils-variables.html
+++ b/docs/phpdoc/files/phpcsutils-utils-variables.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/graphs/classes.html
+++ b/docs/phpdoc/graphs/classes.html
@@ -2,63 +2,103 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
             <script src='https://unpkg.com/panzoom@8.7.3/dist/panzoom.min.js'></script>
 </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <div class="phpdocumentor-class-graph">
-        <img class="phpdocumentor-class-graph__graph" src="classes.svg" id="scene" />
+        <img class="phpdocumentor-class-graph__graph" src="graphs/classes.svg" id="scene" />
     </div>
     <script type="text/javascript">
         var element = document.querySelector('#scene');
@@ -68,20 +108,29 @@
             smoothScroll: false
         })
     </script>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="graphs/classes.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/graphs/classes.html
+++ b/docs/phpdoc/graphs/classes.html
@@ -57,6 +57,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/index.html
+++ b/docs/phpdoc/index.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/index.html
+++ b/docs/phpdoc/index.html
@@ -2,54 +2,98 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    
     <link rel="icon" href="images/favicon.ico"/>
     <link rel="stylesheet" href="css/normalize.css">
     <link rel="stylesheet" href="css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
         <script src="js/search.js"></script>
         <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
                 <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
@@ -67,7 +111,15 @@
                     <h2>Documentation</h2>
 
     
-    
+    <h3 id="packages">
+    Packages
+    <a href="#packages" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+            <dt class="phpdocumentor-table-of-contents__entry -package"><a href="packages/PHPCSUtils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></dt>
+    </dl>
+
 <h3 id="namespaces">
     Namespaces
     <a href="#namespaces" class="headerlink"><i class="fas fa-link"></i></a>
@@ -79,24 +131,154 @@
 
 
 
+<h3 id="toc">
+    Table of Contents
+    <a href="#toc" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
+    <a href="namespaces/default.html#constant_PHPCSUTILS_AUTOLOAD">PHPCSUTILS_AUTOLOAD</a>
+    <span>
+        &nbsp;= \true                            </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
+    <a href="namespaces/default.html#constant_PHPCSUTILS_PHPCS_ALIASES_SET">PHPCSUTILS_PHPCS_ALIASES_SET</a>
+    <span>
+        &nbsp;= \true                            </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
+    <a href="namespaces/default.html#constant_PHPCSUTILS_PHPUNIT_ALIASES_SET">PHPCSUTILS_PHPUNIT_ALIASES_SET</a>
+    <span>
+        &nbsp;= \true                            </span>
+</dt>
+<dd></dd>
+
+                    </dl>
+
+    
+    <section class="phpdocumentor-constants">
+        <h3 class="phpdocumentor-elements__header" id="constants">
+            Constants
+            <a href="namespaces/default.html#constants" class="headerlink"><i class="fas fa-link"></i></a>
+        </h3>
+                    <article class="phpdocumentor-element -constant -public ">
+    <h4 class="phpdocumentor-element__name" id="constant_PHPCSUTILS_AUTOLOAD">
+        PHPCSUTILS_AUTOLOAD
+        <a href="namespaces/default.html#constant_PHPCSUTILS_AUTOLOAD" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="phpcsutils-autoload.php"><a href="files/phpcsutils-autoload.html"><abbr title="phpcsutils-autoload.php">phpcsutils-autoload.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">52</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-signature phpdocumentor-code ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+        <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__name">PHPCSUTILS_AUTOLOAD</span>
+    = <span class="phpdocumentor-signature__default-value">\true</span>
+</code>
+
+
+        <section class="phpdocumentor-description"></section>
+
+        <section class="phpdocumentor-description"></section>
 
     
 
-    
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+</article>
+                    <article class="phpdocumentor-element -constant -public ">
+    <h4 class="phpdocumentor-element__name" id="constant_PHPCSUTILS_PHPCS_ALIASES_SET">
+        PHPCSUTILS_PHPCS_ALIASES_SET
+        <a href="namespaces/default.html#constant_PHPCSUTILS_PHPCS_ALIASES_SET" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
 
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="phpcsutils-autoload.php"><a href="files/phpcsutils-autoload.html"><abbr title="phpcsutils-autoload.php">phpcsutils-autoload.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">98</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-signature phpdocumentor-code ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+        <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__name">PHPCSUTILS_PHPCS_ALIASES_SET</span>
+    = <span class="phpdocumentor-signature__default-value">\true</span>
+</code>
+
+
+        <section class="phpdocumentor-description"></section>
+
+        <section class="phpdocumentor-description"></section>
+
+    
+
+</article>
+                    <article class="phpdocumentor-element -constant -public ">
+    <h4 class="phpdocumentor-element__name" id="constant_PHPCSUTILS_PHPUNIT_ALIASES_SET">
+        PHPCSUTILS_PHPUNIT_ALIASES_SET
+        <a href="namespaces/default.html#constant_PHPCSUTILS_PHPUNIT_ALIASES_SET" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="phpcsutils-autoload.php"><a href="files/phpcsutils-autoload.html"><abbr title="phpcsutils-autoload.php">phpcsutils-autoload.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">119</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-signature phpdocumentor-code ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+        <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__name">PHPCSUTILS_PHPUNIT_ALIASES_SET</span>
+    = <span class="phpdocumentor-signature__default-value">\true</span>
+</code>
+
+
+        <section class="phpdocumentor-description"></section>
+
+        <section class="phpdocumentor-description"></section>
+
+    
+
+</article>
+            </section>
+
+    
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="index.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/indices/files.html
+++ b/docs/phpdoc/indices/files.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -124,6 +128,7 @@
         <ul class="phpdocumentor-list">
                     <li><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></li>
                     <li><a href="files/phpcsutils-utils-conditions.html"><abbr title="PHPCSUtils/Utils/Conditions.php">Conditions.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-utils-context.html"><abbr title="PHPCSUtils/Utils/Context.php">Context.php</abbr></a></li>
                     <li><a href="files/phpcsutils-utils-controlstructures.html"><abbr title="PHPCSUtils/Utils/ControlStructures.php">ControlStructures.php</abbr></a></li>
                 </ul>
                                                                             <h3>F</h3>
@@ -138,11 +143,19 @@
         <ul class="phpdocumentor-list">
                     <li><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></li>
                 </ul>
-                                                                                                <h3>L</h3>
+                                    <h3>I</h3>
+        <ul class="phpdocumentor-list">
+                    <li><a href="files/phpcsutils-exceptions-invalidtokenarray.html"><abbr title="PHPCSUtils/Exceptions/InvalidTokenArray.php">InvalidTokenArray.php</abbr></a></li>
+                </ul>
+                                                                            <h3>L</h3>
         <ul class="phpdocumentor-list">
                     <li><a href="files/phpcsutils-utils-lists.html"><abbr title="PHPCSUtils/Utils/Lists.php">Lists.php</abbr></a></li>
                 </ul>
-                                                        <h3>N</h3>
+                                    <h3>M</h3>
+        <ul class="phpdocumentor-list">
+                    <li><a href="files/phpcsutils-utils-messagehelper.html"><abbr title="PHPCSUtils/Utils/MessageHelper.php">MessageHelper.php</abbr></a></li>
+                </ul>
+                                    <h3>N</h3>
         <ul class="phpdocumentor-list">
                     <li><a href="files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></li>
                     <li><a href="files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></li>
@@ -167,7 +180,11 @@
                 </ul>
                                     <h3>T</h3>
         <ul class="phpdocumentor-list">
+                    <li><a href="files/phpcsutils-exceptions-testfilenotfound.html"><abbr title="PHPCSUtils/Exceptions/TestFileNotFound.php">TestFileNotFound.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-exceptions-testmarkernotfound.html"><abbr title="PHPCSUtils/Exceptions/TestMarkerNotFound.php">TestMarkerNotFound.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-exceptions-testtargetnotfound.html"><abbr title="PHPCSUtils/Exceptions/TestTargetNotFound.php">TestTargetNotFound.php</abbr></a></li>
                     <li><a href="files/phpcsutils-utils-textstrings.html"><abbr title="PHPCSUtils/Utils/TextStrings.php">TextStrings.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-tokens-tokenhelper.html"><abbr title="PHPCSUtils/Tokens/TokenHelper.php">TokenHelper.php</abbr></a></li>
                 </ul>
                                     <h3>U</h3>
         <ul class="phpdocumentor-list">

--- a/docs/phpdoc/indices/files.html
+++ b/docs/phpdoc/indices/files.html
@@ -2,152 +2,205 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     
-    <h2>Files</h2>
+    <h2 class="phpdocumentor-content__title">Files</h2>
                             <h3>A</h3>
         <ul class="phpdocumentor-list">
-                    <li><a href="../files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></li>
-                    <li><a href="../files/phpcsutils-utils-arrays.html"><abbr title="PHPCSUtils/Utils/Arrays.php">Arrays.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-abstractsniffs-abstractarraydeclarationsniff.html"><abbr title="PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php">AbstractArrayDeclarationSniff.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-utils-arrays.html"><abbr title="PHPCSUtils/Utils/Arrays.php">Arrays.php</abbr></a></li>
                 </ul>
                                     <h3>B</h3>
         <ul class="phpdocumentor-list">
-                    <li><a href="../files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></li>
-                    <li><a href="../files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-backcompat-bcfile.html"><abbr title="PHPCSUtils/BackCompat/BCFile.php">BCFile.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-backcompat-bctokens.html"><abbr title="PHPCSUtils/BackCompat/BCTokens.php">BCTokens.php</abbr></a></li>
                 </ul>
                                     <h3>C</h3>
         <ul class="phpdocumentor-list">
-                    <li><a href="../files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></li>
-                    <li><a href="../files/phpcsutils-utils-conditions.html"><abbr title="PHPCSUtils/Utils/Conditions.php">Conditions.php</abbr></a></li>
-                    <li><a href="../files/phpcsutils-utils-controlstructures.html"><abbr title="PHPCSUtils/Utils/ControlStructures.php">ControlStructures.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-tokens-collections.html"><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-utils-conditions.html"><abbr title="PHPCSUtils/Utils/Conditions.php">Conditions.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-utils-controlstructures.html"><abbr title="PHPCSUtils/Utils/ControlStructures.php">ControlStructures.php</abbr></a></li>
                 </ul>
                                                                             <h3>F</h3>
         <ul class="phpdocumentor-list">
-                    <li><a href="../files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-utils-functiondeclarations.html"><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></a></li>
                 </ul>
                                     <h3>G</h3>
         <ul class="phpdocumentor-list">
-                    <li><a href="../files/phpcsutils-utils-gettokensasstring.html"><abbr title="PHPCSUtils/Utils/GetTokensAsString.php">GetTokensAsString.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-utils-gettokensasstring.html"><abbr title="PHPCSUtils/Utils/GetTokensAsString.php">GetTokensAsString.php</abbr></a></li>
                 </ul>
                                     <h3>H</h3>
         <ul class="phpdocumentor-list">
-                    <li><a href="../files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-backcompat-helper.html"><abbr title="PHPCSUtils/BackCompat/Helper.php">Helper.php</abbr></a></li>
                 </ul>
                                                                                                 <h3>L</h3>
         <ul class="phpdocumentor-list">
-                    <li><a href="../files/phpcsutils-utils-lists.html"><abbr title="PHPCSUtils/Utils/Lists.php">Lists.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-utils-lists.html"><abbr title="PHPCSUtils/Utils/Lists.php">Lists.php</abbr></a></li>
                 </ul>
                                                         <h3>N</h3>
         <ul class="phpdocumentor-list">
-                    <li><a href="../files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></li>
-                    <li><a href="../files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></li>
-                    <li><a href="../files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-utils-namespaces.html"><abbr title="PHPCSUtils/Utils/Namespaces.php">Namespaces.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-utils-namingconventions.html"><abbr title="PHPCSUtils/Utils/NamingConventions.php">NamingConventions.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-utils-numbers.html"><abbr title="PHPCSUtils/Utils/Numbers.php">Numbers.php</abbr></a></li>
                 </ul>
                                     <h3>O</h3>
         <ul class="phpdocumentor-list">
-                    <li><a href="../files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></li>
-                    <li><a href="../files/phpcsutils-utils-operators.html"><abbr title="PHPCSUtils/Utils/Operators.php">Operators.php</abbr></a></li>
-                    <li><a href="../files/phpcsutils-utils-orthography.html"><abbr title="PHPCSUtils/Utils/Orthography.php">Orthography.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-utils-objectdeclarations.html"><abbr title="PHPCSUtils/Utils/ObjectDeclarations.php">ObjectDeclarations.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-utils-operators.html"><abbr title="PHPCSUtils/Utils/Operators.php">Operators.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-utils-orthography.html"><abbr title="PHPCSUtils/Utils/Orthography.php">Orthography.php</abbr></a></li>
                 </ul>
                                     <h3>P</h3>
         <ul class="phpdocumentor-list">
-                    <li><a href="../files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></li>
-                    <li><a href="../files/phpcsutils-utils-passedparameters.html"><abbr title="PHPCSUtils/Utils/PassedParameters.php">PassedParameters.php</abbr></a></li>
-                    <li><a href="../files/phpcsutils-autoload.html"><abbr title="phpcsutils-autoload.php">phpcsutils-autoload.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-utils-parentheses.html"><abbr title="PHPCSUtils/Utils/Parentheses.php">Parentheses.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-utils-passedparameters.html"><abbr title="PHPCSUtils/Utils/PassedParameters.php">PassedParameters.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-autoload.html"><abbr title="phpcsutils-autoload.php">phpcsutils-autoload.php</abbr></a></li>
                 </ul>
                                                                             <h3>S</h3>
         <ul class="phpdocumentor-list">
-                    <li><a href="../files/phpcsutils-utils-scopes.html"><abbr title="PHPCSUtils/Utils/Scopes.php">Scopes.php</abbr></a></li>
-                    <li><a href="../files/phpcsutils-fixers-spacesfixer.html"><abbr title="PHPCSUtils/Fixers/SpacesFixer.php">SpacesFixer.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-utils-scopes.html"><abbr title="PHPCSUtils/Utils/Scopes.php">Scopes.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-fixers-spacesfixer.html"><abbr title="PHPCSUtils/Fixers/SpacesFixer.php">SpacesFixer.php</abbr></a></li>
                 </ul>
                                     <h3>T</h3>
         <ul class="phpdocumentor-list">
-                    <li><a href="../files/phpcsutils-utils-textstrings.html"><abbr title="PHPCSUtils/Utils/TextStrings.php">TextStrings.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-utils-textstrings.html"><abbr title="PHPCSUtils/Utils/TextStrings.php">TextStrings.php</abbr></a></li>
                 </ul>
                                     <h3>U</h3>
         <ul class="phpdocumentor-list">
-                    <li><a href="../files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></li>
-                    <li><a href="../files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-utils-usestatements.html"><abbr title="PHPCSUtils/Utils/UseStatements.php">UseStatements.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-testutils-utilitymethodtestcase.html"><abbr title="PHPCSUtils/TestUtils/UtilityMethodTestCase.php">UtilityMethodTestCase.php</abbr></a></li>
                 </ul>
                                     <h3>V</h3>
         <ul class="phpdocumentor-list">
-                    <li><a href="../files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></li>
+                    <li><a href="files/phpcsutils-utils-variables.html"><abbr title="PHPCSUtils/Utils/Variables.php">Variables.php</abbr></a></li>
                 </ul>
-                                                                                                            <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                                                                                                            <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="indices/files.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/js/search.js
+++ b/docs/phpdoc/js/search.js
@@ -68,20 +68,34 @@ var Search = (function () {
     }
 
     function close() {
+        // Start scroll prevention: https://css-tricks.com/prevent-page-scrolling-when-a-modal-is-open/
+        const scrollY = document.body.style.top;
+        document.body.style.position = '';
+        document.body.style.top = '';
+        window.scrollTo(0, parseInt(scrollY || '0') * -1);
+        // End scroll prevention
+
         var form = document.querySelector('[data-search-form]');
         var searchResults = document.querySelector('[data-search-results]');
 
         form.classList.toggle('phpdocumentor-search--has-results', false);
         searchResults.classList.add('phpdocumentor-search-results--hidden');
+        var searchField = document.querySelector('[data-search-form] input[type="search"]');
+        searchField.blur();
     }
 
     function search(event) {
+        // Start scroll prevention: https://css-tricks.com/prevent-page-scrolling-when-a-modal-is-open/
+        document.body.style.position = 'fixed';
+        document.body.style.top = `-${window.scrollY}px`;
+        // End scroll prevention
+
         // prevent enter's from autosubmitting
         event.stopPropagation();
 
         var form = document.querySelector('[data-search-form]');
         var searchResults = document.querySelector('[data-search-results]');
-        var searchResultEntries = document.querySelector('[data-search-results] > ul');
+        var searchResultEntries = document.querySelector('[data-search-results] .phpdocumentor-search-results__entries');
 
         searchResultEntries.innerHTML = '';
 
@@ -92,12 +106,12 @@ var Search = (function () {
 
         form.classList.toggle('phpdocumentor-search--has-results', true);
         searchResults.classList.remove('phpdocumentor-search-results--hidden');
-        var results = fuse.search(event.target.value);
+        var results = fuse.search(event.target.value, {limit: 25});
 
         results.forEach(function (result) {
             var entry = document.createElement("li");
             entry.classList.add("phpdocumentor-search-results__entry");
-            entry.innerHTML += '<h3><a href="' + result.url + '">' + result.name + "</h3>\n";
+            entry.innerHTML += '<h3><a href="' + document.baseURI + result.url + '">' + result.name + "</a></h3>\n";
             entry.innerHTML += '<small>' + result.fqsen + "</small>\n";
             entry.innerHTML += '<div class="phpdocumentor-summary">' + result.summary + '</div>';
             searchResultEntries.appendChild(entry)
@@ -117,19 +131,28 @@ var Search = (function () {
         fuse = new Fuse(index, options);
 
         var form = document.querySelector('[data-search-form]');
-        var searchField = document.querySelector('[data-search-form] input[type="search"');
+        var searchField = document.querySelector('[data-search-form] input[type="search"]');
+
+        var closeButton = document.querySelector('.phpdocumentor-search-results__close');
+        closeButton.addEventListener('click', function() { close() }.bind(this));
+
+        var searchResults = document.querySelector('[data-search-results]');
+        searchResults.addEventListener('click', function() { close() }.bind(this));
 
         form.classList.add('phpdocumentor-search--active');
 
-        searchField.setAttribute('placeholder', 'Search for ..');
+        searchField.setAttribute('placeholder', 'Search (Press "/" to focus)');
         searchField.removeAttribute('disabled');
         searchField.addEventListener('keyup', debounce(search, 300));
 
         window.addEventListener('keyup', function (event) {
+            if (event.key === '/') {
+                searchField.focus();
+            }
             if (event.code === 'Escape') {
                 close();
             }
-        });
+        }.bind(this));
     }
 
     return {

--- a/docs/phpdoc/js/searchIndex.js
+++ b/docs/phpdoc/js/searchIndex.js
@@ -4,1176 +4,1191 @@ Search.appendIndex(
             "fqsen": "\\PHPCSUtils\\AbstractSniffs\\AbstractArrayDeclarationSniff",
             "name": "AbstractArrayDeclarationSniff",
             "summary": "Abstract\u0020sniff\u0020to\u0020easily\u0020examine\u0020all\u0020parts\u0020of\u0020an\u0020array\u0020declaration.",
-            "url": "../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html"
+            "url": "classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html"
         },                {
             "fqsen": "\\PHPCSUtils\\AbstractSniffs\\AbstractArrayDeclarationSniff\u003A\u003A__construct\u0028\u0029",
             "name": "__construct",
             "summary": "Set\u0020up\u0020this\u0020class.",
-            "url": "../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method___construct"
+            "url": "classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method___construct"
         },                {
             "fqsen": "\\PHPCSUtils\\AbstractSniffs\\AbstractArrayDeclarationSniff\u003A\u003Aregister\u0028\u0029",
             "name": "register",
             "summary": "Returns\u0020an\u0020array\u0020of\u0020tokens\u0020this\u0020test\u0020wants\u0020to\u0020listen\u0020for.",
-            "url": "../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_register"
+            "url": "classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_register"
         },                {
             "fqsen": "\\PHPCSUtils\\AbstractSniffs\\AbstractArrayDeclarationSniff\u003A\u003Aprocess\u0028\u0029",
             "name": "process",
             "summary": "Processes\u0020this\u0020test\u0020when\u0020one\u0020of\u0020its\u0020tokens\u0020is\u0020encountered.",
-            "url": "../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_process"
+            "url": "classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_process"
         },                {
             "fqsen": "\\PHPCSUtils\\AbstractSniffs\\AbstractArrayDeclarationSniff\u003A\u003AprocessArray\u0028\u0029",
             "name": "processArray",
             "summary": "Process\u0020every\u0020part\u0020of\u0020the\u0020array\u0020declaration.",
-            "url": "../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processArray"
+            "url": "classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processArray"
         },                {
             "fqsen": "\\PHPCSUtils\\AbstractSniffs\\AbstractArrayDeclarationSniff\u003A\u003AprocessOpenClose\u0028\u0029",
             "name": "processOpenClose",
             "summary": "Process\u0020the\u0020array\u0020opener\u0020and\u0020closer.",
-            "url": "../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processOpenClose"
+            "url": "classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processOpenClose"
         },                {
             "fqsen": "\\PHPCSUtils\\AbstractSniffs\\AbstractArrayDeclarationSniff\u003A\u003AprocessKey\u0028\u0029",
             "name": "processKey",
             "summary": "Process\u0020the\u0020tokens\u0020in\u0020an\u0020array\u0020key.",
-            "url": "../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processKey"
+            "url": "classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processKey"
         },                {
             "fqsen": "\\PHPCSUtils\\AbstractSniffs\\AbstractArrayDeclarationSniff\u003A\u003AprocessNoKey\u0028\u0029",
             "name": "processNoKey",
             "summary": "Process\u0020an\u0020array\u0020item\u0020without\u0020an\u0020array\u0020key.",
-            "url": "../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processNoKey"
+            "url": "classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processNoKey"
         },                {
             "fqsen": "\\PHPCSUtils\\AbstractSniffs\\AbstractArrayDeclarationSniff\u003A\u003AprocessArrow\u0028\u0029",
             "name": "processArrow",
             "summary": "Process\u0020the\u0020double\u0020arrow.",
-            "url": "../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processArrow"
+            "url": "classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processArrow"
         },                {
             "fqsen": "\\PHPCSUtils\\AbstractSniffs\\AbstractArrayDeclarationSniff\u003A\u003AprocessValue\u0028\u0029",
             "name": "processValue",
             "summary": "Process\u0020the\u0020tokens\u0020in\u0020an\u0020array\u0020value.",
-            "url": "../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processValue"
+            "url": "classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processValue"
         },                {
             "fqsen": "\\PHPCSUtils\\AbstractSniffs\\AbstractArrayDeclarationSniff\u003A\u003AprocessComma\u0028\u0029",
             "name": "processComma",
             "summary": "Process\u0020the\u0020comma\u0020after\u0020an\u0020array\u0020item.",
-            "url": "../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processComma"
+            "url": "classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_processComma"
         },                {
             "fqsen": "\\PHPCSUtils\\AbstractSniffs\\AbstractArrayDeclarationSniff\u003A\u003AgetActualArrayKey\u0028\u0029",
             "name": "getActualArrayKey",
             "summary": "Determine\u0020what\u0020the\u0020actual\u0020array\u0020key\u0020would\u0020be.",
-            "url": "../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_getActualArrayKey"
+            "url": "classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#method_getActualArrayKey"
         },                {
             "fqsen": "\\PHPCSUtils\\AbstractSniffs\\AbstractArrayDeclarationSniff\u003A\u003A\u0024stackPtr",
             "name": "stackPtr",
             "summary": "The\u0020stack\u0020pointer\u0020to\u0020the\u0020array\u0020keyword\u0020or\u0020the\u0020short\u0020array\u0020open\u0020token.",
-            "url": "../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_stackPtr"
+            "url": "classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_stackPtr"
         },                {
             "fqsen": "\\PHPCSUtils\\AbstractSniffs\\AbstractArrayDeclarationSniff\u003A\u003A\u0024tokens",
             "name": "tokens",
             "summary": "The\u0020token\u0020stack\u0020for\u0020the\u0020current\u0020file\u0020being\u0020examined.",
-            "url": "../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_tokens"
+            "url": "classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_tokens"
         },                {
             "fqsen": "\\PHPCSUtils\\AbstractSniffs\\AbstractArrayDeclarationSniff\u003A\u003A\u0024arrayOpener",
             "name": "arrayOpener",
             "summary": "The\u0020stack\u0020pointer\u0020to\u0020the\u0020array\u0020opener.",
-            "url": "../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_arrayOpener"
+            "url": "classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_arrayOpener"
         },                {
             "fqsen": "\\PHPCSUtils\\AbstractSniffs\\AbstractArrayDeclarationSniff\u003A\u003A\u0024arrayCloser",
             "name": "arrayCloser",
             "summary": "The\u0020stack\u0020pointer\u0020to\u0020the\u0020array\u0020closer.",
-            "url": "../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_arrayCloser"
+            "url": "classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_arrayCloser"
         },                {
             "fqsen": "\\PHPCSUtils\\AbstractSniffs\\AbstractArrayDeclarationSniff\u003A\u003A\u0024arrayItems",
             "name": "arrayItems",
             "summary": "A\u0020multi\u002Ddimentional\u0020array\u0020with\u0020information\u0020on\u0020each\u0020array\u0020item.",
-            "url": "../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_arrayItems"
+            "url": "classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_arrayItems"
         },                {
             "fqsen": "\\PHPCSUtils\\AbstractSniffs\\AbstractArrayDeclarationSniff\u003A\u003A\u0024itemCount",
             "name": "itemCount",
             "summary": "How\u0020many\u0020items\u0020are\u0020in\u0020the\u0020array.",
-            "url": "../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_itemCount"
+            "url": "classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_itemCount"
         },                {
             "fqsen": "\\PHPCSUtils\\AbstractSniffs\\AbstractArrayDeclarationSniff\u003A\u003A\u0024singleLine",
             "name": "singleLine",
             "summary": "Whether\u0020or\u0020not\u0020the\u0020array\u0020is\u0020single\u0020line.",
-            "url": "../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_singleLine"
+            "url": "classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html#property_singleLine"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCFile",
             "name": "BCFile",
             "summary": "PHPCS\u0020native\u0020utility\u0020functions.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCFile.html"
+            "url": "classes/PHPCSUtils-BackCompat-BCFile.html"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCFile\u003A\u003AgetDeclarationName\u0028\u0029",
             "name": "getDeclarationName",
             "summary": "Returns\u0020the\u0020declaration\u0020names\u0020for\u0020classes,\u0020interfaces,\u0020traits,\u0020and\u0020functions.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCFile.html#method_getDeclarationName"
+            "url": "classes/PHPCSUtils-BackCompat-BCFile.html#method_getDeclarationName"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCFile\u003A\u003AgetMethodParameters\u0028\u0029",
             "name": "getMethodParameters",
             "summary": "Returns\u0020the\u0020method\u0020parameters\u0020for\u0020the\u0020specified\u0020function\u0020token.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCFile.html#method_getMethodParameters"
+            "url": "classes/PHPCSUtils-BackCompat-BCFile.html#method_getMethodParameters"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCFile\u003A\u003AgetMethodProperties\u0028\u0029",
             "name": "getMethodProperties",
             "summary": "Returns\u0020the\u0020visibility\u0020and\u0020implementation\u0020properties\u0020of\u0020a\u0020method.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCFile.html#method_getMethodProperties"
+            "url": "classes/PHPCSUtils-BackCompat-BCFile.html#method_getMethodProperties"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCFile\u003A\u003AgetMemberProperties\u0028\u0029",
             "name": "getMemberProperties",
             "summary": "Returns\u0020the\u0020visibility\u0020and\u0020implementation\u0020properties\u0020of\u0020a\u0020class\u0020member\u0020var.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCFile.html#method_getMemberProperties"
+            "url": "classes/PHPCSUtils-BackCompat-BCFile.html#method_getMemberProperties"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCFile\u003A\u003AgetClassProperties\u0028\u0029",
             "name": "getClassProperties",
             "summary": "Returns\u0020the\u0020implementation\u0020properties\u0020of\u0020a\u0020class.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCFile.html#method_getClassProperties"
+            "url": "classes/PHPCSUtils-BackCompat-BCFile.html#method_getClassProperties"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCFile\u003A\u003AisReference\u0028\u0029",
             "name": "isReference",
             "summary": "Determine\u0020if\u0020the\u0020passed\u0020token\u0020is\u0020a\u0020reference\u0020operator.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCFile.html#method_isReference"
+            "url": "classes/PHPCSUtils-BackCompat-BCFile.html#method_isReference"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCFile\u003A\u003AgetTokensAsString\u0028\u0029",
             "name": "getTokensAsString",
             "summary": "Returns\u0020the\u0020content\u0020of\u0020the\u0020tokens\u0020from\u0020the\u0020specified\u0020start\u0020position\u0020in\nthe\u0020token\u0020stack\u0020for\u0020the\u0020specified\u0020length.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCFile.html#method_getTokensAsString"
+            "url": "classes/PHPCSUtils-BackCompat-BCFile.html#method_getTokensAsString"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCFile\u003A\u003AfindStartOfStatement\u0028\u0029",
             "name": "findStartOfStatement",
             "summary": "Returns\u0020the\u0020position\u0020of\u0020the\u0020first\u0020non\u002Dwhitespace\u0020token\u0020in\u0020a\u0020statement.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCFile.html#method_findStartOfStatement"
+            "url": "classes/PHPCSUtils-BackCompat-BCFile.html#method_findStartOfStatement"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCFile\u003A\u003AfindEndOfStatement\u0028\u0029",
             "name": "findEndOfStatement",
             "summary": "Returns\u0020the\u0020position\u0020of\u0020the\u0020last\u0020non\u002Dwhitespace\u0020token\u0020in\u0020a\u0020statement.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCFile.html#method_findEndOfStatement"
+            "url": "classes/PHPCSUtils-BackCompat-BCFile.html#method_findEndOfStatement"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCFile\u003A\u003AhasCondition\u0028\u0029",
             "name": "hasCondition",
             "summary": "Determine\u0020if\u0020the\u0020passed\u0020token\u0020has\u0020a\u0020condition\u0020of\u0020one\u0020of\u0020the\u0020passed\u0020types.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCFile.html#method_hasCondition"
+            "url": "classes/PHPCSUtils-BackCompat-BCFile.html#method_hasCondition"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCFile\u003A\u003AgetCondition\u0028\u0029",
             "name": "getCondition",
             "summary": "Return\u0020the\u0020position\u0020of\u0020the\u0020condition\u0020for\u0020the\u0020passed\u0020token.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCFile.html#method_getCondition"
+            "url": "classes/PHPCSUtils-BackCompat-BCFile.html#method_getCondition"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCFile\u003A\u003AfindExtendedClassName\u0028\u0029",
             "name": "findExtendedClassName",
             "summary": "Returns\u0020the\u0020name\u0020of\u0020the\u0020class\u0020that\u0020the\u0020specified\u0020class\u0020extends.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCFile.html#method_findExtendedClassName"
+            "url": "classes/PHPCSUtils-BackCompat-BCFile.html#method_findExtendedClassName"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCFile\u003A\u003AfindImplementedInterfaceNames\u0028\u0029",
             "name": "findImplementedInterfaceNames",
             "summary": "Returns\u0020the\u0020names\u0020of\u0020the\u0020interfaces\u0020that\u0020the\u0020specified\u0020class\u0020implements.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCFile.html#method_findImplementedInterfaceNames"
+            "url": "classes/PHPCSUtils-BackCompat-BCFile.html#method_findImplementedInterfaceNames"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens",
             "name": "BCTokens",
             "summary": "Token\u0020arrays\u0020related\u0020utility\u0020methods.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCTokens.html"
+            "url": "classes/PHPCSUtils-BackCompat-BCTokens.html"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003A__callStatic\u0028\u0029",
             "name": "__callStatic",
             "summary": "Handle\u0020calls\u0020to\u0020\u0028undeclared\u0029\u0020methods\u0020for\u0020token\u0020arrays\u0020which\u0020haven\u0027t\u0020received\u0020any\nchanges\u0020since\u0020PHPCS\u00202.6.0.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCTokens.html#method___callStatic"
+            "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method___callStatic"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003AassignmentTokens\u0028\u0029",
             "name": "assignmentTokens",
             "summary": "Tokens\u0020that\u0020represent\u0020assignment\u0020operators.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCTokens.html#method_assignmentTokens"
+            "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method_assignmentTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003AcomparisonTokens\u0028\u0029",
             "name": "comparisonTokens",
             "summary": "Tokens\u0020that\u0020represent\u0020comparison\u0020operators.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCTokens.html#method_comparisonTokens"
+            "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method_comparisonTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003AarithmeticTokens\u0028\u0029",
             "name": "arithmeticTokens",
             "summary": "Tokens\u0020that\u0020represent\u0020arithmetic\u0020operators.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCTokens.html#method_arithmeticTokens"
+            "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method_arithmeticTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003Aoperators\u0028\u0029",
             "name": "operators",
             "summary": "Tokens\u0020that\u0020perform\u0020operations.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCTokens.html#method_operators"
+            "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method_operators"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003AparenthesisOpeners\u0028\u0029",
             "name": "parenthesisOpeners",
             "summary": "Token\u0020types\u0020that\u0020open\u0020parentheses.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCTokens.html#method_parenthesisOpeners"
+            "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method_parenthesisOpeners"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003AphpcsCommentTokens\u0028\u0029",
             "name": "phpcsCommentTokens",
             "summary": "Tokens\u0020that\u0020are\u0020comments\u0020containing\u0020PHPCS\u0020instructions.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCTokens.html#method_phpcsCommentTokens"
+            "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method_phpcsCommentTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003AtextStringTokens\u0028\u0029",
             "name": "textStringTokens",
             "summary": "Tokens\u0020that\u0020represent\u0020text\u0020strings.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCTokens.html#method_textStringTokens"
+            "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method_textStringTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003AfunctionNameTokens\u0028\u0029",
             "name": "functionNameTokens",
             "summary": "Tokens\u0020that\u0020represent\u0020the\u0020names\u0020of\u0020called\u0020functions.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCTokens.html#method_functionNameTokens"
+            "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method_functionNameTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003AooScopeTokens\u0028\u0029",
             "name": "ooScopeTokens",
             "summary": "Tokens\u0020that\u0020open\u0020class\u0020and\u0020object\u0020scopes.",
-            "url": "../classes/PHPCSUtils-BackCompat-BCTokens.html#method_ooScopeTokens"
+            "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method_ooScopeTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\Helper",
             "name": "Helper",
             "summary": "Utility\u0020methods\u0020to\u0020retrieve\u0020\u0028configuration\u0029\u0020information\u0020from\u0020PHP_CodeSniffer.",
-            "url": "../classes/PHPCSUtils-BackCompat-Helper.html"
+            "url": "classes/PHPCSUtils-BackCompat-Helper.html"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\Helper\u003A\u003AgetVersion\u0028\u0029",
             "name": "getVersion",
             "summary": "Get\u0020the\u0020PHP_CodeSniffer\u0020version\u0020number.",
-            "url": "../classes/PHPCSUtils-BackCompat-Helper.html#method_getVersion"
+            "url": "classes/PHPCSUtils-BackCompat-Helper.html#method_getVersion"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\Helper\u003A\u003AsetConfigData\u0028\u0029",
             "name": "setConfigData",
             "summary": "Pass\u0020config\u0020data\u0020to\u0020PHP_CodeSniffer.",
-            "url": "../classes/PHPCSUtils-BackCompat-Helper.html#method_setConfigData"
+            "url": "classes/PHPCSUtils-BackCompat-Helper.html#method_setConfigData"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\Helper\u003A\u003AgetConfigData\u0028\u0029",
             "name": "getConfigData",
             "summary": "Get\u0020the\u0020value\u0020of\u0020a\u0020single\u0020PHP_CodeSniffer\u0020config\u0020key.",
-            "url": "../classes/PHPCSUtils-BackCompat-Helper.html#method_getConfigData"
+            "url": "classes/PHPCSUtils-BackCompat-Helper.html#method_getConfigData"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\Helper\u003A\u003AgetCommandLineData\u0028\u0029",
             "name": "getCommandLineData",
             "summary": "Get\u0020the\u0020value\u0020of\u0020a\u0020CLI\u0020overrulable\u0020single\u0020PHP_CodeSniffer\u0020config\u0020key.",
-            "url": "../classes/PHPCSUtils-BackCompat-Helper.html#method_getCommandLineData"
+            "url": "classes/PHPCSUtils-BackCompat-Helper.html#method_getCommandLineData"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\Helper\u003A\u003AgetTabWidth\u0028\u0029",
             "name": "getTabWidth",
             "summary": "Get\u0020the\u0020applicable\u0020tab\u0020width\u0020as\u0020passed\u0020to\u0020PHP_CodeSniffer\u0020from\u0020the\ncommand\u002Dline\u0020or\u0020the\u0020ruleset.",
-            "url": "../classes/PHPCSUtils-BackCompat-Helper.html#method_getTabWidth"
+            "url": "classes/PHPCSUtils-BackCompat-Helper.html#method_getTabWidth"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\Helper\u003A\u003AgetEncoding\u0028\u0029",
             "name": "getEncoding",
             "summary": "Get\u0020the\u0020applicable\u0020\u0028file\u0029\u0020encoding\u0020as\u0020passed\u0020to\u0020PHP_CodeSniffer\u0020from\u0020the\ncommand\u002Dline\u0020or\u0020the\u0020ruleset.",
-            "url": "../classes/PHPCSUtils-BackCompat-Helper.html#method_getEncoding"
+            "url": "classes/PHPCSUtils-BackCompat-Helper.html#method_getEncoding"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\Helper\u003A\u003AignoreAnnotations\u0028\u0029",
             "name": "ignoreAnnotations",
             "summary": "Check\u0020whether\u0020the\u0020\u0022\u002D\u002Dignore\u002Dannotations\u0022\u0020option\u0020is\u0020in\u0020effect.",
-            "url": "../classes/PHPCSUtils-BackCompat-Helper.html#method_ignoreAnnotations"
+            "url": "classes/PHPCSUtils-BackCompat-Helper.html#method_ignoreAnnotations"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\Helper\u003A\u003ADEFAULT_TABWIDTH",
             "name": "DEFAULT_TABWIDTH",
             "summary": "The\u0020default\u0020tab\u0020width\u0020used\u0020by\u0020PHP_CodeSniffer.",
-            "url": "../classes/PHPCSUtils-BackCompat-Helper.html#constant_DEFAULT_TABWIDTH"
+            "url": "classes/PHPCSUtils-BackCompat-Helper.html#constant_DEFAULT_TABWIDTH"
         },                {
             "fqsen": "\\PHPCSUtils\\Fixers\\SpacesFixer",
             "name": "SpacesFixer",
             "summary": "Utility\u0020to\u0020check\u0020and,\u0020if\u0020necessary,\u0020fix\u0020the\u0020whitespace\u0020between\u0020two\u0020tokens.",
-            "url": "../classes/PHPCSUtils-Fixers-SpacesFixer.html"
+            "url": "classes/PHPCSUtils-Fixers-SpacesFixer.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Fixers\\SpacesFixer\u003A\u003AcheckAndFix\u0028\u0029",
             "name": "checkAndFix",
             "summary": "Check\u0020the\u0020whitespace\u0020between\u0020two\u0020tokens,\u0020throw\u0020an\u0020error\u0020if\u0020it\u0020doesn\u0027t\u0020match\u0020the\nexpected\u0020whitespace\u0020and\u0020if\u0020relevant,\u0020fix\u0020it.",
-            "url": "../classes/PHPCSUtils-Fixers-SpacesFixer.html#method_checkAndFix"
+            "url": "classes/PHPCSUtils-Fixers-SpacesFixer.html#method_checkAndFix"
         },                {
             "fqsen": "\\PHPCSUtils\\TestUtils\\UtilityMethodTestCase",
             "name": "UtilityMethodTestCase",
             "summary": "Base\u0020class\u0020for\u0020use\u0020when\u0020testing\u0020utility\u0020methods\u0020for\u0020PHP_CodeSniffer.",
-            "url": "../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html"
+            "url": "classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html"
         },                {
             "fqsen": "\\PHPCSUtils\\TestUtils\\UtilityMethodTestCase\u003A\u003AsetUpTestFile\u0028\u0029",
             "name": "setUpTestFile",
             "summary": "Initialize\u0020PHPCS\u0020\u0026\u0020tokenize\u0020the\u0020test\u0020case\u0020file.",
-            "url": "../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_setUpTestFile"
+            "url": "classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_setUpTestFile"
         },                {
             "fqsen": "\\PHPCSUtils\\TestUtils\\UtilityMethodTestCase\u003A\u003AskipJSCSSTestsOnPHPCS4\u0028\u0029",
             "name": "skipJSCSSTestsOnPHPCS4",
             "summary": "Skip\u0020JS\u0020and\u0020CSS\u0020related\u0020tests\u0020on\u0020PHPCS\u00204.x.",
-            "url": "../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_skipJSCSSTestsOnPHPCS4"
+            "url": "classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_skipJSCSSTestsOnPHPCS4"
         },                {
             "fqsen": "\\PHPCSUtils\\TestUtils\\UtilityMethodTestCase\u003A\u003AresetTestFile\u0028\u0029",
             "name": "resetTestFile",
             "summary": "Clean\u0020up\u0020after\u0020finished\u0020test.",
-            "url": "../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_resetTestFile"
+            "url": "classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_resetTestFile"
         },                {
             "fqsen": "\\PHPCSUtils\\TestUtils\\UtilityMethodTestCase\u003A\u003AgetTargetToken\u0028\u0029",
             "name": "getTargetToken",
             "summary": "Get\u0020the\u0020token\u0020pointer\u0020for\u0020a\u0020target\u0020token\u0020based\u0020on\u0020a\u0020specific\u0020comment.",
-            "url": "../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_getTargetToken"
+            "url": "classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_getTargetToken"
         },                {
             "fqsen": "\\PHPCSUtils\\TestUtils\\UtilityMethodTestCase\u003A\u003AexpectPhpcsException\u0028\u0029",
             "name": "expectPhpcsException",
             "summary": "Helper\u0020method\u0020to\u0020tell\u0020PHPUnit\u0020to\u0020expect\u0020a\u0020PHPCS\u0020Exception\u0020in\u0020a\u0020PHPUnit\u0020and\u0020PHPCS\u0020cross\u002Dversion\ncompatible\u0020manner.",
-            "url": "../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_expectPhpcsException"
+            "url": "classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_expectPhpcsException"
         },                {
             "fqsen": "\\PHPCSUtils\\TestUtils\\UtilityMethodTestCase\u003A\u003A\u0024phpcsVersion",
             "name": "phpcsVersion",
             "summary": "The\u0020PHPCS\u0020version\u0020the\u0020tests\u0020are\u0020being\u0020run\u0020on.",
-            "url": "../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_phpcsVersion"
+            "url": "classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_phpcsVersion"
         },                {
             "fqsen": "\\PHPCSUtils\\TestUtils\\UtilityMethodTestCase\u003A\u003A\u0024fileExtension",
             "name": "fileExtension",
             "summary": "The\u0020file\u0020extension\u0020of\u0020the\u0020test\u0020case\u0020file\u0020\u0028without\u0020leading\u0020dot\u0029.",
-            "url": "../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_fileExtension"
+            "url": "classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_fileExtension"
         },                {
             "fqsen": "\\PHPCSUtils\\TestUtils\\UtilityMethodTestCase\u003A\u003A\u0024caseFile",
             "name": "caseFile",
             "summary": "Full\u0020path\u0020to\u0020the\u0020test\u0020case\u0020file\u0020associated\u0020with\u0020the\u0020concrete\u0020test\u0020class.",
-            "url": "../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_caseFile"
+            "url": "classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_caseFile"
         },                {
             "fqsen": "\\PHPCSUtils\\TestUtils\\UtilityMethodTestCase\u003A\u003A\u0024tabWidth",
             "name": "tabWidth",
             "summary": "The\u0020tab\u0020width\u0020setting\u0020to\u0020use\u0020when\u0020tokenizing\u0020the\u0020file.",
-            "url": "../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_tabWidth"
+            "url": "classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_tabWidth"
         },                {
             "fqsen": "\\PHPCSUtils\\TestUtils\\UtilityMethodTestCase\u003A\u003A\u0024phpcsFile",
             "name": "phpcsFile",
             "summary": "The\u0020\\PHP_CodeSniffer\\Files\\File\u0020object\u0020containing\u0020the\u0020parsed\u0020contents\u0020of\u0020the\u0020test\u0020case\u0020file.",
-            "url": "../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_phpcsFile"
+            "url": "classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_phpcsFile"
         },                {
             "fqsen": "\\PHPCSUtils\\TestUtils\\UtilityMethodTestCase\u003A\u003A\u0024selectedSniff",
             "name": "selectedSniff",
             "summary": "Set\u0020the\u0020name\u0020of\u0020a\u0020sniff\u0020to\u0020pass\u0020to\u0020PHPCS\u0020to\u0020limit\u0020the\u0020run\u0020\u0028and\u0020force\u0020it\u0020to\u0020record\u0020errors\u0029.",
-            "url": "../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_selectedSniff"
+            "url": "classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#property_selectedSniff"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections",
             "name": "Collections",
             "summary": "Collections\u0020of\u0020related\u0020tokens\u0020as\u0020often\u0020used\u0020and\u0020needed\u0020for\u0020sniffs.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AarrowFunctionTokensBC\u0028\u0029",
             "name": "arrowFunctionTokensBC",
             "summary": "Tokens\u0020which\u0020can\u0020represent\u0020the\u0020arrow\u0020function\u0020keyword.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#method_arrowFunctionTokensBC"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#method_arrowFunctionTokensBC"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AfunctionDeclarationTokens\u0028\u0029",
             "name": "functionDeclarationTokens",
             "summary": "Tokens\u0020which\u0020can\u0020represent\u0020a\u0020keyword\u0020which\u0020starts\u0020a\u0020function\u0020declaration.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokens"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AfunctionDeclarationTokensBC\u0028\u0029",
             "name": "functionDeclarationTokensBC",
             "summary": "Tokens\u0020which\u0020can\u0020represent\u0020a\u0020keyword\u0020which\u0020starts\u0020a\u0020function\u0020declaration.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokensBC"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokensBC"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AparameterTypeTokensBC\u0028\u0029",
             "name": "parameterTypeTokensBC",
             "summary": "Token\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020a\u0020parameter\u0020type\u0020declaration\u0020\u0028cross\u002Dversion\u0029.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#method_parameterTypeTokensBC"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#method_parameterTypeTokensBC"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003ApropertyTypeTokensBC\u0028\u0029",
             "name": "propertyTypeTokensBC",
             "summary": "Token\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020a\u0020property\u0020type\u0020declaration\u0020\u0028cross\u002Dversion\u0029.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#method_propertyTypeTokensBC"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#method_propertyTypeTokensBC"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AreturnTypeTokensBC\u0028\u0029",
             "name": "returnTypeTokensBC",
             "summary": "Token\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020a\u0020return\u0020type\u0020declaration\u0020\u0028cross\u002Dversion\u0029.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokensBC"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokensBC"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024alternativeControlStructureSyntaxTokens",
             "name": "alternativeControlStructureSyntaxTokens",
             "summary": "Control\u0020structures\u0020which\u0020can\u0020use\u0020the\u0020alternative\u0020control\u0020structure\u0020syntax.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_alternativeControlStructureSyntaxTokens"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_alternativeControlStructureSyntaxTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024alternativeControlStructureSyntaxCloserTokens",
             "name": "alternativeControlStructureSyntaxCloserTokens",
             "summary": "Alternative\u0020control\u0020structure\u0020syntax\u0020closer\u0020keyword\u0020tokens.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_alternativeControlStructureSyntaxCloserTokens"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_alternativeControlStructureSyntaxCloserTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024arrayTokens",
             "name": "arrayTokens",
             "summary": "Tokens\u0020which\u0020are\u0020used\u0020to\u0020create\u0020arrays.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokens"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024arrayTokensBC",
             "name": "arrayTokensBC",
             "summary": "Tokens\u0020which\u0020are\u0020used\u0020to\u0020create\u0020arrays.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokensBC"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokensBC"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024classModifierKeywords",
             "name": "classModifierKeywords",
             "summary": "Modifier\u0020keywords\u0020which\u0020can\u0020be\u0020used\u0020for\u0020a\u0020class\u0020declaration.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_classModifierKeywords"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_classModifierKeywords"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024closedScopes",
             "name": "closedScopes",
             "summary": "List\u0020of\u0020tokens\u0020which\u0020represent\u0020\u0022closed\u0022\u0020scopes.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_closedScopes"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_closedScopes"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024controlStructureTokens",
             "name": "controlStructureTokens",
             "summary": "Control\u0020structure\u0020tokens.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_controlStructureTokens"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_controlStructureTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024incrementDecrementOperators",
             "name": "incrementDecrementOperators",
             "summary": "Increment\/decrement\u0020operator\u0020tokens.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_incrementDecrementOperators"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_incrementDecrementOperators"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024listTokens",
             "name": "listTokens",
             "summary": "Tokens\u0020which\u0020are\u0020used\u0020to\u0020create\u0020lists.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_listTokens"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_listTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024listTokensBC",
             "name": "listTokensBC",
             "summary": "Tokens\u0020which\u0020are\u0020used\u0020to\u0020create\u0020lists.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_listTokensBC"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_listTokensBC"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024magicConstants",
             "name": "magicConstants",
             "summary": "Tokens\u0020for\u0020the\u0020PHP\u0020magic\u0020constants.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_magicConstants"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_magicConstants"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024namespaceDeclarationClosers",
             "name": "namespaceDeclarationClosers",
             "summary": "List\u0020of\u0020tokens\u0020which\u0020can\u0020end\u0020a\u0020namespace\u0020declaration\u0020statement.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_namespaceDeclarationClosers"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_namespaceDeclarationClosers"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024objectOperators",
             "name": "objectOperators",
             "summary": "Object\u0020operators.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_objectOperators"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_objectOperators"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024OOCanExtend",
             "name": "OOCanExtend",
             "summary": "OO\u0020structures\u0020which\u0020can\u0020use\u0020the\u0020\u0022extends\u0022\u0020keyword.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_OOCanExtend"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_OOCanExtend"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024OOCanImplement",
             "name": "OOCanImplement",
             "summary": "OO\u0020structures\u0020which\u0020can\u0020use\u0020the\u0020\u0022implements\u0022\u0020keyword.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_OOCanImplement"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_OOCanImplement"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024OOConstantScopes",
             "name": "OOConstantScopes",
             "summary": "OO\u0020scopes\u0020in\u0020which\u0020constants\u0020can\u0020be\u0020declared.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_OOConstantScopes"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_OOConstantScopes"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024OOHierarchyKeywords",
             "name": "OOHierarchyKeywords",
             "summary": "Tokens\u0020types\u0020used\u0020for\u0020\u0022forwarding\u0022\u0020calls\u0020within\u0020OO\u0020structures.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_OOHierarchyKeywords"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_OOHierarchyKeywords"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024OONameTokens",
             "name": "OONameTokens",
             "summary": "Tokens\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020the\u0020fully\/partially\u0020qualified\u0020name\u0020of\u0020an\u0020OO\u0020structure.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_OONameTokens"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_OONameTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024OOPropertyScopes",
             "name": "OOPropertyScopes",
             "summary": "OO\u0020scopes\u0020in\u0020which\u0020properties\u0020can\u0020be\u0020declared.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_OOPropertyScopes"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_OOPropertyScopes"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024parameterTypeTokens",
             "name": "parameterTypeTokens",
             "summary": "Token\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020a\u0020parameter\u0020type\u0020declaration.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_parameterTypeTokens"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_parameterTypeTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024propertyModifierKeywords",
             "name": "propertyModifierKeywords",
             "summary": "Modifier\u0020keywords\u0020which\u0020can\u0020be\u0020used\u0020for\u0020a\u0020property\u0020declaration.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_propertyModifierKeywords"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_propertyModifierKeywords"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024propertyTypeTokens",
             "name": "propertyTypeTokens",
             "summary": "Token\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020a\u0020property\u0020type\u0020declaration.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_propertyTypeTokens"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_propertyTypeTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024returnTypeTokens",
             "name": "returnTypeTokens",
             "summary": "Token\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020a\u0020return\u0020type\u0020declaration.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_returnTypeTokens"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_returnTypeTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024shortArrayTokens",
             "name": "shortArrayTokens",
             "summary": "Tokens\u0020which\u0020are\u0020used\u0020for\u0020short\u0020arrays.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokens"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024shortArrayTokensBC",
             "name": "shortArrayTokensBC",
             "summary": "Tokens\u0020which\u0020are\u0020used\u0020for\u0020short\u0020arrays.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokensBC"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokensBC"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024shortListTokens",
             "name": "shortListTokens",
             "summary": "Tokens\u0020which\u0020are\u0020used\u0020for\u0020short\u0020lists.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokens"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024shortListTokensBC",
             "name": "shortListTokensBC",
             "summary": "Tokens\u0020which\u0020are\u0020used\u0020for\u0020short\u0020lists.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokensBC"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokensBC"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024textStingStartTokens",
             "name": "textStingStartTokens",
             "summary": "Tokens\u0020which\u0020can\u0020start\u0020a\u0020\u002D\u0020potentially\u0020multi\u002Dline\u0020\u002D\u0020text\u0020string.",
-            "url": "../classes/PHPCSUtils-Tokens-Collections.html#property_textStingStartTokens"
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_textStingStartTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Arrays",
             "name": "Arrays",
             "summary": "Utility\u0020functions\u0020for\u0020use\u0020when\u0020examining\u0020arrays.",
-            "url": "../classes/PHPCSUtils-Utils-Arrays.html"
+            "url": "classes/PHPCSUtils-Utils-Arrays.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Arrays\u003A\u003AisShortArray\u0028\u0029",
             "name": "isShortArray",
             "summary": "Determine\u0020whether\u0020a\u0020T_OPEN\/CLOSE_SHORT_ARRAY\u0020token\u0020is\u0020a\u0020short\u0020array\u0020construct\nand\u0020not\u0020a\u0020short\u0020list.",
-            "url": "../classes/PHPCSUtils-Utils-Arrays.html#method_isShortArray"
+            "url": "classes/PHPCSUtils-Utils-Arrays.html#method_isShortArray"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Arrays\u003A\u003AgetOpenClose\u0028\u0029",
             "name": "getOpenClose",
             "summary": "Find\u0020the\u0020array\u0020opener\u0020and\u0020closer\u0020based\u0020on\u0020a\u0020T_ARRAY\u0020or\u0020T_OPEN_SHORT_ARRAY\u0020token.",
-            "url": "../classes/PHPCSUtils-Utils-Arrays.html#method_getOpenClose"
+            "url": "classes/PHPCSUtils-Utils-Arrays.html#method_getOpenClose"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Arrays\u003A\u003AgetDoubleArrowPtr\u0028\u0029",
             "name": "getDoubleArrowPtr",
             "summary": "Get\u0020the\u0020stack\u0020pointer\u0020position\u0020of\u0020the\u0020double\u0020arrow\u0020within\u0020an\u0020array\u0020item.",
-            "url": "../classes/PHPCSUtils-Utils-Arrays.html#method_getDoubleArrowPtr"
+            "url": "classes/PHPCSUtils-Utils-Arrays.html#method_getDoubleArrowPtr"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Conditions",
             "name": "Conditions",
             "summary": "Utility\u0020functions\u0020for\u0020use\u0020when\u0020examining\u0020token\u0020conditions.",
-            "url": "../classes/PHPCSUtils-Utils-Conditions.html"
+            "url": "classes/PHPCSUtils-Utils-Conditions.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Conditions\u003A\u003AgetCondition\u0028\u0029",
             "name": "getCondition",
             "summary": "Retrieve\u0020the\u0020position\u0020of\u0020a\u0020condition\u0020for\u0020the\u0020passed\u0020token.",
-            "url": "../classes/PHPCSUtils-Utils-Conditions.html#method_getCondition"
+            "url": "classes/PHPCSUtils-Utils-Conditions.html#method_getCondition"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Conditions\u003A\u003AhasCondition\u0028\u0029",
             "name": "hasCondition",
             "summary": "Determine\u0020if\u0020the\u0020passed\u0020token\u0020has\u0020a\u0020condition\u0020of\u0020one\u0020of\u0020the\u0020passed\u0020types.",
-            "url": "../classes/PHPCSUtils-Utils-Conditions.html#method_hasCondition"
+            "url": "classes/PHPCSUtils-Utils-Conditions.html#method_hasCondition"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Conditions\u003A\u003AgetFirstCondition\u0028\u0029",
             "name": "getFirstCondition",
             "summary": "Return\u0020the\u0020position\u0020of\u0020the\u0020first\u0020\u0028outermost\u0029\u0020condition\u0020of\u0020a\u0020certain\u0020type\u0020for\u0020the\u0020passed\u0020token.",
-            "url": "../classes/PHPCSUtils-Utils-Conditions.html#method_getFirstCondition"
+            "url": "classes/PHPCSUtils-Utils-Conditions.html#method_getFirstCondition"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Conditions\u003A\u003AgetLastCondition\u0028\u0029",
             "name": "getLastCondition",
             "summary": "Return\u0020the\u0020position\u0020of\u0020the\u0020last\u0020\u0028innermost\u0029\u0020condition\u0020of\u0020a\u0020certain\u0020type\u0020for\u0020the\u0020passed\u0020token.",
-            "url": "../classes/PHPCSUtils-Utils-Conditions.html#method_getLastCondition"
+            "url": "classes/PHPCSUtils-Utils-Conditions.html#method_getLastCondition"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\ControlStructures",
             "name": "ControlStructures",
             "summary": "Utility\u0020functions\u0020for\u0020use\u0020when\u0020examining\u0020control\u0020structures.",
-            "url": "../classes/PHPCSUtils-Utils-ControlStructures.html"
+            "url": "classes/PHPCSUtils-Utils-ControlStructures.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\ControlStructures\u003A\u003AhasBody\u0028\u0029",
             "name": "hasBody",
             "summary": "Check\u0020whether\u0020a\u0020control\u0020structure\u0020has\u0020a\u0020body.",
-            "url": "../classes/PHPCSUtils-Utils-ControlStructures.html#method_hasBody"
+            "url": "classes/PHPCSUtils-Utils-ControlStructures.html#method_hasBody"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\ControlStructures\u003A\u003AisElseIf\u0028\u0029",
             "name": "isElseIf",
             "summary": "Check\u0020whether\u0020an\u0020IF\u0020or\u0020ELSE\u0020token\u0020is\u0020part\u0020of\u0020an\u0020\u0022else\u0020if\u0022.",
-            "url": "../classes/PHPCSUtils-Utils-ControlStructures.html#method_isElseIf"
+            "url": "classes/PHPCSUtils-Utils-ControlStructures.html#method_isElseIf"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\ControlStructures\u003A\u003AgetDeclareScopeOpenClose\u0028\u0029",
             "name": "getDeclareScopeOpenClose",
             "summary": "Get\u0020the\u0020scope\u0020opener\u0020and\u0020closer\u0020for\u0020a\u0020DECLARE\u0020statement.",
-            "url": "../classes/PHPCSUtils-Utils-ControlStructures.html#method_getDeclareScopeOpenClose"
+            "url": "classes/PHPCSUtils-Utils-ControlStructures.html#method_getDeclareScopeOpenClose"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\ControlStructures\u003A\u003AgetCaughtExceptions\u0028\u0029",
             "name": "getCaughtExceptions",
             "summary": "Retrieve\u0020the\u0020exception\u0028s\u0029\u0020being\u0020caught\u0020in\u0020a\u0020CATCH\u0020condition.",
-            "url": "../classes/PHPCSUtils-Utils-ControlStructures.html#method_getCaughtExceptions"
+            "url": "classes/PHPCSUtils-Utils-ControlStructures.html#method_getCaughtExceptions"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\FunctionDeclarations",
             "name": "FunctionDeclarations",
             "summary": "Utility\u0020functions\u0020for\u0020use\u0020when\u0020examining\u0020function\u0020declaration\u0020statements.",
-            "url": "../classes/PHPCSUtils-Utils-FunctionDeclarations.html"
+            "url": "classes/PHPCSUtils-Utils-FunctionDeclarations.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\FunctionDeclarations\u003A\u003AgetName\u0028\u0029",
             "name": "getName",
             "summary": "Returns\u0020the\u0020declaration\u0020name\u0020for\u0020a\u0020function.",
-            "url": "../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getName"
+            "url": "classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getName"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\FunctionDeclarations\u003A\u003AgetProperties\u0028\u0029",
             "name": "getProperties",
             "summary": "Retrieves\u0020the\u0020visibility\u0020and\u0020implementation\u0020properties\u0020of\u0020a\u0020method.",
-            "url": "../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getProperties"
+            "url": "classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getProperties"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\FunctionDeclarations\u003A\u003AgetParameters\u0028\u0029",
             "name": "getParameters",
             "summary": "Retrieves\u0020the\u0020method\u0020parameters\u0020for\u0020the\u0020specified\u0020function\u0020token.",
-            "url": "../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getParameters"
+            "url": "classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getParameters"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\FunctionDeclarations\u003A\u003AisArrowFunction\u0028\u0029",
             "name": "isArrowFunction",
             "summary": "Check\u0020if\u0020an\u0020arbitrary\u0020token\u0020is\u0020the\u0020\u0022fn\u0022\u0020keyword\u0020for\u0020a\u0020PHP\u00207.4\u0020arrow\u0020function.",
-            "url": "../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isArrowFunction"
+            "url": "classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isArrowFunction"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\FunctionDeclarations\u003A\u003AgetArrowFunctionOpenClose\u0028\u0029",
             "name": "getArrowFunctionOpenClose",
             "summary": "Retrieve\u0020the\u0020parenthesis\u0020opener,\u0020parenthesis\u0020closer,\u0020the\u0020scope\u0020opener\u0020and\u0020the\u0020scope\u0020closer\nfor\u0020an\u0020arrow\u0020function.",
-            "url": "../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getArrowFunctionOpenClose"
+            "url": "classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getArrowFunctionOpenClose"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\FunctionDeclarations\u003A\u003AisMagicFunction\u0028\u0029",
             "name": "isMagicFunction",
             "summary": "Checks\u0020if\u0020a\u0020given\u0020function\u0020is\u0020a\u0020PHP\u0020magic\u0020function.",
-            "url": "../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicFunction"
+            "url": "classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicFunction"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\FunctionDeclarations\u003A\u003AisMagicFunctionName\u0028\u0029",
             "name": "isMagicFunctionName",
             "summary": "Verify\u0020if\u0020a\u0020given\u0020function\u0020name\u0020is\u0020the\u0020name\u0020of\u0020a\u0020PHP\u0020magic\u0020function.",
-            "url": "../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicFunctionName"
+            "url": "classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicFunctionName"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\FunctionDeclarations\u003A\u003AisMagicMethod\u0028\u0029",
             "name": "isMagicMethod",
             "summary": "Checks\u0020if\u0020a\u0020given\u0020function\u0020is\u0020a\u0020PHP\u0020magic\u0020method.",
-            "url": "../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicMethod"
+            "url": "classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicMethod"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\FunctionDeclarations\u003A\u003AisMagicMethodName\u0028\u0029",
             "name": "isMagicMethodName",
             "summary": "Verify\u0020if\u0020a\u0020given\u0020function\u0020name\u0020is\u0020the\u0020name\u0020of\u0020a\u0020PHP\u0020magic\u0020method.",
-            "url": "../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicMethodName"
+            "url": "classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isMagicMethodName"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\FunctionDeclarations\u003A\u003AisPHPDoubleUnderscoreMethod\u0028\u0029",
             "name": "isPHPDoubleUnderscoreMethod",
             "summary": "Checks\u0020if\u0020a\u0020given\u0020function\u0020is\u0020a\u0020non\u002Dmagic\u0020PHP\u0020native\u0020double\u0020underscore\u0020method.",
-            "url": "../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isPHPDoubleUnderscoreMethod"
+            "url": "classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isPHPDoubleUnderscoreMethod"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\FunctionDeclarations\u003A\u003AisPHPDoubleUnderscoreMethodName\u0028\u0029",
             "name": "isPHPDoubleUnderscoreMethodName",
             "summary": "Verify\u0020if\u0020a\u0020given\u0020function\u0020name\u0020is\u0020the\u0020name\u0020of\u0020a\u0020non\u002Dmagic\u0020PHP\u0020native\u0020double\u0020underscore\u0020method.",
-            "url": "../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isPHPDoubleUnderscoreMethodName"
+            "url": "classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isPHPDoubleUnderscoreMethodName"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\FunctionDeclarations\u003A\u003AisSpecialMethod\u0028\u0029",
             "name": "isSpecialMethod",
             "summary": "Checks\u0020if\u0020a\u0020given\u0020function\u0020is\u0020a\u0020magic\u0020method\u0020or\u0020a\u0020PHP\u0020native\u0020double\u0020underscore\u0020method.",
-            "url": "../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isSpecialMethod"
+            "url": "classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isSpecialMethod"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\FunctionDeclarations\u003A\u003AisSpecialMethodName\u0028\u0029",
             "name": "isSpecialMethodName",
             "summary": "Verify\u0020if\u0020a\u0020given\u0020function\u0020name\u0020is\u0020the\u0020name\u0020of\u0020a\u0020magic\u0020method\u0020or\u0020a\u0020PHP\u0020native\u0020double\u0020underscore\u0020method.",
-            "url": "../classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isSpecialMethodName"
+            "url": "classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isSpecialMethodName"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\FunctionDeclarations\u003A\u003A\u0024magicFunctions",
             "name": "magicFunctions",
             "summary": "A\u0020list\u0020of\u0020all\u0020PHP\u0020magic\u0020functions.",
-            "url": "../classes/PHPCSUtils-Utils-FunctionDeclarations.html#property_magicFunctions"
+            "url": "classes/PHPCSUtils-Utils-FunctionDeclarations.html#property_magicFunctions"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\FunctionDeclarations\u003A\u003A\u0024magicMethods",
             "name": "magicMethods",
             "summary": "A\u0020list\u0020of\u0020all\u0020PHP\u0020magic\u0020methods.",
-            "url": "../classes/PHPCSUtils-Utils-FunctionDeclarations.html#property_magicMethods"
+            "url": "classes/PHPCSUtils-Utils-FunctionDeclarations.html#property_magicMethods"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\FunctionDeclarations\u003A\u003A\u0024methodsDoubleUnderscore",
             "name": "methodsDoubleUnderscore",
             "summary": "A\u0020list\u0020of\u0020all\u0020PHP\u0020native\u0020non\u002Dmagic\u0020methods\u0020starting\u0020with\u0020a\u0020double\u0020underscore.",
-            "url": "../classes/PHPCSUtils-Utils-FunctionDeclarations.html#property_methodsDoubleUnderscore"
+            "url": "classes/PHPCSUtils-Utils-FunctionDeclarations.html#property_methodsDoubleUnderscore"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\GetTokensAsString",
             "name": "GetTokensAsString",
             "summary": "Utility\u0020functions\u0020to\u0020retrieve\u0020the\u0020content\u0020of\u0020a\u0020set\u0020of\u0020tokens\u0020as\u0020a\u0020string.",
-            "url": "../classes/PHPCSUtils-Utils-GetTokensAsString.html"
+            "url": "classes/PHPCSUtils-Utils-GetTokensAsString.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\GetTokensAsString\u003A\u003Anormal\u0028\u0029",
             "name": "normal",
             "summary": "Retrieve\u0020the\u0020tab\u002Dreplaced\u0020content\u0020of\u0020the\u0020tokens\u0020from\u0020the\u0020specified\u0020start\u0020position\u0020in\nthe\u0020token\u0020stack\u0020to\u0020the\u0020specified\u0020end\u0020position\u0020\u0028inclusive\u0029.",
-            "url": "../classes/PHPCSUtils-Utils-GetTokensAsString.html#method_normal"
+            "url": "classes/PHPCSUtils-Utils-GetTokensAsString.html#method_normal"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\GetTokensAsString\u003A\u003AtabReplaced\u0028\u0029",
             "name": "tabReplaced",
             "summary": "Retrieve\u0020the\u0020tab\u002Dreplaced\u0020content\u0020of\u0020the\u0020tokens\u0020from\u0020the\u0020specified\u0020start\u0020position\u0020in\nthe\u0020token\u0020stack\u0020to\u0020the\u0020specified\u0020end\u0020position\u0020\u0028inclusive\u0029.",
-            "url": "../classes/PHPCSUtils-Utils-GetTokensAsString.html#method_tabReplaced"
+            "url": "classes/PHPCSUtils-Utils-GetTokensAsString.html#method_tabReplaced"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\GetTokensAsString\u003A\u003AorigContent\u0028\u0029",
             "name": "origContent",
             "summary": "Retrieve\u0020the\u0020original\u0020content\u0020of\u0020the\u0020tokens\u0020from\u0020the\u0020specified\u0020start\u0020position\u0020in\nthe\u0020token\u0020stack\u0020to\u0020the\u0020specified\u0020end\u0020position\u0020\u0028inclusive\u0029.",
-            "url": "../classes/PHPCSUtils-Utils-GetTokensAsString.html#method_origContent"
+            "url": "classes/PHPCSUtils-Utils-GetTokensAsString.html#method_origContent"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\GetTokensAsString\u003A\u003AnoComments\u0028\u0029",
             "name": "noComments",
             "summary": "Retrieve\u0020the\u0020content\u0020of\u0020the\u0020tokens\u0020from\u0020the\u0020specified\u0020start\u0020position\u0020in\u0020the\u0020token\nstack\u0020to\u0020the\u0020specified\u0020end\u0020position\u0020\u0028inclusive\u0029\u0020without\u0020comments.",
-            "url": "../classes/PHPCSUtils-Utils-GetTokensAsString.html#method_noComments"
+            "url": "classes/PHPCSUtils-Utils-GetTokensAsString.html#method_noComments"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\GetTokensAsString\u003A\u003AnoEmpties\u0028\u0029",
             "name": "noEmpties",
             "summary": "Retrieve\u0020the\u0020code\u002Dtokens\u0020only\u0020content\u0020of\u0020the\u0020tokens\u0020from\u0020the\u0020specified\u0020start\u0020position\nin\u0020the\u0020token\u0020stack\u0020to\u0020the\u0020specified\u0020end\u0020position\u0020\u0028inclusive\u0029\u0020without\u0020whitespace\u0020or\u0020comments.",
-            "url": "../classes/PHPCSUtils-Utils-GetTokensAsString.html#method_noEmpties"
+            "url": "classes/PHPCSUtils-Utils-GetTokensAsString.html#method_noEmpties"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\GetTokensAsString\u003A\u003Acompact\u0028\u0029",
             "name": "compact",
             "summary": "Retrieve\u0020the\u0020content\u0020of\u0020the\u0020tokens\u0020from\u0020the\u0020specified\u0020start\u0020position\u0020in\u0020the\u0020token\nstack\u0020to\u0020the\u0020specified\u0020end\u0020position\u0020\u0028inclusive\u0029\u0020with\u0020all\u0020consecutive\u0020whitespace\u0020tokens\u0020\u002D\u0020tabs,\nnew\u0020lines,\u0020multiple\u0020spaces\u0020\u002D\u0020replaced\u0020by\u0020a\u0020single\u0020space\u0020and\u0020optionally\u0020without\u0020comments.",
-            "url": "../classes/PHPCSUtils-Utils-GetTokensAsString.html#method_compact"
+            "url": "classes/PHPCSUtils-Utils-GetTokensAsString.html#method_compact"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\GetTokensAsString\u003A\u003AgetString\u0028\u0029",
             "name": "getString",
             "summary": "Retrieve\u0020the\u0020content\u0020of\u0020the\u0020tokens\u0020from\u0020the\u0020specified\u0020start\u0020position\u0020in\u0020the\u0020token\u0020stack\nto\u0020the\u0020specified\u0020end\u0020position\u0020\u0028inclusive\u0029.",
-            "url": "../classes/PHPCSUtils-Utils-GetTokensAsString.html#method_getString"
+            "url": "classes/PHPCSUtils-Utils-GetTokensAsString.html#method_getString"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Lists",
             "name": "Lists",
             "summary": "Utility\u0020functions\u0020to\u0020retrieve\u0020information\u0020when\u0020working\u0020with\u0020lists.",
-            "url": "../classes/PHPCSUtils-Utils-Lists.html"
+            "url": "classes/PHPCSUtils-Utils-Lists.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Lists\u003A\u003AisShortList\u0028\u0029",
             "name": "isShortList",
             "summary": "Determine\u0020whether\u0020a\u0020T_OPEN\/CLOSE_SHORT_ARRAY\u0020token\u0020is\u0020a\u0020short\u0020list\u0028\u0029\u0020construct.",
-            "url": "../classes/PHPCSUtils-Utils-Lists.html#method_isShortList"
+            "url": "classes/PHPCSUtils-Utils-Lists.html#method_isShortList"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Lists\u003A\u003AgetOpenClose\u0028\u0029",
             "name": "getOpenClose",
             "summary": "Find\u0020the\u0020list\u0020opener\u0020and\u0020closer\u0020based\u0020on\u0020a\u0020T_LIST\u0020or\u0020T_OPEN_SHORT_ARRAY\u0020token.",
-            "url": "../classes/PHPCSUtils-Utils-Lists.html#method_getOpenClose"
+            "url": "classes/PHPCSUtils-Utils-Lists.html#method_getOpenClose"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Lists\u003A\u003AgetAssignments\u0028\u0029",
             "name": "getAssignments",
             "summary": "Retrieves\u0020information\u0020on\u0020the\u0020assignments\u0020made\u0020in\u0020the\u0020specified\u0020\u0028long\/short\u0029\u0020list.",
-            "url": "../classes/PHPCSUtils-Utils-Lists.html#method_getAssignments"
+            "url": "classes/PHPCSUtils-Utils-Lists.html#method_getAssignments"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Namespaces",
             "name": "Namespaces",
             "summary": "Utility\u0020functions\u0020for\u0020use\u0020when\u0020examining\u0020T_NAMESPACE\u0020tokens\u0020and\u0020to\u0020determine\u0020the\nnamespace\u0020of\u0020arbitrary\u0020tokens.",
-            "url": "../classes/PHPCSUtils-Utils-Namespaces.html"
+            "url": "classes/PHPCSUtils-Utils-Namespaces.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Namespaces\u003A\u003AgetType\u0028\u0029",
             "name": "getType",
             "summary": "Determine\u0020what\u0020a\u0020T_NAMESPACE\u0020token\u0020is\u0020used\u0020for.",
-            "url": "../classes/PHPCSUtils-Utils-Namespaces.html#method_getType"
+            "url": "classes/PHPCSUtils-Utils-Namespaces.html#method_getType"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Namespaces\u003A\u003AisDeclaration\u0028\u0029",
             "name": "isDeclaration",
             "summary": "Determine\u0020whether\u0020a\u0020T_NAMESPACE\u0020token\u0020is\u0020the\u0020keyword\u0020for\u0020a\u0020namespace\u0020declaration.",
-            "url": "../classes/PHPCSUtils-Utils-Namespaces.html#method_isDeclaration"
+            "url": "classes/PHPCSUtils-Utils-Namespaces.html#method_isDeclaration"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Namespaces\u003A\u003AisOperator\u0028\u0029",
             "name": "isOperator",
             "summary": "Determine\u0020whether\u0020a\u0020T_NAMESPACE\u0020token\u0020is\u0020used\u0020as\u0020an\u0020operator.",
-            "url": "../classes/PHPCSUtils-Utils-Namespaces.html#method_isOperator"
+            "url": "classes/PHPCSUtils-Utils-Namespaces.html#method_isOperator"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Namespaces\u003A\u003AgetDeclaredName\u0028\u0029",
             "name": "getDeclaredName",
             "summary": "Get\u0020the\u0020complete\u0020namespace\u0020name\u0020as\u0020declared.",
-            "url": "../classes/PHPCSUtils-Utils-Namespaces.html#method_getDeclaredName"
+            "url": "classes/PHPCSUtils-Utils-Namespaces.html#method_getDeclaredName"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Namespaces\u003A\u003AfindNamespacePtr\u0028\u0029",
             "name": "findNamespacePtr",
             "summary": "Determine\u0020the\u0020namespace\u0020an\u0020arbitrary\u0020token\u0020lives\u0020in.",
-            "url": "../classes/PHPCSUtils-Utils-Namespaces.html#method_findNamespacePtr"
+            "url": "classes/PHPCSUtils-Utils-Namespaces.html#method_findNamespacePtr"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Namespaces\u003A\u003AdetermineNamespace\u0028\u0029",
             "name": "determineNamespace",
             "summary": "Determine\u0020the\u0020namespace\u0020name\u0020an\u0020arbitrary\u0020token\u0020lives\u0020in.",
-            "url": "../classes/PHPCSUtils-Utils-Namespaces.html#method_determineNamespace"
+            "url": "classes/PHPCSUtils-Utils-Namespaces.html#method_determineNamespace"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\NamingConventions",
             "name": "NamingConventions",
             "summary": "Utility\u0020functions\u0020for\u0020working\u0020with\u0020identifier\u0020names.",
-            "url": "../classes/PHPCSUtils-Utils-NamingConventions.html"
+            "url": "classes/PHPCSUtils-Utils-NamingConventions.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\NamingConventions\u003A\u003AisValidIdentifierName\u0028\u0029",
             "name": "isValidIdentifierName",
             "summary": "Verify\u0020whether\u0020an\u0020arbitrary\u0020text\u0020string\u0020is\u0020valid\u0020as\u0020an\u0020identifier\u0020name\u0020in\u0020PHP.",
-            "url": "../classes/PHPCSUtils-Utils-NamingConventions.html#method_isValidIdentifierName"
+            "url": "classes/PHPCSUtils-Utils-NamingConventions.html#method_isValidIdentifierName"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\NamingConventions\u003A\u003AisEqual\u0028\u0029",
             "name": "isEqual",
             "summary": "Check\u0020if\u0020two\u0020arbitrary\u0020identifier\u0020names\u0020will\u0020be\u0020seen\u0020as\u0020the\u0020same\u0020in\u0020PHP.",
-            "url": "../classes/PHPCSUtils-Utils-NamingConventions.html#method_isEqual"
+            "url": "classes/PHPCSUtils-Utils-NamingConventions.html#method_isEqual"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\NamingConventions\u003A\u003APHP_LABEL_REGEX",
             "name": "PHP_LABEL_REGEX",
             "summary": "Regular\u0020expression\u0020to\u0020check\u0020if\u0020a\u0020given\u0020identifier\u0020name\u0020is\u0020valid\u0020for\u0020use\u0020in\u0020PHP.",
-            "url": "../classes/PHPCSUtils-Utils-NamingConventions.html#constant_PHP_LABEL_REGEX"
+            "url": "classes/PHPCSUtils-Utils-NamingConventions.html#constant_PHP_LABEL_REGEX"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\NamingConventions\u003A\u003AAZ_UPPER",
             "name": "AZ_UPPER",
             "summary": "Uppercase\u0020A\u002DZ.",
-            "url": "../classes/PHPCSUtils-Utils-NamingConventions.html#constant_AZ_UPPER"
+            "url": "classes/PHPCSUtils-Utils-NamingConventions.html#constant_AZ_UPPER"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\NamingConventions\u003A\u003AAZ_LOWER",
             "name": "AZ_LOWER",
             "summary": "Lowercase\u0020a\u002Dz.",
-            "url": "../classes/PHPCSUtils-Utils-NamingConventions.html#constant_AZ_LOWER"
+            "url": "classes/PHPCSUtils-Utils-NamingConventions.html#constant_AZ_LOWER"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Numbers",
             "name": "Numbers",
             "summary": "Utility\u0020functions\u0020for\u0020working\u0020with\u0020integer\/float\u0020tokens.",
-            "url": "../classes/PHPCSUtils-Utils-Numbers.html"
+            "url": "classes/PHPCSUtils-Utils-Numbers.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AgetCompleteNumber\u0028\u0029",
             "name": "getCompleteNumber",
             "summary": "Retrieve\u0020information\u0020about\u0020a\u0020number\u0020token\u0020in\u0020a\u0020cross\u002Dversion\u0020compatible\u0020manner.",
-            "url": "../classes/PHPCSUtils-Utils-Numbers.html#method_getCompleteNumber"
+            "url": "classes/PHPCSUtils-Utils-Numbers.html#method_getCompleteNumber"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AgetDecimalValue\u0028\u0029",
             "name": "getDecimalValue",
             "summary": "Get\u0020the\u0020decimal\u0020number\u0020value\u0020of\u0020a\u0020numeric\u0020string.",
-            "url": "../classes/PHPCSUtils-Utils-Numbers.html#method_getDecimalValue"
+            "url": "classes/PHPCSUtils-Utils-Numbers.html#method_getDecimalValue"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AisDecimalInt\u0028\u0029",
             "name": "isDecimalInt",
             "summary": "Verify\u0020whether\u0020the\u0020contents\u0020of\u0020an\u0020arbitrary\u0020string\u0020represents\u0020a\u0020decimal\u0020integer.",
-            "url": "../classes/PHPCSUtils-Utils-Numbers.html#method_isDecimalInt"
+            "url": "classes/PHPCSUtils-Utils-Numbers.html#method_isDecimalInt"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AisHexidecimalInt\u0028\u0029",
             "name": "isHexidecimalInt",
             "summary": "Verify\u0020whether\u0020the\u0020contents\u0020of\u0020an\u0020arbitrary\u0020string\u0020represents\u0020a\u0020hexidecimal\u0020integer.",
-            "url": "../classes/PHPCSUtils-Utils-Numbers.html#method_isHexidecimalInt"
+            "url": "classes/PHPCSUtils-Utils-Numbers.html#method_isHexidecimalInt"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AisBinaryInt\u0028\u0029",
             "name": "isBinaryInt",
             "summary": "Verify\u0020whether\u0020the\u0020contents\u0020of\u0020an\u0020arbitrary\u0020string\u0020represents\u0020a\u0020binary\u0020integer.",
-            "url": "../classes/PHPCSUtils-Utils-Numbers.html#method_isBinaryInt"
+            "url": "classes/PHPCSUtils-Utils-Numbers.html#method_isBinaryInt"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AisOctalInt\u0028\u0029",
             "name": "isOctalInt",
             "summary": "Verify\u0020whether\u0020the\u0020contents\u0020of\u0020an\u0020arbitrary\u0020string\u0020represents\u0020an\u0020octal\u0020integer.",
-            "url": "../classes/PHPCSUtils-Utils-Numbers.html#method_isOctalInt"
+            "url": "classes/PHPCSUtils-Utils-Numbers.html#method_isOctalInt"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AisFloat\u0028\u0029",
             "name": "isFloat",
             "summary": "Verify\u0020whether\u0020the\u0020contents\u0020of\u0020an\u0020arbitrary\u0020string\u0020represents\u0020a\u0020floating\u0020point\u0020number.",
-            "url": "../classes/PHPCSUtils-Utils-Numbers.html#method_isFloat"
+            "url": "classes/PHPCSUtils-Utils-Numbers.html#method_isFloat"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AREGEX_DECIMAL_INT",
             "name": "REGEX_DECIMAL_INT",
             "summary": "Regex\u0020to\u0020determine\u0020whether\u0020the\u0020contents\u0020of\u0020an\u0020arbitrary\u0020string\u0020represents\u0020a\u0020decimal\u0020integer.",
-            "url": "../classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_DECIMAL_INT"
+            "url": "classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_DECIMAL_INT"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AREGEX_OCTAL_INT",
             "name": "REGEX_OCTAL_INT",
             "summary": "Regex\u0020to\u0020determine\u0020whether\u0020the\u0020contents\u0020of\u0020an\u0020arbitrary\u0020string\u0020represents\u0020an\u0020octal\u0020integer.",
-            "url": "../classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_OCTAL_INT"
+            "url": "classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_OCTAL_INT"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AREGEX_BINARY_INT",
             "name": "REGEX_BINARY_INT",
             "summary": "Regex\u0020to\u0020determine\u0020whether\u0020the\u0020contents\u0020of\u0020an\u0020arbitrary\u0020string\u0020represents\u0020a\u0020binary\u0020integer.",
-            "url": "../classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_BINARY_INT"
+            "url": "classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_BINARY_INT"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AREGEX_HEX_INT",
             "name": "REGEX_HEX_INT",
             "summary": "Regex\u0020to\u0020determine\u0020whether\u0020the\u0020contents\u0020of\u0020an\u0020arbitrary\u0020string\u0020represents\u0020a\u0020hexidecimal\u0020integer.",
-            "url": "../classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_HEX_INT"
+            "url": "classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_HEX_INT"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AREGEX_FLOAT",
             "name": "REGEX_FLOAT",
             "summary": "Regex\u0020to\u0020determine\u0020whether\u0020the\u0020contents\u0020of\u0020an\u0020arbitrary\u0020string\u0020represents\u0020a\u0020float.",
-            "url": "../classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_FLOAT"
+            "url": "classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_FLOAT"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AREGEX_NUMLIT_STRING",
             "name": "REGEX_NUMLIT_STRING",
             "summary": "Regex\u0020to\u0020determine\u0020if\u0020a\u0020T_STRING\u0020following\u0020a\u0020T_\u005BDL\u005DNUMBER\u0020is\u0020part\u0020of\u0020a\u0020numeric\u0020literal\u0020sequence.",
-            "url": "../classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_NUMLIT_STRING"
+            "url": "classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_NUMLIT_STRING"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AREGEX_HEX_NUMLIT_STRING",
             "name": "REGEX_HEX_NUMLIT_STRING",
             "summary": "Regex\u0020to\u0020determine\u0020is\u0020a\u0020T_STRING\u0020following\u0020a\u0020T_\u005BDL\u005DNUMBER\u0020is\u0020part\u0020of\u0020a\u0020hexidecimal\u0020numeric\u0020literal\u0020sequence.",
-            "url": "../classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_HEX_NUMLIT_STRING"
+            "url": "classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_HEX_NUMLIT_STRING"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AUNSUPPORTED_PHPCS_VERSION",
             "name": "UNSUPPORTED_PHPCS_VERSION",
             "summary": "PHPCS\u0020versions\u0020in\u0020which\u0020the\u0020backfill\u0020for\u0020PHP\u00207.4\u0020numeric\u0020literal\u0020separators\u0020is\u0020broken.",
-            "url": "../classes/PHPCSUtils-Utils-Numbers.html#constant_UNSUPPORTED_PHPCS_VERSION"
+            "url": "classes/PHPCSUtils-Utils-Numbers.html#constant_UNSUPPORTED_PHPCS_VERSION"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\ObjectDeclarations",
             "name": "ObjectDeclarations",
             "summary": "Utility\u0020functions\u0020for\u0020use\u0020when\u0020examining\u0020object\u0020declaration\u0020statements.",
-            "url": "../classes/PHPCSUtils-Utils-ObjectDeclarations.html"
+            "url": "classes/PHPCSUtils-Utils-ObjectDeclarations.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\ObjectDeclarations\u003A\u003AgetName\u0028\u0029",
             "name": "getName",
             "summary": "Retrieves\u0020the\u0020declaration\u0020name\u0020for\u0020classes,\u0020interfaces,\u0020traits,\u0020and\u0020functions.",
-            "url": "../classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getName"
+            "url": "classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getName"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\ObjectDeclarations\u003A\u003AgetClassProperties\u0028\u0029",
             "name": "getClassProperties",
             "summary": "Retrieves\u0020the\u0020implementation\u0020properties\u0020of\u0020a\u0020class.",
-            "url": "../classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getClassProperties"
+            "url": "classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getClassProperties"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\ObjectDeclarations\u003A\u003AfindExtendedClassName\u0028\u0029",
             "name": "findExtendedClassName",
             "summary": "Retrieves\u0020the\u0020name\u0020of\u0020the\u0020class\u0020that\u0020the\u0020specified\u0020class\u0020extends.",
-            "url": "../classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findExtendedClassName"
+            "url": "classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findExtendedClassName"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\ObjectDeclarations\u003A\u003AfindImplementedInterfaceNames\u0028\u0029",
             "name": "findImplementedInterfaceNames",
             "summary": "Retrieves\u0020the\u0020names\u0020of\u0020the\u0020interfaces\u0020that\u0020the\u0020specified\u0020class\u0020implements.",
-            "url": "../classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findImplementedInterfaceNames"
+            "url": "classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findImplementedInterfaceNames"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\ObjectDeclarations\u003A\u003AfindExtendedInterfaceNames\u0028\u0029",
             "name": "findExtendedInterfaceNames",
             "summary": "Retrieves\u0020the\u0020names\u0020of\u0020the\u0020interfaces\u0020that\u0020the\u0020specified\u0020interface\u0020extends.",
-            "url": "../classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findExtendedInterfaceNames"
+            "url": "classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findExtendedInterfaceNames"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Operators",
             "name": "Operators",
             "summary": "Utility\u0020functions\u0020for\u0020use\u0020when\u0020working\u0020with\u0020operators.",
-            "url": "../classes/PHPCSUtils-Utils-Operators.html"
+            "url": "classes/PHPCSUtils-Utils-Operators.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Operators\u003A\u003AisReference\u0028\u0029",
             "name": "isReference",
             "summary": "Determine\u0020if\u0020the\u0020passed\u0020token\u0020is\u0020a\u0020reference\u0020operator.",
-            "url": "../classes/PHPCSUtils-Utils-Operators.html#method_isReference"
+            "url": "classes/PHPCSUtils-Utils-Operators.html#method_isReference"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Operators\u003A\u003AisUnaryPlusMinus\u0028\u0029",
             "name": "isUnaryPlusMinus",
             "summary": "Determine\u0020whether\u0020a\u0020T_MINUS\/T_PLUS\u0020token\u0020is\u0020a\u0020unary\u0020operator.",
-            "url": "../classes/PHPCSUtils-Utils-Operators.html#method_isUnaryPlusMinus"
+            "url": "classes/PHPCSUtils-Utils-Operators.html#method_isUnaryPlusMinus"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Operators\u003A\u003AisShortTernary\u0028\u0029",
             "name": "isShortTernary",
             "summary": "Determine\u0020whether\u0020a\u0020ternary\u0020is\u0020a\u0020short\u0020ternary\/elvis\u0020operator,\u0020i.e.\u0020without\u0020\u0022middle\u0022.",
-            "url": "../classes/PHPCSUtils-Utils-Operators.html#method_isShortTernary"
+            "url": "classes/PHPCSUtils-Utils-Operators.html#method_isShortTernary"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Orthography",
             "name": "Orthography",
             "summary": "Utility\u0020functions\u0020for\u0020checking\u0020the\u0020orthography\u0020of\u0020arbitrary\u0020text\u0020strings.",
-            "url": "../classes/PHPCSUtils-Utils-Orthography.html"
+            "url": "classes/PHPCSUtils-Utils-Orthography.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Orthography\u003A\u003AisFirstCharCapitalized\u0028\u0029",
             "name": "isFirstCharCapitalized",
             "summary": "Check\u0020if\u0020the\u0020first\u0020character\u0020of\u0020an\u0020arbitrary\u0020text\u0020string\u0020is\u0020a\u0020capital\u0020letter.",
-            "url": "../classes/PHPCSUtils-Utils-Orthography.html#method_isFirstCharCapitalized"
+            "url": "classes/PHPCSUtils-Utils-Orthography.html#method_isFirstCharCapitalized"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Orthography\u003A\u003AisFirstCharLowercase\u0028\u0029",
             "name": "isFirstCharLowercase",
             "summary": "Check\u0020if\u0020the\u0020first\u0020character\u0020of\u0020an\u0020arbitrary\u0020text\u0020string\u0020is\u0020a\u0020lowercase\u0020letter.",
-            "url": "../classes/PHPCSUtils-Utils-Orthography.html#method_isFirstCharLowercase"
+            "url": "classes/PHPCSUtils-Utils-Orthography.html#method_isFirstCharLowercase"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Orthography\u003A\u003AisLastCharPunctuation\u0028\u0029",
             "name": "isLastCharPunctuation",
             "summary": "Check\u0020if\u0020the\u0020last\u0020character\u0020of\u0020an\u0020arbitrary\u0020text\u0020string\u0020is\u0020a\u0020valid\u0020punctuation\u0020character.",
-            "url": "../classes/PHPCSUtils-Utils-Orthography.html#method_isLastCharPunctuation"
+            "url": "classes/PHPCSUtils-Utils-Orthography.html#method_isLastCharPunctuation"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Orthography\u003A\u003ATERMINAL_POINTS",
             "name": "TERMINAL_POINTS",
             "summary": "Characters\u0020which\u0020are\u0020considered\u0020terminal\u0020points\u0020for\u0020a\u0020sentence.",
-            "url": "../classes/PHPCSUtils-Utils-Orthography.html#constant_TERMINAL_POINTS"
+            "url": "classes/PHPCSUtils-Utils-Orthography.html#constant_TERMINAL_POINTS"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses",
             "name": "Parentheses",
             "summary": "Utility\u0020functions\u0020for\u0020use\u0020when\u0020examining\u0020parenthesis\u0020tokens\u0020and\u0020arbitrary\u0020tokens\u0020wrapped\u0020in\nparentheses.",
-            "url": "../classes/PHPCSUtils-Utils-Parentheses.html"
+            "url": "classes/PHPCSUtils-Utils-Parentheses.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AgetOwner\u0028\u0029",
             "name": "getOwner",
             "summary": "Get\u0020the\u0020pointer\u0020to\u0020the\u0020parentheses\u0020owner\u0020of\u0020an\u0020open\/close\u0020parenthesis.",
-            "url": "../classes/PHPCSUtils-Utils-Parentheses.html#method_getOwner"
+            "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_getOwner"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AisOwnerIn\u0028\u0029",
             "name": "isOwnerIn",
             "summary": "Check\u0020whether\u0020the\u0020parenthesis\u0020owner\u0020of\u0020an\u0020open\/close\u0020parenthesis\u0020is\u0020within\u0020a\u0020limited\nset\u0020of\u0020valid\u0020owners.",
-            "url": "../classes/PHPCSUtils-Utils-Parentheses.html#method_isOwnerIn"
+            "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_isOwnerIn"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AhasOwner\u0028\u0029",
             "name": "hasOwner",
             "summary": "Check\u0020whether\u0020the\u0020passed\u0020token\u0020is\u0020nested\u0020within\u0020parentheses\u0020owned\u0020by\u0020one\u0020of\u0020the\u0020valid\u0020owners.",
-            "url": "../classes/PHPCSUtils-Utils-Parentheses.html#method_hasOwner"
+            "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_hasOwner"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AgetFirstOpener\u0028\u0029",
             "name": "getFirstOpener",
             "summary": "Retrieve\u0020the\u0020position\u0020of\u0020the\u0020opener\u0020to\u0020the\u0020first\u0020\u0028outer\u0029\u0020set\u0020of\u0020parentheses\u0020an\u0020arbitrary\ntoken\u0020is\u0020wrapped\u0020in,\u0020where\u0020the\u0020parentheses\u0020owner\u0020is\u0020within\u0020the\u0020set\u0020of\u0020valid\u0020owners.",
-            "url": "../classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstOpener"
+            "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstOpener"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AgetFirstCloser\u0028\u0029",
             "name": "getFirstCloser",
             "summary": "Retrieve\u0020the\u0020position\u0020of\u0020the\u0020closer\u0020to\u0020the\u0020first\u0020\u0028outer\u0029\u0020set\u0020of\u0020parentheses\u0020an\u0020arbitrary\ntoken\u0020is\u0020wrapped\u0020in,\u0020where\u0020the\u0020parentheses\u0020owner\u0020is\u0020within\u0020the\u0020set\u0020of\u0020valid\u0020owners.",
-            "url": "../classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstCloser"
+            "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstCloser"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AgetFirstOwner\u0028\u0029",
             "name": "getFirstOwner",
             "summary": "Retrieve\u0020the\u0020position\u0020of\u0020the\u0020parentheses\u0020owner\u0020to\u0020the\u0020first\u0020\u0028outer\u0029\u0020set\u0020of\u0020parentheses\u0020an\narbitrary\u0020token\u0020is\u0020wrapped\u0020in,\u0020where\u0020the\u0020parentheses\u0020owner\u0020is\u0020within\u0020the\u0020set\u0020of\u0020valid\u0020owners.",
-            "url": "../classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstOwner"
+            "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstOwner"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AgetLastOpener\u0028\u0029",
             "name": "getLastOpener",
             "summary": "Retrieve\u0020the\u0020position\u0020of\u0020the\u0020opener\u0020to\u0020the\u0020last\u0020\u0028inner\u0029\u0020set\u0020of\u0020parentheses\u0020an\u0020arbitrary\ntoken\u0020is\u0020wrapped\u0020in,\u0020where\u0020the\u0020parentheses\u0020owner\u0020is\u0020within\u0020the\u0020set\u0020of\u0020valid\u0020owners.",
-            "url": "../classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOpener"
+            "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOpener"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AgetLastCloser\u0028\u0029",
             "name": "getLastCloser",
             "summary": "Retrieve\u0020the\u0020position\u0020of\u0020the\u0020closer\u0020to\u0020the\u0020last\u0020\u0028inner\u0029\u0020set\u0020of\u0020parentheses\u0020an\u0020arbitrary\ntoken\u0020is\u0020wrapped\u0020in,\u0020where\u0020the\u0020parentheses\u0020owner\u0020is\u0020within\u0020the\u0020set\u0020of\u0020valid\u0020owners.",
-            "url": "../classes/PHPCSUtils-Utils-Parentheses.html#method_getLastCloser"
+            "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_getLastCloser"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AgetLastOwner\u0028\u0029",
             "name": "getLastOwner",
             "summary": "Retrieve\u0020the\u0020position\u0020of\u0020the\u0020parentheses\u0020owner\u0020to\u0020the\u0020last\u0020\u0028inner\u0029\u0020set\u0020of\u0020parentheses\u0020an\narbitrary\u0020token\u0020is\u0020wrapped\u0020in\u0020where\u0020the\u0020parentheses\u0020owner\u0020is\u0020within\u0020the\u0020set\u0020of\u0020valid\u0020owners.",
-            "url": "../classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOwner"
+            "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOwner"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AfirstOwnerIn\u0028\u0029",
             "name": "firstOwnerIn",
             "summary": "Check\u0020whether\u0020the\u0020owner\u0020of\u0020a\u0020outermost\u0020wrapping\u0020set\u0020of\u0020parentheses\u0020of\u0020an\u0020arbitrary\u0020token\nis\u0020within\u0020a\u0020limited\u0020set\u0020of\u0020acceptable\u0020token\u0020types.",
-            "url": "../classes/PHPCSUtils-Utils-Parentheses.html#method_firstOwnerIn"
+            "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_firstOwnerIn"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AlastOwnerIn\u0028\u0029",
             "name": "lastOwnerIn",
             "summary": "Check\u0020whether\u0020the\u0020owner\u0020of\u0020a\u0020innermost\u0020wrapping\u0020set\u0020of\u0020parentheses\u0020of\u0020an\u0020arbitrary\u0020token\nis\u0020within\u0020a\u0020limited\u0020set\u0020of\u0020acceptable\u0020token\u0020types.",
-            "url": "../classes/PHPCSUtils-Utils-Parentheses.html#method_lastOwnerIn"
+            "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_lastOwnerIn"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\PassedParameters",
             "name": "PassedParameters",
             "summary": "Utility\u0020functions\u0020to\u0020retrieve\u0020information\u0020about\u0020parameters\u0020passed\u0020to\u0020function\u0020calls,\narray\u0020declarations,\u0020isset\u0020and\u0020unset\u0020constructs.",
-            "url": "../classes/PHPCSUtils-Utils-PassedParameters.html"
+            "url": "classes/PHPCSUtils-Utils-PassedParameters.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\PassedParameters\u003A\u003AhasParameters\u0028\u0029",
             "name": "hasParameters",
             "summary": "Checks\u0020if\u0020any\u0020parameters\u0020have\u0020been\u0020passed.",
-            "url": "../classes/PHPCSUtils-Utils-PassedParameters.html#method_hasParameters"
+            "url": "classes/PHPCSUtils-Utils-PassedParameters.html#method_hasParameters"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\PassedParameters\u003A\u003AgetParameters\u0028\u0029",
             "name": "getParameters",
             "summary": "Get\u0020information\u0020on\u0020all\u0020parameters\u0020passed.",
-            "url": "../classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameters"
+            "url": "classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameters"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\PassedParameters\u003A\u003AgetParameter\u0028\u0029",
             "name": "getParameter",
             "summary": "Get\u0020information\u0020on\u0020a\u0020specific\u0020parameter\u0020passed.",
-            "url": "../classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameter"
+            "url": "classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameter"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\PassedParameters\u003A\u003AgetParameterCount\u0028\u0029",
             "name": "getParameterCount",
             "summary": "Count\u0020the\u0020number\u0020of\u0020parameters\u0020which\u0020have\u0020been\u0020passed.",
-            "url": "../classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameterCount"
+            "url": "classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameterCount"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Scopes",
             "name": "Scopes",
             "summary": "Utility\u0020functions\u0020for\u0020use\u0020when\u0020examining\u0020token\u0020scopes.",
-            "url": "../classes/PHPCSUtils-Utils-Scopes.html"
+            "url": "classes/PHPCSUtils-Utils-Scopes.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Scopes\u003A\u003AvalidDirectScope\u0028\u0029",
             "name": "validDirectScope",
             "summary": "Check\u0020whether\u0020the\u0020direct\u0020wrapping\u0020scope\u0020of\u0020a\u0020token\u0020is\u0020within\u0020a\u0020limited\u0020set\u0020of\nacceptable\u0020tokens.",
-            "url": "../classes/PHPCSUtils-Utils-Scopes.html#method_validDirectScope"
+            "url": "classes/PHPCSUtils-Utils-Scopes.html#method_validDirectScope"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Scopes\u003A\u003AisOOConstant\u0028\u0029",
             "name": "isOOConstant",
             "summary": "Check\u0020whether\u0020a\u0020T_CONST\u0020token\u0020is\u0020a\u0020class\/interface\u0020constant\u0020declaration.",
-            "url": "../classes/PHPCSUtils-Utils-Scopes.html#method_isOOConstant"
+            "url": "classes/PHPCSUtils-Utils-Scopes.html#method_isOOConstant"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Scopes\u003A\u003AisOOProperty\u0028\u0029",
             "name": "isOOProperty",
             "summary": "Check\u0020whether\u0020a\u0020T_VARIABLE\u0020token\u0020is\u0020a\u0020class\/trait\u0020property\u0020declaration.",
-            "url": "../classes/PHPCSUtils-Utils-Scopes.html#method_isOOProperty"
+            "url": "classes/PHPCSUtils-Utils-Scopes.html#method_isOOProperty"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Scopes\u003A\u003AisOOMethod\u0028\u0029",
             "name": "isOOMethod",
             "summary": "Check\u0020whether\u0020a\u0020T_FUNCTION\u0020token\u0020is\u0020a\u0020class\/interface\/trait\u0020method\u0020declaration.",
-            "url": "../classes/PHPCSUtils-Utils-Scopes.html#method_isOOMethod"
+            "url": "classes/PHPCSUtils-Utils-Scopes.html#method_isOOMethod"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\TextStrings",
             "name": "TextStrings",
             "summary": "Utility\u0020functions\u0020for\u0020working\u0020with\u0020text\u0020string\u0020tokens.",
-            "url": "../classes/PHPCSUtils-Utils-TextStrings.html"
+            "url": "classes/PHPCSUtils-Utils-TextStrings.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\TextStrings\u003A\u003AgetCompleteTextString\u0028\u0029",
             "name": "getCompleteTextString",
             "summary": "Get\u0020the\u0020complete\u0020contents\u0020of\u0020a\u0020\u002D\u0020potentially\u0020multi\u002Dline\u0020\u002D\u0020text\u0020string.",
-            "url": "../classes/PHPCSUtils-Utils-TextStrings.html#method_getCompleteTextString"
+            "url": "classes/PHPCSUtils-Utils-TextStrings.html#method_getCompleteTextString"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\TextStrings\u003A\u003AstripQuotes\u0028\u0029",
             "name": "stripQuotes",
             "summary": "Strip\u0020text\u0020delimiter\u0020quotes\u0020from\u0020an\u0020arbitrary\u0020string.",
-            "url": "../classes/PHPCSUtils-Utils-TextStrings.html#method_stripQuotes"
+            "url": "classes/PHPCSUtils-Utils-TextStrings.html#method_stripQuotes"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\UseStatements",
             "name": "UseStatements",
             "summary": "Utility\u0020functions\u0020for\u0020examining\u0020use\u0020statements.",
-            "url": "../classes/PHPCSUtils-Utils-UseStatements.html"
+            "url": "classes/PHPCSUtils-Utils-UseStatements.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\UseStatements\u003A\u003AgetType\u0028\u0029",
             "name": "getType",
             "summary": "Determine\u0020what\u0020a\u0020T_USE\u0020token\u0020is\u0020used\u0020for.",
-            "url": "../classes/PHPCSUtils-Utils-UseStatements.html#method_getType"
+            "url": "classes/PHPCSUtils-Utils-UseStatements.html#method_getType"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\UseStatements\u003A\u003AisClosureUse\u0028\u0029",
             "name": "isClosureUse",
             "summary": "Determine\u0020whether\u0020a\u0020T_USE\u0020token\u0020represents\u0020a\u0020closure\u0020use\u0020statement.",
-            "url": "../classes/PHPCSUtils-Utils-UseStatements.html#method_isClosureUse"
+            "url": "classes/PHPCSUtils-Utils-UseStatements.html#method_isClosureUse"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\UseStatements\u003A\u003AisImportUse\u0028\u0029",
             "name": "isImportUse",
             "summary": "Determine\u0020whether\u0020a\u0020T_USE\u0020token\u0020represents\u0020a\u0020class\/function\/constant\u0020import\u0020use\u0020statement.",
-            "url": "../classes/PHPCSUtils-Utils-UseStatements.html#method_isImportUse"
+            "url": "classes/PHPCSUtils-Utils-UseStatements.html#method_isImportUse"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\UseStatements\u003A\u003AisTraitUse\u0028\u0029",
             "name": "isTraitUse",
             "summary": "Determine\u0020whether\u0020a\u0020T_USE\u0020token\u0020represents\u0020a\u0020trait\u0020use\u0020statement.",
-            "url": "../classes/PHPCSUtils-Utils-UseStatements.html#method_isTraitUse"
+            "url": "classes/PHPCSUtils-Utils-UseStatements.html#method_isTraitUse"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\UseStatements\u003A\u003AsplitImportUseStatement\u0028\u0029",
             "name": "splitImportUseStatement",
             "summary": "Split\u0020an\u0020import\u0020use\u0020statement\u0020into\u0020individual\u0020imports.",
-            "url": "../classes/PHPCSUtils-Utils-UseStatements.html#method_splitImportUseStatement"
+            "url": "classes/PHPCSUtils-Utils-UseStatements.html#method_splitImportUseStatement"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\UseStatements\u003A\u003AsplitAndMergeImportUseStatement\u0028\u0029",
             "name": "splitAndMergeImportUseStatement",
             "summary": "Split\u0020an\u0020import\u0020use\u0020statement\u0020into\u0020individual\u0020imports\u0020and\u0020merge\u0020it\u0020with\u0020an\u0020array\u0020of\u0020previously\nseen\u0020import\u0020use\u0020statements.",
-            "url": "../classes/PHPCSUtils-Utils-UseStatements.html#method_splitAndMergeImportUseStatement"
+            "url": "classes/PHPCSUtils-Utils-UseStatements.html#method_splitAndMergeImportUseStatement"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Variables",
             "name": "Variables",
             "summary": "Utility\u0020functions\u0020for\u0020use\u0020when\u0020examining\u0020variables.",
-            "url": "../classes/PHPCSUtils-Utils-Variables.html"
+            "url": "classes/PHPCSUtils-Utils-Variables.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Variables\u003A\u003AgetMemberProperties\u0028\u0029",
             "name": "getMemberProperties",
             "summary": "Retrieve\u0020the\u0020visibility\u0020and\u0020implementation\u0020properties\u0020of\u0020a\u0020class\u0020member\u0020variable.",
-            "url": "../classes/PHPCSUtils-Utils-Variables.html#method_getMemberProperties"
+            "url": "classes/PHPCSUtils-Utils-Variables.html#method_getMemberProperties"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Variables\u003A\u003AisPHPReservedVarName\u0028\u0029",
             "name": "isPHPReservedVarName",
             "summary": "Verify\u0020if\u0020a\u0020given\u0020variable\u0020name\u0020is\u0020the\u0020name\u0020of\u0020a\u0020PHP\u0020reserved\u0020variable.",
-            "url": "../classes/PHPCSUtils-Utils-Variables.html#method_isPHPReservedVarName"
+            "url": "classes/PHPCSUtils-Utils-Variables.html#method_isPHPReservedVarName"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Variables\u003A\u003AisSuperglobal\u0028\u0029",
             "name": "isSuperglobal",
             "summary": "Verify\u0020if\u0020a\u0020given\u0020variable\u0020or\u0020array\u0020key\u0020token\u0020points\u0020to\u0020a\u0020PHP\u0020superglobal.",
-            "url": "../classes/PHPCSUtils-Utils-Variables.html#method_isSuperglobal"
+            "url": "classes/PHPCSUtils-Utils-Variables.html#method_isSuperglobal"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Variables\u003A\u003AisSuperglobalName\u0028\u0029",
             "name": "isSuperglobalName",
             "summary": "Verify\u0020if\u0020a\u0020given\u0020variable\u0020name\u0020is\u0020the\u0020name\u0020of\u0020a\u0020PHP\u0020superglobal.",
-            "url": "../classes/PHPCSUtils-Utils-Variables.html#method_isSuperglobalName"
+            "url": "classes/PHPCSUtils-Utils-Variables.html#method_isSuperglobalName"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Variables\u003A\u003A\u0024phpReservedVars",
             "name": "phpReservedVars",
             "summary": "List\u0020of\u0020PHP\u0020Reserved\u0020variables.",
-            "url": "../classes/PHPCSUtils-Utils-Variables.html#property_phpReservedVars"
+            "url": "classes/PHPCSUtils-Utils-Variables.html#property_phpReservedVars"
+        },                {
+            "fqsen": "\\PHPCSUTILS_AUTOLOAD",
+            "name": "PHPCSUTILS_AUTOLOAD",
+            "summary": "",
+            "url": "namespaces/default.html#constant_PHPCSUTILS_AUTOLOAD"
+        },                {
+            "fqsen": "\\PHPCSUTILS_PHPCS_ALIASES_SET",
+            "name": "PHPCSUTILS_PHPCS_ALIASES_SET",
+            "summary": "",
+            "url": "namespaces/default.html#constant_PHPCSUTILS_PHPCS_ALIASES_SET"
+        },                {
+            "fqsen": "\\PHPCSUTILS_PHPUNIT_ALIASES_SET",
+            "name": "PHPCSUTILS_PHPUNIT_ALIASES_SET",
+            "summary": "",
+            "url": "namespaces/default.html#constant_PHPCSUTILS_PHPUNIT_ALIASES_SET"
         },                {
             "fqsen": "\\",
             "name": "\\",
             "summary": "",
-            "url": "../namespaces/default.html"
+            "url": "namespaces/default.html"
         },                {
             "fqsen": "\\PHPCSUtils\\AbstractSniffs",
             "name": "AbstractSniffs",
             "summary": "",
-            "url": "../namespaces/phpcsutils-abstractsniffs.html"
+            "url": "namespaces/phpcsutils-abstractsniffs.html"
         },                {
             "fqsen": "\\PHPCSUtils",
             "name": "PHPCSUtils",
             "summary": "",
-            "url": "../namespaces/phpcsutils.html"
+            "url": "namespaces/phpcsutils.html"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat",
             "name": "BackCompat",
             "summary": "",
-            "url": "../namespaces/phpcsutils-backcompat.html"
+            "url": "namespaces/phpcsutils-backcompat.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Fixers",
             "name": "Fixers",
             "summary": "",
-            "url": "../namespaces/phpcsutils-fixers.html"
+            "url": "namespaces/phpcsutils-fixers.html"
         },                {
             "fqsen": "\\PHPCSUtils\\TestUtils",
             "name": "TestUtils",
             "summary": "",
-            "url": "../namespaces/phpcsutils-testutils.html"
+            "url": "namespaces/phpcsutils-testutils.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens",
             "name": "Tokens",
             "summary": "",
-            "url": "../namespaces/phpcsutils-tokens.html"
+            "url": "namespaces/phpcsutils-tokens.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils",
             "name": "Utils",
             "summary": "",
-            "url": "../namespaces/phpcsutils-utils.html"
+            "url": "namespaces/phpcsutils-utils.html"
         }            ]
 );

--- a/docs/phpdoc/js/searchIndex.js
+++ b/docs/phpdoc/js/searchIndex.js
@@ -103,7 +103,7 @@ Search.appendIndex(
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCFile\u003A\u003AgetDeclarationName\u0028\u0029",
             "name": "getDeclarationName",
-            "summary": "Returns\u0020the\u0020declaration\u0020names\u0020for\u0020classes,\u0020interfaces,\u0020traits,\u0020and\u0020functions.",
+            "summary": "Returns\u0020the\u0020declaration\u0020name\u0020for\u0020classes,\u0020interfaces,\u0020traits,\u0020enums,\u0020and\u0020functions.",
             "url": "classes/PHPCSUtils-BackCompat-BCFile.html#method_getDeclarationName"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCFile\u003A\u003AgetMethodParameters\u0028\u0029",
@@ -163,7 +163,7 @@ Search.appendIndex(
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCFile\u003A\u003AfindImplementedInterfaceNames\u0028\u0029",
             "name": "findImplementedInterfaceNames",
-            "summary": "Returns\u0020the\u0020names\u0020of\u0020the\u0020interfaces\u0020that\u0020the\u0020specified\u0020class\u0020implements.",
+            "summary": "Returns\u0020the\u0020names\u0020of\u0020the\u0020interfaces\u0020that\u0020the\u0020specified\u0020class\u0020or\u0020enum\u0020implements.",
             "url": "classes/PHPCSUtils-BackCompat-BCFile.html#method_findImplementedInterfaceNames"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens",
@@ -173,53 +173,13 @@ Search.appendIndex(
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003A__callStatic\u0028\u0029",
             "name": "__callStatic",
-            "summary": "Handle\u0020calls\u0020to\u0020\u0028undeclared\u0029\u0020methods\u0020for\u0020token\u0020arrays\u0020which\u0020haven\u0027t\u0020received\u0020any\nchanges\u0020since\u0020PHPCS\u00202.6.0.",
+            "summary": "Handle\u0020calls\u0020to\u0020\u0028undeclared\u0029\u0020methods\u0020for\u0020token\u0020arrays\u0020which\u0020haven\u0027t\u0020received\u0020any\nchanges\u0020since\u0020PHPCS\u00203.7.1.",
             "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method___callStatic"
-        },                {
-            "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003AassignmentTokens\u0028\u0029",
-            "name": "assignmentTokens",
-            "summary": "Tokens\u0020that\u0020represent\u0020assignment\u0020operators.",
-            "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method_assignmentTokens"
-        },                {
-            "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003AcomparisonTokens\u0028\u0029",
-            "name": "comparisonTokens",
-            "summary": "Tokens\u0020that\u0020represent\u0020comparison\u0020operators.",
-            "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method_comparisonTokens"
-        },                {
-            "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003AarithmeticTokens\u0028\u0029",
-            "name": "arithmeticTokens",
-            "summary": "Tokens\u0020that\u0020represent\u0020arithmetic\u0020operators.",
-            "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method_arithmeticTokens"
-        },                {
-            "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003Aoperators\u0028\u0029",
-            "name": "operators",
-            "summary": "Tokens\u0020that\u0020perform\u0020operations.",
-            "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method_operators"
-        },                {
-            "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003AparenthesisOpeners\u0028\u0029",
-            "name": "parenthesisOpeners",
-            "summary": "Token\u0020types\u0020that\u0020open\u0020parentheses.",
-            "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method_parenthesisOpeners"
-        },                {
-            "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003AphpcsCommentTokens\u0028\u0029",
-            "name": "phpcsCommentTokens",
-            "summary": "Tokens\u0020that\u0020are\u0020comments\u0020containing\u0020PHPCS\u0020instructions.",
-            "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method_phpcsCommentTokens"
-        },                {
-            "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003AtextStringTokens\u0028\u0029",
-            "name": "textStringTokens",
-            "summary": "Tokens\u0020that\u0020represent\u0020text\u0020strings.",
-            "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method_textStringTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003AfunctionNameTokens\u0028\u0029",
             "name": "functionNameTokens",
             "summary": "Tokens\u0020that\u0020represent\u0020the\u0020names\u0020of\u0020called\u0020functions.",
             "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method_functionNameTokens"
-        },                {
-            "fqsen": "\\PHPCSUtils\\BackCompat\\BCTokens\u003A\u003AooScopeTokens\u0028\u0029",
-            "name": "ooScopeTokens",
-            "summary": "Tokens\u0020that\u0020open\u0020class\u0020and\u0020object\u0020scopes.",
-            "url": "classes/PHPCSUtils-BackCompat-BCTokens.html#method_ooScopeTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\BackCompat\\Helper",
             "name": "Helper",
@@ -293,8 +253,13 @@ Search.appendIndex(
         },                {
             "fqsen": "\\PHPCSUtils\\TestUtils\\UtilityMethodTestCase\u003A\u003AresetTestFile\u0028\u0029",
             "name": "resetTestFile",
-            "summary": "Clean\u0020up\u0020after\u0020finished\u0020test.",
+            "summary": "Clean\u0020up\u0020after\u0020finished\u0020test\u0020by\u0020resetting\u0020all\u0020static\u0020properties\u0020to\u0020their\u0020default\u0020values.",
             "url": "classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_resetTestFile"
+        },                {
+            "fqsen": "\\PHPCSUtils\\TestUtils\\UtilityMethodTestCase\u003A\u003AusesPhp8NameTokens\u0028\u0029",
+            "name": "usesPhp8NameTokens",
+            "summary": "Check\u0020whether\u0020or\u0020not\u0020the\u0020PHP\u00208.0\u0020identifier\u0020name\u0020tokens\u0020will\u0020be\u0020in\u0020use.",
+            "url": "classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html#method_usesPhp8NameTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\TestUtils\\UtilityMethodTestCase\u003A\u003AgetTargetToken\u0028\u0029",
             "name": "getTargetToken",
@@ -341,174 +306,229 @@ Search.appendIndex(
             "summary": "Collections\u0020of\u0020related\u0020tokens\u0020as\u0020often\u0020used\u0020and\u0020needed\u0020for\u0020sniffs.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html"
         },                {
+            "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A__callStatic\u0028\u0029",
+            "name": "__callStatic",
+            "summary": "Handle\u0020calls\u0020to\u0020\u0028undeclared\u0029\u0020methods\u0020for\u0020token\u0020arrays\u0020which\u0020don\u0027t\u0020need\u0020special\u0020handling.",
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#method___callStatic"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AalternativeControlStructureSyntaxes\u0028\u0029",
+            "name": "alternativeControlStructureSyntaxes",
+            "summary": "Tokens\u0020for\u0020control\u0020structures\u0020which\u0020can\u0020use\u0020the\u0020alternative\u0020control\u0020structure\u0020syntax.",
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#method_alternativeControlStructureSyntaxes"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AalternativeControlStructureSyntaxClosers\u0028\u0029",
+            "name": "alternativeControlStructureSyntaxClosers",
+            "summary": "Tokens\u0020representing\u0020alternative\u0020control\u0020structure\u0020syntax\u0020closer\u0020keywords.",
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#method_alternativeControlStructureSyntaxClosers"
+        },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AarrowFunctionTokensBC\u0028\u0029",
             "name": "arrowFunctionTokensBC",
-            "summary": "Tokens\u0020which\u0020can\u0020represent\u0020the\u0020arrow\u0020function\u0020keyword.",
+            "summary": "DEPRECATED\u003A\u0020Tokens\u0020which\u0020can\u0020represent\u0020the\u0020arrow\u0020function\u0020keyword.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#method_arrowFunctionTokensBC"
         },                {
-            "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AfunctionDeclarationTokens\u0028\u0029",
-            "name": "functionDeclarationTokens",
-            "summary": "Tokens\u0020which\u0020can\u0020represent\u0020a\u0020keyword\u0020which\u0020starts\u0020a\u0020function\u0020declaration.",
-            "url": "classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokens"
+            "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AfunctionCallTokens\u0028\u0029",
+            "name": "functionCallTokens",
+            "summary": "Tokens\u0020which\u0020can\u0020represent\u0020function\u0020calls\u0020and\u0020function\u002Dcall\u002Dlike\u0020language\u0020constructs.",
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#method_functionCallTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AfunctionDeclarationTokensBC\u0028\u0029",
             "name": "functionDeclarationTokensBC",
-            "summary": "Tokens\u0020which\u0020can\u0020represent\u0020a\u0020keyword\u0020which\u0020starts\u0020a\u0020function\u0020declaration.",
+            "summary": "DEPRECATED\u003A\u0020Tokens\u0020which\u0020represent\u0020a\u0020keyword\u0020which\u0020starts\u0020a\u0020function\u0020declaration.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokensBC"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AnamespacedNameTokens\u0028\u0029",
+            "name": "namespacedNameTokens",
+            "summary": "Tokens\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020a\u0020fully,\u0020partially\u0020or\u0020unqualified\u0020name.",
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#method_namespacedNameTokens"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AooCanExtend\u0028\u0029",
+            "name": "ooCanExtend",
+            "summary": "OO\u0020structures\u0020which\u0020can\u0020use\u0020the\u0020\u0022extends\u0022\u0020keyword.",
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#method_ooCanExtend"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AooCanImplement\u0028\u0029",
+            "name": "ooCanImplement",
+            "summary": "OO\u0020structures\u0020which\u0020can\u0020use\u0020the\u0020\u0022implements\u0022\u0020keyword.",
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#method_ooCanImplement"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AooConstantScopes\u0028\u0029",
+            "name": "ooConstantScopes",
+            "summary": "OO\u0020scopes\u0020in\u0020which\u0020constants\u0020can\u0020be\u0020declared.",
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#method_ooConstantScopes"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AooHierarchyKeywords\u0028\u0029",
+            "name": "ooHierarchyKeywords",
+            "summary": "Tokens\u0020types\u0020used\u0020for\u0020\u0022forwarding\u0022\u0020calls\u0020within\u0020OO\u0020structures.",
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#method_ooHierarchyKeywords"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AooPropertyScopes\u0028\u0029",
+            "name": "ooPropertyScopes",
+            "summary": "OO\u0020scopes\u0020in\u0020which\u0020properties\u0020can\u0020be\u0020declared.",
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#method_ooPropertyScopes"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AparameterPassingTokens\u0028\u0029",
+            "name": "parameterPassingTokens",
+            "summary": "Tokens\u0020which\u0020can\u0020be\u0020passed\u0020to\u0020the\u0020methods\u0020in\u0020the\u0020PassedParameter\u0020class.",
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#method_parameterPassingTokens"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024parameterTypeTokens",
+            "name": "parameterTypeTokens",
+            "summary": "DEPRECATED\u003A\u0020Token\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020a\u0020parameter\u0020type\u0020declaration.",
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_parameterTypeTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AparameterTypeTokensBC\u0028\u0029",
             "name": "parameterTypeTokensBC",
-            "summary": "Token\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020a\u0020parameter\u0020type\u0020declaration\u0020\u0028cross\u002Dversion\u0029.",
+            "summary": "DEPRECATED\u003A\u0020Token\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020a\u0020parameter\u0020type\u0020declaration\u0020\u0028cross\u002Dversion\u0029.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#method_parameterTypeTokensBC"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024propertyTypeTokens",
+            "name": "propertyTypeTokens",
+            "summary": "DEPRECATED\u003A\u0020Token\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020a\u0020property\u0020type\u0020declaration.",
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_propertyTypeTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003ApropertyTypeTokensBC\u0028\u0029",
             "name": "propertyTypeTokensBC",
-            "summary": "Token\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020a\u0020property\u0020type\u0020declaration\u0020\u0028cross\u002Dversion\u0029.",
+            "summary": "DEPRECATED\u003A\u0020Token\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020a\u0020property\u0020type\u0020declaration\u0020\u0028cross\u002Dversion\u0029.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#method_propertyTypeTokensBC"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024returnTypeTokens",
+            "name": "returnTypeTokens",
+            "summary": "DEPRECATED\u003A\u0020Token\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020a\u0020return\u0020type\u0020declaration.",
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_returnTypeTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AreturnTypeTokensBC\u0028\u0029",
             "name": "returnTypeTokensBC",
-            "summary": "Token\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020a\u0020return\u0020type\u0020declaration\u0020\u0028cross\u002Dversion\u0029.",
+            "summary": "DEPRECATED\u003A\u0020Token\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020a\u0020return\u0020type\u0020declaration\u0020\u0028cross\u002Dversion\u0029.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokensBC"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003AtextStringStartTokens\u0028\u0029",
+            "name": "textStringStartTokens",
+            "summary": "Tokens\u0020which\u0020can\u0020start\u0020a\u0020\u002D\u0020potentially\u0020multi\u002Dline\u0020\u002D\u0020text\u0020string.",
+            "url": "classes/PHPCSUtils-Tokens-Collections.html#method_textStringStartTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024alternativeControlStructureSyntaxTokens",
             "name": "alternativeControlStructureSyntaxTokens",
-            "summary": "Control\u0020structures\u0020which\u0020can\u0020use\u0020the\u0020alternative\u0020control\u0020structure\u0020syntax.",
+            "summary": "DEPRECATED\u003A\u0020Tokens\u0020for\u0020control\u0020structures\u0020which\u0020can\u0020use\u0020the\u0020alternative\u0020control\u0020structure\u0020syntax.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_alternativeControlStructureSyntaxTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024alternativeControlStructureSyntaxCloserTokens",
             "name": "alternativeControlStructureSyntaxCloserTokens",
-            "summary": "Alternative\u0020control\u0020structure\u0020syntax\u0020closer\u0020keyword\u0020tokens.",
+            "summary": "DEPRECATED\u003A\u0020Tokens\u0020representing\u0020alternative\u0020control\u0020structure\u0020syntax\u0020closer\u0020keywords.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_alternativeControlStructureSyntaxCloserTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024arrayTokens",
             "name": "arrayTokens",
-            "summary": "Tokens\u0020which\u0020are\u0020used\u0020to\u0020create\u0020arrays.",
+            "summary": "DEPRECATED\u003A\u0020Tokens\u0020which\u0020are\u0020used\u0020to\u0020create\u0020arrays.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024arrayTokensBC",
             "name": "arrayTokensBC",
-            "summary": "Tokens\u0020which\u0020are\u0020used\u0020to\u0020create\u0020arrays.",
+            "summary": "DEPRECATED\u003A\u0020Tokens\u0020which\u0020are\u0020used\u0020to\u0020create\u0020arrays\u0020\u0028PHPCS\u0020cross\u002Dversion\u0020compatible\u0029.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokensBC"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024classModifierKeywords",
             "name": "classModifierKeywords",
-            "summary": "Modifier\u0020keywords\u0020which\u0020can\u0020be\u0020used\u0020for\u0020a\u0020class\u0020declaration.",
+            "summary": "DEPRECATED\u003A\u0020Modifier\u0020keywords\u0020which\u0020can\u0020be\u0020used\u0020for\u0020a\u0020class\u0020declaration.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_classModifierKeywords"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024closedScopes",
             "name": "closedScopes",
-            "summary": "List\u0020of\u0020tokens\u0020which\u0020represent\u0020\u0022closed\u0022\u0020scopes.",
+            "summary": "DEPRECATED\u003A\u0020List\u0020of\u0020tokens\u0020which\u0020represent\u0020\u0022closed\u0022\u0020scopes.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_closedScopes"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024controlStructureTokens",
             "name": "controlStructureTokens",
-            "summary": "Control\u0020structure\u0020tokens.",
+            "summary": "DEPRECATED\u003A\u0020Control\u0020structure\u0020tokens.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_controlStructureTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024incrementDecrementOperators",
             "name": "incrementDecrementOperators",
-            "summary": "Increment\/decrement\u0020operator\u0020tokens.",
+            "summary": "DEPRECATED\u003A\u0020Increment\/decrement\u0020operator\u0020tokens.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_incrementDecrementOperators"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024listTokens",
             "name": "listTokens",
-            "summary": "Tokens\u0020which\u0020are\u0020used\u0020to\u0020create\u0020lists.",
+            "summary": "DEPRECATED\u003A\u0020Tokens\u0020which\u0020are\u0020used\u0020to\u0020create\u0020lists.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_listTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024listTokensBC",
             "name": "listTokensBC",
-            "summary": "Tokens\u0020which\u0020are\u0020used\u0020to\u0020create\u0020lists.",
+            "summary": "DEPRECATED\u003A\u0020Tokens\u0020which\u0020are\u0020used\u0020to\u0020create\u0020lists\u0020\u0028PHPCS\u0020cross\u002Dversion\u0020compatible\u0029.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_listTokensBC"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024magicConstants",
             "name": "magicConstants",
-            "summary": "Tokens\u0020for\u0020the\u0020PHP\u0020magic\u0020constants.",
+            "summary": "DEPRECATED\u003A\u0020Tokens\u0020for\u0020the\u0020PHP\u0020magic\u0020constants.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_magicConstants"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024namespaceDeclarationClosers",
             "name": "namespaceDeclarationClosers",
-            "summary": "List\u0020of\u0020tokens\u0020which\u0020can\u0020end\u0020a\u0020namespace\u0020declaration\u0020statement.",
+            "summary": "DEPRECATED\u003A\u0020List\u0020of\u0020tokens\u0020which\u0020can\u0020end\u0020a\u0020namespace\u0020declaration\u0020statement.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_namespaceDeclarationClosers"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024objectOperators",
             "name": "objectOperators",
-            "summary": "Object\u0020operators.",
+            "summary": "DEPRECATED\u003A\u0020Object\u0020operator\u0020tokens.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_objectOperators"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024OOCanExtend",
             "name": "OOCanExtend",
-            "summary": "OO\u0020structures\u0020which\u0020can\u0020use\u0020the\u0020\u0022extends\u0022\u0020keyword.",
+            "summary": "DEPRECATED\u003A\u0020OO\u0020structures\u0020which\u0020can\u0020use\u0020the\u0020\u0022extends\u0022\u0020keyword.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_OOCanExtend"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024OOCanImplement",
             "name": "OOCanImplement",
-            "summary": "OO\u0020structures\u0020which\u0020can\u0020use\u0020the\u0020\u0022implements\u0022\u0020keyword.",
+            "summary": "DEPRECATED\u003A\u0020OO\u0020structures\u0020which\u0020can\u0020use\u0020the\u0020\u0022implements\u0022\u0020keyword.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_OOCanImplement"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024OOConstantScopes",
             "name": "OOConstantScopes",
-            "summary": "OO\u0020scopes\u0020in\u0020which\u0020constants\u0020can\u0020be\u0020declared.",
+            "summary": "DEPRECATED\u003A\u0020OO\u0020scopes\u0020in\u0020which\u0020constants\u0020can\u0020be\u0020declared.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_OOConstantScopes"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024OOHierarchyKeywords",
             "name": "OOHierarchyKeywords",
-            "summary": "Tokens\u0020types\u0020used\u0020for\u0020\u0022forwarding\u0022\u0020calls\u0020within\u0020OO\u0020structures.",
+            "summary": "DEPRECATED\u003A\u0020Tokens\u0020types\u0020used\u0020for\u0020\u0022forwarding\u0022\u0020calls\u0020within\u0020OO\u0020structures.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_OOHierarchyKeywords"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024OONameTokens",
             "name": "OONameTokens",
-            "summary": "Tokens\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020the\u0020fully\/partially\u0020qualified\u0020name\u0020of\u0020an\u0020OO\u0020structure.",
+            "summary": "DEPRECATED\u003A\u0020Tokens\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020the\u0020fully\/partially\u0020qualified\u0020name\u0020of\u0020an\u0020OO\u0020structure.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_OONameTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024OOPropertyScopes",
             "name": "OOPropertyScopes",
-            "summary": "OO\u0020scopes\u0020in\u0020which\u0020properties\u0020can\u0020be\u0020declared.",
+            "summary": "DEPRECATED\u003A\u0020OO\u0020scopes\u0020in\u0020which\u0020properties\u0020can\u0020be\u0020declared.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_OOPropertyScopes"
-        },                {
-            "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024parameterTypeTokens",
-            "name": "parameterTypeTokens",
-            "summary": "Token\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020a\u0020parameter\u0020type\u0020declaration.",
-            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_parameterTypeTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024propertyModifierKeywords",
             "name": "propertyModifierKeywords",
-            "summary": "Modifier\u0020keywords\u0020which\u0020can\u0020be\u0020used\u0020for\u0020a\u0020property\u0020declaration.",
+            "summary": "DEPRECATED\u003A\u0020Modifier\u0020keywords\u0020which\u0020can\u0020be\u0020used\u0020for\u0020a\u0020property\u0020declaration.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_propertyModifierKeywords"
-        },                {
-            "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024propertyTypeTokens",
-            "name": "propertyTypeTokens",
-            "summary": "Token\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020a\u0020property\u0020type\u0020declaration.",
-            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_propertyTypeTokens"
-        },                {
-            "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024returnTypeTokens",
-            "name": "returnTypeTokens",
-            "summary": "Token\u0020types\u0020which\u0020can\u0020be\u0020encountered\u0020in\u0020a\u0020return\u0020type\u0020declaration.",
-            "url": "classes/PHPCSUtils-Tokens-Collections.html#property_returnTypeTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024shortArrayTokens",
             "name": "shortArrayTokens",
-            "summary": "Tokens\u0020which\u0020are\u0020used\u0020for\u0020short\u0020arrays.",
+            "summary": "DEPRECATED\u003A\u0020Tokens\u0020which\u0020are\u0020used\u0020for\u0020short\u0020arrays.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024shortArrayTokensBC",
             "name": "shortArrayTokensBC",
-            "summary": "Tokens\u0020which\u0020are\u0020used\u0020for\u0020short\u0020arrays.",
+            "summary": "DEPRECATED\u003A\u0020Tokens\u0020which\u0020are\u0020used\u0020for\u0020short\u0020arrays\u0020\u0028PHPCS\u0020cross\u002Dversion\u0020compatible\u0029.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokensBC"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024shortListTokens",
             "name": "shortListTokens",
-            "summary": "Tokens\u0020which\u0020are\u0020used\u0020for\u0020short\u0020lists.",
+            "summary": "DEPRECATED\u003A\u0020Tokens\u0020which\u0020are\u0020used\u0020for\u0020short\u0020lists.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024shortListTokensBC",
             "name": "shortListTokensBC",
-            "summary": "Tokens\u0020which\u0020are\u0020used\u0020for\u0020short\u0020lists.",
+            "summary": "DEPRECATED\u003A\u0020Tokens\u0020which\u0020are\u0020used\u0020for\u0020short\u0020lists\u0020\u0028PHPCS\u0020cross\u002Dversion\u0020compatible\u0029.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokensBC"
         },                {
             "fqsen": "\\PHPCSUtils\\Tokens\\Collections\u003A\u003A\u0024textStingStartTokens",
             "name": "textStingStartTokens",
-            "summary": "Tokens\u0020which\u0020can\u0020start\u0020a\u0020\u002D\u0020potentially\u0020multi\u002Dline\u0020\u002D\u0020text\u0020string.",
+            "summary": "DEPRECATED\u003A\u0020Tokens\u0020which\u0020can\u0020start\u0020a\u0020\u002D\u0020potentially\u0020multi\u002Dline\u0020\u002D\u0020text\u0020string.",
             "url": "classes/PHPCSUtils-Tokens-Collections.html#property_textStingStartTokens"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Arrays",
@@ -798,7 +818,7 @@ Search.appendIndex(
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AgetCompleteNumber\u0028\u0029",
             "name": "getCompleteNumber",
-            "summary": "Retrieve\u0020information\u0020about\u0020a\u0020number\u0020token\u0020in\u0020a\u0020cross\u002Dversion\u0020compatible\u0020manner.",
+            "summary": "Retrieve\u0020information\u0020about\u0020a\u0020number\u0020token.",
             "url": "classes/PHPCSUtils-Utils-Numbers.html#method_getCompleteNumber"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AgetDecimalValue\u0028\u0029",
@@ -856,21 +876,6 @@ Search.appendIndex(
             "summary": "Regex\u0020to\u0020determine\u0020whether\u0020the\u0020contents\u0020of\u0020an\u0020arbitrary\u0020string\u0020represents\u0020a\u0020float.",
             "url": "classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_FLOAT"
         },                {
-            "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AREGEX_NUMLIT_STRING",
-            "name": "REGEX_NUMLIT_STRING",
-            "summary": "Regex\u0020to\u0020determine\u0020if\u0020a\u0020T_STRING\u0020following\u0020a\u0020T_\u005BDL\u005DNUMBER\u0020is\u0020part\u0020of\u0020a\u0020numeric\u0020literal\u0020sequence.",
-            "url": "classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_NUMLIT_STRING"
-        },                {
-            "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AREGEX_HEX_NUMLIT_STRING",
-            "name": "REGEX_HEX_NUMLIT_STRING",
-            "summary": "Regex\u0020to\u0020determine\u0020is\u0020a\u0020T_STRING\u0020following\u0020a\u0020T_\u005BDL\u005DNUMBER\u0020is\u0020part\u0020of\u0020a\u0020hexidecimal\u0020numeric\u0020literal\u0020sequence.",
-            "url": "classes/PHPCSUtils-Utils-Numbers.html#constant_REGEX_HEX_NUMLIT_STRING"
-        },                {
-            "fqsen": "\\PHPCSUtils\\Utils\\Numbers\u003A\u003AUNSUPPORTED_PHPCS_VERSION",
-            "name": "UNSUPPORTED_PHPCS_VERSION",
-            "summary": "PHPCS\u0020versions\u0020in\u0020which\u0020the\u0020backfill\u0020for\u0020PHP\u00207.4\u0020numeric\u0020literal\u0020separators\u0020is\u0020broken.",
-            "url": "classes/PHPCSUtils-Utils-Numbers.html#constant_UNSUPPORTED_PHPCS_VERSION"
-        },                {
             "fqsen": "\\PHPCSUtils\\Utils\\ObjectDeclarations",
             "name": "ObjectDeclarations",
             "summary": "Utility\u0020functions\u0020for\u0020use\u0020when\u0020examining\u0020object\u0020declaration\u0020statements.",
@@ -878,7 +883,7 @@ Search.appendIndex(
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\ObjectDeclarations\u003A\u003AgetName\u0028\u0029",
             "name": "getName",
-            "summary": "Retrieves\u0020the\u0020declaration\u0020name\u0020for\u0020classes,\u0020interfaces,\u0020traits,\u0020and\u0020functions.",
+            "summary": "Retrieves\u0020the\u0020declaration\u0020name\u0020for\u0020classes,\u0020interfaces,\u0020traits,\u0020enums\u0020and\u0020functions.",
             "url": "classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_getName"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\ObjectDeclarations\u003A\u003AgetClassProperties\u0028\u0029",
@@ -893,7 +898,7 @@ Search.appendIndex(
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\ObjectDeclarations\u003A\u003AfindImplementedInterfaceNames\u0028\u0029",
             "name": "findImplementedInterfaceNames",
-            "summary": "Retrieves\u0020the\u0020names\u0020of\u0020the\u0020interfaces\u0020that\u0020the\u0020specified\u0020class\u0020implements.",
+            "summary": "Retrieves\u0020the\u0020names\u0020of\u0020the\u0020interfaces\u0020that\u0020the\u0020specified\u0020class\u0020or\u0020enum\u0020implements.",
             "url": "classes/PHPCSUtils-Utils-ObjectDeclarations.html#method_findImplementedInterfaceNames"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\ObjectDeclarations\u003A\u003AfindExtendedInterfaceNames\u0028\u0029",
@@ -948,12 +953,12 @@ Search.appendIndex(
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses",
             "name": "Parentheses",
-            "summary": "Utility\u0020functions\u0020for\u0020use\u0020when\u0020examining\u0020parenthesis\u0020tokens\u0020and\u0020arbitrary\u0020tokens\u0020wrapped\u0020in\nparentheses.",
+            "summary": "Utility\u0020functions\u0020for\u0020use\u0020when\u0020examining\u0020parenthesis\u0020tokens\u0020and\u0020arbitrary\u0020tokens\u0020wrapped\nin\u0020parentheses.",
             "url": "classes/PHPCSUtils-Utils-Parentheses.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AgetOwner\u0028\u0029",
             "name": "getOwner",
-            "summary": "Get\u0020the\u0020pointer\u0020to\u0020the\u0020parentheses\u0020owner\u0020of\u0020an\u0020open\/close\u0020parenthesis.",
+            "summary": "Get\u0020the\u0020stack\u0020pointer\u0020to\u0020the\u0020parentheses\u0020owner\u0020of\u0020an\u0020open\/close\u0020parenthesis.",
             "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_getOwner"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AisOwnerIn\u0028\u0029",
@@ -968,47 +973,47 @@ Search.appendIndex(
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AgetFirstOpener\u0028\u0029",
             "name": "getFirstOpener",
-            "summary": "Retrieve\u0020the\u0020position\u0020of\u0020the\u0020opener\u0020to\u0020the\u0020first\u0020\u0028outer\u0029\u0020set\u0020of\u0020parentheses\u0020an\u0020arbitrary\ntoken\u0020is\u0020wrapped\u0020in,\u0020where\u0020the\u0020parentheses\u0020owner\u0020is\u0020within\u0020the\u0020set\u0020of\u0020valid\u0020owners.",
+            "summary": "Retrieve\u0020the\u0020stack\u0020pointer\u0020to\u0020the\u0020parentheses\u0020opener\u0020of\u0020the\u0020first\u0020\u0028outer\u0029\u0020set\u0020of\u0020parentheses\nan\u0020arbitrary\u0020token\u0020is\u0020wrapped\u0020in.",
             "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstOpener"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AgetFirstCloser\u0028\u0029",
             "name": "getFirstCloser",
-            "summary": "Retrieve\u0020the\u0020position\u0020of\u0020the\u0020closer\u0020to\u0020the\u0020first\u0020\u0028outer\u0029\u0020set\u0020of\u0020parentheses\u0020an\u0020arbitrary\ntoken\u0020is\u0020wrapped\u0020in,\u0020where\u0020the\u0020parentheses\u0020owner\u0020is\u0020within\u0020the\u0020set\u0020of\u0020valid\u0020owners.",
+            "summary": "Retrieve\u0020the\u0020stack\u0020pointer\u0020to\u0020the\u0020parentheses\u0020closer\u0020of\u0020the\u0020first\u0020\u0028outer\u0029\u0020set\u0020of\u0020parentheses\nan\u0020arbitrary\u0020token\u0020is\u0020wrapped\u0020in.",
             "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstCloser"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AgetFirstOwner\u0028\u0029",
             "name": "getFirstOwner",
-            "summary": "Retrieve\u0020the\u0020position\u0020of\u0020the\u0020parentheses\u0020owner\u0020to\u0020the\u0020first\u0020\u0028outer\u0029\u0020set\u0020of\u0020parentheses\u0020an\narbitrary\u0020token\u0020is\u0020wrapped\u0020in,\u0020where\u0020the\u0020parentheses\u0020owner\u0020is\u0020within\u0020the\u0020set\u0020of\u0020valid\u0020owners.",
+            "summary": "Retrieve\u0020the\u0020stack\u0020pointer\u0020to\u0020the\u0020parentheses\u0020owner\u0020of\u0020the\u0020first\u0020\u0028outer\u0029\u0020set\u0020of\u0020parentheses\nan\u0020arbitrary\u0020token\u0020is\u0020wrapped\u0020in.",
             "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_getFirstOwner"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AgetLastOpener\u0028\u0029",
             "name": "getLastOpener",
-            "summary": "Retrieve\u0020the\u0020position\u0020of\u0020the\u0020opener\u0020to\u0020the\u0020last\u0020\u0028inner\u0029\u0020set\u0020of\u0020parentheses\u0020an\u0020arbitrary\ntoken\u0020is\u0020wrapped\u0020in,\u0020where\u0020the\u0020parentheses\u0020owner\u0020is\u0020within\u0020the\u0020set\u0020of\u0020valid\u0020owners.",
+            "summary": "Retrieve\u0020the\u0020stack\u0020pointer\u0020to\u0020the\u0020parentheses\u0020opener\u0020of\u0020the\u0020last\u0020\u0028inner\u0029\u0020set\u0020of\u0020parentheses\nan\u0020arbitrary\u0020token\u0020is\u0020wrapped\u0020in.",
             "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOpener"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AgetLastCloser\u0028\u0029",
             "name": "getLastCloser",
-            "summary": "Retrieve\u0020the\u0020position\u0020of\u0020the\u0020closer\u0020to\u0020the\u0020last\u0020\u0028inner\u0029\u0020set\u0020of\u0020parentheses\u0020an\u0020arbitrary\ntoken\u0020is\u0020wrapped\u0020in,\u0020where\u0020the\u0020parentheses\u0020owner\u0020is\u0020within\u0020the\u0020set\u0020of\u0020valid\u0020owners.",
+            "summary": "Retrieve\u0020the\u0020stack\u0020pointer\u0020to\u0020the\u0020parentheses\u0020closer\u0020of\u0020the\u0020last\u0020\u0028inner\u0029\u0020set\u0020of\u0020parentheses\nan\u0020arbitrary\u0020token\u0020is\u0020wrapped\u0020in.",
             "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_getLastCloser"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AgetLastOwner\u0028\u0029",
             "name": "getLastOwner",
-            "summary": "Retrieve\u0020the\u0020position\u0020of\u0020the\u0020parentheses\u0020owner\u0020to\u0020the\u0020last\u0020\u0028inner\u0029\u0020set\u0020of\u0020parentheses\u0020an\narbitrary\u0020token\u0020is\u0020wrapped\u0020in\u0020where\u0020the\u0020parentheses\u0020owner\u0020is\u0020within\u0020the\u0020set\u0020of\u0020valid\u0020owners.",
+            "summary": "Retrieve\u0020the\u0020stack\u0020pointer\u0020to\u0020the\u0020parentheses\u0020owner\u0020of\u0020the\u0020last\u0020\u0028inner\u0029\u0020set\u0020of\u0020parentheses\nan\u0020arbitrary\u0020token\u0020is\u0020wrapped\u0020in.",
             "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_getLastOwner"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AfirstOwnerIn\u0028\u0029",
             "name": "firstOwnerIn",
-            "summary": "Check\u0020whether\u0020the\u0020owner\u0020of\u0020a\u0020outermost\u0020wrapping\u0020set\u0020of\u0020parentheses\u0020of\u0020an\u0020arbitrary\u0020token\nis\u0020within\u0020a\u0020limited\u0020set\u0020of\u0020acceptable\u0020token\u0020types.",
+            "summary": "Check\u0020whether\u0020the\u0020owner\u0020of\u0020the\u0020outermost\u0020wrapping\u0020set\u0020of\u0020parentheses\u0020of\u0020an\u0020arbitrary\u0020token\nis\u0020within\u0020a\u0020limited\u0020set\u0020of\u0020acceptable\u0020token\u0020types.",
             "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_firstOwnerIn"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Parentheses\u003A\u003AlastOwnerIn\u0028\u0029",
             "name": "lastOwnerIn",
-            "summary": "Check\u0020whether\u0020the\u0020owner\u0020of\u0020a\u0020innermost\u0020wrapping\u0020set\u0020of\u0020parentheses\u0020of\u0020an\u0020arbitrary\u0020token\nis\u0020within\u0020a\u0020limited\u0020set\u0020of\u0020acceptable\u0020token\u0020types.",
+            "summary": "Check\u0020whether\u0020the\u0020owner\u0020of\u0020the\u0020innermost\u0020wrapping\u0020set\u0020of\u0020parentheses\u0020of\u0020an\u0020arbitrary\u0020token\nis\u0020within\u0020a\u0020limited\u0020set\u0020of\u0020acceptable\u0020token\u0020types.",
             "url": "classes/PHPCSUtils-Utils-Parentheses.html#method_lastOwnerIn"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\PassedParameters",
             "name": "PassedParameters",
-            "summary": "Utility\u0020functions\u0020to\u0020retrieve\u0020information\u0020about\u0020parameters\u0020passed\u0020to\u0020function\u0020calls,\narray\u0020declarations,\u0020isset\u0020and\u0020unset\u0020constructs.",
+            "summary": "Utility\u0020functions\u0020to\u0020retrieve\u0020information\u0020about\u0020parameters\u0020passed\u0020to\u0020function\u0020calls,\nclass\u0020instantiations,\u0020array\u0020declarations,\u0020isset\u0020and\u0020unset\u0020constructs.",
             "url": "classes/PHPCSUtils-Utils-PassedParameters.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\PassedParameters\u003A\u003AhasParameters\u0028\u0029",
@@ -1031,6 +1036,11 @@ Search.appendIndex(
             "summary": "Count\u0020the\u0020number\u0020of\u0020parameters\u0020which\u0020have\u0020been\u0020passed.",
             "url": "classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameterCount"
         },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\PassedParameters\u003A\u003AgetParameterFromStack\u0028\u0029",
+            "name": "getParameterFromStack",
+            "summary": "Get\u0020information\u0020on\u0020a\u0020specific\u0020function\u0020call\u0020parameter\u0020passed.",
+            "url": "classes/PHPCSUtils-Utils-PassedParameters.html#method_getParameterFromStack"
+        },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Scopes",
             "name": "Scopes",
             "summary": "Utility\u0020functions\u0020for\u0020use\u0020when\u0020examining\u0020token\u0020scopes.",
@@ -1043,7 +1053,7 @@ Search.appendIndex(
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Scopes\u003A\u003AisOOConstant\u0028\u0029",
             "name": "isOOConstant",
-            "summary": "Check\u0020whether\u0020a\u0020T_CONST\u0020token\u0020is\u0020a\u0020class\/interface\u0020constant\u0020declaration.",
+            "summary": "Check\u0020whether\u0020a\u0020T_CONST\u0020token\u0020is\u0020a\u0020class\/interface\/trait\/enum\u0020constant\u0020declaration.",
             "url": "classes/PHPCSUtils-Utils-Scopes.html#method_isOOConstant"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Scopes\u003A\u003AisOOProperty\u0028\u0029",
@@ -1053,7 +1063,7 @@ Search.appendIndex(
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Scopes\u003A\u003AisOOMethod\u0028\u0029",
             "name": "isOOMethod",
-            "summary": "Check\u0020whether\u0020a\u0020T_FUNCTION\u0020token\u0020is\u0020a\u0020class\/interface\/trait\u0020method\u0020declaration.",
+            "summary": "Check\u0020whether\u0020a\u0020T_FUNCTION\u0020token\u0020is\u0020a\u0020class\/interface\/trait\/enum\u0020method\u0020declaration.",
             "url": "classes/PHPCSUtils-Utils-Scopes.html#method_isOOMethod"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\TextStrings",
@@ -1066,10 +1076,40 @@ Search.appendIndex(
             "summary": "Get\u0020the\u0020complete\u0020contents\u0020of\u0020a\u0020\u002D\u0020potentially\u0020multi\u002Dline\u0020\u002D\u0020text\u0020string.",
             "url": "classes/PHPCSUtils-Utils-TextStrings.html#method_getCompleteTextString"
         },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\TextStrings\u003A\u003AgetEndOfCompleteTextString\u0028\u0029",
+            "name": "getEndOfCompleteTextString",
+            "summary": "Get\u0020the\u0020stack\u0020pointer\u0020to\u0020the\u0020end\u0020of\u0020a\u0020\u002D\u0020potentially\u0020multi\u002Dline\u0020\u002D\u0020text\u0020string.",
+            "url": "classes/PHPCSUtils-Utils-TextStrings.html#method_getEndOfCompleteTextString"
+        },                {
             "fqsen": "\\PHPCSUtils\\Utils\\TextStrings\u003A\u003AstripQuotes\u0028\u0029",
             "name": "stripQuotes",
-            "summary": "Strip\u0020text\u0020delimiter\u0020quotes\u0020from\u0020an\u0020arbitrary\u0020string.",
+            "summary": "Strip\u0020text\u0020delimiter\u0020quotes\u0020from\u0020an\u0020arbitrary\u0020text\u0020string.",
             "url": "classes/PHPCSUtils-Utils-TextStrings.html#method_stripQuotes"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\TextStrings\u003A\u003AgetEmbeds\u0028\u0029",
+            "name": "getEmbeds",
+            "summary": "Get\u0020the\u0020embedded\u0020variables\/expressions\u0020from\u0020an\u0020arbitrary\u0020string.",
+            "url": "classes/PHPCSUtils-Utils-TextStrings.html#method_getEmbeds"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\TextStrings\u003A\u003AstripEmbeds\u0028\u0029",
+            "name": "stripEmbeds",
+            "summary": "Strip\u0020embedded\u0020variables\/expressions\u0020from\u0020an\u0020arbitrary\u0020string.",
+            "url": "classes/PHPCSUtils-Utils-TextStrings.html#method_stripEmbeds"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\TextStrings\u003A\u003AgetStripEmbeds\u0028\u0029",
+            "name": "getStripEmbeds",
+            "summary": "Split\u0020an\u0020arbitrary\u0020text\u0020string\u0020into\u0020embedded\u0020variables\/expressions\u0020and\u0020remaining\u0020text.",
+            "url": "classes/PHPCSUtils-Utils-TextStrings.html#method_getStripEmbeds"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\TextStrings\u003A\u003ASTART_OF_EMBED",
+            "name": "START_OF_EMBED",
+            "summary": "Regex\u0020to\u0020match\u0020the\u0020start\u0020of\u0020an\u0020embedded\u0020variable\/expression.",
+            "url": "classes/PHPCSUtils-Utils-TextStrings.html#constant_START_OF_EMBED"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\TextStrings\u003A\u003ATYPE1_EMBED_AFTER_DOLLAR",
+            "name": "TYPE1_EMBED_AFTER_DOLLAR",
+            "summary": "Regex\u0020to\u0020match\u0020a\u0020\u0022type\u00201\u0022\u0020\u002D\u0020directly\u0020embedded\u0020\u002D\u0020variable\u0020without\u0020the\u0020dollar\u0020sign.",
+            "url": "classes/PHPCSUtils-Utils-TextStrings.html#constant_TYPE1_EMBED_AFTER_DOLLAR"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\UseStatements",
             "name": "UseStatements",
@@ -1105,6 +1145,11 @@ Search.appendIndex(
             "name": "splitAndMergeImportUseStatement",
             "summary": "Split\u0020an\u0020import\u0020use\u0020statement\u0020into\u0020individual\u0020imports\u0020and\u0020merge\u0020it\u0020with\u0020an\u0020array\u0020of\u0020previously\nseen\u0020import\u0020use\u0020statements.",
             "url": "classes/PHPCSUtils-Utils-UseStatements.html#method_splitAndMergeImportUseStatement"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\UseStatements\u003A\u003AmergeImportUseStatements\u0028\u0029",
+            "name": "mergeImportUseStatements",
+            "summary": "Merge\u0020two\u0020import\u0020use\u0020statement\u0020arrays.",
+            "url": "classes/PHPCSUtils-Utils-UseStatements.html#method_mergeImportUseStatements"
         },                {
             "fqsen": "\\PHPCSUtils\\Utils\\Variables",
             "name": "Variables",
@@ -1151,6 +1196,116 @@ Search.appendIndex(
             "summary": "",
             "url": "namespaces/default.html#constant_PHPCSUTILS_PHPUNIT_ALIASES_SET"
         },                {
+            "fqsen": "\\PHPCSUtils\\Exceptions\\InvalidTokenArray",
+            "name": "InvalidTokenArray",
+            "summary": "Exception\u0020thrown\u0020when\u0020an\u0020non\u002Dexistent\u0020token\u0020array\u0020is\u0020requested.",
+            "url": "classes/PHPCSUtils-Exceptions-InvalidTokenArray.html"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Exceptions\\InvalidTokenArray\u003A\u003Acreate\u0028\u0029",
+            "name": "create",
+            "summary": "Create\u0020a\u0020new\u0020invalid\u0020token\u0020array\u0020exception\u0020with\u0020a\u0020standardized\u0020text.",
+            "url": "classes/PHPCSUtils-Exceptions-InvalidTokenArray.html#method_create"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Exceptions\\TestFileNotFound",
+            "name": "TestFileNotFound",
+            "summary": "Exception\u0020thrown\u0020when\u0020the\u0020UtilityMethodTestCase\u003A\u003AgetTargetToken\u0028\u0029\u0020method\u0020is\u0020run\u0020without\u0020a\ntokenized\u0020test\u0020case\u0020file\u0020being\u0020available.",
+            "url": "classes/PHPCSUtils-Exceptions-TestFileNotFound.html"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Exceptions\\TestFileNotFound\u003A\u003A__construct\u0028\u0029",
+            "name": "__construct",
+            "summary": "Create\u0020a\u0020new\u0020\u0022test\u0020file\u0020not\u0020found\u0022\u0020exception\u0020with\u0020a\u0020standardized\u0020text.",
+            "url": "classes/PHPCSUtils-Exceptions-TestFileNotFound.html#method___construct"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Exceptions\\TestMarkerNotFound",
+            "name": "TestMarkerNotFound",
+            "summary": "Exception\u0020thrown\u0020when\u0020a\u0020delimiter\u0020comment\u0020can\u0020not\u0020be\u0020found\u0020in\u0020a\u0020test\u0020case\u0020file.",
+            "url": "classes/PHPCSUtils-Exceptions-TestMarkerNotFound.html"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Exceptions\\TestMarkerNotFound\u003A\u003Acreate\u0028\u0029",
+            "name": "create",
+            "summary": "Create\u0020a\u0020new\u0020\u0022test\u0020marker\u0020not\u0020found\u0022\u0020exception\u0020with\u0020a\u0020standardized\u0020text.",
+            "url": "classes/PHPCSUtils-Exceptions-TestMarkerNotFound.html#method_create"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Exceptions\\TestTargetNotFound",
+            "name": "TestTargetNotFound",
+            "summary": "Exception\u0020thrown\u0020when\u0020a\u0020test\u0020target\u0020token\u0020can\u0020not\u0020be\u0020found\u0020in\u0020a\u0020test\u0020case\u0020file.",
+            "url": "classes/PHPCSUtils-Exceptions-TestTargetNotFound.html"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Exceptions\\TestTargetNotFound\u003A\u003Acreate\u0028\u0029",
+            "name": "create",
+            "summary": "Create\u0020a\u0020new\u0020\u0022test\u0020target\u0020token\u0020not\u0020found\u0022\u0020exception\u0020with\u0020a\u0020standardized\u0020text.",
+            "url": "classes/PHPCSUtils-Exceptions-TestTargetNotFound.html#method_create"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Tokens\\TokenHelper",
+            "name": "TokenHelper",
+            "summary": "Helpers\u0020for\u0020working\u0020with\u0020tokens.",
+            "url": "classes/PHPCSUtils-Tokens-TokenHelper.html"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Tokens\\TokenHelper\u003A\u003AtokenExists\u0028\u0029",
+            "name": "tokenExists",
+            "summary": "Check\u0020whether\u0020a\u0020PHP\u0020native\u0020token\u0020exists\u0020\u0028for\u0020real\u0029.",
+            "url": "classes/PHPCSUtils-Tokens-TokenHelper.html#method_tokenExists"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\Context",
+            "name": "Context",
+            "summary": "Utility\u0020functions\u0020for\u0020examining\u0020in\u0020which\u0020context\u0020a\u0020certain\u0020token\u0020is\u0020used.",
+            "url": "classes/PHPCSUtils-Utils-Context.html"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\Context\u003A\u003AinEmpty\u0028\u0029",
+            "name": "inEmpty",
+            "summary": "Check\u0020whether\u0020an\u0020arbitrary\u0020token\u0020is\u0020within\u0020a\u0020call\u0020to\u0020empty\u0028\u0029.",
+            "url": "classes/PHPCSUtils-Utils-Context.html#method_inEmpty"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\Context\u003A\u003AinIsset\u0028\u0029",
+            "name": "inIsset",
+            "summary": "Check\u0020whether\u0020an\u0020arbitrary\u0020token\u0020is\u0020within\u0020a\u0020call\u0020to\u0020isset\u0028\u0029.",
+            "url": "classes/PHPCSUtils-Utils-Context.html#method_inIsset"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\Context\u003A\u003AinUnset\u0028\u0029",
+            "name": "inUnset",
+            "summary": "Check\u0020whether\u0020an\u0020arbitrary\u0020token\u0020is\u0020within\u0020a\u0020call\u0020to\u0020unset\u0028\u0029.",
+            "url": "classes/PHPCSUtils-Utils-Context.html#method_inUnset"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\Context\u003A\u003AinAttribute\u0028\u0029",
+            "name": "inAttribute",
+            "summary": "Check\u0020whether\u0020an\u0020arbitrary\u0020token\u0020is\u0020within\u0020an\u0020attribute.",
+            "url": "classes/PHPCSUtils-Utils-Context.html#method_inAttribute"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\Context\u003A\u003AinForeachCondition\u0028\u0029",
+            "name": "inForeachCondition",
+            "summary": "Check\u0020whether\u0020an\u0020arbitrary\u0020token\u0020is\u0020in\u0020a\u0020foreach\u0020condition\u0020and\u0020if\u0020so,\u0020in\u0020which\u0020part\u003A\nbefore\u0020or\u0020after\u0020the\u0020\u0022as\u0022.",
+            "url": "classes/PHPCSUtils-Utils-Context.html#method_inForeachCondition"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\Context\u003A\u003AinForCondition\u0028\u0029",
+            "name": "inForCondition",
+            "summary": "Check\u0020whether\u0020an\u0020arbitrary\u0020token\u0020is\u0020in\u0020a\u0020for\u0020condition\u0020and\u0020if\u0020so,\u0020in\u0020which\u0020part\u003A\nthe\u0020first,\u0020second\u0020or\u0020third\u0020expression.",
+            "url": "classes/PHPCSUtils-Utils-Context.html#method_inForCondition"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\MessageHelper",
+            "name": "MessageHelper",
+            "summary": "Helper\u0020functions\u0020for\u0020creating\u0020PHPCS\u0020error\/warning\u0020messages.",
+            "url": "classes/PHPCSUtils-Utils-MessageHelper.html"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\MessageHelper\u003A\u003AaddMessage\u0028\u0029",
+            "name": "addMessage",
+            "summary": "Add\u0020a\u0020PHPCS\u0020message\u0020to\u0020the\u0020output\u0020stack\u0020as\u0020either\u0020a\u0020warning\u0020or\u0020an\u0020error.",
+            "url": "classes/PHPCSUtils-Utils-MessageHelper.html#method_addMessage"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\MessageHelper\u003A\u003AaddFixableMessage\u0028\u0029",
+            "name": "addFixableMessage",
+            "summary": "Add\u0020a\u0020PHPCS\u0020message\u0020to\u0020the\u0020output\u0020stack\u0020as\u0020either\u0020a\u0020fixable\u0020warning\u0020or\u0020a\u0020fixable\u0020error.",
+            "url": "classes/PHPCSUtils-Utils-MessageHelper.html#method_addFixableMessage"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\MessageHelper\u003A\u003AstringToErrorcode\u0028\u0029",
+            "name": "stringToErrorcode",
+            "summary": "Convert\u0020an\u0020arbitrary\u0020text\u0020string\u0020to\u0020an\u0020alphanumeric\u0020string\u0020with\u0020underscores.",
+            "url": "classes/PHPCSUtils-Utils-MessageHelper.html#method_stringToErrorcode"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Utils\\MessageHelper\u003A\u003AshowEscapeChars\u0028\u0029",
+            "name": "showEscapeChars",
+            "summary": "Make\u0020the\u0020whitespace\u0020escape\u0020codes\u0020used\u0020in\u0020an\u0020arbitrary\u0020text\u0020string\u0020visible.",
+            "url": "classes/PHPCSUtils-Utils-MessageHelper.html#method_showEscapeChars"
+        },                {
             "fqsen": "\\",
             "name": "\\",
             "summary": "",
@@ -1170,6 +1325,11 @@ Search.appendIndex(
             "name": "BackCompat",
             "summary": "",
             "url": "namespaces/phpcsutils-backcompat.html"
+        },                {
+            "fqsen": "\\PHPCSUtils\\Exceptions",
+            "name": "Exceptions",
+            "summary": "",
+            "url": "namespaces/phpcsutils-exceptions.html"
         },                {
             "fqsen": "\\PHPCSUtils\\Fixers",
             "name": "Fixers",

--- a/docs/phpdoc/namespaces/default.html
+++ b/docs/phpdoc/namespaces/default.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -77,30 +121,160 @@
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-            <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></dt>
     </dl>
 
 
 
+<h3 id="toc">
+    Table of Contents
+    <a href="#toc" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
+    <a href="namespaces/default.html#constant_PHPCSUTILS_AUTOLOAD">PHPCSUTILS_AUTOLOAD</a>
+    <span>
+        &nbsp;= \true                            </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
+    <a href="namespaces/default.html#constant_PHPCSUTILS_PHPCS_ALIASES_SET">PHPCSUTILS_PHPCS_ALIASES_SET</a>
+    <span>
+        &nbsp;= \true                            </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
+    <a href="namespaces/default.html#constant_PHPCSUTILS_PHPUNIT_ALIASES_SET">PHPCSUTILS_PHPUNIT_ALIASES_SET</a>
+    <span>
+        &nbsp;= \true                            </span>
+</dt>
+<dd></dd>
+
+                    </dl>
 
         
+    <section class="phpdocumentor-constants">
+        <h3 class="phpdocumentor-elements__header" id="constants">
+            Constants
+            <a href="namespaces/default.html#constants" class="headerlink"><i class="fas fa-link"></i></a>
+        </h3>
+                    <article class="phpdocumentor-element -constant -public ">
+    <h4 class="phpdocumentor-element__name" id="constant_PHPCSUTILS_AUTOLOAD">
+        PHPCSUTILS_AUTOLOAD
+        <a href="namespaces/default.html#constant_PHPCSUTILS_AUTOLOAD" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="phpcsutils-autoload.php"><a href="files/phpcsutils-autoload.html"><abbr title="phpcsutils-autoload.php">phpcsutils-autoload.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">52</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-signature phpdocumentor-code ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+        <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__name">PHPCSUTILS_AUTOLOAD</span>
+    = <span class="phpdocumentor-signature__default-value">\true</span>
+</code>
+
+
+        <section class="phpdocumentor-description"></section>
+
+        <section class="phpdocumentor-description"></section>
+
+    
+
+</article>
+                    <article class="phpdocumentor-element -constant -public ">
+    <h4 class="phpdocumentor-element__name" id="constant_PHPCSUTILS_PHPCS_ALIASES_SET">
+        PHPCSUTILS_PHPCS_ALIASES_SET
+        <a href="namespaces/default.html#constant_PHPCSUTILS_PHPCS_ALIASES_SET" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="phpcsutils-autoload.php"><a href="files/phpcsutils-autoload.html"><abbr title="phpcsutils-autoload.php">phpcsutils-autoload.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">98</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-signature phpdocumentor-code ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+        <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__name">PHPCSUTILS_PHPCS_ALIASES_SET</span>
+    = <span class="phpdocumentor-signature__default-value">\true</span>
+</code>
+
+
+        <section class="phpdocumentor-description"></section>
+
+        <section class="phpdocumentor-description"></section>
+
+    
+
+</article>
+                    <article class="phpdocumentor-element -constant -public ">
+    <h4 class="phpdocumentor-element__name" id="constant_PHPCSUTILS_PHPUNIT_ALIASES_SET">
+        PHPCSUTILS_PHPUNIT_ALIASES_SET
+        <a href="namespaces/default.html#constant_PHPCSUTILS_PHPUNIT_ALIASES_SET" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="phpcsutils-autoload.php"><a href="files/phpcsutils-autoload.html"><abbr title="phpcsutils-autoload.php">phpcsutils-autoload.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">119</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-signature phpdocumentor-code ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+        <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__name">PHPCSUTILS_PHPUNIT_ALIASES_SET</span>
+    = <span class="phpdocumentor-signature__default-value">\true</span>
+</code>
+
+
+        <section class="phpdocumentor-description"></section>
+
+        <section class="phpdocumentor-description"></section>
+
+    
+
+</article>
+            </section>
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="namespaces/default.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/namespaces/default.html
+++ b/docs/phpdoc/namespaces/default.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/namespaces/phpcsutils-abstractsniffs.html
+++ b/docs/phpdoc/namespaces/phpcsutils-abstractsniffs.html
@@ -2,70 +2,114 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="-active">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -namespace">
@@ -74,14 +118,15 @@
         
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html"><abbr title="\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff">AbstractArrayDeclarationSniff</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html"><abbr title="\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff">AbstractArrayDeclarationSniff</abbr></a></dt>
         <dd>Abstract sniff to easily examine all parts of an array declaration.</dd>
+    
     
     </dl>
 
@@ -91,20 +136,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="namespaces/phpcsutils-abstractsniffs.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/namespaces/phpcsutils-abstractsniffs.html
+++ b/docs/phpdoc/namespaces/phpcsutils-abstractsniffs.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/namespaces/phpcsutils-backcompat.html
+++ b/docs/phpdoc/namespaces/phpcsutils-backcompat.html
@@ -2,70 +2,114 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="-active">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -namespace">
@@ -74,18 +118,19 @@
         
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-BackCompat-BCFile.html"><abbr title="\PHPCSUtils\BackCompat\BCFile">BCFile</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-BackCompat-BCFile.html"><abbr title="\PHPCSUtils\BackCompat\BCFile">BCFile</abbr></a></dt>
         <dd>PHPCS native utility functions.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-BackCompat-BCTokens.html"><abbr title="\PHPCSUtils\BackCompat\BCTokens">BCTokens</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-BackCompat-BCTokens.html"><abbr title="\PHPCSUtils\BackCompat\BCTokens">BCTokens</abbr></a></dt>
         <dd>Token arrays related utility methods.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-BackCompat-Helper.html"><abbr title="\PHPCSUtils\BackCompat\Helper">Helper</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-BackCompat-Helper.html"><abbr title="\PHPCSUtils\BackCompat\Helper">Helper</abbr></a></dt>
         <dd>Utility methods to retrieve (configuration) information from PHP_CodeSniffer.</dd>
+    
     
     </dl>
 
@@ -95,20 +140,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="namespaces/phpcsutils-backcompat.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/namespaces/phpcsutils-backcompat.html
+++ b/docs/phpdoc/namespaces/phpcsutils-backcompat.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/namespaces/phpcsutils-exceptions.html
+++ b/docs/phpdoc/namespaces/phpcsutils-exceptions.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+            <title>PHPCSUtils</title>
+    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
+                <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
+        <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
+    </head>
+<body id="top">
+    <header class="phpdocumentor-header phpdocumentor-section">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
+    <section data-search-form class="phpdocumentor-search">
+    <label>
+        <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
+        <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
+    </label>
+</section>
+
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
+
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="-active">Exceptions</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
+                        </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
+
+                        </section>
+            
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
+    </section>
+
+    <section class="phpdocumentor-sidebar__category">
+        <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
+    </section>
+</aside>
+
+            <div class="phpdocumentor-column -eight phpdocumentor-content">
+                    <ul class="phpdocumentor-breadcrumbs">
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
+    </ul>
+
+    <article class="phpdocumentor-element -namespace">
+        <h2 class="phpdocumentor-content__title">Exceptions</h2>
+
+        
+
+<h3 id="interfaces_class_traits">
+    Interfaces, Classes, Traits and Enums
+    <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+    
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Exceptions-InvalidTokenArray.html"><abbr title="\PHPCSUtils\Exceptions\InvalidTokenArray">InvalidTokenArray</abbr></a></dt>
+        <dd>Exception thrown when an non-existent token array is requested.</dd>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Exceptions-TestFileNotFound.html"><abbr title="\PHPCSUtils\Exceptions\TestFileNotFound">TestFileNotFound</abbr></a></dt>
+        <dd>Exception thrown when the UtilityMethodTestCase::getTargetToken() method is run without a
+tokenized test case file being available.</dd>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Exceptions-TestMarkerNotFound.html"><abbr title="\PHPCSUtils\Exceptions\TestMarkerNotFound">TestMarkerNotFound</abbr></a></dt>
+        <dd>Exception thrown when a delimiter comment can not be found in a test case file.</dd>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Exceptions-TestTargetNotFound.html"><abbr title="\PHPCSUtils\Exceptions\TestTargetNotFound">TestTargetNotFound</abbr></a></dt>
+        <dd>Exception thrown when a test target token can not be found in a test case file.</dd>
+    
+    
+    </dl>
+
+
+
+        
+
+        
+    </article>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
+            </div>
+        </div>
+        <a href="namespaces/phpcsutils-exceptions.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+
+    </main>
+
+    <script>
+        cssVars({});
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
+</body>
+</html>

--- a/docs/phpdoc/namespaces/phpcsutils-fixers.html
+++ b/docs/phpdoc/namespaces/phpcsutils-fixers.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="-active">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/namespaces/phpcsutils-fixers.html
+++ b/docs/phpdoc/namespaces/phpcsutils-fixers.html
@@ -2,70 +2,114 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="-active">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -namespace">
@@ -74,14 +118,15 @@
         
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Fixers-SpacesFixer.html"><abbr title="\PHPCSUtils\Fixers\SpacesFixer">SpacesFixer</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Fixers-SpacesFixer.html"><abbr title="\PHPCSUtils\Fixers\SpacesFixer">SpacesFixer</abbr></a></dt>
         <dd>Utility to check and, if necessary, fix the whitespace between two tokens.</dd>
+    
     
     </dl>
 
@@ -91,20 +136,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="namespaces/phpcsutils-fixers.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/namespaces/phpcsutils-testutils.html
+++ b/docs/phpdoc/namespaces/phpcsutils-testutils.html
@@ -2,70 +2,114 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="-active">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -namespace">
@@ -74,14 +118,15 @@
         
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html"><abbr title="\PHPCSUtils\TestUtils\UtilityMethodTestCase">UtilityMethodTestCase</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html"><abbr title="\PHPCSUtils\TestUtils\UtilityMethodTestCase">UtilityMethodTestCase</abbr></a></dt>
         <dd>Base class for use when testing utility methods for PHP_CodeSniffer.</dd>
+    
     
     </dl>
 
@@ -91,20 +136,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="namespaces/phpcsutils-testutils.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/namespaces/phpcsutils-testutils.html
+++ b/docs/phpdoc/namespaces/phpcsutils-testutils.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/namespaces/phpcsutils-tokens.html
+++ b/docs/phpdoc/namespaces/phpcsutils-tokens.html
@@ -2,70 +2,114 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="-active">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -namespace">
@@ -74,14 +118,15 @@
         
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Tokens-Collections.html"><abbr title="\PHPCSUtils\Tokens\Collections">Collections</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Tokens-Collections.html"><abbr title="\PHPCSUtils\Tokens\Collections">Collections</abbr></a></dt>
         <dd>Collections of related tokens as often used and needed for sniffs.</dd>
+    
     
     </dl>
 
@@ -91,20 +136,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="namespaces/phpcsutils-tokens.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/namespaces/phpcsutils-tokens.html
+++ b/docs/phpdoc/namespaces/phpcsutils-tokens.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -126,6 +130,8 @@
     
             <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Tokens-Collections.html"><abbr title="\PHPCSUtils\Tokens\Collections">Collections</abbr></a></dt>
         <dd>Collections of related tokens as often used and needed for sniffs.</dd>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Tokens-TokenHelper.html"><abbr title="\PHPCSUtils\Tokens\TokenHelper">TokenHelper</abbr></a></dt>
+        <dd>Helpers for working with tokens.</dd>
     
     
     </dl>

--- a/docs/phpdoc/namespaces/phpcsutils-utils.html
+++ b/docs/phpdoc/namespaces/phpcsutils-utils.html
@@ -2,70 +2,114 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="-active">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-            <li class="phpdocumentor-breadcrumb"><a href="../namespaces/phpcsutils.html">PHPCSUtils</a></li>
+            <li class="phpdocumentor-breadcrumb"><a href="namespaces/phpcsutils.html">PHPCSUtils</a></li>
     </ul>
 
     <article class="phpdocumentor-element -namespace">
@@ -74,51 +118,52 @@
         
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Arrays.html"><abbr title="\PHPCSUtils\Utils\Arrays">Arrays</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Arrays.html"><abbr title="\PHPCSUtils\Utils\Arrays">Arrays</abbr></a></dt>
         <dd>Utility functions for use when examining arrays.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Conditions.html"><abbr title="\PHPCSUtils\Utils\Conditions">Conditions</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Conditions.html"><abbr title="\PHPCSUtils\Utils\Conditions">Conditions</abbr></a></dt>
         <dd>Utility functions for use when examining token conditions.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-ControlStructures.html"><abbr title="\PHPCSUtils\Utils\ControlStructures">ControlStructures</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-ControlStructures.html"><abbr title="\PHPCSUtils\Utils\ControlStructures">ControlStructures</abbr></a></dt>
         <dd>Utility functions for use when examining control structures.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations">FunctionDeclarations</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations">FunctionDeclarations</abbr></a></dt>
         <dd>Utility functions for use when examining function declaration statements.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-GetTokensAsString.html"><abbr title="\PHPCSUtils\Utils\GetTokensAsString">GetTokensAsString</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-GetTokensAsString.html"><abbr title="\PHPCSUtils\Utils\GetTokensAsString">GetTokensAsString</abbr></a></dt>
         <dd>Utility functions to retrieve the content of a set of tokens as a string.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Lists.html"><abbr title="\PHPCSUtils\Utils\Lists">Lists</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Lists.html"><abbr title="\PHPCSUtils\Utils\Lists">Lists</abbr></a></dt>
         <dd>Utility functions to retrieve information when working with lists.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Namespaces.html"><abbr title="\PHPCSUtils\Utils\Namespaces">Namespaces</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Namespaces.html"><abbr title="\PHPCSUtils\Utils\Namespaces">Namespaces</abbr></a></dt>
         <dd>Utility functions for use when examining T_NAMESPACE tokens and to determine the
 namespace of arbitrary tokens.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-NamingConventions.html"><abbr title="\PHPCSUtils\Utils\NamingConventions">NamingConventions</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-NamingConventions.html"><abbr title="\PHPCSUtils\Utils\NamingConventions">NamingConventions</abbr></a></dt>
         <dd>Utility functions for working with identifier names.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Numbers.html"><abbr title="\PHPCSUtils\Utils\Numbers">Numbers</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Numbers.html"><abbr title="\PHPCSUtils\Utils\Numbers">Numbers</abbr></a></dt>
         <dd>Utility functions for working with integer/float tokens.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-ObjectDeclarations.html"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations">ObjectDeclarations</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations">ObjectDeclarations</abbr></a></dt>
         <dd>Utility functions for use when examining object declaration statements.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Operators.html"><abbr title="\PHPCSUtils\Utils\Operators">Operators</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Operators.html"><abbr title="\PHPCSUtils\Utils\Operators">Operators</abbr></a></dt>
         <dd>Utility functions for use when working with operators.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Orthography.html"><abbr title="\PHPCSUtils\Utils\Orthography">Orthography</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Orthography.html"><abbr title="\PHPCSUtils\Utils\Orthography">Orthography</abbr></a></dt>
         <dd>Utility functions for checking the orthography of arbitrary text strings.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Parentheses.html"><abbr title="\PHPCSUtils\Utils\Parentheses">Parentheses</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Parentheses.html"><abbr title="\PHPCSUtils\Utils\Parentheses">Parentheses</abbr></a></dt>
         <dd>Utility functions for use when examining parenthesis tokens and arbitrary tokens wrapped in
 parentheses.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-PassedParameters.html"><abbr title="\PHPCSUtils\Utils\PassedParameters">PassedParameters</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-PassedParameters.html"><abbr title="\PHPCSUtils\Utils\PassedParameters">PassedParameters</abbr></a></dt>
         <dd>Utility functions to retrieve information about parameters passed to function calls,
 array declarations, isset and unset constructs.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Scopes.html"><abbr title="\PHPCSUtils\Utils\Scopes">Scopes</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Scopes.html"><abbr title="\PHPCSUtils\Utils\Scopes">Scopes</abbr></a></dt>
         <dd>Utility functions for use when examining token scopes.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-TextStrings.html"><abbr title="\PHPCSUtils\Utils\TextStrings">TextStrings</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-TextStrings.html"><abbr title="\PHPCSUtils\Utils\TextStrings">TextStrings</abbr></a></dt>
         <dd>Utility functions for working with text string tokens.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-UseStatements.html"><abbr title="\PHPCSUtils\Utils\UseStatements">UseStatements</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-UseStatements.html"><abbr title="\PHPCSUtils\Utils\UseStatements">UseStatements</abbr></a></dt>
         <dd>Utility functions for examining use statements.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Variables.html"><abbr title="\PHPCSUtils\Utils\Variables">Variables</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Variables.html"><abbr title="\PHPCSUtils\Utils\Variables">Variables</abbr></a></dt>
         <dd>Utility functions for use when examining variables.</dd>
+    
     
     </dl>
 
@@ -128,20 +173,29 @@ array declarations, isset and unset constructs.</dd>
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="namespaces/phpcsutils-utils.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/namespaces/phpcsutils-utils.html
+++ b/docs/phpdoc/namespaces/phpcsutils-utils.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -150,11 +154,11 @@ namespace of arbitrary tokens.</dd>
             <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Orthography.html"><abbr title="\PHPCSUtils\Utils\Orthography">Orthography</abbr></a></dt>
         <dd>Utility functions for checking the orthography of arbitrary text strings.</dd>
             <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Parentheses.html"><abbr title="\PHPCSUtils\Utils\Parentheses">Parentheses</abbr></a></dt>
-        <dd>Utility functions for use when examining parenthesis tokens and arbitrary tokens wrapped in
-parentheses.</dd>
+        <dd>Utility functions for use when examining parenthesis tokens and arbitrary tokens wrapped
+in parentheses.</dd>
             <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-PassedParameters.html"><abbr title="\PHPCSUtils\Utils\PassedParameters">PassedParameters</abbr></a></dt>
         <dd>Utility functions to retrieve information about parameters passed to function calls,
-array declarations, isset and unset constructs.</dd>
+class instantiations, array declarations, isset and unset constructs.</dd>
             <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Scopes.html"><abbr title="\PHPCSUtils\Utils\Scopes">Scopes</abbr></a></dt>
         <dd>Utility functions for use when examining token scopes.</dd>
             <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-TextStrings.html"><abbr title="\PHPCSUtils\Utils\TextStrings">TextStrings</abbr></a></dt>
@@ -163,6 +167,10 @@ array declarations, isset and unset constructs.</dd>
         <dd>Utility functions for examining use statements.</dd>
             <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Variables.html"><abbr title="\PHPCSUtils\Utils\Variables">Variables</abbr></a></dt>
         <dd>Utility functions for use when examining variables.</dd>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Context.html"><abbr title="\PHPCSUtils\Utils\Context">Context</abbr></a></dt>
+        <dd>Utility functions for examining in which context a certain token is used.</dd>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-MessageHelper.html"><abbr title="\PHPCSUtils\Utils\MessageHelper">MessageHelper</abbr></a></dt>
+        <dd>Helper functions for creating PHPCS error/warning messages.</dd>
     
     
     </dl>

--- a/docs/phpdoc/namespaces/phpcsutils.html
+++ b/docs/phpdoc/namespaces/phpcsutils.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="-active">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -77,12 +121,12 @@
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-            <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></dt>
-            <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></dt>
-            <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></dt>
-            <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></dt>
-            <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></dt>
-            <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></dt>
     </dl>
 
 
@@ -92,20 +136,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="namespaces/phpcsutils.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/namespaces/phpcsutils.html
+++ b/docs/phpdoc/namespaces/phpcsutils.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -123,6 +127,7 @@
 <dl class="phpdocumentor-table-of-contents">
             <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></dt>
             <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="namespaces/phpcsutils-exceptions.html"><abbr title="\PHPCSUtils\Exceptions">Exceptions</abbr></a></dt>
             <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></dt>
             <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></dt>
             <dt class="phpdocumentor-table-of-contents__entry -namespace"><a href="namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></dt>

--- a/docs/phpdoc/packages/PHPCSUtils.html
+++ b/docs/phpdoc/packages/PHPCSUtils.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="-active">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -73,88 +117,219 @@
         
 
 <h3 id="interfaces_class_traits">
-    Interfaces, Classes and Traits
+    Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
     
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html"><abbr title="\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff">AbstractArrayDeclarationSniff</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-AbstractSniffs-AbstractArrayDeclarationSniff.html"><abbr title="\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff">AbstractArrayDeclarationSniff</abbr></a></dt>
         <dd>Abstract sniff to easily examine all parts of an array declaration.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-BackCompat-BCFile.html"><abbr title="\PHPCSUtils\BackCompat\BCFile">BCFile</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-BackCompat-BCFile.html"><abbr title="\PHPCSUtils\BackCompat\BCFile">BCFile</abbr></a></dt>
         <dd>PHPCS native utility functions.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-BackCompat-BCTokens.html"><abbr title="\PHPCSUtils\BackCompat\BCTokens">BCTokens</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-BackCompat-BCTokens.html"><abbr title="\PHPCSUtils\BackCompat\BCTokens">BCTokens</abbr></a></dt>
         <dd>Token arrays related utility methods.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-BackCompat-Helper.html"><abbr title="\PHPCSUtils\BackCompat\Helper">Helper</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-BackCompat-Helper.html"><abbr title="\PHPCSUtils\BackCompat\Helper">Helper</abbr></a></dt>
         <dd>Utility methods to retrieve (configuration) information from PHP_CodeSniffer.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Fixers-SpacesFixer.html"><abbr title="\PHPCSUtils\Fixers\SpacesFixer">SpacesFixer</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Fixers-SpacesFixer.html"><abbr title="\PHPCSUtils\Fixers\SpacesFixer">SpacesFixer</abbr></a></dt>
         <dd>Utility to check and, if necessary, fix the whitespace between two tokens.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html"><abbr title="\PHPCSUtils\TestUtils\UtilityMethodTestCase">UtilityMethodTestCase</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-TestUtils-UtilityMethodTestCase.html"><abbr title="\PHPCSUtils\TestUtils\UtilityMethodTestCase">UtilityMethodTestCase</abbr></a></dt>
         <dd>Base class for use when testing utility methods for PHP_CodeSniffer.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Tokens-Collections.html"><abbr title="\PHPCSUtils\Tokens\Collections">Collections</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Tokens-Collections.html"><abbr title="\PHPCSUtils\Tokens\Collections">Collections</abbr></a></dt>
         <dd>Collections of related tokens as often used and needed for sniffs.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Arrays.html"><abbr title="\PHPCSUtils\Utils\Arrays">Arrays</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Arrays.html"><abbr title="\PHPCSUtils\Utils\Arrays">Arrays</abbr></a></dt>
         <dd>Utility functions for use when examining arrays.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Conditions.html"><abbr title="\PHPCSUtils\Utils\Conditions">Conditions</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Conditions.html"><abbr title="\PHPCSUtils\Utils\Conditions">Conditions</abbr></a></dt>
         <dd>Utility functions for use when examining token conditions.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-ControlStructures.html"><abbr title="\PHPCSUtils\Utils\ControlStructures">ControlStructures</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-ControlStructures.html"><abbr title="\PHPCSUtils\Utils\ControlStructures">ControlStructures</abbr></a></dt>
         <dd>Utility functions for use when examining control structures.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-FunctionDeclarations.html"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations">FunctionDeclarations</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations">FunctionDeclarations</abbr></a></dt>
         <dd>Utility functions for use when examining function declaration statements.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-GetTokensAsString.html"><abbr title="\PHPCSUtils\Utils\GetTokensAsString">GetTokensAsString</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-GetTokensAsString.html"><abbr title="\PHPCSUtils\Utils\GetTokensAsString">GetTokensAsString</abbr></a></dt>
         <dd>Utility functions to retrieve the content of a set of tokens as a string.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Lists.html"><abbr title="\PHPCSUtils\Utils\Lists">Lists</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Lists.html"><abbr title="\PHPCSUtils\Utils\Lists">Lists</abbr></a></dt>
         <dd>Utility functions to retrieve information when working with lists.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Namespaces.html"><abbr title="\PHPCSUtils\Utils\Namespaces">Namespaces</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Namespaces.html"><abbr title="\PHPCSUtils\Utils\Namespaces">Namespaces</abbr></a></dt>
         <dd>Utility functions for use when examining T_NAMESPACE tokens and to determine the
 namespace of arbitrary tokens.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-NamingConventions.html"><abbr title="\PHPCSUtils\Utils\NamingConventions">NamingConventions</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-NamingConventions.html"><abbr title="\PHPCSUtils\Utils\NamingConventions">NamingConventions</abbr></a></dt>
         <dd>Utility functions for working with identifier names.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Numbers.html"><abbr title="\PHPCSUtils\Utils\Numbers">Numbers</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Numbers.html"><abbr title="\PHPCSUtils\Utils\Numbers">Numbers</abbr></a></dt>
         <dd>Utility functions for working with integer/float tokens.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-ObjectDeclarations.html"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations">ObjectDeclarations</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-ObjectDeclarations.html"><abbr title="\PHPCSUtils\Utils\ObjectDeclarations">ObjectDeclarations</abbr></a></dt>
         <dd>Utility functions for use when examining object declaration statements.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Operators.html"><abbr title="\PHPCSUtils\Utils\Operators">Operators</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Operators.html"><abbr title="\PHPCSUtils\Utils\Operators">Operators</abbr></a></dt>
         <dd>Utility functions for use when working with operators.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Orthography.html"><abbr title="\PHPCSUtils\Utils\Orthography">Orthography</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Orthography.html"><abbr title="\PHPCSUtils\Utils\Orthography">Orthography</abbr></a></dt>
         <dd>Utility functions for checking the orthography of arbitrary text strings.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Parentheses.html"><abbr title="\PHPCSUtils\Utils\Parentheses">Parentheses</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Parentheses.html"><abbr title="\PHPCSUtils\Utils\Parentheses">Parentheses</abbr></a></dt>
         <dd>Utility functions for use when examining parenthesis tokens and arbitrary tokens wrapped in
 parentheses.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-PassedParameters.html"><abbr title="\PHPCSUtils\Utils\PassedParameters">PassedParameters</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-PassedParameters.html"><abbr title="\PHPCSUtils\Utils\PassedParameters">PassedParameters</abbr></a></dt>
         <dd>Utility functions to retrieve information about parameters passed to function calls,
 array declarations, isset and unset constructs.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Scopes.html"><abbr title="\PHPCSUtils\Utils\Scopes">Scopes</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Scopes.html"><abbr title="\PHPCSUtils\Utils\Scopes">Scopes</abbr></a></dt>
         <dd>Utility functions for use when examining token scopes.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-TextStrings.html"><abbr title="\PHPCSUtils\Utils\TextStrings">TextStrings</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-TextStrings.html"><abbr title="\PHPCSUtils\Utils\TextStrings">TextStrings</abbr></a></dt>
         <dd>Utility functions for working with text string tokens.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-UseStatements.html"><abbr title="\PHPCSUtils\Utils\UseStatements">UseStatements</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-UseStatements.html"><abbr title="\PHPCSUtils\Utils\UseStatements">UseStatements</abbr></a></dt>
         <dd>Utility functions for examining use statements.</dd>
-            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="../classes/PHPCSUtils-Utils-Variables.html"><abbr title="\PHPCSUtils\Utils\Variables">Variables</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Variables.html"><abbr title="\PHPCSUtils\Utils\Variables">Variables</abbr></a></dt>
         <dd>Utility functions for use when examining variables.</dd>
+    
     
     </dl>
 
 
+<h3 id="toc">
+    Table of Contents
+    <a href="#toc" class="headerlink"><i class="fas fa-link"></i></a>
+</h3>
+
+<dl class="phpdocumentor-table-of-contents">
+            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
+    <a href="namespaces/default.html#constant_PHPCSUTILS_AUTOLOAD">PHPCSUTILS_AUTOLOAD</a>
+    <span>
+        &nbsp;= \true                            </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
+    <a href="namespaces/default.html#constant_PHPCSUTILS_PHPCS_ALIASES_SET">PHPCSUTILS_PHPCS_ALIASES_SET</a>
+    <span>
+        &nbsp;= \true                            </span>
+</dt>
+<dd></dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -constant -public">
+    <a href="namespaces/default.html#constant_PHPCSUTILS_PHPUNIT_ALIASES_SET">PHPCSUTILS_PHPUNIT_ALIASES_SET</a>
+    <span>
+        &nbsp;= \true                            </span>
+</dt>
+<dd></dd>
+
+                    </dl>
 
         
+    <section class="phpdocumentor-constants">
+        <h3 class="phpdocumentor-elements__header" id="constants">
+            Constants
+            <a href="packages/PHPCSUtils.html#constants" class="headerlink"><i class="fas fa-link"></i></a>
+        </h3>
+                    <article class="phpdocumentor-element -constant -public ">
+    <h4 class="phpdocumentor-element__name" id="constant_PHPCSUTILS_AUTOLOAD">
+        PHPCSUTILS_AUTOLOAD
+        <a href="namespaces/default.html#constant_PHPCSUTILS_AUTOLOAD" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="phpcsutils-autoload.php"><a href="files/phpcsutils-autoload.html"><abbr title="phpcsutils-autoload.php">phpcsutils-autoload.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">52</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-signature phpdocumentor-code ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+        <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__name">PHPCSUTILS_AUTOLOAD</span>
+    = <span class="phpdocumentor-signature__default-value">\true</span>
+</code>
+
+
+        <section class="phpdocumentor-description"></section>
+
+        <section class="phpdocumentor-description"></section>
+
+    
+
+</article>
+                    <article class="phpdocumentor-element -constant -public ">
+    <h4 class="phpdocumentor-element__name" id="constant_PHPCSUTILS_PHPCS_ALIASES_SET">
+        PHPCSUTILS_PHPCS_ALIASES_SET
+        <a href="namespaces/default.html#constant_PHPCSUTILS_PHPCS_ALIASES_SET" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="phpcsutils-autoload.php"><a href="files/phpcsutils-autoload.html"><abbr title="phpcsutils-autoload.php">phpcsutils-autoload.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">98</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-signature phpdocumentor-code ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+        <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__name">PHPCSUTILS_PHPCS_ALIASES_SET</span>
+    = <span class="phpdocumentor-signature__default-value">\true</span>
+</code>
+
+
+        <section class="phpdocumentor-description"></section>
+
+        <section class="phpdocumentor-description"></section>
+
+    
+
+</article>
+                    <article class="phpdocumentor-element -constant -public ">
+    <h4 class="phpdocumentor-element__name" id="constant_PHPCSUTILS_PHPUNIT_ALIASES_SET">
+        PHPCSUTILS_PHPUNIT_ALIASES_SET
+        <a href="namespaces/default.html#constant_PHPCSUTILS_PHPUNIT_ALIASES_SET" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="phpcsutils-autoload.php"><a href="files/phpcsutils-autoload.html"><abbr title="phpcsutils-autoload.php">phpcsutils-autoload.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">119</span>
+
+    </aside>
+
+    
+    <code class="phpdocumentor-signature phpdocumentor-code ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+        <span class="phpdocumentor-signature__type">mixed</span>
+    <span class="phpdocumentor-signature__name">PHPCSUTILS_PHPUNIT_ALIASES_SET</span>
+    = <span class="phpdocumentor-signature__default-value">\true</span>
+</code>
+
+
+        <section class="phpdocumentor-description"></section>
+
+        <section class="phpdocumentor-description"></section>
+
+    
+
+</article>
+            </section>
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="packages/PHPCSUtils.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/packages/PHPCSUtils.html
+++ b/docs/phpdoc/packages/PHPCSUtils.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -163,11 +167,11 @@ namespace of arbitrary tokens.</dd>
             <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Orthography.html"><abbr title="\PHPCSUtils\Utils\Orthography">Orthography</abbr></a></dt>
         <dd>Utility functions for checking the orthography of arbitrary text strings.</dd>
             <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Parentheses.html"><abbr title="\PHPCSUtils\Utils\Parentheses">Parentheses</abbr></a></dt>
-        <dd>Utility functions for use when examining parenthesis tokens and arbitrary tokens wrapped in
-parentheses.</dd>
+        <dd>Utility functions for use when examining parenthesis tokens and arbitrary tokens wrapped
+in parentheses.</dd>
             <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-PassedParameters.html"><abbr title="\PHPCSUtils\Utils\PassedParameters">PassedParameters</abbr></a></dt>
         <dd>Utility functions to retrieve information about parameters passed to function calls,
-array declarations, isset and unset constructs.</dd>
+class instantiations, array declarations, isset and unset constructs.</dd>
             <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Scopes.html"><abbr title="\PHPCSUtils\Utils\Scopes">Scopes</abbr></a></dt>
         <dd>Utility functions for use when examining token scopes.</dd>
             <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-TextStrings.html"><abbr title="\PHPCSUtils\Utils\TextStrings">TextStrings</abbr></a></dt>
@@ -176,6 +180,21 @@ array declarations, isset and unset constructs.</dd>
         <dd>Utility functions for examining use statements.</dd>
             <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Variables.html"><abbr title="\PHPCSUtils\Utils\Variables">Variables</abbr></a></dt>
         <dd>Utility functions for use when examining variables.</dd>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Exceptions-InvalidTokenArray.html"><abbr title="\PHPCSUtils\Exceptions\InvalidTokenArray">InvalidTokenArray</abbr></a></dt>
+        <dd>Exception thrown when an non-existent token array is requested.</dd>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Exceptions-TestFileNotFound.html"><abbr title="\PHPCSUtils\Exceptions\TestFileNotFound">TestFileNotFound</abbr></a></dt>
+        <dd>Exception thrown when the UtilityMethodTestCase::getTargetToken() method is run without a
+tokenized test case file being available.</dd>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Exceptions-TestMarkerNotFound.html"><abbr title="\PHPCSUtils\Exceptions\TestMarkerNotFound">TestMarkerNotFound</abbr></a></dt>
+        <dd>Exception thrown when a delimiter comment can not be found in a test case file.</dd>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Exceptions-TestTargetNotFound.html"><abbr title="\PHPCSUtils\Exceptions\TestTargetNotFound">TestTargetNotFound</abbr></a></dt>
+        <dd>Exception thrown when a test target token can not be found in a test case file.</dd>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Tokens-TokenHelper.html"><abbr title="\PHPCSUtils\Tokens\TokenHelper">TokenHelper</abbr></a></dt>
+        <dd>Helpers for working with tokens.</dd>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-Context.html"><abbr title="\PHPCSUtils\Utils\Context">Context</abbr></a></dt>
+        <dd>Utility functions for examining in which context a certain token is used.</dd>
+            <dt class="phpdocumentor-table-of-contents__entry -class"><a href="classes/PHPCSUtils-Utils-MessageHelper.html"><abbr title="\PHPCSUtils\Utils\MessageHelper">MessageHelper</abbr></a></dt>
+        <dd>Helper functions for creating PHPCS error/warning messages.</dd>
     
     
     </dl>

--- a/docs/phpdoc/packages/default.html
+++ b/docs/phpdoc/packages/default.html
@@ -2,64 +2,108 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>PHPCSUtils</title>
+            <title>PHPCSUtils</title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
@@ -76,7 +120,7 @@
 </h3>
 
 <dl class="phpdocumentor-table-of-contents">
-            <dt class="phpdocumentor-table-of-contents__entry -package"><a href="../packages/PHPCSUtils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></dt>
+            <dt class="phpdocumentor-table-of-contents__entry -package"><a href="packages/PHPCSUtils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></dt>
     </dl>
 
 
@@ -87,20 +131,29 @@
 
         
     </article>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="packages/default.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/packages/default.html
+++ b/docs/phpdoc/packages/default.html
@@ -68,6 +68,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/reports/deprecated.html
+++ b/docs/phpdoc/reports/deprecated.html
@@ -69,6 +69,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -116,10 +120,265 @@
     <div class="phpdocumentor-row">
         <h2 class="phpdocumentor-content__title">Deprecated</h2>
 
+                <h3>Table of Contents</h3>
+        <table class="phpdocumentor-table_of_contents">
+                            <tr>
+                    <td class="phpdocumentor-cell"><a href="reports/deprecated.html#PHPCSUtils/Tokens/Collections.php">PHPCSUtils/Tokens/Collections.php</a></td>
+                </tr>
+                            <tr>
+                    <td class="phpdocumentor-cell"><a href="reports/deprecated.html#PHPCSUtils/Utils/ControlStructures.php">PHPCSUtils/Utils/ControlStructures.php</a></td>
+                </tr>
+                            <tr>
+                    <td class="phpdocumentor-cell"><a href="reports/deprecated.html#PHPCSUtils/Utils/FunctionDeclarations.php">PHPCSUtils/Utils/FunctionDeclarations.php</a></td>
+                </tr>
+                    </table>
         
-                    <div class="phpdocumentor-admonition phpdocumentor-admonition--success">
-                No deprecated elements have been found in this project.
-            </div>
+                    <a id="PHPCSUtils/Tokens/Collections.php"></a>
+            <h3><abbr title="PHPCSUtils/Tokens/Collections.php">Collections.php</abbr></h3>
+            <table>
+                <tr>
+                    <th class="phpdocumentor-heading">Line</th>
+                    <th class="phpdocumentor-heading">Element</th>
+                    <th class="phpdocumentor-heading">Reason</th>
+                </tr>
+                                                            <tr>
+                            <td class="phpdocumentor-cell">782</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#method_arrowFunctionTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::arrowFunctionTokensBC()">Collections::arrowFunctionTokensBC()</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <code class="prettyprint">T_FN</code> token constant instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">820</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#method_functionDeclarationTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::functionDeclarationTokensBC()">Collections::functionDeclarationTokensBC()</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::functionDeclarationTokens()">Collections::functionDeclarationTokens()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">493</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_parameterTypeTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$parameterTypeTokens">Collections::$parameterTypeTokens</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::parameterTypeTokens()">Collections::parameterTypeTokens()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">978</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#method_parameterTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::parameterTypeTokensBC()">Collections::parameterTypeTokensBC()</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::parameterTypeTokens()">Collections::parameterTypeTokens()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">549</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_propertyTypeTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$propertyTypeTokens">Collections::$propertyTypeTokens</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::propertyTypeTokens()">Collections::propertyTypeTokens()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">1019</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#method_propertyTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::propertyTypeTokensBC()">Collections::propertyTypeTokensBC()</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::propertyTypeTokens()">Collections::propertyTypeTokens()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">574</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_returnTypeTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$returnTypeTokens">Collections::$returnTypeTokens</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::returnTypeTokens()">Collections::returnTypeTokens()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">1061</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#method_returnTypeTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::returnTypeTokensBC()">Collections::returnTypeTokensBC()</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::returnTypeTokens()">Collections::returnTypeTokens()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">70</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_alternativeControlStructureSyntaxTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$alternativeControlStructureSyntaxTokens">Collections::$alternativeControlStructureSyntaxTokens</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_alternativeControlStructureSyntaxes"><abbr title="\PHPCSUtils\Tokens\Collections::alternativeControlStructureSyntaxes()">Collections::alternativeControlStructureSyntaxes()</abbr></a>
+method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">91</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_alternativeControlStructureSyntaxCloserTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$alternativeControlStructureSyntaxCloserTokens">Collections::$alternativeControlStructureSyntaxCloserTokens</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_alternativeControlStructureSyntaxClosers"><abbr title="\PHPCSUtils\Tokens\Collections::alternativeControlStructureSyntaxClosers()">Collections::alternativeControlStructureSyntaxClosers()</abbr></a>
+method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">138</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$arrayTokens">Collections::$arrayTokens</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::arrayTokens()">Collections::arrayTokens()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">162</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_arrayTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::$arrayTokensBC">Collections::$arrayTokensBC</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::arrayTokensBC()">Collections::arrayTokensBC()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">180</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_classModifierKeywords"><abbr title="\PHPCSUtils\Tokens\Collections::$classModifierKeywords">Collections::$classModifierKeywords</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::classModifierKeywords()">Collections::classModifierKeywords()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">202</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_closedScopes"><abbr title="\PHPCSUtils\Tokens\Collections::$closedScopes">Collections::$closedScopes</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::closedScopes()">Collections::closedScopes()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">222</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_controlStructureTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$controlStructureTokens">Collections::$controlStructureTokens</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::controlStructureTokens()">Collections::controlStructureTokens()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">257</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_incrementDecrementOperators"><abbr title="\PHPCSUtils\Tokens\Collections::$incrementDecrementOperators">Collections::$incrementDecrementOperators</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::incrementDecrementOperators()">Collections::incrementDecrementOperators()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">276</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_listTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$listTokens">Collections::$listTokens</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::listTokens()">Collections::listTokens()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">298</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_listTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::$listTokensBC">Collections::$listTokensBC</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::listTokensBC()">Collections::listTokensBC()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">316</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_magicConstants"><abbr title="\PHPCSUtils\Tokens\Collections::$magicConstants">Collections::$magicConstants</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHP_CodeSniffer\Util\Tokens::$magicConstants">Tokens::$magicConstants</abbr> property
+or the <abbr title="\PHPCSUtils\BackCompat\BCTokens::magicConstants()">BCTokens::magicConstants()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">336</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_namespaceDeclarationClosers"><abbr title="\PHPCSUtils\Tokens\Collections::$namespaceDeclarationClosers">Collections::$namespaceDeclarationClosers</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::namespaceDeclarationClosers()">Collections::namespaceDeclarationClosers()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">374</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_objectOperators"><abbr title="\PHPCSUtils\Tokens\Collections::$objectOperators">Collections::$objectOperators</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::objectOperators()">Collections::objectOperators()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">389</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOCanExtend"><abbr title="\PHPCSUtils\Tokens\Collections::$OOCanExtend">Collections::$OOCanExtend</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooCanExtend"><abbr title="\PHPCSUtils\Tokens\Collections::ooCanExtend()">Collections::ooCanExtend()</abbr></a> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">405</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOCanImplement"><abbr title="\PHPCSUtils\Tokens\Collections::$OOCanImplement">Collections::$OOCanImplement</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooCanImplement"><abbr title="\PHPCSUtils\Tokens\Collections::ooCanImplement()">Collections::ooCanImplement()</abbr></a> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">424</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOConstantScopes"><abbr title="\PHPCSUtils\Tokens\Collections::$OOConstantScopes">Collections::$OOConstantScopes</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooConstantScopes"><abbr title="\PHPCSUtils\Tokens\Collections::ooConstantScopes()">Collections::ooConstantScopes()</abbr></a> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">443</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOHierarchyKeywords"><abbr title="\PHPCSUtils\Tokens\Collections::$OOHierarchyKeywords">Collections::$OOHierarchyKeywords</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooHierarchyKeywords"><abbr title="\PHPCSUtils\Tokens\Collections::ooHierarchyKeywords()">Collections::ooHierarchyKeywords()</abbr></a> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">458</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_OONameTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$OONameTokens">Collections::$OONameTokens</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_namespacedNameTokens"><abbr title="\PHPCSUtils\Tokens\Collections::namespacedNameTokens()">Collections::namespacedNameTokens()</abbr></a> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">475</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_OOPropertyScopes"><abbr title="\PHPCSUtils\Tokens\Collections::$OOPropertyScopes">Collections::$OOPropertyScopes</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_ooPropertyScopes"><abbr title="\PHPCSUtils\Tokens\Collections::ooPropertyScopes()">Collections::ooPropertyScopes()</abbr></a> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">528</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_propertyModifierKeywords"><abbr title="\PHPCSUtils\Tokens\Collections::$propertyModifierKeywords">Collections::$propertyModifierKeywords</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::propertyModifierKeywords()">Collections::propertyModifierKeywords()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">615</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$shortArrayTokens">Collections::$shortArrayTokens</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::shortArrayTokens()">Collections::shortArrayTokens()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">636</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortArrayTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::$shortArrayTokensBC">Collections::$shortArrayTokensBC</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::shortArrayTokensBC()">Collections::shortArrayTokensBC()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">654</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$shortListTokens">Collections::$shortListTokens</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::shortListTokens()">Collections::shortListTokens()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">675</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_shortListTokensBC"><abbr title="\PHPCSUtils\Tokens\Collections::$shortListTokensBC">Collections::$shortListTokensBC</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <abbr title="\PHPCSUtils\Tokens\Collections::shortListTokensBC()">Collections::shortListTokensBC()</abbr> method instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">691</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Tokens-Collections.html#property_textStingStartTokens"><abbr title="\PHPCSUtils\Tokens\Collections::$textStingStartTokens">Collections::$textStingStartTokens</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the <a href="classes/PHPCSUtils-Tokens-Collections.html#method_textStringStartTokens"><abbr title="\PHPCSUtils\Tokens\Collections::textStringStartTokens()">Collections::textStringStartTokens()</abbr></a> method instead.</p>
+</td>
+                        </tr>
+                                                </table>
+                    <a id="PHPCSUtils/Utils/ControlStructures.php"></a>
+            <h3><abbr title="PHPCSUtils/Utils/ControlStructures.php">ControlStructures.php</abbr></h3>
+            <table>
+                <tr>
+                    <th class="phpdocumentor-heading">Line</th>
+                    <th class="phpdocumentor-heading">Element</th>
+                    <th class="phpdocumentor-heading">Reason</th>
+                </tr>
+                                                            <tr>
+                            <td class="phpdocumentor-cell">224</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Utils-ControlStructures.html#method_getDeclareScopeOpenClose"><abbr title="\PHPCSUtils\Utils\ControlStructures::getDeclareScopeOpenClose()">ControlStructures::getDeclareScopeOpenClose()</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Check the scope_opener/scope_closer instead.</p>
+</td>
+                        </tr>
+                                                </table>
+                    <a id="PHPCSUtils/Utils/FunctionDeclarations.php"></a>
+            <h3><abbr title="PHPCSUtils/Utils/FunctionDeclarations.php">FunctionDeclarations.php</abbr></h3>
+            <table>
+                <tr>
+                    <th class="phpdocumentor-heading">Line</th>
+                    <th class="phpdocumentor-heading">Element</th>
+                    <th class="phpdocumentor-heading">Reason</th>
+                </tr>
+                                                            <tr>
+                            <td class="phpdocumentor-cell">643</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isArrowFunction"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations::isArrowFunction()">FunctionDeclarations::isArrowFunction()</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the T_FN token constant instead.</p>
+</td>
+                        </tr>
+                                                                                <tr>
+                            <td class="phpdocumentor-cell">695</td>
+                            <td class="phpdocumentor-cell"><a href="classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getArrowFunctionOpenClose"><abbr title="\PHPCSUtils\Utils\FunctionDeclarations::getArrowFunctionOpenClose()">FunctionDeclarations::getArrowFunctionOpenClose()</abbr></a></td>
+                            <td class="phpdocumentor-cell"><p>Use the T_FN token constant instead.</p>
+</td>
+                        </tr>
+                                                </table>
             </div>
                 <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
     <section class="phpdocumentor-search-results__dialog">

--- a/docs/phpdoc/reports/deprecated.html
+++ b/docs/phpdoc/reports/deprecated.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>    PHPCSUtils &raquo; Deprecated elements
+            <title>    PHPCSUtils &raquo; Deprecated elements
 </title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-        <li><a href="../index.html">Home</a></li>
+        <li><a href="">Home</a></li>
     </ul>
 
     <div class="phpdocumentor-row">
@@ -77,20 +121,29 @@
                 No deprecated elements have been found in this project.
             </div>
             </div>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="reports/deprecated.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/reports/errors.html
+++ b/docs/phpdoc/reports/errors.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>    PHPCSUtils &raquo; Compilation errors
+            <title>    PHPCSUtils &raquo; Compilation errors
 </title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                 <ul class="phpdocumentor-breadcrumbs">
-    <li><a href="../index.html">Home</a></li>
+    <li><a href="">Home</a></li>
 </ul>
 
 <div class="phpdocumentor-row">
@@ -75,7 +119,7 @@
         <h3>Table of Contents</h3>
     <table class="phpdocumentor-table_of_contents">
                                             <tr>
-                    <td class="phpdocumentor-cell"><a href="#PHPCSUtils/BackCompat/BCFile.php">PHPCSUtils/BackCompat/BCFile.php</a></td>
+                    <td class="phpdocumentor-cell"><a href="reports/errors.html#PHPCSUtils/BackCompat/BCFile.php">PHPCSUtils/BackCompat/BCFile.php</a></td>
                     <td class="phpdocumentor-cell">1</td>
                 </tr>
                                     </table>
@@ -102,20 +146,29 @@ With documentation contributions from:&quot; has error </td>
                         </tbody>
         </table>
     </div>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="reports/errors.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>

--- a/docs/phpdoc/reports/errors.html
+++ b/docs/phpdoc/reports/errors.html
@@ -69,6 +69,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>

--- a/docs/phpdoc/reports/markers.html
+++ b/docs/phpdoc/reports/markers.html
@@ -69,6 +69,10 @@
                 
             </li>
                     <li>
+                <a href="namespaces/phpcsutils-exceptions.html" class="">Exceptions</a>
+                
+            </li>
+                    <li>
                 <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
                 
             </li>
@@ -137,7 +141,7 @@
                 <tbody>
                                     <tr>
                         <td class="phpdocumentor-cell">TODO</td>
-                        <td class="phpdocumentor-cell">839</td>
+                        <td class="phpdocumentor-cell">743</td>
                         <td class="phpdocumentor-cell">Add check for the function declaration being namespaced!</td>
                     </tr>
                                 </tbody>

--- a/docs/phpdoc/reports/markers.html
+++ b/docs/phpdoc/reports/markers.html
@@ -2,71 +2,115 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>    PHPCSUtils &raquo; Markers
+            <title>    PHPCSUtils &raquo; Markers
 </title>
+    
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="../images/favicon.ico"/>
-    <link rel="stylesheet" href="../css/normalize.css">
-    <link rel="stylesheet" href="../css/base.css">
-            <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="../css/template.css">
+    <base href="../">
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
+            <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/themes/prism-okaidia.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.css">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.css">
                 <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="../js/search.js"></script>
-        <script defer src="../js/searchIndex.js"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     </head>
 <body id="top">
     <header class="phpdocumentor-header phpdocumentor-section">
-    <h1 class="phpdocumentor-title"><a href="../">PHPCSUtils</a></h1>
-    <nav class="phpdocumentor-topnav">
-    </nav>
-</header>
-
-    <main class="phpdocumentor">
-        <div class="phpdocumentor-section">
-            <aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+    <h1 class="phpdocumentor-title"><a href="" class="phpdocumentor-title__link">PHPCSUtils</a></h1>
+    <input class="phpdocumentor-header__menu-button" type="checkbox" id="menu-button" name="menu-button" />
+    <label class="phpdocumentor-header__menu-icon" for="menu-button">
+        <i class="fas fa-bars"></i>
+    </label>
     <section data-search-form class="phpdocumentor-search">
-    <h2 class="phpdocumentor-sidebar__category-header">Search</h2>
-    <label class="phpdocumentor-label">
+    <label>
         <span class="visually-hidden">Search for</span>
+        <svg class="phpdocumentor-search__icon" width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="7.5" cy="7.5" r="6.5" stroke="currentColor" stroke-width="2"/>
+            <line x1="12.4892" y1="12.2727" x2="19.1559" y2="18.9393" stroke="currentColor" stroke-width="3"/>
+        </svg>
         <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
     </label>
 </section>
 
+    <nav class="phpdocumentor-topnav">
+    <ul class="phpdocumentor-topnav__menu">
+        </ul>
+</nav>
+</header>
 
-    
-    <section class="phpdocumentor-sidebar__category">
-        <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
-                                                <h4 class="phpdocumentor-sidebar__root-namespace"><a href="../namespaces/phpcsutils.html"><abbr title="\PHPCSUtils">PHPCSUtils</abbr></a></h4>
-                <ul class="phpdocumentor-list">
-                                            <li><a href="../namespaces/phpcsutils-abstractsniffs.html"><abbr title="\PHPCSUtils\AbstractSniffs">AbstractSniffs</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-backcompat.html"><abbr title="\PHPCSUtils\BackCompat">BackCompat</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-fixers.html"><abbr title="\PHPCSUtils\Fixers">Fixers</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-testutils.html"><abbr title="\PHPCSUtils\TestUtils">TestUtils</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-tokens.html"><abbr title="\PHPCSUtils\Tokens">Tokens</abbr></a></li>
-                                            <li><a href="../namespaces/phpcsutils-utils.html"><abbr title="\PHPCSUtils\Utils">Utils</abbr></a></li>
-                                    </ul>
+    <main class="phpdocumentor">
+        <div class="phpdocumentor-section">
+            <input class="phpdocumentor-sidebar__menu-button" type="checkbox" id="sidebar-button" name="sidebar-button" />
+<label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
+    Menu
+</label>
+<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+                    <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Namespaces</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="namespaces/phpcsutils.html" class="">PHPCSUtils</a>
+</h4>
+    <ul class="phpdocumentor-list">
+                    <li>
+                <a href="namespaces/phpcsutils-abstractsniffs.html" class="">AbstractSniffs</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-backcompat.html" class="">BackCompat</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-fixers.html" class="">Fixers</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-testutils.html" class="">TestUtils</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-tokens.html" class="">Tokens</a>
+                
+            </li>
+                    <li>
+                <a href="namespaces/phpcsutils-utils.html" class="">Utils</a>
+                
+            </li>
+            </ul>
+
                         </section>
+                <section class="phpdocumentor-sidebar__category">
+            <h2 class="phpdocumentor-sidebar__category-header">Packages</h2>
+                                    <h4 class="phpdocumentor-sidebar__root-namespace">
+    <a href="packages/PHPCSUtils.html" class="">PHPCSUtils</a>
+</h4>
 
-    
+                        </section>
+            
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
-                <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/deprecated.html">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/errors.html">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../reports/markers.html">Markers</a></h3>
+                <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="../indices/files.html">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>
 
             <div class="phpdocumentor-column -eight phpdocumentor-content">
                     <ul class="phpdocumentor-breadcrumbs">
-        <li><a href="../index.html">Home</a></li>
+        <li><a href="">Home</a></li>
     </ul>
 
     <div class="phpdocumentor-row">
@@ -75,7 +119,7 @@
                     <h3>Table of Contents</h3>
             <table class="phpdocumentor-table_of_contents">
                                                             <tr>
-                            <td class="phpdocumentor-cell"><a href="#PHPCSUtils/Utils/FunctionDeclarations.php">PHPCSUtils/Utils/FunctionDeclarations.php</a></td>
+                            <td class="phpdocumentor-cell"><a href="reports/markers.html#PHPCSUtils/Utils/FunctionDeclarations.php">PHPCSUtils/Utils/FunctionDeclarations.php</a></td>
                             <td class="phpdocumentor-cell">1</td>
                         </tr>
                                                 </table>
@@ -99,20 +143,29 @@
                                 </tbody>
             </table>
             </div>
-                <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
-
-    <h2>Search results</h2>
-    <ul class="phpdocumentor-search-results__entries">
-    </ul>
-</div>
+                <section data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+    <section class="phpdocumentor-search-results__dialog">
+        <header class="phpdocumentor-search-results__header">
+            <h2 class="phpdocumentor-search-results__title">Search results</h2>
+            <button class="phpdocumentor-search-results__close"><i class="fas fa-times"></i></button>
+        </header>
+        <section class="phpdocumentor-search-results__body">
+            <ul class="phpdocumentor-search-results__entries"></ul>
+        </section>
+    </section>
+</section>
             </div>
         </div>
-        <a href="#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+        <a href="reports/markers.html#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
 
     </main>
 
     <script>
         cssVars({});
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.23.0/plugins/line-highlight/prism-line-highlight.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Doc website: update the phpDocumentor configuration

... after recent fixes in phpDocumentor3.

### Doc website: regen of PHPCSUtils 1.0.0-alpha3 documentation

... using the latest released version of phpDocumentor (`3.3.1`) so the diff for the actual regen of version 1.0.0-alpha4 will only show the differences in content, not document structure.

### Doc website: update documentation for PHPCSUtils 1.0.0-alpha4

The docs have been regenerated using phpDocumentor 3.3.1 with `--visibility=public,protected`.

### GH Pages: minor template tweaks

* Always display link to the project on GH.
    The `site.github.is_project_page` key does not seem to be reliable.
* Display the version number of the last release, if available.
* Always display the "Maintained by" link.
* Remove duplicate `header` close tag.

### GH Pages: minor tweaks to the configuration file

Includes adding a `commonmark` configuration to prevent Commonmark blindly stripping _all_ HTML.

### Docs website: sync readme changes into docs index.md