### PR TITLE
Composer: remove the explicit PHPUnit requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
         "phpcsstandards/phpcsdevcs": "^1.1.3",
         "php-parallel-lint/php-parallel-lint": "^1.3.2",
         "php-parallel-lint/php-console-highlighter": "^1.0",
-        "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3",
         "yoast/phpunit-polyfills": "^1.0.1"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
... in favour of letting the PHPUnit Polyfills handle the supported PHPUnit versions.