### PR TITLE
[BackCompat|ObjectDeclarations]::get[Declaration]Name(): add extra tests

### DIFF
--- a/Tests/BackCompat/BCFile/GetDeclarationNameTest.inc
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameTest.inc
@@ -85,6 +85,9 @@ enum Hoo : string
 /* testBackedEnumNoSpaceBetweenNameAndColon */
 enum Suit: int implements Colorful, CardGame {}
 
+/* testFunctionReturnByRefWithReservedKeywordEach */
+function &each() {}
+
 /* testLiveCoding */
 // Intentional parse error. This has to be the last test in the file.
 function // Comment.

--- a/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
@@ -192,6 +192,10 @@ class GetDeclarationNameTest extends UtilityMethodTestCase
                 '/* testBackedEnumNoSpaceBetweenNameAndColon */',
                 'Suit',
             ],
+            'function-return-by-reference-with-reserved-keyword-each' => [
+                '/* testFunctionReturnByRefWithReservedKeywordEach */',
+                'each',
+            ],
         ];
     }
 }

--- a/Tests/Utils/ObjectDeclarations/GetNameDiffTest.inc
+++ b/Tests/Utils/ObjectDeclarations/GetNameDiffTest.inc
@@ -12,6 +12,15 @@ interface switch{ // Intentional parse error.
     public function someFunction();
 }
 
+/* testFunctionReturnByRefWithReservedKeywordParent */
+function &parent() {}
+
+/* testFunctionReturnByRefWithReservedKeywordSelf */
+function &self() {}
+
+/* testFunctionReturnByRefWithReservedKeywordStatic */
+function &static() {}
+
 /* testLiveCoding */
 // Intentional parse error. Redundancy testing.
 abstract class

--- a/Tests/Utils/ObjectDeclarations/GetNameDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameDiffTest.php
@@ -117,6 +117,18 @@ final class GetNameDiffTest extends UtilityMethodTestCase
                 'testMarker' => '/* testInvalidInterfaceName */',
                 'expected'   => 'switch',
             ],
+            'function-return-by-reference-with-reserved-keyword-parent' => [
+                '/* testFunctionReturnByRefWithReservedKeywordParent */',
+                'parent',
+            ],
+            'function-return-by-reference-with-reserved-keyword-self' => [
+                '/* testFunctionReturnByRefWithReservedKeywordSelf */',
+                'self',
+            ],
+            'function-return-by-reference-with-reserved-keyword-static' => [
+                '/* testFunctionReturnByRefWithReservedKeywordStatic */',
+                'static',
+            ],
         ];
     }
 }


### PR DESCRIPTION
... documenting how the OO hierarchy keywords when used as function/method name are handled.

* The `ObjectDeclarations::getName()` method handles these correctly.
* The PHPCS native `File::getDeclarationName()` and the related `BackCompat::getDeclarationName()` methods do not handle these correctly.

Related to upstream PR https://github.com/squizlabs/PHP_CodeSniffer/pull/3797