### PR TITLE
FunctionDeclarations::getProperties(): add caching

### DIFF
--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -193,6 +193,10 @@ final class FunctionDeclarations
             throw new RuntimeException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or an arrow function');
         }
 
+        if (Cache::isCached($phpcsFile, __METHOD__, $stackPtr) === true) {
+            return Cache::get($phpcsFile, __METHOD__, $stackPtr);
+        }
+
         if ($tokens[$stackPtr]['code'] === \T_FUNCTION) {
             $valid = Tokens::$methodPrefixes;
         } else {
@@ -292,7 +296,7 @@ final class FunctionDeclarations
             $returnType = '?' . $returnType;
         }
 
-        return [
+        $returnValue = [
             'scope'                 => $scope,
             'scope_specified'       => $scopeSpecified,
             'return_type'           => $returnType,
@@ -304,6 +308,9 @@ final class FunctionDeclarations
             'is_static'             => $isStatic,
             'has_body'              => $hasBody,
         ];
+
+        Cache::set($phpcsFile, __METHOD__, $stackPtr, $returnValue);
+        return $returnValue;
     }
 
     /**


### PR DESCRIPTION
Follow up on #332

While parsing the properties of function declarations was reasonably straight forward, with the introduction of union type in PHP 8.0, intersection types in PHP 8.1 and disjunctive normal form types in PHP 8.2, the retrieving of the return type has become more token walking intensive.

With that in mind, caching the results of the function seems prudent.

Includes a dedicated test to verify the cache is used and working.