### PR TITLE
Handle case where fixer is not available for cache

### DIFF
--- a/PHPCSUtils/Internal/Cache.php
+++ b/PHPCSUtils/Internal/Cache.php
@@ -95,7 +95,7 @@ final class Cache
         }
 
         $fileName = $phpcsFile->getFilename();
-        $loop     = $phpcsFile->fixer->enabled === true ? $phpcsFile->fixer->loops : 0;
+        $loop     = (isset($phpcsFile->fixer) && $phpcsFile->fixer->enabled === true) ? $phpcsFile->fixer->loops : 0;
 
         return isset(self::$cache[$loop][$fileName][$key])
             && \array_key_exists($id, self::$cache[$loop][$fileName][$key]);
@@ -124,7 +124,7 @@ final class Cache
         }
 
         $fileName = $phpcsFile->getFilename();
-        $loop     = $phpcsFile->fixer->enabled === true ? $phpcsFile->fixer->loops : 0;
+        $loop     = (isset($phpcsFile->fixer) && $phpcsFile->fixer->enabled === true) ? $phpcsFile->fixer->loops : 0;
 
         if (isset(self::$cache[$loop][$fileName][$key])
             && \array_key_exists($id, self::$cache[$loop][$fileName][$key])

--- a/Tests/Internal/Cache/GetClearTest.php
+++ b/Tests/Internal/Cache/GetClearTest.php
@@ -124,6 +124,21 @@ final class GetClearTest extends UtilityMethodTestCase
     }
 
     /**
+     * Test that a cache key which has not been set is identified correctly as such, even without a fixer available.
+     *
+     * @covers ::isCached
+     *
+     * @return void
+     */
+    public function testIsCachedWillReturnFalseForUnavailableKeyWithNoFixer()
+    {
+        $fixer = self::$phpcsFile->fixer;
+        self::$phpcsFile->fixer = null;
+        $this->assertFalse(Cache::isCached(self::$phpcsFile, 'Utility3', 'numeric string'));
+        self::$phpcsFile->fixer = $fixer;
+    }
+
+    /**
      * Test that a cache id which has not been set is identified correctly as such.
      *
      * @covers ::isCached
@@ -190,6 +205,21 @@ final class GetClearTest extends UtilityMethodTestCase
     public function testGetWillReturnNullForUnavailableId()
     {
         $this->assertNull(Cache::get(self::$phpcsFile, 'Utility1', 'this ID does not exist'));
+    }
+
+    /**
+     * Test that retrieving a cache key which has not been set, yields null, even without a fixer avaialble.
+     *
+     * @covers ::get
+     *
+     * @return void
+     */
+    public function testGetWillReturnNullForUnavailableKeyWithNoFixer()
+    {
+        $fixer = self::$phpcsFile->fixer;
+        self::$phpcsFile->fixer = null;
+        $this->assertNull(Cache::get(self::$phpcsFile, 'Utility3', 'numeric string'));
+        self::$phpcsFile->fixer = $fixer;
     }
 
     /**


### PR DESCRIPTION
Fixes #481, includes test. After adding the test, I noticed that `Cache::get()` also suffered from the same assumption as `Cache::isCached()`.