### PR TITLE
Docs: improve return array documentation

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -107,25 +107,25 @@ final class BCFile
      * Each parameter is in the following format:
      * ```php
      * 0 => array(
-     *   'name'                => '$var',  // The variable name.
-     *   'token'               => integer, // The stack pointer to the variable name.
-     *   'content'             => string,  // The full content of the variable definition.
-     *   'has_attributes'      => boolean, // Does the parameter have one or more attributes attached ?
-     *   'pass_by_reference'   => boolean, // Is the variable passed by reference?
-     *   'reference_token'     => integer, // The stack pointer to the reference operator
-     *                                     // or FALSE if the param is not passed by reference.
-     *   'variable_length'     => boolean, // Is the param of variable length through use of `...` ?
-     *   'variadic_token'      => integer, // The stack pointer to the ... operator
-     *                                     // or FALSE if the param is not variable length.
-     *   'type_hint'           => string,  // The type hint for the variable.
-     *   'type_hint_token'     => integer, // The stack pointer to the start of the type hint
-     *                                     // or FALSE if there is no type hint.
-     *   'type_hint_end_token' => integer, // The stack pointer to the end of the type hint
-     *                                     // or FALSE if there is no type hint.
-     *   'nullable_type'       => boolean, // TRUE if the var type is preceded by the nullability
-     *                                     // operator.
-     *   'comma_token'         => integer, // The stack pointer to the comma after the param
-     *                                     // or FALSE if this is the last param.
+     *   'name'                => string,        // The variable name.
+     *   'token'               => integer,       // The stack pointer to the variable name.
+     *   'content'             => string,        // The full content of the variable definition.
+     *   'has_attributes'      => boolean,       // Does the parameter have one or more attributes attached ?
+     *   'pass_by_reference'   => boolean,       // Is the variable passed by reference?
+     *   'reference_token'     => integer|false, // The stack pointer to the reference operator
+     *                                           // or FALSE if the param is not passed by reference.
+     *   'variable_length'     => boolean,       // Is the param of variable length through use of `...` ?
+     *   'variadic_token'      => integer|false, // The stack pointer to the ... operator
+     *                                           // or FALSE if the param is not variable length.
+     *   'type_hint'           => string,        // The type hint for the variable.
+     *   'type_hint_token'     => integer|false, // The stack pointer to the start of the type hint
+     *                                           // or FALSE if there is no type hint.
+     *   'type_hint_end_token' => integer|false, // The stack pointer to the end of the type hint
+     *                                           // or FALSE if there is no type hint.
+     *   'nullable_type'       => boolean,       // TRUE if the var type is preceded by the nullability
+     *                                           // operator.
+     *   'comma_token'         => integer|false, // The stack pointer to the comma after the param
+     *                                           // or FALSE if this is the last param.
      * )
      * ```
      *
@@ -142,6 +142,7 @@ final class BCFile
      *   'visibility_token'    => integer, // The stack pointer to the visibility modifier token.
      *   'property_readonly'   => bool,    // TRUE if the readonly keyword was found.
      *   'readonly_token'      => integer, // The stack pointer to the readonly modifier token.
+     *                                     // This index will only be set if the property is readonly.
      * ```
      *
      * PHPCS cross-version compatible version of the `File::getMethodParameters()` method.
@@ -431,19 +432,19 @@ final class BCFile
      * The format of the return value is:
      * ```php
      * array(
-     *   'scope'                 => 'public', // Public, private, or protected
-     *   'scope_specified'       => true,     // TRUE if the scope keyword was found.
-     *   'return_type'           => '',       // The return type of the method.
-     *   'return_type_token'     => integer,  // The stack pointer to the start of the return type
-     *                                        // or FALSE if there is no return type.
-     *   'return_type_end_token' => integer,  // The stack pointer to the end of the return type
-     *                                        // or FALSE if there is no return type.
-     *   'nullable_return_type'  => false,    // TRUE if the return type is preceded by
-     *                                        // the nullability operator.
-     *   'is_abstract'           => false,    // TRUE if the abstract keyword was found.
-     *   'is_final'              => false,    // TRUE if the final keyword was found.
-     *   'is_static'             => false,    // TRUE if the static keyword was found.
-     *   'has_body'              => false,    // TRUE if the method has a body
+     *   'scope'                 => string,        // Public, private, or protected
+     *   'scope_specified'       => boolean,       // TRUE if the scope keyword was found.
+     *   'return_type'           => string,        // The return type of the method.
+     *   'return_type_token'     => integer|false, // The stack pointer to the start of the return type
+     *                                             // or FALSE if there is no return type.
+     *   'return_type_end_token' => integer|false, // The stack pointer to the end of the return type
+     *                                             // or FALSE if there is no return type.
+     *   'nullable_return_type'  => boolean,       // TRUE if the return type is preceded by
+     *                                             // the nullability operator.
+     *   'is_abstract'           => boolean,       // TRUE if the abstract keyword was found.
+     *   'is_final'              => boolean,       // TRUE if the final keyword was found.
+     *   'is_static'             => boolean,       // TRUE if the static keyword was found.
+     *   'has_body'              => boolean,       // TRUE if the method has a body
      * );
      * ```
      *
@@ -478,17 +479,17 @@ final class BCFile
      * The format of the return value is:
      * ```php
      * array(
-     *   'scope'           => string,  // Public, private, or protected.
-     *   'scope_specified' => boolean, // TRUE if the scope was explicitly specified.
-     *   'is_static'       => boolean, // TRUE if the static keyword was found.
-     *   'is_readonly'     => boolean, // TRUE if the readonly keyword was found.
-     *   'type'            => string,  // The type of the var (empty if no type specified).
-     *   'type_token'      => integer, // The stack pointer to the start of the type
-     *                                 // or FALSE if there is no type.
-     *   'type_end_token'  => integer, // The stack pointer to the end of the type
-     *                                 // or FALSE if there is no type.
-     *   'nullable_type'   => boolean, // TRUE if the type is preceded by the
-     *                                 // nullability operator.
+     *   'scope'           => string,        // Public, private, or protected.
+     *   'scope_specified' => boolean,       // TRUE if the scope was explicitly specified.
+     *   'is_static'       => boolean,       // TRUE if the static keyword was found.
+     *   'is_readonly'     => boolean,       // TRUE if the readonly keyword was found.
+     *   'type'            => string,        // The type of the var (empty if no type specified).
+     *   'type_token'      => integer|false, // The stack pointer to the start of the type
+     *                                       // or FALSE if there is no type.
+     *   'type_end_token'  => integer|false, // The stack pointer to the end of the type
+     *                                       // or FALSE if there is no type.
+     *   'nullable_type'   => boolean,       // TRUE if the type is preceded by the
+     *                                       // nullability operator.
      * );
      * ```
      *
@@ -524,8 +525,8 @@ final class BCFile
      * The format of the return value is:
      * ```php
      * array(
-     *   'is_abstract' => false, // TRUE if the abstract keyword was found.
-     *   'is_final'    => false, // TRUE if the final keyword was found.
+     *   'is_abstract' => boolean, // TRUE if the abstract keyword was found.
+     *   'is_final'    => boolean, // TRUE if the final keyword was found.
      * );
      * ```
      *

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -314,25 +314,25 @@ final class FunctionDeclarations
      *
      * ```php
      * 0 => array(
-     *   'name'                => string, // The variable name.
-     *   'token'               => int,    // The stack pointer to the variable name.
-     *   'content'             => string, // The full content of the variable definition.
-     *   'has_attributes'      => bool,   // Does the parameter have one or more attributes attached ?
-     *   'pass_by_reference'   => bool,   // Is the variable passed by reference?
-     *   'reference_token'     => int,    // The stack pointer to the reference operator
-     *                                    // or FALSE if the param is not passed by reference.
-     *   'variable_length'     => bool,   // Is the param of variable length through use of `...` ?
-     *   'variadic_token'      => int,    // The stack pointer to the ... operator
-     *                                    // or FALSE if the param is not variable length.
-     *   'type_hint'           => string, // The type hint for the variable.
-     *   'type_hint_token'     => int,    // The stack pointer to the start of the type hint
-     *                                    // or FALSE if there is no type hint.
-     *   'type_hint_end_token' => int,    // The stack pointer to the end of the type hint
-     *                                    // or FALSE if there is no type hint.
-     *   'nullable_type'       => bool,   // TRUE if the var type is preceded by the nullability
-     *                                    // operator.
-     *   'comma_token'         => int,    // The stack pointer to the comma after the param
-     *                                    // or FALSE if this is the last param.
+     *   'name'                => string,    // The variable name.
+     *   'token'               => int,       // The stack pointer to the variable name.
+     *   'content'             => string,    // The full content of the variable definition.
+     *   'has_attributes'      => bool,      // Does the parameter have one or more attributes attached ?
+     *   'pass_by_reference'   => bool,      // Is the variable passed by reference?
+     *   'reference_token'     => int|false, // The stack pointer to the reference operator
+     *                                       // or FALSE if the param is not passed by reference.
+     *   'variable_length'     => bool,      // Is the param of variable length through use of `...` ?
+     *   'variadic_token'      => int|false, // The stack pointer to the ... operator
+     *                                       // or FALSE if the param is not variable length.
+     *   'type_hint'           => string,    // The type hint for the variable.
+     *   'type_hint_token'     => int|false, // The stack pointer to the start of the type hint
+     *                                       // or FALSE if there is no type hint.
+     *   'type_hint_end_token' => int|false, // The stack pointer to the end of the type hint
+     *                                       // or FALSE if there is no type hint.
+     *   'nullable_type'       => bool,      // TRUE if the var type is preceded by the nullability
+     *                                       // operator.
+     *   'comma_token'         => int|false, // The stack pointer to the comma after the param
+     *                                       // or FALSE if this is the last param.
      * )
      * ```
      *
@@ -349,6 +349,7 @@ final class FunctionDeclarations
      *   'visibility_token'    => int,    // The stack pointer to the visibility modifier token.
      *   'property_readonly'   => bool,   // TRUE if the readonly keyword was found.
      *   'readonly_token'      => int,    // The stack pointer to the readonly modifier token.
+     *                                    // This index will only be set if the property is readonly.
      * ```
      *
      * Main differences with the PHPCS version:

--- a/PHPCSUtils/Utils/Variables.php
+++ b/PHPCSUtils/Utils/Variables.php
@@ -96,17 +96,17 @@ final class Variables
      *               The format of the return value is:
      *               ```php
      *               array(
-     *                 'scope'           => string,  // Public, private, or protected.
-     *                 'scope_specified' => boolean, // TRUE if the scope was explicitly specified.
-     *                 'is_static'       => boolean, // TRUE if the static keyword was found.
-     *                 'is_readonly'     => boolean, // TRUE if the readonly keyword was found.
-     *                 'type'            => string,  // The type of the var (empty if no type specified).
-     *                 'type_token'      => integer, // The stack pointer to the start of the type
-     *                                               // or FALSE if there is no type.
-     *                 'type_end_token'  => integer, // The stack pointer to the end of the type
-     *                                               // or FALSE if there is no type.
-     *                 'nullable_type'   => boolean, // TRUE if the type is preceded by the
-     *                                               // nullability operator.
+     *                 'scope'           => string,        // Public, private, or protected.
+     *                 'scope_specified' => boolean,       // TRUE if the scope was explicitly specified.
+     *                 'is_static'       => boolean,       // TRUE if the static keyword was found.
+     *                 'is_readonly'     => boolean,       // TRUE if the readonly keyword was found.
+     *                 'type'            => string,        // The type of the var (empty if no type specified).
+     *                 'type_token'      => integer|false, // The stack pointer to the start of the type
+     *                                                     // or FALSE if there is no type.
+     *                 'type_end_token'  => integer|false, // The stack pointer to the end of the type
+     *                                                     // or FALSE if there is no type.
+     *                 'nullable_type'   => boolean,       // TRUE if the type is preceded by the
+     *                                                     // nullability operator.
      *               );
      *               ```
      *


### PR DESCRIPTION
... for the `BCFile|FunctionDeclarations::get[Method]Parameters()`, `BCFile|FunctionDeclarations::get[Method]Properties()`, `BCFile|Variables::getMemberProperties()` and the `BCFile|ObjectDeclarations::get[Class]Properties()` methods.

Ensuring that the return value format documentation is consistent and correct regarding the type and availability of each index in the returned arrays.

Similar to upstream PR squizlabs/PHP_CodeSniffer#3800