### PR TITLE
Docs: QA on `@since` tags

### DIFF
--- a/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
+++ b/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
@@ -24,7 +24,6 @@ use PHPCSUtils\Utils\TextStrings;
  * Abstract sniff to easily examine all parts of an array declaration.
  *
  * @since 1.0.0
- * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
 abstract class AbstractArrayDeclarationSniff implements Sniff
 {

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -63,7 +63,6 @@ use PHPCSUtils\Tokens\Collections;
  * @see \PHP_CodeSniffer\Files\File Original source of these utility methods.
  *
  * @since 1.0.0
- * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
 final class BCFile
 {
@@ -155,8 +154,6 @@ final class BCFile
      * @see \PHPCSUtils\Utils\FunctionDeclarations::getParameters() PHPCSUtils native improved version.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha2 Added support for PHP 7.4 arrow functions.
-     * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokens.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the function token

--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -42,7 +42,6 @@ use PHPCSUtils\Tokens\Collections;
  * the token arrays returned by this class.
  *
  * @since 1.0.0
- * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  *
  * @method static array arithmeticTokens()         Tokens that represent arithmetic operators.
  * @method static array assignmentTokens()         Tokens that represent assignments.

--- a/PHPCSUtils/BackCompat/Helper.php
+++ b/PHPCSUtils/BackCompat/Helper.php
@@ -19,9 +19,8 @@ use PHP_CodeSniffer\Files\File;
  *
  * PHP_CodeSniffer cross-version compatibility helper.
  *
- * @since 1.0.0        The initial methods in this class have been ported over from
- *                     the external PHPCompatibility & WPCS standards.
- * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
+ * @since 1.0.0 The initial methods in this class have been ported over from
+ *              the external PHPCompatibility & WPCS standards.
  */
 final class Helper
 {
@@ -143,7 +142,7 @@ final class Helper
      * Get the applicable (file) encoding as passed to PHP_CodeSniffer from the
      * command-line or the ruleset.
      *
-     * @since 1.0.0-alpha3
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File|null $phpcsFile Optional. The current file being processed.
      *

--- a/PHPCSUtils/Exceptions/InvalidTokenArray.php
+++ b/PHPCSUtils/Exceptions/InvalidTokenArray.php
@@ -15,7 +15,7 @@ use PHP_CodeSniffer\Exceptions\RuntimeException;
 /**
  * Exception thrown when an non-existent token array is requested.
  *
- * @since 1.0.0-alpha4
+ * @since 1.0.0
  */
 final class InvalidTokenArray extends RuntimeException
 {
@@ -23,7 +23,7 @@ final class InvalidTokenArray extends RuntimeException
     /**
      * Create a new invalid token array exception with a standardized text.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param string $name The name of the token array requested.
      *

--- a/PHPCSUtils/Exceptions/TestFileNotFound.php
+++ b/PHPCSUtils/Exceptions/TestFileNotFound.php
@@ -16,7 +16,7 @@ use BadMethodCallException;
  * Exception thrown when the UtilityMethodTestCase::getTargetToken() method is run without a
  * tokenized test case file being available.
  *
- * @since 1.0.0-alpha4
+ * @since 1.0.0
  */
 final class TestFileNotFound extends BadMethodCallException
 {
@@ -24,7 +24,7 @@ final class TestFileNotFound extends BadMethodCallException
     /**
      * Create a new "test file not found" exception with a standardized text.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param string          $message  The Exception message to throw.
      * @param int             $code     The Exception code.

--- a/PHPCSUtils/Exceptions/TestMarkerNotFound.php
+++ b/PHPCSUtils/Exceptions/TestMarkerNotFound.php
@@ -15,7 +15,7 @@ use OutOfBoundsException;
 /**
  * Exception thrown when a delimiter comment can not be found in a test case file.
  *
- * @since 1.0.0-alpha4
+ * @since 1.0.0
  */
 final class TestMarkerNotFound extends OutOfBoundsException
 {
@@ -23,7 +23,7 @@ final class TestMarkerNotFound extends OutOfBoundsException
     /**
      * Create a new "test marker not found" exception with a standardized text.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param string $marker The delimiter comment.
      * @param string $file   The file in which the delimiter was not found.

--- a/PHPCSUtils/Exceptions/TestTargetNotFound.php
+++ b/PHPCSUtils/Exceptions/TestTargetNotFound.php
@@ -15,7 +15,7 @@ use OutOfBoundsException;
 /**
  * Exception thrown when a test target token can not be found in a test case file.
  *
- * @since 1.0.0-alpha4
+ * @since 1.0.0
  */
 final class TestTargetNotFound extends OutOfBoundsException
 {
@@ -23,7 +23,7 @@ final class TestTargetNotFound extends OutOfBoundsException
     /**
      * Create a new "test target token not found" exception with a standardized text.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param string $marker  The delimiter comment.
      * @param string $content The (optional) target token content.

--- a/PHPCSUtils/Internal/Cache.php
+++ b/PHPCSUtils/Internal/Cache.php
@@ -57,6 +57,8 @@ final class Cache
      *
      * Don't forget to always turn the cache back on in a `tear_down()` method!
      *
+     * @since 1.0.0
+     *
      * @var bool
      */
     public static $enabled = true;
@@ -64,12 +66,16 @@ final class Cache
     /**
      * Results cache.
      *
+     * @since 1.0.0
+     *
      * @var array<int, array<string, array>> Format: $cache[$loop][$fileName][$key][$id] = mixed $value;
      */
     private static $cache = [];
 
     /**
      * Check whether a result has been cached for a certain utility function.
+     *
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param string                      $key       The key to identify a particular set of results.
@@ -97,6 +103,8 @@ final class Cache
 
     /**
      * Retrieve a previously cached result for a certain utility function.
+     *
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param string                      $key       The key to identify a particular set of results.
@@ -130,6 +138,8 @@ final class Cache
     /**
      * Retrieve all previously cached results for a certain utility function and a certain file.
      *
+     * @since 1.0.0
+     *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param string                      $key       The key to identify a particular set of results.
      *                                               It is recommended to pass __METHOD__ to this parameter.
@@ -156,6 +166,8 @@ final class Cache
 
     /**
      * Cache the result for a certain utility function.
+     *
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param string                      $key       The key to identify a particular set of results.
@@ -193,6 +205,8 @@ final class Cache
 
     /**
      * Clear the cache.
+     *
+     * @since 1.0.0
      *
      * @return void
      */

--- a/PHPCSUtils/Internal/IsShortArrayOrList.php
+++ b/PHPCSUtils/Internal/IsShortArrayOrList.php
@@ -49,7 +49,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @internal
  *
- * @since 1.0.0-alpha4
+ * @since 1.0.0
  */
 final class IsShortArrayOrList
 {
@@ -57,7 +57,7 @@ final class IsShortArrayOrList
     /**
      * Type annotation for short arrays.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var string
      */
@@ -66,7 +66,7 @@ final class IsShortArrayOrList
     /**
      * Type annotation for short lists.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var string
      */
@@ -75,7 +75,7 @@ final class IsShortArrayOrList
     /**
      * Type annotation for square brackets.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var string
      */
@@ -84,7 +84,7 @@ final class IsShortArrayOrList
     /**
      * Limit for the amount of items to retrieve from inside a nested array/list.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var int
      */
@@ -93,7 +93,7 @@ final class IsShortArrayOrList
     /**
      * Limit for recursing over inner nested arrays/lists.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var int
      */
@@ -102,7 +102,7 @@ final class IsShortArrayOrList
     /**
      * The PHPCS file in which the current stackPtr was found.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var \PHP_CodeSniffer\Files\File
      */
@@ -111,7 +111,7 @@ final class IsShortArrayOrList
     /**
      * The token stack from the current file.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var array
      */
@@ -120,7 +120,7 @@ final class IsShortArrayOrList
     /**
      * Stack pointer to the open bracket.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var int
      */
@@ -129,7 +129,7 @@ final class IsShortArrayOrList
     /**
      * Stack pointer to the close bracket.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var int
      */
@@ -138,7 +138,7 @@ final class IsShortArrayOrList
     /**
      * Stack pointer to the first non-empty token before the open bracket.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var int
      */
@@ -147,7 +147,7 @@ final class IsShortArrayOrList
     /**
      * Stack pointer to the first non-empty token after the close bracket.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var int|false Will be `false` if the close bracket is the last token in the file.
      */
@@ -156,7 +156,7 @@ final class IsShortArrayOrList
     /**
      * Current PHPCS version being used.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var string
      */
@@ -165,7 +165,7 @@ final class IsShortArrayOrList
     /**
      * Tokens which can open a short array or short list (PHPCS cross-version compatible).
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @return array <int|string> => <int|string>
      */
@@ -174,7 +174,7 @@ final class IsShortArrayOrList
     /**
      * Constructor.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the short array opener token.
@@ -216,7 +216,7 @@ final class IsShortArrayOrList
     /**
      * Determine whether the bracket is a short array, short list or real square bracket.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @return string Either 'short array', 'short list' or 'square brackets'.
      */
@@ -325,7 +325,7 @@ final class IsShortArrayOrList
     /**
      * Check if the brackets are in actual fact real square brackets.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @return bool TRUE if these are real square brackets; FALSE otherwise.
      */
@@ -353,7 +353,7 @@ final class IsShortArrayOrList
      * - {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/3013 PHPCS#3013} (PHPCS < 3.5.6)
      * - {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/3172 PHPCS#3172} (PHPCS < 3.6.0)
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @return bool TRUE if this is actually a short array bracket which needs to be examined,
      *              FALSE if it is an (incorrectly tokenized) square bracket.
@@ -391,7 +391,7 @@ final class IsShortArrayOrList
     /**
      * Check is this set of brackets is used within a foreach expression.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @return string|false The determined type or FALSE if undetermined.
      */
@@ -437,7 +437,7 @@ final class IsShortArrayOrList
      *
      * This won't walk the complete contents as that could be a huge performance drain. Just the first x items.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param int $opener     The position of the short array open bracket token.
      * @param int $recursions Optional. Keep track of how often we've recursed into this methd.
@@ -559,7 +559,7 @@ final class IsShortArrayOrList
      *
      * This should really be the last resort, if all else fails to determine the type of the brackets.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @return string|false The determined type or FALSE if undetermined.
      */

--- a/PHPCSUtils/Internal/IsShortArrayOrListWithCache.php
+++ b/PHPCSUtils/Internal/IsShortArrayOrListWithCache.php
@@ -30,7 +30,7 @@ use PHPCSUtils\Tokens\Collections;
  *
  * @internal
  *
- * @since 1.0.0-alpha4
+ * @since 1.0.0
  */
 final class IsShortArrayOrListWithCache
 {
@@ -38,7 +38,7 @@ final class IsShortArrayOrListWithCache
     /**
      * Key used for caching the return value of the short array/short list determination.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var string
      */
@@ -47,7 +47,7 @@ final class IsShortArrayOrListWithCache
     /**
      * The PHPCS file in which the current stackPtr was found.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var \PHP_CodeSniffer\Files\File
      */
@@ -56,7 +56,7 @@ final class IsShortArrayOrListWithCache
     /**
      * The token stack from the current file.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var array
      */
@@ -65,7 +65,7 @@ final class IsShortArrayOrListWithCache
     /**
      * The current stack pointer.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var int
      */
@@ -74,7 +74,7 @@ final class IsShortArrayOrListWithCache
     /**
      * Stack pointer to the open bracket.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var int
      */
@@ -88,7 +88,7 @@ final class IsShortArrayOrListWithCache
      * PHPCS cross-version compatible as the short array tokenizing has been plagued by
      * a number of bugs over time.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the short array bracket token.
@@ -110,7 +110,7 @@ final class IsShortArrayOrListWithCache
      * PHPCS cross-version compatible as the short array tokenizing has been plagued by
      * a number of bugs over time, which affects the short list determination.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the short array bracket token.
@@ -131,7 +131,7 @@ final class IsShortArrayOrListWithCache
      * PHPCS cross-version compatible as the short array tokenizing has been plagued by
      * a number of bugs over time, which affects the short list determination.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the short array bracket token.
@@ -148,7 +148,7 @@ final class IsShortArrayOrListWithCache
     /**
      * Constructor.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the short array bracket token.
@@ -166,7 +166,7 @@ final class IsShortArrayOrListWithCache
      * Determine whether a T_[OPEN|CLOSE}_[SHORT_ARRAY|SQUARE_BRACKET] token is a short array
      * or short list construct using previously cached results whenever possible.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @return string|false The type of construct this bracket was determined to be.
      *                      Either 'short array', 'short list' or 'square brackets'.
@@ -208,7 +208,7 @@ final class IsShortArrayOrListWithCache
     /**
      * Verify the passed token could potentially be a short array or short list token.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @return bool
      */
@@ -221,7 +221,7 @@ final class IsShortArrayOrListWithCache
     /**
      * Get the stack pointer to the short array/list opener.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @return int
      */
@@ -238,7 +238,7 @@ final class IsShortArrayOrListWithCache
     /**
      * Retrieve the bracket "type" of a token from the cache.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @return string|false The previously determined type (which could be an empty string)
      *                      or FALSE if no cache entry was found for this token.
@@ -255,7 +255,7 @@ final class IsShortArrayOrListWithCache
     /**
      * Update the cache with information about a particular bracket token.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param string $type The type this bracket has been determined to be.
      *                     Either 'short array', 'short list' or 'square brackets'.

--- a/PHPCSUtils/Internal/NoFileCache.php
+++ b/PHPCSUtils/Internal/NoFileCache.php
@@ -53,6 +53,8 @@ final class NoFileCache
      *
      * Don't forget to always turn the cache back on in a `tear_down()` method!
      *
+     * @since 1.0.0
+     *
      * @var bool
      */
     public static $enabled = true;
@@ -60,12 +62,16 @@ final class NoFileCache
     /**
      * Results cache.
      *
+     * @since 1.0.0
+     *
      * @var array<string, array<int|string, mixed>> Format: $cache[$key][$id] = mixed $value;
      */
     private static $cache = [];
 
     /**
      * Check whether a result has been cached for a certain utility function.
+     *
+     * @since 1.0.0
      *
      * @param string     $key The key to identify a particular set of results.
      *                        It is recommended to pass `__METHOD__` to this parameter.
@@ -82,6 +88,8 @@ final class NoFileCache
 
     /**
      * Retrieve a previously cached result for a certain utility function.
+     *
+     * @since 1.0.0
      *
      * @param string     $key The key to identify a particular set of results.
      *                        It is recommended to pass `__METHOD__` to this parameter.
@@ -103,6 +111,8 @@ final class NoFileCache
     /**
      * Retrieve all previously cached results for a certain utility function.
      *
+     * @since 1.0.0
+     *
      * @param string $key The key to identify a particular set of results.
      *                    It is recommended to pass `__METHOD__` to this parameter.
      *
@@ -119,6 +129,8 @@ final class NoFileCache
 
     /**
      * Cache the result for a certain utility function.
+     *
+     * @since 1.0.0
      *
      * @param string     $key   The key to identify a particular set of results.
      *                          It is recommended to pass `__METHOD__` to this parameter.
@@ -140,6 +152,8 @@ final class NoFileCache
 
     /**
      * Clear the cache.
+     *
+     * @since 1.0.0
      *
      * @return void
      */

--- a/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+++ b/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
@@ -100,7 +100,6 @@ use ReflectionClass;
  *   for the PHPCSUtils utility functions themselves.
  *
  * @since 1.0.0
- * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
 abstract class UtilityMethodTestCase extends TestCase
 {
@@ -108,7 +107,7 @@ abstract class UtilityMethodTestCase extends TestCase
     /**
      * The PHPCS version the tests are being run on.
      *
-     * @since 1.0.0-alpha3
+     * @since 1.0.0
      *
      * @var string
      */
@@ -260,7 +259,7 @@ abstract class UtilityMethodTestCase extends TestCase
      * Note: This is a PHPUnit cross-version compatible {@see \PHPUnit\Framework\TestCase::setUp()}
      * method.
      *
-     * @since 1.0.0-alpha3
+     * @since 1.0.0
      *
      * @before
      *
@@ -329,9 +328,6 @@ abstract class UtilityMethodTestCase extends TestCase
      * distinguish between comments used *in* a test and test delimiters.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha4 Will throw an exception whether the delimiter comment or the target
-     *                     token is not found.
-     * @since 1.0.0-alpha4 This method is now `static`, which allows for it to be used in "set up before class".
      *
      * @param string           $commentString The complete delimiter comment to look for as a string.
      *                                        This string should include the comment opener and closer.

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -22,10 +22,6 @@ use PHPCSUtils\Exceptions\InvalidTokenArray;
  * @see \PHPCSUtils\BackCompat\BCTokens Backward compatible version of the PHPCS native token groups.
  *
  * @since 1.0.0
- * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
- * @since 1.0.0-alpha4 Direct property access is deprecated for forward-compatibility reasons.
- *                     Use the methods of the same name as the property instead.
- * @since 1.0.0-rc1    Direct property access has been removed.
  *
  * @method static array alternativeControlStructureSyntaxes()      Tokens for control structures which can use the
  *                                                                 alternative control structure syntax.
@@ -82,9 +78,7 @@ final class Collections
     /**
      * Tokens for control structures which can use the alternative control structure syntax.
      *
-     * @since 1.0.0-alpha2
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::alternativeControlStructureSyntaxes()} method for access.
+     * @since 1.0.0 Use the {@see Collections::alternativeControlStructureSyntaxes()} method for access.
      *
      * @var array <int> => <int>
      */
@@ -102,9 +96,7 @@ final class Collections
     /**
      * Tokens representing alternative control structure syntax closer keywords.
      *
-     * @since 1.0.0-alpha2
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::alternativeControlStructureSyntaxClosers()} method for access.
+     * @since 1.0.0 Use the {@see Collections::alternativeControlStructureSyntaxClosers()} method for access.
      *
      * @var array <int> => <int>
      */
@@ -129,7 +121,7 @@ final class Collections
      * @see \PHPCSUtils\Tokens\Collections::shortArrayTokensBC() Related method to retrieve only tokens used
      *                                                           for short arrays (PHPCS cross-version).
      *
-     * @since 1.0.0-alpha4 Use the {@see Collections::arrayOpenTokensBC()} method for access.
+     * @since 1.0.0 Use the {@see Collections::arrayOpenTokensBC()} method for access.
      *
      * @return array <int|string> => <int|string>
      */
@@ -149,9 +141,7 @@ final class Collections
      * @see \PHPCSUtils\Tokens\Collections::shortArrayTokens()  Related method to retrieve only tokens used
      *                                                          for short arrays.
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::arrayTokens()} method for access.
+     * @since 1.0.0 Use the {@see Collections::arrayTokens()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -173,9 +163,7 @@ final class Collections
      * @see \PHPCSUtils\Tokens\Collections::shortArrayTokensBC() Related method to retrieve only tokens used
      *                                                           for short arrays (PHPCS cross-version compatible).
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::arrayTokensBC()} method for access.
+     * @since 1.0.0 Use the {@see Collections::arrayTokensBC()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -190,10 +178,7 @@ final class Collections
     /**
      * Modifier keywords which can be used for a class declaration.
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-alpha4 Added the T_READONLY token for PHP 8.2 readonly classes.
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::classModifierKeywords()} method for access.
+     * @since 1.0.0 Use the {@see Collections::classModifierKeywords()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -212,10 +197,7 @@ final class Collections
      * This list doesn't contain the `T_NAMESPACE` token on purpose as variables declared
      * within a namespace scope are still global and not limited to that namespace.
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-alpha4 Added the PHP 8.1 T_ENUM token.
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::closedScopes()} method for access.
+     * @since 1.0.0 Use the {@see Collections::closedScopes()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -235,7 +217,7 @@ final class Collections
      * - PHP 7.1 added class constants visibility support.
      * - PHP 8.1 added support for final class constants.
      *
-     * @since 1.0.0-rc1 Use the {@see Collections::constantModifierKeywords()} method for access.
+     * @since 1.0.0 Use the {@see Collections::constantModifierKeywords()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -249,10 +231,7 @@ final class Collections
     /**
      * Control structure tokens.
      *
-     * @since 1.0.0-alpha2
-     * @since 1.0.0-alpha4 Added the T_MATCH token for PHP 8.0 match expressions.
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::controlStructureTokens()} method for access.
+     * @since 1.0.0 Use the {@see Collections::controlStructureTokens()} method for access.
      *
      * @var array <int> => <int>
      */
@@ -272,7 +251,7 @@ final class Collections
     /**
      * Tokens which represent a keyword which starts a function declaration.
      *
-     * @since 1.0.0-alpha4 Use the {@see Collections::functionDeclarationTokens()} method for access.
+     * @since 1.0.0 Use the {@see Collections::functionDeclarationTokens()} method for access.
      *
      * @return array <int|string> => <int|string>
      */
@@ -285,9 +264,7 @@ final class Collections
     /**
      * Increment/decrement operator tokens.
      *
-     * @since 1.0.0-alpha3
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::incrementDecrementOperators()} method for access.
+     * @since 1.0.0 Use the {@see Collections::incrementDecrementOperators()} method for access.
      *
      * @var array <int> => <int>
      */
@@ -308,7 +285,7 @@ final class Collections
      * @see \PHPCSUtils\Tokens\Collections::shortListTokensBC() Related method to retrieve only tokens used
      *                                                          for short lists (PHPCS cross-version).
      *
-     * @since 1.0.0-rc1 Use the {@see Collections::listOpenTokensBC()} method for access.
+     * @since 1.0.0 Use the {@see Collections::listOpenTokensBC()} method for access.
      *
      * @return array <int|string> => <int|string>
      */
@@ -326,9 +303,7 @@ final class Collections
      * @see \PHPCSUtils\Tokens\Collections::shortListTokens() Related method to retrieve only tokens used
      *                                                        for short lists.
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::listTokens()} method for access.
+     * @since 1.0.0 Use the {@see Collections::listTokens()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -348,9 +323,7 @@ final class Collections
      * @see \PHPCSUtils\Tokens\Collections::shortListTokensBC() Related method to retrieve only tokens used
      *                                                          for short lists (cross-version).
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::listTokensBC()} method for access.
+     * @since 1.0.0 Use the {@see Collections::listTokensBC()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -365,9 +338,7 @@ final class Collections
     /**
      * List of tokens which can end a namespace declaration statement.
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::namespaceDeclarationClosers()} method for access.
+     * @since 1.0.0 Use the {@see Collections::namespaceDeclarationClosers()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -388,7 +359,7 @@ final class Collections
      *
      * @link https://wiki.php.net/rfc/namespaced_names_as_token PHP RFC on namespaced names as single token
      *
-     * @since 1.0.0-alpha4 Use the {@see Collections::nameTokens()} method for access.
+     * @since 1.0.0 Use the {@see Collections::nameTokens()} method for access.
      *
      * @return array <int|string> => <int|string>
      */
@@ -402,10 +373,7 @@ final class Collections
     /**
      * Object operator tokens.
      *
-     * @since 1.0.0-alpha3
-     * @since 1.0.0-alpha4 Added the PHP 8.0 T_NULLSAFE_OBJECT_OPERATOR token.
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::objectOperators()} method for access.
+     * @since 1.0.0 Use the {@see Collections::objectOperators()} method for access.
      *
      * @var array <int> => <int>
      */
@@ -418,9 +386,7 @@ final class Collections
     /**
      * OO structures which can use the "extends" keyword.
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::ooCanExtend()} method for access.
+     * @since 1.0.0 Use the {@see Collections::ooCanExtend()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -433,10 +399,7 @@ final class Collections
     /**
      * OO structures which can use the "implements" keyword.
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-alpha4 Added the PHP 8.1 T_ENUM token.
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::ooCanImplement()} method for access.
+     * @since 1.0.0 Use the {@see Collections::ooCanImplement()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -451,11 +414,7 @@ final class Collections
      *
      * Note: traits can only declare constants since PHP 8.2.
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-alpha4 Added the PHP 8.1 T_ENUM token.
-     * @since 1.0.0-alpha4 Added the T_TRAIT token for PHP 8.2 constants in traits.
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::ooConstantScopes()} method for access.
+     * @since 1.0.0 Use the {@see Collections::ooConstantScopes()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -472,9 +431,7 @@ final class Collections
      *
      * @link https://www.php.net/language.oop5.paamayim-nekudotayim PHP Manual on OO forwarding calls
      *
-     * @since 1.0.0-alpha3
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::ooHierarchyKeywords()} method for access.
+     * @since 1.0.0 Use the {@see Collections::ooHierarchyKeywords()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -489,9 +446,7 @@ final class Collections
      *
      * Note: interfaces can not declare properties.
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::ooPropertyScopes()} method for access.
+     * @since 1.0.0 Use the {@see Collections::ooPropertyScopes()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -504,12 +459,7 @@ final class Collections
     /**
      * Token types which can be encountered in a parameter type declaration.
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-alpha4 Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.
-     * @since 1.0.0-alpha4 Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.
-     * @since 1.0.0-alpha4 Added the T_TRUE token for PHP 8.2 true type support.
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::parameterTypeTokens()} method for access.
+     * @since 1.0.0 Use the {@see Collections::parameterTypeTokens()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -527,7 +477,7 @@ final class Collections
     /**
      * Tokens which open PHP.
      *
-     * @since 1.0.0-alpha4 Use the {@see Collections::phpOpenTags()} method for access.
+     * @since 1.0.0 Use the {@see Collections::phpOpenTags()} method for access.
      *
      * @return array <int|string> => <int|string>
      */
@@ -539,10 +489,7 @@ final class Collections
     /**
      * Modifier keywords which can be used for a property declaration.
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-alpha4 Added the T_READONLY token for PHP 8.1 readonly properties.
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::propertyModifierKeywords()} method for access.
+     * @since 1.0.0 Use the {@see Collections::propertyModifierKeywords()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -558,12 +505,7 @@ final class Collections
     /**
      * Token types which can be encountered in a property type declaration.
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-alpha4 Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.
-     * @since 1.0.0-alpha4 Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.
-     * @since 1.0.0-alpha4 Added the T_TRUE token for PHP 8.2 true type support.
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::propertyTypeTokens()} method for access.
+     * @since 1.0.0 Use the {@see Collections::propertyTypeTokens()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -581,12 +523,7 @@ final class Collections
     /**
      * Token types which can be encountered in a return type declaration.
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-alpha4 Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.
-     * @since 1.0.0-alpha4 Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.
-     * @since 1.0.0-alpha4 Added the T_TRUE token for PHP 8.2 true type support.
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::returnTypeTokens()} method for access.
+     * @since 1.0.0 Use the {@see Collections::returnTypeTokens()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -606,7 +543,7 @@ final class Collections
      * to the retokenization to `T_OPEN_SHORT_ARRAY`.
      * Should only be used selectively.
      *
-     * @since 1.0.0-alpha4 Use the {@see Collections::shortArrayListOpenTokensBC()} method for access.
+     * @since 1.0.0 Use the {@see Collections::shortArrayListOpenTokensBC()} method for access.
      *
      * @return array <int|string> => <int|string>
      */
@@ -620,9 +557,7 @@ final class Collections
      *
      * @see \PHPCSUtils\Tokens\Collections::arrayTokens() Related method to retrieve all tokens used for arrays.
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::shortArrayTokens()} method for access.
+     * @since 1.0.0 Use the {@see Collections::shortArrayTokens()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -641,9 +576,7 @@ final class Collections
      * @see \PHPCSUtils\Tokens\Collections::arrayTokensBC() Related method to retrieve all tokens used for arrays
      *                                                      (cross-version).
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::shortArrayTokensBC()} method for access.
+     * @since 1.0.0 Use the {@see Collections::shortArrayTokensBC()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -659,9 +592,7 @@ final class Collections
      *
      * @see \PHPCSUtils\Tokens\Collections::listTokens() Related method to retrieve all tokens used for lists.
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::shortListTokens()} method for access.
+     * @since 1.0.0 Use the {@see Collections::shortListTokens()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -680,9 +611,7 @@ final class Collections
      * @see \PHPCSUtils\Tokens\Collections::listTokensBC() Related method to retrieve all tokens used for lists
      *                                                     (cross-version).
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::shortListTokensBC()} method for access.
+     * @since 1.0.0 Use the {@see Collections::shortListTokensBC()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -696,9 +625,7 @@ final class Collections
     /**
      * Tokens which can start a - potentially multi-line - text string.
      *
-     * @since 1.0.0-alpha1
-     * @since 1.0.0-rc1    This property is now private.
-     *                     Use the {@see Collections::textStringStartTokens()} method for access.
+     * @since 1.0.0 Use the {@see Collections::textStringStartTokens()} method for access.
      *
      * @var array <int|string> => <int|string>
      */
@@ -712,7 +639,7 @@ final class Collections
     /**
      * Handle calls to (undeclared) methods for token arrays which don't need special handling.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param string $name The name of the method which has been called.
      * @param array  $args Any arguments passed to the method.
@@ -735,7 +662,7 @@ final class Collections
     /**
      * Throw a deprecation notice with a standardized deprecation message.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param string $method      The name of the method which is deprecated.
      * @param string $version     The version since which the method is deprecated.
@@ -763,7 +690,7 @@ final class Collections
      *
      * @see \PHPCSUtils\Tokens\Collections::parameterPassingTokens() Related method.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @return array <int|string> => <int|string>
      */
@@ -788,7 +715,7 @@ final class Collections
      * echo namespace\Sub\ClassName::method();
      * ```
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @return array <int|string> => <int|string>
      */
@@ -809,7 +736,7 @@ final class Collections
      *
      * @see \PHPCSUtils\Utils\PassedParameters
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @return array <int|string> => <int|string>
      */
@@ -831,11 +758,7 @@ final class Collections
     /**
      * Token types which can be encountered in a parameter type declaration.
      *
-     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$parameterTypeTokens} property.
-     * @since 1.0.0-alpha4 Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.
-     * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokens.
-     * @since 1.0.0-alpha4 Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.
-     * @since 1.0.0-alpha4 Added the T_TRUE token for PHP 8.2 true type support.
+     * @since 1.0.0
      *
      * @return array <int|string> => <int|string>
      */
@@ -850,11 +773,7 @@ final class Collections
     /**
      * Token types which can be encountered in a property type declaration.
      *
-     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$propertyTypeTokens} property.
-     * @since 1.0.0-alpha4 Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.
-     * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokens.
-     * @since 1.0.0-alpha4 Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.
-     * @since 1.0.0-alpha4 Added the T_TRUE token for PHP 8.2 true type support.
+     * @since 1.0.0
      *
      * @return array <int|string> => <int|string>
      */
@@ -869,11 +788,7 @@ final class Collections
     /**
      * Token types which can be encountered in a return type declaration.
      *
-     * @since 1.0.0-alpha4 This method replaces the {@see Collections::$returnTypeTokens} property.
-     * @since 1.0.0-alpha4 Added the T_TYPE_UNION, T_FALSE, T_NULL tokens for PHP 8.0 union type support.
-     * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokens.
-     * @since 1.0.0-alpha4 Added the T_TYPE_INTERSECTION token for PHP 8.1 intersection type support.
-     * @since 1.0.0-alpha4 Added the T_TRUE token for PHP 8.2 true type support.
+     * @since 1.0.0
      *
      * @return array <int|string> => <int|string>
      */

--- a/PHPCSUtils/Tokens/TokenHelper.php
+++ b/PHPCSUtils/Tokens/TokenHelper.php
@@ -42,7 +42,7 @@ final class TokenHelper
      * @link https://github.com/sebastianbergmann/php-code-coverage/issues/798       PHP-Code-Coverage#798
      * @link https://github.com/nikic/PHP-Parser/blob/master/lib/PhpParser/Lexer.php PHP-Parser Lexer code
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param string $name The token name.
      *

--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -20,7 +20,6 @@ use PHPCSUtils\Tokens\Collections;
  * Utility functions for use when examining arrays.
  *
  * @since 1.0.0
- * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
 final class Arrays
 {
@@ -144,9 +143,6 @@ final class Arrays
      * {@see \PHPCSUtils\Utils\PassedParameters::getParameters()}.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha2 Now allows for arrow functions in arrays.
-     * @since 1.0.0-alpha4 Now allows for match expressions in arrays.
-     * @since 1.0.0-alpha4 Now allows for attributes in arrays.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being examined.
      * @param int                         $start     Stack pointer to the start of the array item.

--- a/PHPCSUtils/Utils/Conditions.php
+++ b/PHPCSUtils/Utils/Conditions.php
@@ -38,10 +38,6 @@ final class Conditions
      * @see \PHPCSUtils\BackCompat\BCFile::getCondition() Cross-version compatible version of the original.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha2 The `$reverse` parameter has been renamed to `$first` and the meaning of the
-     *                     boolean reversed (`true` = first, `false` = last, was: `true` = last, `false` = first)
-     *                     to be in line with PHPCS itself which added the `$first` parameter in v 3.5.4
-     *                     to allow for the same/similar functionality as `$reverse` already offered.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the token we are checking.

--- a/PHPCSUtils/Utils/Context.php
+++ b/PHPCSUtils/Utils/Context.php
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Parentheses;
  * - A sniff looking for incrementor/decrementors may want to disregard these when used
  *   as the third expression in a `for()` condition.
  *
- * @since 1.0.0-alpha4
+ * @since 1.0.0
  */
 final class Context
 {
@@ -34,7 +34,7 @@ final class Context
      * For more complex/combined queries, it is recommended to call the {@see Parentheses::getLastOwner()}
      * method directly._
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the token we are checking.
@@ -53,7 +53,7 @@ final class Context
      * For more complex/combined queries, it is recommended to call the {@see Parentheses::getLastOwner()}
      * method directly._
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the token we are checking.
@@ -72,7 +72,7 @@ final class Context
      * For more complex/combined queries, it is recommended to call the {@see Parentheses::getLastOwner()}
      * method directly._
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the token we are checking.
@@ -87,7 +87,7 @@ final class Context
     /**
      * Check whether an arbitrary token is within an attribute.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the token we are checking.
@@ -115,7 +115,7 @@ final class Context
      * Check whether an arbitrary token is in a foreach condition and if so, in which part:
      * before or after the "as".
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the token we are checking.
@@ -167,7 +167,7 @@ final class Context
      * Note: the semicolons separating the conditions are regarded as belonging with the
      * expression before it.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the token we are checking.

--- a/PHPCSUtils/Utils/ControlStructures.php
+++ b/PHPCSUtils/Utils/ControlStructures.php
@@ -19,7 +19,6 @@ use PHPCSUtils\Tokens\Collections;
  * Utility functions for use when examining control structures.
  *
  * @since 1.0.0
- * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
 final class ControlStructures
 {
@@ -37,7 +36,6 @@ final class ControlStructures
      * regarded as empty.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha4 Added support for PHP 8.0 match control structures.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile  The file being scanned.
      * @param int                         $stackPtr   The position of the token we are checking.
@@ -196,8 +194,7 @@ final class ControlStructures
     /**
      * Retrieve the exception(s) being caught in a CATCH condition.
      *
-     * @since 1.0.0-alpha3
-     * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokenization.
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the token we are checking.

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -23,13 +23,12 @@ use PHPCSUtils\Utils\UseStatements;
 /**
  * Utility functions for use when examining function declaration statements.
  *
- * @since 1.0.0        The `FunctionDeclarations::getProperties()` and the
- *                     `FunctionDeclarations::getParameters()` methods are based on and
- *                     inspired by respectively the `getMethodProperties()`
- *                     and `getMethodParameters()` methods in the PHPCS native
- *                     `PHP_CodeSniffer\Files\File` class.
- *                     Also see {@see \PHPCSUtils\BackCompat\BCFile}.
- * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
+ * @since 1.0.0 The `FunctionDeclarations::getProperties()` and the
+ *              `FunctionDeclarations::getParameters()` methods are based on and
+ *              inspired by respectively the `getMethodProperties()`
+ *              and `getMethodParameters()` methods in the PHPCS native
+ *              `PHP_CodeSniffer\Files\File` class.
+ *              Also see {@see \PHPCSUtils\BackCompat\BCFile}.
  */
 final class FunctionDeclarations
 {
@@ -155,11 +154,6 @@ final class FunctionDeclarations
      * @see \PHPCSUtils\BackCompat\BCFile::getMethodProperties() Cross-version compatible version of the original.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha2 Added support for PHP 7.4 arrow functions.
-     * @since 1.0.0-alpha3 Added support for PHP 8.0 static return type.
-     * @since 1.0.0-alpha4 Added support for PHP 8.0 union types.
-     * @since 1.0.0-alpha4 Added support for PHP 8.1 intersection types.
-     * @since 1.0.0-alpha4 Added support for PHP 8.2 true type.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the function token to
@@ -370,14 +364,6 @@ final class FunctionDeclarations
      * @see \PHPCSUtils\BackCompat\BCFile::getMethodParameters() Cross-version compatible version of the original.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha2 Added support for PHP 7.4 arrow functions.
-     * @since 1.0.0-alpha4 Added support for PHP 8.0 union types.
-     * @since 1.0.0-alpha4 Added support for PHP 8.0 constructor property promotion.
-     * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokenization.
-     * @since 1.0.0-alpha4 Added support for PHP 8.0 parameter attributes.
-     * @since 1.0.0-alpha4 Added support for PHP 8.1 readonly keyword for constructor property promotion.
-     * @since 1.0.0-alpha4 Added support for PHP 8.1 intersection types.
-     * @since 1.0.0-alpha4 Added support for PHP 8.2 true type.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the function token

--- a/PHPCSUtils/Utils/Lists.php
+++ b/PHPCSUtils/Utils/Lists.php
@@ -22,7 +22,6 @@ use PHPCSUtils\Utils\GetTokensAsString;
  * Utility functions to retrieve information when working with lists.
  *
  * @since 1.0.0
- * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
 final class Lists
 {
@@ -186,8 +185,6 @@ final class Lists
      * ```
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha3 The returned value has been simplified with sensible defaults and always
-     *                     available keys.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the function token

--- a/PHPCSUtils/Utils/MessageHelper.php
+++ b/PHPCSUtils/Utils/MessageHelper.php
@@ -23,7 +23,7 @@ final class MessageHelper
     /**
      * Add a PHPCS message to the output stack as either a warning or an error.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
      * @param string                      $message   The message.
@@ -59,7 +59,7 @@ final class MessageHelper
     /**
      * Add a PHPCS message to the output stack as either a fixable warning or a fixable error.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
      * @param string                      $message   The message.
@@ -97,7 +97,7 @@ final class MessageHelper
      *
      * Pre-empt issues in XML and PHP when arbitrary strings are being used as error codes.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param string $text       Arbitrary text string intended to be used in an error code.
      * @param bool   $strtolower Whether or not to convert the text string to lowercase.
@@ -129,7 +129,7 @@ final class MessageHelper
      * @see \PHPCSUtils\Utils\GetTokensToString             Methods to retrieve a multi-token code snippet.
      * @see \PHP_CodeSniffer\Util\Common\prepareForOutput() Similar PHPCS native method.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param string $text Arbitrary text string.
      *

--- a/PHPCSUtils/Utils/Namespaces.php
+++ b/PHPCSUtils/Utils/Namespaces.php
@@ -27,7 +27,6 @@ use PHPCSUtils\Utils\Parentheses;
  * @link https://www.php.net/language.namespaces PHP Manual on namespaces.
  *
  * @since 1.0.0
- * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
 final class Namespaces
 {
@@ -36,7 +35,6 @@ final class Namespaces
      * Determine what a T_NAMESPACE token is used for.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokenization.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the `T_NAMESPACE` token.

--- a/PHPCSUtils/Utils/NamingConventions.php
+++ b/PHPCSUtils/Utils/NamingConventions.php
@@ -23,7 +23,7 @@ namespace PHPCSUtils\Utils;
  * - {@link https://www.php.net/language.variables.basics variable} names;
  * - {@link https://www.php.net/language.constants constant} names.
  *
- * @since 1.0.0-alpha3
+ * @since 1.0.0
  */
 final class NamingConventions
 {

--- a/PHPCSUtils/Utils/Numbers.php
+++ b/PHPCSUtils/Utils/Numbers.php
@@ -29,11 +29,6 @@ use PHP_CodeSniffer\Files\File;
  *       PHP Manual on the introduction of the integer octal literal prefix.
  *
  * @since 1.0.0
- * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
- * @since 1.0.0-alpha4 Removed the following class constants:
- *                     - `Numbers::REGEX_NUMLIT_STRING`
- *                     - `Numbers::REGEX_HEX_NUMLIT_STRING`
- *                     - `Numbers::UNSUPPORTED_PHPCS_VERSION`
  */
 final class Numbers
 {

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -19,13 +19,12 @@ use PHPCSUtils\Utils\GetTokensAsString;
 /**
  * Utility functions for use when examining object declaration statements.
  *
- * @since 1.0.0        The `ObjectDeclarations::get(Declaration)Name()`,
- *                     `ObjectDeclarations::getClassProperties()`, `ObjectDeclarations::findExtendedClassName()`
- *                     and `ObjectDeclarations::findImplementedInterfaceNames()` methods are based on and
- *                     inspired by the methods of the same name in the PHPCS native
- *                     `PHP_CodeSniffer\Files\File` class.
- *                     Also see {@see \PHPCSUtils\BackCompat\BCFile}.
- * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
+ * @since 1.0.0 The `ObjectDeclarations::get(Declaration)Name()`,
+ *              `ObjectDeclarations::getClassProperties()`, `ObjectDeclarations::findExtendedClassName()`
+ *              and `ObjectDeclarations::findImplementedInterfaceNames()` methods are based on and
+ *              inspired by the methods of the same name in the PHPCS native
+ *              PHP_CodeSniffer\Files\File` class.
+ *              Also see {@see \PHPCSUtils\BackCompat\BCFile}.
  */
 final class ObjectDeclarations
 {
@@ -48,7 +47,6 @@ final class ObjectDeclarations
      * @see \PHPCSUtils\BackCompat\BCFile::getDeclarationName() Cross-version compatible version of the original.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha4 Added support for PHP 8.1 enums.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the declaration token
@@ -145,7 +143,6 @@ final class ObjectDeclarations
      * @see \PHPCSUtils\BackCompat\BCFile::getClassProperties() Cross-version compatible version of the original.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha4 Added support for the PHP 8.2 readonly keyword.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the `T_CLASS`
@@ -272,7 +269,6 @@ final class ObjectDeclarations
      *                                                                     the original.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha4 Added support for PHP 8.1 enums.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The stack position of the class or enum token.
@@ -313,7 +309,6 @@ final class ObjectDeclarations
      * interfaces that the specific class/interface declaration extends/implements.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokenization.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile  The file where this token was found.
      * @param int                         $stackPtr   The stack position of the

--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -21,12 +21,11 @@ use PHPCSUtils\Utils\Parentheses;
  *
  * @link https://www.php.net/language.operators PHP manual on operators.
  *
- * @since 1.0.0        The `isReference()` method is based on and inspired by
- *                     the method of the same name in the PHPCS native `File` class.
- *                     Also see {@see \PHPCSUtils\BackCompat\BCFile}.
- *                     The `isUnaryPlusMinus()` method is, in part, inspired by the
- *                     `Squiz.WhiteSpace.OperatorSpacing` sniff.
- * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
+ * @since 1.0.0 The `isReference()` method is based on and inspired by
+ *              the method of the same name in the PHPCS native `File` class.
+ *              Also see {@see \PHPCSUtils\BackCompat\BCFile}.
+ *              The `isUnaryPlusMinus()` method is, in part, inspired by the
+ *              `Squiz.WhiteSpace.OperatorSpacing` sniff.
  */
 final class Operators
 {
@@ -70,8 +69,6 @@ final class Operators
      * @see \PHPCSUtils\BackCompat\BCFile::isReference() Cross-version compatible version of the original.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha2 Added support for PHP 7.4 arrow functions.
-     * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokenization.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the `T_BITWISE_AND` token.

--- a/PHPCSUtils/Utils/Parentheses.php
+++ b/PHPCSUtils/Utils/Parentheses.php
@@ -21,9 +21,6 @@ use PHP_CodeSniffer\Util\Tokens;
  * will be considered parentheses owners by the functions in this class.
  *
  * @since 1.0.0
- * @since 1.0.0-alpha4 Added support for `isset()`, `unset()`, `empty()`, `exit()`, `die()`
- *                     and `eval()` as parentheses owners to all applicable functions.
- * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
 final class Parentheses
 {
@@ -35,7 +32,7 @@ final class Parentheses
      *    owners, but are considered such for the purposes of this class.
      *    Also see {@link https://github.com/squizlabs/PHP_CodeSniffer/issues/3118 PHPCS#3118}.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @var array <int|string> => <int|string>
      */
@@ -51,7 +48,6 @@ final class Parentheses
      * Get the stack pointer to the parentheses owner of an open/close parenthesis.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha2 Added support for PHP 7.4 arrow functions.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
      * @param int                         $stackPtr  The position of `T_OPEN/CLOSE_PARENTHESIS` token.
@@ -98,7 +94,6 @@ final class Parentheses
      * set of valid owners.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha2 Added support for PHP 7.4 arrow functions.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
      * @param int                         $stackPtr    The position of `T_OPEN/CLOSE_PARENTHESIS` token.

--- a/PHPCSUtils/Utils/PassedParameters.php
+++ b/PHPCSUtils/Utils/PassedParameters.php
@@ -23,7 +23,6 @@ use PHPCSUtils\Utils\GetTokensAsString;
  * class instantiations, array declarations, isset and unset constructs.
  *
  * @since 1.0.0
- * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
 final class PassedParameters
 {
@@ -64,10 +63,6 @@ final class PassedParameters
      *   language constructs have "parameters".
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha4 Added the `$isShortArray` parameter.
-     * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokenization.
-     * @since 1.0.0-alpha4 Added defensive coding against PHP 8.1 first class callables
-     *                     being passed as if they were function calls.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file where this token was found.
      * @param int                         $stackPtr     The position of function call name,
@@ -157,10 +152,6 @@ final class PassedParameters
      * See {@see PassedParameters::hasParameters()} for information on the supported constructs.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha4 Added the `$limit` and `$isShortArray` parameters.
-     * @since 1.0.0-alpha4 Added support for PHP 8.0 function calls with named arguments by introducing
-     *                     the `'name'` and `'name_token'` index keys as well as using the name
-     *                     as the index for the top-level array for named parameters.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file where this token was found.
      * @param int                         $stackPtr     The position of function call name,
@@ -365,7 +356,6 @@ final class PassedParameters
      *                                                already retrieved.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha4 Added the `$paramNames` parameter.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
      * @param int                         $stackPtr    The position of function call name,
@@ -455,7 +445,7 @@ final class PassedParameters
      *
      * See {@see PassedParameters::hasParameters()} for information on the supported constructs.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param array           $parameters  The output of a previous call to {@see PassedParameters::getParameters()}.
      * @param int             $paramOffset The 1-based index position of the parameter to retrieve.

--- a/PHPCSUtils/Utils/Scopes.php
+++ b/PHPCSUtils/Utils/Scopes.php
@@ -59,8 +59,6 @@ final class Scopes
      * Check whether a T_CONST token is a class/interface/trait/enum constant declaration.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha4 Added support for PHP 8.1 enums.
-     * @since 1.0.0-alpha4 Added support for PHP 8.2 constants in traits.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
      * @param int                         $stackPtr  The position in the stack of the
@@ -121,7 +119,6 @@ final class Scopes
      * Check whether a T_FUNCTION token is a class/interface/trait/enum method declaration.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha4 Added support for PHP 8.1 enums.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
      * @param int                         $stackPtr  The position in the stack of the

--- a/PHPCSUtils/Utils/TextStrings.php
+++ b/PHPCSUtils/Utils/TextStrings.php
@@ -22,7 +22,6 @@ use PHPCSUtils\Utils\GetTokensAsString;
  * Utility functions for working with text string tokens.
  *
  * @since 1.0.0
- * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
 final class TextStrings
 {
@@ -106,7 +105,7 @@ final class TextStrings
      * @see \PHPCSUtils\Utils\TextStrings::getCompleteTextString() Retrieve the contents of a complete - potentially
      *                                                             multi-line - text string.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
      * @param int                         $stackPtr  Pointer to the first text string token
@@ -195,7 +194,7 @@ final class TextStrings
      * Note: this function gets the complete variables/expressions _as they are embedded_,
      * i.e. including potential curly brace wrappers, array access, method calls etc.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param string $text The contents of a T_DOUBLE_QUOTED_STRING or T_HEREDOC token.
      *
@@ -210,7 +209,7 @@ final class TextStrings
     /**
      * Strip embedded variables/expressions from an arbitrary string.
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param string $text The contents of a T_DOUBLE_QUOTED_STRING or T_HEREDOC token.
      *
@@ -238,7 +237,7 @@ final class TextStrings
      * @link https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation    PHP RFC on deprecating select
      *                                                                               string interpolation syntaxes
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param string $text The contents of a T_DOUBLE_QUOTED_STRING or T_HEREDOC token.
      *

--- a/PHPCSUtils/Utils/TextStrings.php
+++ b/PHPCSUtils/Utils/TextStrings.php
@@ -31,6 +31,8 @@ final class TextStrings
      *
      * Prevents matching escaped variables/expressions.
      *
+     * @since 1.0.0
+     *
      * @var string
      */
     const START_OF_EMBED = '`(?<!\\\\)(\\\\{2})*(\{\$|\$\{|\$(?=[a-zA-Z_\x7f-\xff]))`';
@@ -39,6 +41,8 @@ final class TextStrings
      * Regex to match a "type 1" - directly embedded - variable without the dollar sign.
      *
      * Allows for array access and property access in as far as supported (single level).
+     *
+     * @since 1.0.0
      *
      * @var string
      */

--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -21,7 +21,6 @@ use PHPCSUtils\Utils\Parentheses;
  * Utility functions for examining use statements.
  *
  * @since 1.0.0
- * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
  */
 final class UseStatements
 {
@@ -153,7 +152,6 @@ final class UseStatements
      * Handles single import, multi-import and group-import use statements.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha4 Added support for PHP 8.0 identifier name tokenization.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
      * @param int                         $stackPtr  The position in the stack of the `T_USE` token.
@@ -357,7 +355,7 @@ final class UseStatements
      * @see \PHPCSUtils\Utils\UseStatements::splitImportUseStatement()
      * @see \PHPCSUtils\Utils\UseStatements::mergeImportUseStatements()
      *
-     * @since 1.0.0-alpha3
+     * @since 1.0.0
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile             The file where this token was found.
      * @param int                         $stackPtr              The position in the stack of the `T_USE` token.
@@ -392,7 +390,7 @@ final class UseStatements
      *
      * @see \PHPCSUtils\Utils\UseStatements::splitImportUseStatement()
      *
-     * @since 1.0.0-alpha4
+     * @since 1.0.0
      *
      * @param array $previousUseStatements The import `use` statements collected so far.
      *                                     This should be either the output of a

--- a/PHPCSUtils/Utils/Variables.php
+++ b/PHPCSUtils/Utils/Variables.php
@@ -20,10 +20,9 @@ use PHPCSUtils\Utils\TextStrings;
 /**
  * Utility functions for use when examining variables.
  *
- * @since 1.0.0        The `Variables::getMemberProperties()` method is based on and inspired by
- *                     the method of the same name in the PHPCS native `PHP_CodeSniffer\Files\File` class.
- *                     Also see {@see \PHPCSUtils\BackCompat\BCFile}.
- * @since 1.0.0-alpha4 Dropped support for PHPCS < 3.7.1.
+ * @since 1.0.0 The `Variables::getMemberProperties()` method is based on and inspired by
+ *              the method of the same name in the PHPCS native `PHP_CodeSniffer\Files\File` class.
+ *              Also see {@see \PHPCSUtils\BackCompat\BCFile}.
  */
 final class Variables
 {
@@ -88,11 +87,6 @@ final class Variables
      * @see \PHPCSUtils\BackCompat\BCFile::getMemberProperties() Cross-version compatible version of the original.
      *
      * @since 1.0.0
-     * @since 1.0.0-alpha4 Added support for PHP 8.0 union types.
-     * @since 1.0.0-alpha4 No longer gets confused by PHP 8.0 property attributes.
-     * @since 1.0.0-alpha4 Added support for PHP 8.1 readonly properties.
-     * @since 1.0.0-alpha4 Added support for PHP 8.1 intersection types.
-     * @since 1.0.0-alpha4 Added support for PHP 8.2 true type.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the `T_VARIABLE` token


### PR DESCRIPTION
### Docs; remove QA release references from `@since` tags

Now that the 1.0.0 version has been released, what changed in which alpha/beta/rc is no longer relevant.

### Docs: add missing `@since` tags