### PR TITLE
GH Actions: fix CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -331,6 +331,14 @@ jobs:
           php-version: 7.4
           coverage: none
 
+      # The dependencies of PHPUnit, once installed and locked for the test run, will often
+      # be locked at a version not compatible with PHP 7.4, which would block the install of the
+      # Coveralls package, so just remove PHPUnit and be done with it as we no longer need it
+      # for this workflow anyway.
+      - name: Remove PHPUnit
+        if: ${{ success() }}
+        run: composer remove --dev yoast/phpunit-polyfills phpunit/phpunit --no-interaction
+
       - name: Install Coveralls
         if: ${{ success() }}
         run: composer require php-coveralls/php-coveralls:"^2.4.2"


### PR DESCRIPTION
Grrr....

When PHPUnit has been installed on a high PHP version, some of the dependencies of PHPUnit will now be installed in versions not compatible with PHP 7.4, which blocks the install of the Coveralls package.

Removing PHPUnit before installing PHP Coveralls should fix it.

I just wish PHP Coveralls would finally release a version compatible with PHP >  8.0....