### PR TITLE
AbstractArrayDeclarationSniff: extra defensive coding for live coding/parse errors

### DIFF
--- a/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
+++ b/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
@@ -184,9 +184,14 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
             return;
         }
 
+        $openClose = Arrays::getOpenClose($phpcsFile, $stackPtr, true);
+        if ($openClose === false) {
+            // Parse error or live coding.
+            return;
+        }
+
         $this->stackPtr    = $stackPtr;
         $this->tokens      = $phpcsFile->getTokens();
-        $openClose         = Arrays::getOpenClose($phpcsFile, $stackPtr, true);
         $this->arrayOpener = $openClose['opener'];
         $this->arrayCloser = $openClose['closer'];
         $this->itemCount   = \count($this->arrayItems);

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.inc
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.inc
@@ -30,3 +30,7 @@ $array = [1, 'a' => 2, ];
 
 /* testShortList */
 [$a, $b] = $array;
+
+/* testLiveCoding */
+// This must be the last test in the file!!
+$array = array(

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
@@ -611,4 +611,38 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
 
         $mockObj->process(self::$phpcsFile, $target);
     }
+
+    /**
+     * Test that the abstract sniff correctly bows out when presented with an unfinished array.
+     *
+     * @return void
+     */
+    public function testBowOutOnUnfinishedArray()
+    {
+        $target = $this->getTargetToken('/* testLiveCoding */', Collections::arrayOpenTokensBC());
+
+        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
+            ->setMethods($this->methodsToMock)
+            ->getMockForAbstractClass();
+
+        $mockObj->expects($this->never())
+            ->method('processOpenClose');
+
+        $mockObj->expects($this->never())
+            ->method('processKey');
+
+        $mockObj->expects($this->never())
+            ->method('processNoKey');
+
+        $mockObj->expects($this->never())
+            ->method('processArrow');
+
+        $mockObj->expects($this->never())
+            ->method('processValue');
+
+        $mockObj->expects($this->never())
+            ->method('processComma');
+
+        $mockObj->process(self::$phpcsFile, $target);
+    }
 }


### PR DESCRIPTION
In case of live coding/an unfinished array, the `PassedParameters::getParameters()` will return an empty array (no items), while in reality, it couldn't be determined.

To prevent incorrect sniff results, it is better for the sniff to bow out early in those situations.
This prevents a "Trying to access array offset on value of type bool" PHP notice.

Fixed now.

Includes additional test.