### PR TITLE
BCFile::getMethodParameters(): sync with upstream / readonly without visibility

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -138,23 +138,25 @@ final class BCFile
      *
      * Parameters declared using PHP 8 constructor property promotion, have these additional array indexes:
      * ```php
-     *   'property_visibility' => string,  // The property visibility as declared.
-     *   'visibility_token'    => integer, // The stack pointer to the visibility modifier token.
-     *   'property_readonly'   => bool,    // TRUE if the readonly keyword was found.
-     *   'readonly_token'      => integer, // The stack pointer to the readonly modifier token.
-     *                                     // This index will only be set if the property is readonly.
+     *   'property_visibility' => string,        // The property visibility as declared.
+     *   'visibility_token'    => integer,|false // The stack pointer to the visibility modifier token.
+     *                                           // or FALSE if the visibility is not explicitly declared.
+     *   'property_readonly'   => bool,          // TRUE if the readonly keyword was found.
+     *   'readonly_token'      => integer,       // The stack pointer to the readonly modifier token.
+     *                                           // This index will only be set if the property is readonly.
      * ```
      *
      * PHPCS cross-version compatible version of the `File::getMethodParameters()` method.
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.7.1.
+     * - PHPCS 3.8.0: Added support for constructor property promotion with readonly without explicit visibility.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodParameters()      Original source.
      * @see \PHPCSUtils\Utils\FunctionDeclarations::getParameters() PHPCSUtils native improved version.
      *
      * @since 1.0.0
+     * @since 1.0.6 Sync with PHPCS 3.8.0, support for readonly properties without explicit visibility. PHPCS#3801.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the function token
@@ -380,15 +382,20 @@ final class BCFile
                     $vars[$paramCount]['type_hint_end_token'] = $typeHintEndToken;
                     $vars[$paramCount]['nullable_type']       = $nullableType;
 
-                    if ($visibilityToken !== null) {
-                        $vars[$paramCount]['property_visibility'] = $tokens[$visibilityToken]['content'];
-                        $vars[$paramCount]['visibility_token']    = $visibilityToken;
+                    if ($visibilityToken !== null || $readonlyToken !== null) {
+                        $vars[$paramCount]['property_visibility'] = 'public';
+                        $vars[$paramCount]['visibility_token']    = false;
                         $vars[$paramCount]['property_readonly']   = false;
-                    }
 
-                    if ($readonlyToken !== null) {
-                        $vars[$paramCount]['property_readonly'] = true;
-                        $vars[$paramCount]['readonly_token']    = $readonlyToken;
+                        if ($visibilityToken !== null) {
+                            $vars[$paramCount]['property_visibility'] = $tokens[$visibilityToken]['content'];
+                            $vars[$paramCount]['visibility_token']    = $visibilityToken;
+                        }
+
+                        if ($readonlyToken !== null) {
+                            $vars[$paramCount]['property_readonly'] = true;
+                            $vars[$paramCount]['readonly_token']    = $readonlyToken;
+                        }
                     }
 
                     if ($tokens[$i]['code'] === T_COMMA) {

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -148,7 +148,6 @@ final class FunctionDeclarations
      * - Defensive coding against incorrect calls to this method.
      * - More efficient checking whether a function has a body.
      * - Support for PHP 8.0 identifier name tokens in return types, cross-version PHP & PHPCS.
-     * - Support for constructor property promotion with the PHP 8.1 readonly keyword without explicit visibility.
      * - Support for the PHP 8.2 `true` type.
      * - The results of this function call are cached during a PHPCS run for faster response times.
      *

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
@@ -212,6 +212,11 @@ class ConstructorPropertyPromotionWithReadOnlyNoTypeDeclaration {
     public function __construct(public readonly $promotedProp, ReadOnly private &$promotedToo) {}
 }
 
+class ConstructorPropertyPromotionWithOnlyReadOnly {
+    /* testPHP81ConstructorPropertyPromotionWithOnlyReadOnly */
+    public function __construct(readonly Foo&Bar $promotedProp, readonly ?bool $promotedToo,) {}
+}
+
 /* testPHP8ConstructorPropertyPromotionGlobalFunction */
 // Intentional fatal error. Property promotion not allowed in non-constructor, but that's not the concern of this method.
 function globalFunction(private $x) {}

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -2013,6 +2013,57 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     }
 
     /**
+     * Verify recognition of PHP8 constructor with property promotion using PHP 8.1 readonly
+     * keyword without explicit visibility.
+     *
+     * @return void
+     */
+    public function testPHP81ConstructorPropertyPromotionWithOnlyReadOnly()
+    {
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 10, // Offset from the T_FUNCTION token.
+            'name'                => '$promotedProp',
+            'content'             => 'readonly Foo&Bar $promotedProp',
+            'has_attributes'      => false,
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'Foo&Bar',
+            'type_hint_token'     => 6, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 8, // Offset from the T_FUNCTION token.
+            'nullable_type'       => false,
+            'property_visibility' => 'public',
+            'visibility_token'    => false,
+            'property_readonly'   => true,
+            'readonly_token'      => 4, // Offset from the T_FUNCTION token.
+            'comma_token'         => 11,
+        ];
+        $expected[1] = [
+            'token'               => 18, // Offset from the T_FUNCTION token.
+            'name'                => '$promotedToo',
+            'content'             => 'readonly ?bool $promotedToo',
+            'has_attributes'      => false,
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '?bool',
+            'type_hint_token'     => 16, // Offset from the T_FUNCTION token.
+            'type_hint_end_token' => 16, // Offset from the T_FUNCTION token.
+            'nullable_type'       => true,
+            'property_visibility' => 'public',
+            'visibility_token'    => false,
+            'property_readonly'   => true,
+            'readonly_token'      => 13, // Offset from the T_FUNCTION token.
+            'comma_token'         => 19,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Verify behaviour when a non-constructor function uses PHP 8 property promotion syntax.
      *
      * @return void
@@ -2717,7 +2768,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             if (isset($param['default_equal_token'])) {
                 $expected[$key]['default_equal_token'] += $target;
             }
-            if (isset($param['visibility_token'])) {
+            if (isset($param['visibility_token']) && $param['visibility_token'] !== false) {
                 $expected[$key]['visibility_token'] += $target;
             }
             if (isset($param['readonly_token'])) {

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.inc
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.inc
@@ -6,8 +6,3 @@ function pseudoTypeTrue(?true $var = true) {}
 /* testPHP82PseudoTypeFalseAndTrue */
 // Intentional fatal error - Type contains both true and false, bool should be used instead, but that's not the concern of the method.
 function pseudoTypeFalseAndTrue(true|false $var = true) {}
-
-class ConstructorPropertyPromotionWithOnlyReadOnly {
-    /* testPHP81ConstructorPropertyPromotionWithOnlyReadOnly */
-    public function __construct(readonly Foo&Bar $promotedProp, readonly ?bool $promotedToo,) {}
-}

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
@@ -103,57 +103,6 @@ final class GetParametersDiffTest extends UtilityMethodTestCase
     }
 
     /**
-     * Verify recognition of PHP8 constructor with property promotion using PHP 8.1 readonly
-     * keyword without explicit visibility.
-     *
-     * @return void
-     */
-    public function testPHP81ConstructorPropertyPromotionWithOnlyReadOnly()
-    {
-        $expected    = [];
-        $expected[0] = [
-            'token'               => 10, // Offset from the T_FUNCTION token.
-            'name'                => '$promotedProp',
-            'content'             => 'readonly Foo&Bar $promotedProp',
-            'has_attributes'      => false,
-            'pass_by_reference'   => false,
-            'reference_token'     => false,
-            'variable_length'     => false,
-            'variadic_token'      => false,
-            'type_hint'           => 'Foo&Bar',
-            'type_hint_token'     => 6, // Offset from the T_FUNCTION token.
-            'type_hint_end_token' => 8, // Offset from the T_FUNCTION token.
-            'nullable_type'       => false,
-            'property_visibility' => 'public',
-            'visibility_token'    => false,
-            'property_readonly'   => true,
-            'readonly_token'      => 4, // Offset from the T_FUNCTION token.
-            'comma_token'         => 11,
-        ];
-        $expected[1] = [
-            'token'               => 18, // Offset from the T_FUNCTION token.
-            'name'                => '$promotedToo',
-            'content'             => 'readonly ?bool $promotedToo',
-            'has_attributes'      => false,
-            'pass_by_reference'   => false,
-            'reference_token'     => false,
-            'variable_length'     => false,
-            'variadic_token'      => false,
-            'type_hint'           => '?bool',
-            'type_hint_token'     => 16, // Offset from the T_FUNCTION token.
-            'type_hint_end_token' => 16, // Offset from the T_FUNCTION token.
-            'nullable_type'       => true,
-            'property_visibility' => 'public',
-            'visibility_token'    => false,
-            'property_readonly'   => true,
-            'readonly_token'      => 13, // Offset from the T_FUNCTION token.
-            'comma_token'         => 19,
-        ];
-
-        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
-    }
-
-    /**
      * Test helper.
      *
      * @param string $marker     The comment which preceeds the test.

--- a/Tests/Utils/FunctionDeclarations/GetParametersTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersTest.php
@@ -140,7 +140,7 @@ final class GetParametersTest extends BCFile_GetMethodParametersTest
             if (isset($param['default_equal_token'])) {
                 $expected[$key]['default_equal_token'] += $target;
             }
-            if (isset($param['visibility_token'])) {
+            if (isset($param['visibility_token']) && $param['visibility_token'] !== false) {
                 $expected[$key]['visibility_token'] += $target;
             }
             if (isset($param['readonly_token'])) {


### PR DESCRIPTION
PHPCS upstream has now also added support for constructor property promotion with `readonly` properties without explicit visibility.

This commit updates the `BCFile::getMethodParameters()` method to reflect this.

Support for readonly constructor properties without visibility was previously already added to the `FunctionDeclarations::getParameter()` method in PR #456.

The associated "diff" test has now been moved to the base test file for these methods.

Refs:
* squizlabs/PHP_CodeSniffer#3801.