### PR TITLE
Lists::getOpenClose(): efficiency fix - only accept list open tokens

### DIFF
--- a/PHPCSUtils/Utils/Lists.php
+++ b/PHPCSUtils/Utils/Lists.php
@@ -104,7 +104,7 @@ final class Lists
 
         // Is this one of the tokens this function handles ?
         if (isset($tokens[$stackPtr]) === false
-            || isset(Collections::listTokensBC()[$tokens[$stackPtr]['code']]) === false
+            || isset(Collections::listOpenTokensBC()[$tokens[$stackPtr]['code']]) === false
         ) {
             return false;
         }

--- a/Tests/Utils/Lists/GetOpenCloseTest.php
+++ b/Tests/Utils/Lists/GetOpenCloseTest.php
@@ -39,30 +39,49 @@ final class GetOpenCloseTest extends UtilityMethodTestCase
     /**
      * Test that false is returned when a non-(short) list token is passed.
      *
-     * @dataProvider dataNotListToken
+     * @dataProvider dataNotListOpenToken
      *
-     * @param string $testMarker The comment which prefaces the target token in the test file.
+     * @param string           $testMarker  The comment which prefaces the target token in the test file.
+     * @param int|string|array $targetToken The token type(s) to look for.
      *
      * @return void
      */
-    public function testNotListToken($testMarker)
+    public function testNotListOpenToken($testMarker, $targetToken)
     {
-        $target = $this->getTargetToken($testMarker, Collections::shortArrayListOpenTokensBC());
+        $target = $this->getTargetToken($testMarker, $targetToken);
         $this->assertFalse(Lists::getOpenClose(self::$phpcsFile, $target));
     }
 
     /**
      * Data provider.
      *
-     * @see testNotListToken() For the array format.
+     * @see testNotListOpenToken() For the array format.
      *
      * @return array
      */
-    public function dataNotListToken()
+    public function dataNotListOpenToken()
     {
         return [
-            'short-array'                 => ['/* testShortArray */'],
-            'array-access-square-bracket' => ['/* testArrayAccess */'],
+            'short-array' => [
+                'testMarker'  => '/* testShortArray */',
+                'targetToken' => Collections::shortArrayListOpenTokensBC(),
+            ],
+            'array-access-square-bracket' => [
+                'testMarker'  => '/* testArrayAccess */',
+                'targetToken' => Collections::shortArrayListOpenTokensBC(),
+            ],
+            'short-array-closer' => [
+                'testMarker'  => '/* testShortArray */',
+                'targetToken' => \T_CLOSE_SHORT_ARRAY,
+            ],
+            'short-list-closer' => [
+                'testMarker'  => '/* testNestedShortList */',
+                'targetToken' => \T_CLOSE_SHORT_ARRAY,
+            ],
+            'array-access-square-bracket-closer' => [
+                'testMarker'  => '/* testArrayAccess */',
+                'targetToken' => \T_CLOSE_SQUARE_BRACKET,
+            ],
         ];
     }
 


### PR DESCRIPTION
The `Lists::getOpenClose()` method only _handled_ list open tokens, but _accepted_ both open as well as close tokens. This meant that for list close tokens, the method would not bow out early, while it should have.

Fixed now. Includes some additional tests.