### PR TITLE
BCFile::getClassProperties(): sync with upstream / add support for readonly classes

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -527,6 +527,7 @@ final class BCFile
      * array(
      *   'is_abstract' => boolean, // TRUE if the abstract keyword was found.
      *   'is_final'    => boolean, // TRUE if the final keyword was found.
+     *   'is_readonly' => false, // TRUE if the readonly keyword was found.
      * );
      * ```
      *
@@ -534,12 +535,13 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.3.0.
-     * - The upstream method has received no significant updates since PHPCS 3.7.1.
+     * - PHPCS 3.8.0: Added support for PHP 8.2 `readonly` classes.
      *
      * @see \PHP_CodeSniffer\Files\File::getClassProperties()          Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::getClassProperties() PHPCSUtils native improved version.
      *
      * @since 1.0.0
+     * @since 1.0.6 Sync with PHPCS 3.8.0, support for readonly classes. PHPCS#3686.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the `T_CLASS`
@@ -552,7 +554,50 @@ final class BCFile
      */
     public static function getClassProperties(File $phpcsFile, $stackPtr)
     {
-        return $phpcsFile->getClassProperties($stackPtr);
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['code'] !== T_CLASS) {
+            throw new RuntimeException('$stackPtr must be of type T_CLASS');
+        }
+
+        $valid = [
+            T_FINAL       => T_FINAL,
+            T_ABSTRACT    => T_ABSTRACT,
+            T_READONLY    => T_READONLY,
+            T_WHITESPACE  => T_WHITESPACE,
+            T_COMMENT     => T_COMMENT,
+            T_DOC_COMMENT => T_DOC_COMMENT,
+        ];
+
+        $isAbstract = false;
+        $isFinal    = false;
+        $isReadonly = false;
+
+        for ($i = ($stackPtr - 1); $i > 0; $i--) {
+            if (isset($valid[$tokens[$i]['code']]) === false) {
+                break;
+            }
+
+            switch ($tokens[$i]['code']) {
+                case T_ABSTRACT:
+                    $isAbstract = true;
+                    break;
+
+                case T_FINAL:
+                    $isFinal = true;
+                    break;
+
+                case T_READONLY:
+                    $isReadonly = true;
+                    break;
+            }
+        }
+
+        return [
+            'is_abstract' => $isAbstract,
+            'is_final'    => $isFinal,
+            'is_readonly' => $isReadonly,
+        ];
     }
 
     /**

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -136,7 +136,6 @@ final class ObjectDeclarations
      *   - Handling of PHPCS annotations.
      *   - Handling of unorthodox docblock placement.
      * - Defensive coding against incorrect calls to this method.
-     * - Support for PHP 8.2 readonly classes.
      * - Additional `'abstract_token'`, `'final_token'`, and `'readonly_token'` indexes in the return array.
      *
      * @see \PHP_CodeSniffer\Files\File::getClassProperties()   Original source.

--- a/Tests/BackCompat/BCFile/GetClassPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetClassPropertiesTest.inc
@@ -18,6 +18,23 @@ abstract class AbstractClass {}
 /* testFinalClass */
 final class FinalClass {}
 
+/* testReadonlyClass */
+readonly class ReadOnlyClass {}
+
+/* testFinalReadonlyClass */
+final readonly class FinalReadOnlyClass extends Foo {}
+
+/* testReadonlyFinalClass */
+readonly /*comment*/ final class ReadOnlyFinalClass {}
+
+/* testAbstractReadonlyClass */
+abstract readonly class AbstractReadOnlyClass {}
+
+/* testReadonlyAbstractClass */
+readonly
+abstract
+class ReadOnlyAbstractClass {}
+
 /* testWithCommentsAndNewLines */
 abstract
     /* comment */

--- a/Tests/BackCompat/BCFile/GetClassPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetClassPropertiesTest.php
@@ -92,12 +92,7 @@ class GetClassPropertiesTest extends UtilityMethodTestCase
     public function testGetClassProperties($testMarker, $expected)
     {
         // Remove keys which will only exist in the PHPCSUtils version of this method.
-        unset(
-            $expected['abstract_token'],
-            $expected['final_token'],
-            $expected['is_readonly'],
-            $expected['readonly_token']
-        );
+        unset($expected['abstract_token'], $expected['final_token'], $expected['readonly_token']);
 
         $class  = $this->getTargetToken($testMarker, \T_CLASS);
         $result = BCFile::getClassProperties(self::$phpcsFile, $class);
@@ -145,6 +140,61 @@ class GetClassPropertiesTest extends UtilityMethodTestCase
                     'final_token'    => -2,
                     'is_readonly'    => false,
                     'readonly_token' => false,
+                ],
+            ],
+            'readonly' => [
+                '/* testReadonlyClass */',
+                [
+                    'is_abstract'    => false,
+                    'abstract_token' => false,
+                    'is_final'       => false,
+                    'final_token'    => false,
+                    'is_readonly'    => true,
+                    'readonly_token' => -2,
+                ],
+            ],
+            'final-readonly' => [
+                '/* testFinalReadonlyClass */',
+                [
+                    'is_abstract'    => false,
+                    'abstract_token' => false,
+                    'is_final'       => true,
+                    'final_token'    => -4,
+                    'is_readonly'    => true,
+                    'readonly_token' => -2,
+                ],
+            ],
+            'readonly-final' => [
+                '/* testReadonlyFinalClass */',
+                [
+                    'is_abstract'    => false,
+                    'abstract_token' => false,
+                    'is_final'       => true,
+                    'final_token'    => -2,
+                    'is_readonly'    => true,
+                    'readonly_token' => -6,
+                ],
+            ],
+            'abstract-readonly' => [
+                '/* testAbstractReadonlyClass */',
+                [
+                    'is_abstract'    => true,
+                    'abstract_token' => -4,
+                    'is_final'       => false,
+                    'final_token'    => false,
+                    'is_readonly'    => true,
+                    'readonly_token' => -2,
+                ],
+            ],
+            'readonly-abstract' => [
+                '/* testReadonlyAbstractClass */',
+                [
+                    'is_abstract'    => true,
+                    'abstract_token' => -2,
+                    'is_final'       => false,
+                    'final_token'    => false,
+                    'is_readonly'    => true,
+                    'readonly_token' => -4,
                 ],
             ],
             'comments-and-new-lines' => [

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.inc
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.inc
@@ -16,20 +16,3 @@ final
  * @phpcs:disable Standard.Cat.SniffName -- Just because.
  */
 class ClassWithModifierBeforeDocblock {}
-
-/* testReadonlyClass */
-readonly class ReadOnlyClass {}
-
-/* testFinalReadonlyClass */
-final readonly class FinalReadOnlyClass extends Foo {}
-
-/* testReadonlyFinalClass */
-readonly /*comment*/ final class ReadOnlyFinalClass {}
-
-/* testAbstractReadonlyClass */
-abstract readonly class AbstractReadOnlyClass {}
-
-/* testReadonlyAbstractClass */
-readonly
-abstract
-class ReadOnlyAbstractClass {}

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
@@ -101,61 +101,6 @@ final class GetClassPropertiesDiffTest extends UtilityMethodTestCase
                     'readonly_token' => false,
                 ],
             ],
-            'readonly' => [
-                '/* testReadonlyClass */',
-                [
-                    'is_abstract'    => false,
-                    'abstract_token' => false,
-                    'is_final'       => false,
-                    'final_token'    => false,
-                    'is_readonly'    => true,
-                    'readonly_token' => -2,
-                ],
-            ],
-            'final-readonly' => [
-                '/* testFinalReadonlyClass */',
-                [
-                    'is_abstract'    => false,
-                    'abstract_token' => false,
-                    'is_final'       => true,
-                    'final_token'    => -4,
-                    'is_readonly'    => true,
-                    'readonly_token' => -2,
-                ],
-            ],
-            'readonly-final' => [
-                '/* testReadonlyFinalClass */',
-                [
-                    'is_abstract'    => false,
-                    'abstract_token' => false,
-                    'is_final'       => true,
-                    'final_token'    => -2,
-                    'is_readonly'    => true,
-                    'readonly_token' => -6,
-                ],
-            ],
-            'abstract-readonly' => [
-                '/* testAbstractReadonlyClass */',
-                [
-                    'is_abstract'    => true,
-                    'abstract_token' => -4,
-                    'is_final'       => false,
-                    'final_token'    => false,
-                    'is_readonly'    => true,
-                    'readonly_token' => -2,
-                ],
-            ],
-            'readonly-abstract' => [
-                '/* testReadonlyAbstractClass */',
-                [
-                    'is_abstract'    => true,
-                    'abstract_token' => -2,
-                    'is_final'       => false,
-                    'final_token'    => false,
-                    'is_readonly'    => true,
-                    'readonly_token' => -4,
-                ],
-            ],
         ];
     }
 }


### PR DESCRIPTION
> PHP 8.2 introduces `readonly` classes. The `readonly` keyword can be combined with the `abstract` or `final` keyword. See: https://3v4l.org/VIXgD

Includes unit tests.

Support for readonly classes was previously already added to the `ObjectDeclarations::getClassProperties()` in PR #367.

Refs:
* https://wiki.php.net/rfc/readonly_classes
* squizlabs/PHP_CodeSniffer#3686.