### PR TITLE
Coveralls: use Coveralls specific token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -347,7 +347,7 @@ jobs:
       - name: Upload coverage results to Coveralls
         if: ${{ success() }}
         env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: php-${{ matrix.php }}-phpcs-${{ matrix.phpcs_version }}
         run: php-coveralls -v -x build/logs/clover.xml
@@ -362,5 +362,5 @@ jobs:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@v2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COVERALLS_TOKEN }}
           parallel-finished: true


### PR DESCRIPTION
Coveralls prefers for repos to be identified with the Coveralls specific token they provide. While the GitHub secret token still works, the intention is to drop support for it at some point in the future.

This commit anticipates on that by switching the token.

Notes:
* The `COVERALLS_TOKEN` has been added to the repo secrets.
* People with admin access to the GH repo automatically also have access to the admin settings in Coveralls. If ever needed, the Coveralls token can be found (and regenerated) in the Coveralls admin for a repo.
* After regeneration, the token as stored in the GH repo Settings -> Secrets and Variables -> Actions -> Repository secrets should be updated.

:point_right: This does mean that forks which have turned Coveralls on for their own fork of this repo will also need to add a `COVERALLS_TOKEN` secret to their GitHub fork (with the token as can be found in the Coveralls settings for their fork). This is a one-time only action.