### PR TITLE
Arrays::getOpenClose(): efficiency fix - only accept array open tokens

### DIFF
--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -102,7 +102,7 @@ final class Arrays
 
         // Is this one of the tokens this function handles ?
         if (isset($tokens[$stackPtr]) === false
-            || isset(Collections::arrayTokensBC()[$tokens[$stackPtr]['code']]) === false
+            || isset(Collections::arrayOpenTokensBC()[$tokens[$stackPtr]['code']]) === false
         ) {
             return false;
         }

--- a/Tests/Utils/Arrays/GetOpenCloseTest.php
+++ b/Tests/Utils/Arrays/GetOpenCloseTest.php
@@ -39,30 +39,49 @@ final class GetOpenCloseTest extends UtilityMethodTestCase
     /**
      * Test that false is returned when a non-(short) array token is passed.
      *
-     * @dataProvider dataNotArrayToken
+     * @dataProvider dataNotArrayOpenToken
      *
-     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param string           $testMarker  The comment which prefaces the target token in the test file.
+     * @param int|string|array $targetToken The token type(s) to look for.
      *
      * @return void
      */
-    public function testNotArrayToken($testMarker)
+    public function testNotArrayOpenToken($testMarker, $targetToken)
     {
-        $target = $this->getTargetToken($testMarker, Collections::shortArrayListOpenTokensBC());
+        $target = $this->getTargetToken($testMarker, $targetToken);
         $this->assertFalse(Arrays::getOpenClose(self::$phpcsFile, $target));
     }
 
     /**
      * Data provider.
      *
-     * @see testNotArrayToken() For the array format.
+     * @see testNotArrayOpenToken() For the array format.
      *
      * @return array
      */
-    public function dataNotArrayToken()
+    public function dataNotArrayOpenToken()
     {
         return [
-            'short-list'                  => ['/* testShortList */'],
-            'array-access-square-bracket' => ['/* testArrayAccess */'],
+            'short-list' => [
+                'testMarker'  => '/* testShortList */',
+                'targetToken' => Collections::shortArrayListOpenTokensBC(),
+            ],
+            'array-access-square-bracket' => [
+                'testMarker'  => '/* testArrayAccess */',
+                'targetToken' => Collections::shortArrayListOpenTokensBC(),
+            ],
+            'short-array-closer' => [
+                'testMarker'  => '/* testNestedShortArray */',
+                'targetToken' => \T_CLOSE_SHORT_ARRAY,
+            ],
+            'short-list-closer' => [
+                'testMarker'  => '/* testShortList */',
+                'targetToken' => \T_CLOSE_SHORT_ARRAY,
+            ],
+            'array-access-square-bracket-closer' => [
+                'testMarker'  => '/* testArrayAccess */',
+                'targetToken' => \T_CLOSE_SQUARE_BRACKET,
+            ],
         ];
     }
 


### PR DESCRIPTION
The `Arrays::getOpenClose()` method only _handled_ array open tokens, but _accepted_ both open as well as close tokens. This meant that for array close tokens, the method would not bow out early, while it should have.

Fixed now. Includes some additional tests.