### PR TITLE
ObjectDeclarations::getClassProperties(): add token pointer indexes to return array

### DIFF
--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -139,6 +139,7 @@ final class ObjectDeclarations
      *   - Handling of unorthodox docblock placement.
      * - Defensive coding against incorrect calls to this method.
      * - Support for PHP 8.2 readonly classes.
+     * - Additional `'abstract_token'`, `'final_token'`, and `'readonly_token'` indexes in the return array.
      *
      * @see \PHP_CodeSniffer\Files\File::getClassProperties()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getClassProperties() Cross-version compatible version of the original.
@@ -154,9 +155,15 @@ final class ObjectDeclarations
      *               The format of the return value is:
      *               ```php
      *               array(
-     *                 'is_abstract' => false, // TRUE if the abstract keyword was found.
-     *                 'is_final'    => false, // TRUE if the final keyword was found.
-     *                 'is_readonly' => false, // TRUE if the readonly keyword was found.
+     *                 'is_abstract'    => bool,      // TRUE if the abstract keyword was found.
+     *                 'abstract_token' => int|false, // The stack pointer to the `abstract` keyword or
+     *                                                // FALSE if the abstract keyword was not found.
+     *                 'is_final'       => bool,      // TRUE if the final keyword was found.
+     *                 'final_token'    => int|false, // The stack pointer to the `final` keyword or
+     *                                                // FALSE if the abstract keyword was not found.
+     *                 'is_readonly'    => bool,      // TRUE if the readonly keyword was found.
+     *                 'readonly_token' => int|false, // The stack pointer to the `readonly` keyword or
+     *                                                // FALSE if the abstract keyword was not found.
      *               );
      *               ```
      *
@@ -173,9 +180,12 @@ final class ObjectDeclarations
 
         $valid      = Collections::classModifierKeywords() + Tokens::$emptyTokens;
         $properties = [
-            'is_abstract' => false,
-            'is_final'    => false,
-            'is_readonly' => false,
+            'is_abstract'    => false,
+            'abstract_token' => false,
+            'is_final'       => false,
+            'final_token'    => false,
+            'is_readonly'    => false,
+            'readonly_token' => false,
         ];
 
         for ($i = ($stackPtr - 1); $i > 0; $i--) {
@@ -185,15 +195,18 @@ final class ObjectDeclarations
 
             switch ($tokens[$i]['code']) {
                 case \T_ABSTRACT:
-                    $properties['is_abstract'] = true;
+                    $properties['is_abstract']    = true;
+                    $properties['abstract_token'] = $i;
                     break;
 
                 case \T_FINAL:
-                    $properties['is_final'] = true;
+                    $properties['is_final']    = true;
+                    $properties['final_token'] = $i;
                     break;
 
                 case \T_READONLY:
-                    $properties['is_readonly'] = true;
+                    $properties['is_readonly']    = true;
+                    $properties['readonly_token'] = $i;
                     break;
             }
         }

--- a/Tests/BackCompat/BCFile/GetClassPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetClassPropertiesTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
+use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
 /**
@@ -90,10 +91,16 @@ class GetClassPropertiesTest extends UtilityMethodTestCase
      */
     public function testGetClassProperties($testMarker, $expected)
     {
-        $testClass = static::TEST_CLASS;
+        // Remove keys which will only exist in the PHPCSUtils version of this method.
+        unset(
+            $expected['abstract_token'],
+            $expected['final_token'],
+            $expected['is_readonly'],
+            $expected['readonly_token']
+        );
 
         $class  = $this->getTargetToken($testMarker, \T_CLASS);
-        $result = $testClass::getClassProperties(self::$phpcsFile, $class);
+        $result = BCFile::getClassProperties(self::$phpcsFile, $class);
         $this->assertSame($expected, $result);
     }
 
@@ -110,43 +117,67 @@ class GetClassPropertiesTest extends UtilityMethodTestCase
             'no-properties' => [
                 '/* testClassWithoutProperties */',
                 [
-                    'is_abstract' => false,
-                    'is_final'    => false,
+                    'is_abstract'    => false,
+                    'abstract_token' => false,
+                    'is_final'       => false,
+                    'final_token'    => false,
+                    'is_readonly'    => false,
+                    'readonly_token' => false,
                 ],
             ],
             'abstract' => [
                 '/* testAbstractClass */',
                 [
-                    'is_abstract' => true,
-                    'is_final'    => false,
+                    'is_abstract'    => true,
+                    'abstract_token' => -2,
+                    'is_final'       => false,
+                    'final_token'    => false,
+                    'is_readonly'    => false,
+                    'readonly_token' => false,
                 ],
             ],
             'final' => [
                 '/* testFinalClass */',
                 [
-                    'is_abstract' => false,
-                    'is_final'    => true,
+                    'is_abstract'    => false,
+                    'abstract_token' => false,
+                    'is_final'       => true,
+                    'final_token'    => -2,
+                    'is_readonly'    => false,
+                    'readonly_token' => false,
                 ],
             ],
             'comments-and-new-lines' => [
                 '/* testWithCommentsAndNewLines */',
                 [
-                    'is_abstract' => true,
-                    'is_final'    => false,
+                    'is_abstract'    => true,
+                    'abstract_token' => -6,
+                    'is_final'       => false,
+                    'final_token'    => false,
+                    'is_readonly'    => false,
+                    'readonly_token' => false,
                 ],
             ],
             'no-properties-with-docblock' => [
                 '/* testWithDocblockWithoutProperties */',
                 [
-                    'is_abstract' => false,
-                    'is_final'    => false,
+                    'is_abstract'    => false,
+                    'abstract_token' => false,
+                    'is_final'       => false,
+                    'final_token'    => false,
+                    'is_readonly'    => false,
+                    'readonly_token' => false,
                 ],
             ],
             'abstract-final-parse-error' => [
                 '/* testParseErrorAbstractFinal */',
                 [
-                    'is_abstract' => true,
-                    'is_final'    => true,
+                    'is_abstract'    => true,
+                    'abstract_token' => -5,
+                    'is_final'       => true,
+                    'final_token'    => -11,
+                    'is_readonly'    => false,
+                    'readonly_token' => false,
                 ],
             ],
         ];

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
@@ -52,7 +52,19 @@ final class GetClassPropertiesDiffTest extends UtilityMethodTestCase
      */
     public function testGetClassProperties($testMarker, $expected)
     {
-        $class  = $this->getTargetToken($testMarker, \T_CLASS);
+        $class = $this->getTargetToken($testMarker, \T_CLASS);
+
+        // Translate offsets to absolute token positions.
+        if ($expected['abstract_token'] !== false) {
+            $expected['abstract_token'] += $class;
+        }
+        if ($expected['final_token'] !== false) {
+            $expected['final_token'] += $class;
+        }
+        if ($expected['readonly_token'] !== false) {
+            $expected['readonly_token'] += $class;
+        }
+
         $result = ObjectDeclarations::getClassProperties(self::$phpcsFile, $class);
         $this->assertSame($expected, $result);
     }
@@ -70,57 +82,78 @@ final class GetClassPropertiesDiffTest extends UtilityMethodTestCase
             'phpcs-annotation' => [
                 'testMarker' => '/* testPHPCSAnnotations */',
                 'expected'   => [
-                    'is_abstract' => false,
-                    'is_final'    => true,
-                    'is_readonly' => false,
+                    'is_abstract'    => false,
+                    'abstract_token' => false,
+                    'is_final'       => true,
+                    'final_token'    => -5,
+                    'is_readonly'    => false,
+                    'readonly_token' => false,
                 ],
             ],
             'unorthodox-docblock-placement' => [
                 'testMarker' => '/* testWithDocblockWithWeirdlyPlacedModifier */',
                 'expected'   => [
-                    'is_abstract' => false,
-                    'is_final'    => true,
-                    'is_readonly' => false,
+                    'is_abstract'    => false,
+                    'abstract_token' => false,
+                    'is_final'       => true,
+                    'final_token'    => -31,
+                    'is_readonly'    => false,
+                    'readonly_token' => false,
                 ],
             ],
             'readonly' => [
                 '/* testReadonlyClass */',
                 [
-                    'is_abstract' => false,
-                    'is_final'    => false,
-                    'is_readonly' => true,
+                    'is_abstract'    => false,
+                    'abstract_token' => false,
+                    'is_final'       => false,
+                    'final_token'    => false,
+                    'is_readonly'    => true,
+                    'readonly_token' => -2,
                 ],
             ],
             'final-readonly' => [
                 '/* testFinalReadonlyClass */',
                 [
-                    'is_abstract' => false,
-                    'is_final'    => true,
-                    'is_readonly' => true,
+                    'is_abstract'    => false,
+                    'abstract_token' => false,
+                    'is_final'       => true,
+                    'final_token'    => -4,
+                    'is_readonly'    => true,
+                    'readonly_token' => -2,
                 ],
             ],
             'readonly-final' => [
                 '/* testReadonlyFinalClass */',
                 [
-                    'is_abstract' => false,
-                    'is_final'    => true,
-                    'is_readonly' => true,
+                    'is_abstract'    => false,
+                    'abstract_token' => false,
+                    'is_final'       => true,
+                    'final_token'    => -2,
+                    'is_readonly'    => true,
+                    'readonly_token' => -6,
                 ],
             ],
             'abstract-readonly' => [
                 '/* testAbstractReadonlyClass */',
                 [
-                    'is_abstract' => true,
-                    'is_final'    => false,
-                    'is_readonly' => true,
+                    'is_abstract'    => true,
+                    'abstract_token' => -4,
+                    'is_final'       => false,
+                    'final_token'    => false,
+                    'is_readonly'    => true,
+                    'readonly_token' => -2,
                 ],
             ],
             'readonly-abstract' => [
                 '/* testReadonlyAbstractClass */',
                 [
-                    'is_abstract' => true,
-                    'is_final'    => false,
-                    'is_readonly' => true,
+                    'is_abstract'    => true,
+                    'abstract_token' => -2,
+                    'is_final'       => false,
+                    'final_token'    => false,
+                    'is_readonly'    => true,
+                    'readonly_token' => -4,
                 ],
             ],
         ];

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesTest.php
@@ -11,6 +11,7 @@
 namespace PHPCSUtils\Tests\Utils\ObjectDeclarations;
 
 use PHPCSUtils\Tests\BackCompat\BCFile\GetClassPropertiesTest as BCFile_GetClassPropertiesTest;
+use PHPCSUtils\Utils\ObjectDeclarations;
 
 /**
  * Tests for the \PHPCSUtils\Utils\ObjectDeclarations::getClassProperties() method.
@@ -57,19 +58,31 @@ final class GetClassPropertiesTest extends BCFile_GetClassPropertiesTest
     }
 
     /**
-     * Data provider.
+     * Test retrieving the properties for a class declaration.
      *
-     * @see testGetClassProperties() For the array format.
+     * @dataProvider dataGetClassProperties
      *
-     * @return array
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param array  $expected   Expected function output.
+     *
+     * @return void
      */
-    public function dataGetClassProperties()
+    public function testGetClassProperties($testMarker, $expected)
     {
-        $data = parent::dataGetClassProperties();
-        foreach ($data as $name => $dataset) {
-            $data[$name][1]['is_readonly'] = false;
+        $class = $this->getTargetToken($testMarker, \T_CLASS);
+
+        // Translate offsets to absolute token positions.
+        if ($expected['abstract_token'] !== false) {
+            $expected['abstract_token'] += $class;
+        }
+        if ($expected['final_token'] !== false) {
+            $expected['final_token'] += $class;
+        }
+        if ($expected['readonly_token'] !== false) {
+            $expected['readonly_token'] += $class;
         }
 
-        return $data;
+        $result = ObjectDeclarations::getClassProperties(self::$phpcsFile, $class);
+        $this->assertSame($expected, $result);
     }
 }


### PR DESCRIPTION
... as quite some sniffs will need those anyway and it prevents having to duplicate the token walking.

Includes tests.