### PR TITLE
UseStatements::splitImportUseStatement(): cache more often and check cache earlier

### DIFF
--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -199,6 +199,10 @@ final class UseStatements
             throw new RuntimeException('$stackPtr must be an import use statement');
         }
 
+        if (Cache::isCached($phpcsFile, __METHOD__, $stackPtr) === true) {
+            return Cache::get($phpcsFile, __METHOD__, $stackPtr);
+        }
+
         $statements = [
             'name'     => [],
             'function' => [],
@@ -208,11 +212,8 @@ final class UseStatements
         $endOfStatement = $phpcsFile->findNext([\T_SEMICOLON, \T_CLOSE_TAG], ($stackPtr + 1));
         if ($endOfStatement === false) {
             // Live coding or parse error.
+            Cache::set($phpcsFile, __METHOD__, $stackPtr, $statements);
             return $statements;
-        }
-
-        if (Cache::isCached($phpcsFile, __METHOD__, $stackPtr) === true) {
-            return Cache::get($phpcsFile, __METHOD__, $stackPtr);
         }
 
         ++$endOfStatement;

--- a/Tests/Utils/UseStatements/SplitImportUseStatementTest.php
+++ b/Tests/Utils/UseStatements/SplitImportUseStatementTest.php
@@ -333,4 +333,36 @@ final class SplitImportUseStatementTest extends UtilityMethodTestCase
         $this->assertTrue($isCached, 'Cache::isCached() could not find the cached value');
         $this->assertSame($resultFirstRun, $resultSecondRun, 'Second result did not match first');
     }
+
+    /**
+     * Verify that the build-in caching is used when caching is enabled and a parse error is encountered.
+     *
+     * @return void
+     */
+    public function testResultIsCachedForParseError()
+    {
+        $methodName = 'PHPCSUtils\\Utils\\UseStatements::splitImportUseStatement';
+        $cases      = $this->dataSplitImportUseStatement();
+        $testMarker = $cases['parse-error']['testMarker'];
+        $expected   = $cases['parse-error']['expected'];
+
+        $stackPtr = $this->getTargetToken($testMarker, \T_USE);
+
+        // Verify the caching works.
+        $origStatus     = Cache::$enabled;
+        Cache::$enabled = true;
+
+        $resultFirstRun  = UseStatements::splitImportUseStatement(self::$phpcsFile, $stackPtr);
+        $isCached        = Cache::isCached(self::$phpcsFile, $methodName, $stackPtr);
+        $resultSecondRun = UseStatements::splitImportUseStatement(self::$phpcsFile, $stackPtr);
+
+        if ($origStatus === false) {
+            Cache::clear();
+        }
+        Cache::$enabled = $origStatus;
+
+        $this->assertSame($expected, $resultFirstRun, 'First result did not match expectation');
+        $this->assertTrue($isCached, 'Cache::isCached() could not find the cached value');
+        $this->assertSame($resultFirstRun, $resultSecondRun, 'Second result did not match first');
+    }
 }


### PR DESCRIPTION
Follow up on #332.

Includes additional test.