### PR TITLE
RemarkLint: switch plugin

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -143,6 +143,7 @@ jobs:
           remark-preset-lint-markdown-style-guide
           remark-lint-checkbox-content-indent
           remark-lint-linebreak-style
+          remark-lint-no-dead-urls
           remark-lint-no-duplicate-defined-urls
           remark-lint-no-empty-url
           remark-lint-no-heading-like-paragraph
@@ -154,7 +155,6 @@ jobs:
           remark-lint-list-item-punctuation
           remark-lint-match-punctuation
           remark-lint-no-hr-after-heading
-          remark-lint-are-links-valid-alive
           remark-lint-are-links-valid-duplicate
           remark-validate-links
 

--- a/.remarkrc
+++ b/.remarkrc
@@ -8,6 +8,7 @@
     ["remark-lint-linebreak-style", "unix"],
     ["remark-lint-link-title-style", "\""],
     ["remark-lint-ordered-list-marker-style", "."],
+    "remark-lint-no-dead-urls",
     "remark-lint-no-duplicate-defined-urls",
     "remark-lint-no-duplicate-definitions",
     "remark-lint-no-empty-url",
@@ -29,7 +30,6 @@
     "remark-lint-list-item-punctuation",
     "remark-lint-match-punctuation",
     "remark-lint-no-hr-after-heading",
-    "remark-lint-are-links-valid-alive",
     "remark-lint-are-links-valid-duplicate",
     "remark-validate-links"
   ]


### PR DESCRIPTION
The [`remark-lint-are-links-valid-alive`](https://github.com/wemake-services/remark-lint-are-links-valid) plugin has been abandoned and doesn't allow to skip false positives.
The [`remark-lint-no-dead-urls`](https://github.com/remarkjs/remark-lint-no-dead-urls) plugin is still maintained and does allow adding some configuration to skip false positives.

This commit switches the one plugin out for the other.