### PR TITLE
IsShortArrayOrList::walkInside(): minor efficiency tweak

### DIFF
--- a/PHPCSUtils/Internal/IsShortArrayOrList.php
+++ b/PHPCSUtils/Internal/IsShortArrayOrList.php
@@ -472,7 +472,7 @@ final class IsShortArrayOrList
              * If we encounter a completely empty item, this must be a short list as arrays cannot contain
              * empty items.
              */
-            if ($item['raw'] === '') {
+            if ($item['clean'] === '') {
                 return self::SHORT_LIST;
             }
 

--- a/Tests/Internal/IsShortArrayOrList/WalkInsideTest.inc
+++ b/Tests/Internal/IsShortArrayOrList/WalkInsideTest.inc
@@ -139,6 +139,8 @@ $array = [
     [, $a, $b],
     /* testNestedShortListEmptyEntryInMiddle */
     [$a,, $b],
+    /* testNestedShortListEmptyEntryInMiddleWithComment */
+    [$a, /*empty*/, $b],
     /* testNestedShortListEmptyEntryAtEnd */
     [$a, $b, , ],
 

--- a/Tests/Internal/IsShortArrayOrList/WalkInsideTest.php
+++ b/Tests/Internal/IsShortArrayOrList/WalkInsideTest.php
@@ -225,6 +225,10 @@ final class WalkInsideTest extends UtilityMethodTestCase
                 'testMarker' => '/* testNestedShortListEmptyEntryInMiddle */',
                 'expected'   => IsShortArrayOrList::SHORT_LIST,
             ],
+            'nested-short-list-empty-entry-in-middle-with-comment' => [
+                'testMarker' => '/* testNestedShortListEmptyEntryInMiddleWithComment */',
+                'expected'   => IsShortArrayOrList::SHORT_LIST,
+            ],
             'nested-short-list-empty-entry-at-end' => [
                 'testMarker' => '/* testNestedShortListEmptyEntryAtEnd */',
                 'expected'   => IsShortArrayOrList::SHORT_LIST,


### PR DESCRIPTION
Since PHPCSUtils 1.0.0-alpha4, the item array returned by `PassedParameters` will contain a `'clean'` key which contains the "parameter" (array/list item) content without comments.

Using this key, instead of the `'raw'` key, can prevent some unnecessary token walking for short lists.