### PR TITLE
Update all references to the main branch from `master` to `stable`

### DIFF
--- a/.github/release-checklist.md
+++ b/.github/release-checklist.md
@@ -1,4 +1,4 @@
-# Template to use for release PRs from `develop` to `master`
+# Template to use for release PRs from `develop` to `stable`
 
 PR for tracking changes for the x.x.x release. Target release date: **DOW MONTH DAY YEAR**.
 
@@ -35,7 +35,7 @@ PR for tracking changes for the x.x.x release. Target release date: **DOW MONTH 
 - [ ] Close the milestone
 - [ ] Open a new milestone for the next release
 - [ ] If any open PRs/issues which were milestoned for this release did not make it into the release, update their milestone.
-- [ ] Fast-forward `develop` to be equal to `master`
+- [ ] Fast-forward `develop` to be equal to `stable`
 
 ### Publicize
 

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -1,10 +1,10 @@
 name: Quicktest
 
 on:
-  # Run on pushes, including merges, to all branches except `master`.
+  # Run on pushes, including merges, to all branches except `stable` and `develop`.
   push:
     branches-ignore:
-      - master
+      - stable
       - develop
     paths-ignore:
       - '**.md'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,10 @@
 name: Test
 
 on:
-  # Run on pushes to `master` and on all pull requests.
+  # Run on pushes to `stable` and `develop` and on all pull requests.
   push:
     branches:
-      - master
+      - stable
       - develop
     paths-ignore:
       - '**.md'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,7 +309,7 @@ This initial alpha release contains the following utility classes:
 * [`Variables`]: Utility functions for use when examining variables.
 
 
-[Unreleased]:   https://github.com/PHPCSStandards/PHPCSUtils/compare/1.0.0-alpha3...HEAD
+[Unreleased]:   https://github.com/PHPCSStandards/PHPCSUtils/compare/stable...HEAD
 [1.0.0-alpha3]: https://github.com/PHPCSStandards/PHPCSUtils/compare/1.0.0-alpha2...1.0.0-alpha3
 [1.0.0-alpha2]: https://github.com/PHPCSStandards/PHPCSUtils/compare/1.0.0-alpha1...1.0.0-alpha2
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/PHPCSStandards/PHPCSUtils/badge.svg?branch=develop)](https://coveralls.io/github/PHPCSStandards/PHPCSUtils?branch=develop)
 
 [![Docs Build Status](https://github.com/PHPCSStandards/PHPCSUtils/actions/workflows/ghpages.yml/badge.svg)][phpcsutils-web]
-[![License: LGPLv3](https://poser.pugx.org/phpcsstandards/phpcsutils/license)](https://github.com/PHPCSStandards/PHPCSUtils/blob/master/LICENSE)
+[![License: LGPLv3](https://poser.pugx.org/phpcsstandards/phpcsutils/license)](https://github.com/PHPCSStandards/PHPCSUtils/blob/stable/LICENSE)
 ![Awesome](https://img.shields.io/badge/awesome%3F-yes!-brightgreen.svg)
 
 </div>

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.x-dev",
+            "dev-stable": "1.x-dev",
             "dev-develop": "1.x-dev"
         }
     },


### PR DESCRIPTION
... ahead of actually renaming the branch (just before release).

Related to #290