### PR TITLE
GH Actions: various tweaks

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         php: ['5.4', 'latest']
-        phpcs_version: ['3.7.1', 'dev-master']
+        phpcs_version: ['lowest', 'dev-master']
 
     name: "QTest${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 
@@ -60,8 +60,9 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      - name: 'Composer: set PHPCS version for tests'
-        run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
+      - name: "Composer: set PHPCS version for tests (master)"
+        if: ${{ matrix.phpcs_version != 'lowest' }}
+        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
@@ -70,6 +71,10 @@ jobs:
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: "Composer: set PHPCS version for tests (lowest)"
+        if: ${{ matrix.phpcs_version == 'lowest' }}
+        run: composer update squizlabs/php_codesniffer --prefer-lowest --no-scripts --no-interaction
 
       - name: Lint against parse errors
         if: matrix.phpcs_version == 'dev-master'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
         if: ${{ matrix.php >= 8.3 }}
         uses: "ramsey/composer-install@v2"
         with:
-          composer-options: --ignore-platform-reqs
+          composer-options: --ignore-platform-req=php+
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Lint against parse errors (PHP < 7.2)"
@@ -193,7 +193,7 @@ jobs:
         if: ${{ matrix.php >= 8.3 }}
         uses: "ramsey/composer-install@v2"
         with:
-          composer-options: --ignore-platform-reqs
+          composer-options: --ignore-platform-req=php+
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Run the unit tests without caching (non-risky)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,13 +92,13 @@ jobs:
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
         php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
-        phpcs_version: ['3.7.1', 'dev-master']
+        phpcs_version: ['lowest', 'dev-master']
         risky: [false]
         experimental: [false]
 
         include:
           - php: '5.6'
-            phpcs_version: '3.7.1'
+            phpcs_version: 'lowest'
             risky: false
             experimental: false
             extensions: ':iconv' # Run with iconv disabled.
@@ -126,7 +126,7 @@ jobs:
             experimental: true
 
           - php: '5.4'
-            phpcs_version: '3.7.1'
+            phpcs_version: 'lowest'
             risky: true
             experimental: true
 
@@ -136,7 +136,7 @@ jobs:
             experimental: true
 
           - php: '8.2'
-            phpcs_version: '3.7.1'
+            phpcs_version: 'lowest'
             risky: true
             experimental: true
 
@@ -172,8 +172,9 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      - name: 'Composer: set PHPCS version for tests'
-        run: composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
+      - name: "Composer: set PHPCS version for tests (master)"
+        if: ${{ matrix.phpcs_version != 'lowest' }}
+        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
       # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
       - name: 'Composer: remove PHPCSDevCS'
@@ -195,6 +196,10 @@ jobs:
         with:
           composer-options: --ignore-platform-req=php+
           custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: "Composer: set PHPCS version for tests (lowest)"
+        if: ${{ matrix.phpcs_version == 'lowest' }}
+        run: composer update squizlabs/php_codesniffer --prefer-lowest --no-scripts --no-interaction
 
       - name: Run the unit tests without caching (non-risky)
         if: ${{ matrix.risky == false }}
@@ -246,12 +251,12 @@ jobs:
           - php: '8.2'
             phpcs_version: 'dev-master'
           - php: '8.2'
-            phpcs_version: '3.7.1'
+            phpcs_version: 'lowest'
             extensions: ':iconv' # Run one build with iconv disabled.
           - php: '5.4'
             phpcs_version: 'dev-master'
           - php: '5.4'
-            phpcs_version: '3.7.1'
+            phpcs_version: 'lowest'
 
     name: "Coverage: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 
@@ -281,16 +286,19 @@ jobs:
       - name: "DEBUG: Show version details"
         run: php -v
 
-      - name: 'Composer: adjust dependencies'
-        run: |
-          # Set a specific PHPCS version.
-          composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-scripts
+      - name: "Composer: set PHPCS version for tests (master)"
+        if: ${{ matrix.phpcs_version != 'lowest' }}
+        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: "Composer: set PHPCS version for tests (lowest)"
+        if: ${{ matrix.phpcs_version == 'lowest' }}
+        run: composer update squizlabs/php_codesniffer --prefer-lowest --no-scripts --no-interaction
 
       - name: Grab PHPUnit version
         id: phpunit_version

--- a/Tests/BackCompat/Helper/GetVersionTest.php
+++ b/Tests/BackCompat/Helper/GetVersionTest.php
@@ -50,6 +50,10 @@ final class GetVersionTest extends TestCase
             return;
         }
 
+        if ($expected === 'lowest') {
+            $expected = '3.7.1';
+        }
+
         $result = Helper::getVersion();
 
         if ($expected === 'dev-master') {


### PR DESCRIPTION
### GH Actions: minor tweak to composer install

Since Composer 2.2, we can be more specific about which platform requirements should be ignored.

This change ensures that only the "high" end of a PHP requirement will be ignored and no other platform requirements are ignored.

Ref: https://blog.packagist.com/composer-2-2/#-ignore-platform-req-improvements

### GH Actions: tweak the way the PHPCS versions are set

As things were, whenever the minimum PHPCS version would be changed, the branch protection settings for both the `master` and the `develop` branch would need to be updated and all "required builds" referencing the old PHPCS version would need to be removed, while new "required builds" would need to be added referencing the new minimum PHPCS version.

This was a fiddly process and time-consuming.

The change proposed in this commit takes advantage of the Composer `--prefer-lowest` setting to achieve the same without a hard-coded PHPCS version in the build name, which means that once the branch protection settings have been updated for this PR, they shouldn't need updating anymore for future PHPCS version bumps.

### GetVersionTest: allow for CI `lowest` for PHPCS version

While this change does mean that on a version bump, this test will need to be updated as well, that should still make life easier as that is a simple committed change, which is much less involved than having to update the branch protection.