### PR TITLE
GH Actions: minor tweaks related to Coveralls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -359,7 +359,7 @@ jobs:
 
     steps:
       - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -331,17 +331,10 @@ jobs:
           php-version: 7.4
           coverage: none
 
-      # The dependencies of PHPUnit, once installed and locked for the test run, will often
-      # be locked at a version not compatible with PHP 7.4, which would block the install of the
-      # Coveralls package, so just remove PHPUnit and be done with it as we no longer need it
-      # for this workflow anyway.
-      - name: Remove PHPUnit
-        if: ${{ success() }}
-        run: composer remove --dev yoast/phpunit-polyfills phpunit/phpunit --no-interaction
-
+      # Global install is used to prevent a conflict with the local composer.lock in PHP 8.0+.
       - name: Install Coveralls
         if: ${{ success() }}
-        run: composer require php-coveralls/php-coveralls:"^2.4.2"
+        run: composer global require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
 
       - name: Upload coverage results to Coveralls
         if: ${{ success() }}
@@ -349,7 +342,7 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: php-${{ matrix.php }}-phpcs-${{ matrix.phpcs_version }}
-        run: vendor/bin/php-coveralls -v -x build/logs/clover.xml
+        run: php-coveralls -v -x build/logs/clover.xml
 
   coveralls-finish:
     needs: coverage


### PR DESCRIPTION
### GH Actions: used a named branch for coverallsapp

The `coverallsapp/github-action` action runner has (finally) created a named branch for the 1.x series, so let's use that.

Ref: https://github.com/coverallsapp/github-action/issues/100

### GH Actions: simplify Coveralls fix

Follow up on #433

By installing the `php-coveralls/php-coveralls` globally, we can also prevent the conflict with the PHPUnit versions, while we won't need to maintain a list of packages to be removed.

Includes updating the version constraint to reference the latest release of the package.