### PR TITLE
Coveralls test - push vs pull

### DIFF
--- a/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
+++ b/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
@@ -23,6 +23,8 @@ use PHPCSUtils\Utils\TextStrings;
 /**
  * Abstract sniff to easily examine all parts of an array declaration.
  *
+ * Just testing...
+ *
  * @since 1.0.0
  */
 abstract class AbstractArrayDeclarationSniff implements Sniff


### PR DESCRIPTION
This is just a test.

Elsewhere I'm seeing an issue that on a `push` build, Coveralls correctly receives all test build reports and correctly reports the coverage, while on a `pull`  build it does not.

This PR is just to test if this is an issue with that particular other repo or if this is a wider issue with Coveralls itself.

DO NOT MERGE THIS PR.