### PR TITLE
ControlStructures::hasBody(): handle no body due to PHP close tag

### DIFF
--- a/PHPCSUtils/Utils/ControlStructures.php
+++ b/PHPCSUtils/Utils/ControlStructures.php
@@ -112,7 +112,10 @@ final class ControlStructures
             null,
             true
         );
-        if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] === \T_SEMICOLON) {
+        if ($nextNonEmpty === false
+            || $tokens[$nextNonEmpty]['code'] === \T_SEMICOLON
+            || $tokens[$nextNonEmpty]['code'] === \T_CLOSE_TAG
+        ) {
             // Parse error or single line statement.
             return false;
         }

--- a/Tests/Utils/ControlStructures/HasBodyTest.inc
+++ b/Tests/Utils/ControlStructures/HasBodyTest.inc
@@ -10,6 +10,25 @@ echo 123;
 /* testIfWithoutBody */
 if ($a); // Surprisingly enough not a parse error.
 
+/* testIfWithoutBodyDueToCloseTag */
+if ($a) ?>
+    This will always be printed as the if is closed by the PHP close tag.
+<?php
+
+if (true)
+    do_something();
+/* testElseIfWithoutBodyDueToCloseTag */
+else if(false) ?>
+    This will always be printed as the elseif is closed by the PHP close tag.
+<?php
+
+if (true)
+    do_something();
+/* testElseWithoutBodyDueToCloseTag */
+else ?>
+    This will always be printed as the else is closed by the PHP close tag.
+<?php
+
 /* testIfEmptyBody */
 if ( true ) {
     // Comment.
@@ -46,6 +65,11 @@ else if (false) {
 /* testForWithoutBody */
 for ($i = 1, $j = 0; $i <= 10; $j += $i, print $i, $i++);
 
+/* testForWithoutBodyDueToCloseTag */
+for ($i = 1, $j = 0; $i <= 10; $j += $i, print $i, $i++) ?>
+    This will always be printed as the for is closed by the PHP close tag.
+<?php
+
 /* testForEmptyBody */
 for ($i = 1; $i <= 10; $i++) {}
 
@@ -56,6 +80,11 @@ for ($i = 1; $i <= 10; $i++) {
 
 /* testForEachWithoutBody */
 foreach($a as $b => $c); // Surprisingly enough not a parse error.
+
+/* testForEachWithoutBodyDueToCloseTag */
+foreach($a as $b => $c) ?>
+    This will always be printed as the foreach is closed by the PHP close tag.
+<?php
 
 /* testForEachEmptyBody */
 foreach ($a as $k => $v) {
@@ -69,6 +98,11 @@ foreach ($a as $k => $v) {
 
 /* testWhileWithoutBody */
 while (++$i <= 10) /*comment*/ ;
+
+/* testWhileWithoutBodyDueToCloseTag */
+while (++$i <= 10) ?>
+    This will always be printed as the while is closed by the PHP close tag.
+<?php
 
 /* testWhileEmptyBody */
 while (++$i <= 10) {}
@@ -91,6 +125,11 @@ do {
 // Intentional parse error.
 switch ($foo);
 
+/* testSwitchWithoutBodyDueToCloseTag */
+// Intentional parse error.
+switch ($foo) ?>
+<?php
+
 /* testSwitchEmptyBody */
 switch ($foo) {
     // Kind of useless, but not a parse error.
@@ -105,6 +144,10 @@ switch ($foo) {
 
 /* testDeclareWithoutBody */
 declare(ticks=1);
+
+/* testDeclareWithoutBodyDueToCloseTag */
+declare(ticks=1) ?>
+<?php
 
 /* testDeclareEmptyBody */
 declare(ticks=1) {

--- a/Tests/Utils/ControlStructures/HasBodyTest.php
+++ b/Tests/Utils/ControlStructures/HasBodyTest.php
@@ -86,6 +86,21 @@ final class HasBodyTest extends UtilityMethodTestCase
                 'hasBody'         => false,
                 'hasNonEmptyBody' => false,
             ],
+            'if-without-body-due-to-php-close-tag' => [
+                'testMarker'      => '/* testIfWithoutBodyDueToCloseTag */',
+                'hasBody'         => false,
+                'hasNonEmptyBody' => false,
+            ],
+            'elseif-without-body-due-to-php-close-tag' => [
+                'testMarker'      => '/* testElseIfWithoutBodyDueToCloseTag */',
+                'hasBody'         => false,
+                'hasNonEmptyBody' => false,
+            ],
+            'else-without-body-due-to-php-close-tag' => [
+                'testMarker'      => '/* testElseWithoutBodyDueToCloseTag */',
+                'hasBody'         => false,
+                'hasNonEmptyBody' => false,
+            ],
             'if-empty-body' => [
                 'testMarker'      => '/* testIfEmptyBody */',
                 'hasBody'         => true,
@@ -131,6 +146,11 @@ final class HasBodyTest extends UtilityMethodTestCase
                 'hasBody'         => false,
                 'hasNonEmptyBody' => false,
             ],
+            'for-without-body-due-to-php-close-tag' => [
+                'testMarker'      => '/* testForWithoutBodyDueToCloseTag */',
+                'hasBody'         => false,
+                'hasNonEmptyBody' => false,
+            ],
             'for-empty-body' => [
                 'testMarker'      => '/* testForEmptyBody */',
                 'hasBody'         => true,
@@ -146,6 +166,11 @@ final class HasBodyTest extends UtilityMethodTestCase
                 'hasBody'         => false,
                 'hasNonEmptyBody' => false,
             ],
+            'foreach-without-body-due-to-php-close-tag' => [
+                'testMarker'      => '/* testForEachWithoutBodyDueToCloseTag */',
+                'hasBody'         => false,
+                'hasNonEmptyBody' => false,
+            ],
             'foreach-empty-body' => [
                 'testMarker'      => '/* testForEachEmptyBody */',
                 'hasBody'         => true,
@@ -158,6 +183,11 @@ final class HasBodyTest extends UtilityMethodTestCase
             ],
             'while-without-body' => [
                 'testMarker'      => '/* testWhileWithoutBody */',
+                'hasBody'         => false,
+                'hasNonEmptyBody' => false,
+            ],
+            'while-without-body-due-to-php-close-tag' => [
+                'testMarker'      => '/* testWhileWithoutBodyDueToCloseTag */',
                 'hasBody'         => false,
                 'hasNonEmptyBody' => false,
             ],
@@ -186,6 +216,11 @@ final class HasBodyTest extends UtilityMethodTestCase
                 'hasBody'         => false,
                 'hasNonEmptyBody' => false,
             ],
+            'switch-without-body-due-to-php-close-tag' => [
+                'testMarker'      => '/* testSwitchWithoutBodyDueToCloseTag */',
+                'hasBody'         => false,
+                'hasNonEmptyBody' => false,
+            ],
             'switch-empty-body' => [
                 'testMarker'      => '/* testSwitchEmptyBody */',
                 'hasBody'         => true,
@@ -198,6 +233,11 @@ final class HasBodyTest extends UtilityMethodTestCase
             ],
             'declare-without-body' => [
                 'testMarker'      => '/* testDeclareWithoutBody */',
+                'hasBody'         => false,
+                'hasNonEmptyBody' => false,
+            ],
+            'declare-without-body-due-to-php-close-tag' => [
+                'testMarker'      => '/* testDeclareWithoutBodyDueToCloseTag */',
                 'hasBody'         => false,
                 'hasNonEmptyBody' => false,
             ],


### PR DESCRIPTION
When a control structure condition is directly followed by a PHP close tag, a semicolon is silently inserted by PHP and the control structure will turn into a control structure without body.

The `ControlStructures::hasBody()` method previously did not take this into account.

This commit fixes this bug.

Includes additional tests.