### PR TITLE
AbstractArrayDeclarationSniff: improve the property reset

### DIFF
--- a/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
+++ b/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
@@ -204,7 +204,8 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
         $this->processArray($phpcsFile);
 
         // Reset select properties between calls to this sniff to lower memory usage.
-        unset($this->tokens, $this->arrayItems);
+        $this->tokens     = [];
+        $this->arrayItems = [];
     }
 
     /**


### PR DESCRIPTION
Unsetting a property leaves a property in a different PHP internal state then (re)setting it to an empty value.

Most notably, an unset property triggers the magic `__set()`/`__get()` etc methods if available, and while this abstract doesn't declare those methods, a sniff implementing the abstract _may_.

This change maintains the target behaviour (resetting the property values to save memory), while preventing side-effects from using `unset()` on these properties.