### PR TITLE
Tests: make test suite compatible with PHPUnit 10.x

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -80,14 +80,32 @@ jobs:
         if: matrix.phpcs_version == 'dev-master'
         run: composer lint-lt72
 
+      - name: Grab PHPUnit version
+        id: phpunit_version
+        # yamllint disable-line rule:line-length
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+
+      - name: Determine PHPUnit config file to use
+        id: phpunit_config
+        run: |
+          if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}" == "true" ]; then
+            echo 'FILE=phpunit10.xml.dist' >> $GITHUB_OUTPUT
+            echo 'EXTRA_ARGS=' >> $GITHUB_OUTPUT
+          else
+            echo 'FILE=phpunit.xml.dist' >> $GITHUB_OUTPUT
+            echo 'EXTRA_ARGS= --repeat 2' >> $GITHUB_OUTPUT
+          fi
+
       - name: Run the unit tests without caching
-        run: vendor/bin/phpunit --no-coverage
+        run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }} --no-coverage
         env:
           PHPCS_VERSION: ${{ matrix.phpcs_version }}
           PHPCSUTILS_USE_CACHE: false
 
       - name: Run the unit tests with caching
-        run: vendor/bin/phpunit --testsuite PHPCSUtils --no-coverage --repeat 2
+        run: >
+          vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }}
+          --testsuite PHPCSUtils --no-coverage ${{ steps.phpunit_config.outputs.EXTRA_ARGS }}
         env:
           PHPCS_VERSION: ${{ matrix.phpcs_version }}
           PHPCSUTILS_USE_CACHE: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,16 +201,34 @@ jobs:
         if: ${{ matrix.phpcs_version == 'lowest' }}
         run: composer update squizlabs/php_codesniffer --prefer-lowest --no-scripts --no-interaction
 
+      - name: Grab PHPUnit version
+        id: phpunit_version
+        # yamllint disable-line rule:line-length
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+
+      - name: Determine PHPUnit config file to use
+        id: phpunit_config
+        run: |
+          if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}" == "true" ]; then
+            echo 'FILE=phpunit10.xml.dist' >> $GITHUB_OUTPUT
+            echo 'EXTRA_ARGS=' >> $GITHUB_OUTPUT
+          else
+            echo 'FILE=phpunit.xml.dist' >> $GITHUB_OUTPUT
+            echo 'EXTRA_ARGS= --repeat 2' >> $GITHUB_OUTPUT
+          fi
+
       - name: Run the unit tests without caching (non-risky)
         if: ${{ matrix.risky == false }}
-        run: vendor/bin/phpunit --no-coverage
+        run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }} --no-coverage
         env:
           PHPCS_VERSION: ${{ matrix.phpcs_version == '4.0.x-dev' && '4.0.0' || matrix.phpcs_version }}
           PHPCSUTILS_USE_CACHE: false
 
       - name: Run the unit tests with caching (non-risky)
         if: ${{ matrix.risky == false }}
-        run: vendor/bin/phpunit --testsuite PHPCSUtils --no-coverage --repeat 2
+        run: >
+          vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }}
+          --testsuite PHPCSUtils --no-coverage ${{ steps.phpunit_config.outputs.EXTRA_ARGS }}
         env:
           PHPCS_VERSION: ${{ matrix.phpcs_version == '4.0.x-dev' && '4.0.0' || matrix.phpcs_version }}
           PHPCSUTILS_USE_CACHE: true
@@ -220,7 +238,7 @@ jobs:
       - name: Run the unit tests (risky, comparewithPHPCS)
         if: ${{ matrix.risky && matrix.phpcs_version == 'dev-master' }}
         # "nothing" is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
-        run: vendor/bin/phpunit --no-coverage --group compareWithPHPCS --exclude-group nothing
+        run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }} --no-coverage --group compareWithPHPCS --exclude-group nothing
         env:
           PHPCS_VERSION: ${{ matrix.phpcs_version == '4.0.x-dev' && '4.0.0' || matrix.phpcs_version }}
 
@@ -228,7 +246,7 @@ jobs:
       - name: Run the unit tests (risky, xtra)
         if: ${{ matrix.risky }}
         # "nothing" is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
-        run: vendor/bin/phpunit --no-coverage --group xtra --exclude-group nothing
+        run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }} --no-coverage --group xtra --exclude-group nothing
         env:
           PHPCS_VERSION: ${{ matrix.phpcs_version == '4.0.x-dev' && '4.0.0' || matrix.phpcs_version }}
 
@@ -312,20 +330,21 @@ jobs:
       # As of PHPUnit 9.3.4, a cache warming option is available.
       # Using that option prevents issues with PHP-Parser backfilling PHP tokens when PHPCS does not (yet),
       # which would otherwise cause tests to fail on tokens being available when they shouldn't be.
+      # As coverage is only run on high/low PHP, the high PHP version will use PHPUnit 10, so just check for that.
       - name: "Warm the PHPUnit cache (PHPUnit 9.3+)"
-        if: ${{ steps.phpunit_version.outputs.VERSION >= '9.3' }}
-        run: vendor/bin/phpunit --coverage-cache ./build/phpunit-cache --warm-coverage-cache
+        if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
+        run: vendor/bin/phpunit -c phpunit10.xml.dist --coverage-cache ./build/phpunit-cache --warm-coverage-cache
 
-      - name: "Run the unit tests without caching with code coverage (PHPUnit < 9.3)"
-        if: ${{ steps.phpunit_version.outputs.VERSION < '9.3' }}
+      - name: "Run the unit tests without caching with code coverage (PHPUnit < 10)"
+        if: ${{ ! startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
         run: vendor/bin/phpunit
         env:
           PHPCS_VERSION: ${{ matrix.phpcs_version }}
           PHPCSUTILS_USE_CACHE: false
 
-      - name: "Run the unit tests without caching with code coverage (PHPUnit 9.3+)"
-        if: ${{ steps.phpunit_version.outputs.VERSION >= '9.3' }}
-        run: vendor/bin/phpunit --coverage-cache ./build/phpunit-cache
+      - name: "Run the unit tests without caching with code coverage (PHPUnit 10+)"
+        if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
+        run: vendor/bin/phpunit -c phpunit10.xml.dist --coverage-cache ./build/phpunit-cache
         env:
           PHPCS_VERSION: ${{ matrix.phpcs_version }}
           PHPCSUTILS_USE_CACHE: false

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
@@ -136,29 +136,25 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
                 $this->identicalTo($target + 5)
             );
 
-        $mockObj->expects($this->exactly(2))
-            ->method('processNoKey')
-            ->withConsecutive(
-                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 1), $this->equalTo(1)],
-                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 3), $this->equalTo(2)]
-            );
+        $this->setExpectationWithConsecutiveArgs(
+            $mockObj,
+            $this->exactly(2),
+            'processNoKey',
+            [
+                [self::$phpcsFile, $target + 1, 1],
+                [self::$phpcsFile, $target + 3, 2],
+            ]
+        );
 
-        $mockObj->expects($this->exactly(2))
-            ->method('processValue')
-            ->withConsecutive(
-                [
-                    $this->identicalTo(self::$phpcsFile),
-                    $this->equalTo($target + 1),
-                    $this->equalTo($target + 1),
-                    $this->equalTo(1),
-                ],
-                [
-                    $this->identicalTo(self::$phpcsFile),
-                    $this->equalTo($target + 3),
-                    $this->equalTo($target + 4),
-                    $this->equalTo(2),
-                ]
-            );
+        $this->setExpectationWithConsecutiveArgs(
+            $mockObj,
+            $this->exactly(2),
+            'processValue',
+            [
+                [self::$phpcsFile, $target + 1, $target + 1, 1],
+                [self::$phpcsFile, $target + 3, $target + 4, 2],
+            ]
+        );
 
         $mockObj->expects($this->once())
             ->method('processComma')
@@ -203,67 +199,48 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
                 $this->identicalTo($target + 35)
             );
 
-        $mockObj->expects($this->exactly(3))
-            ->method('processKey')
-            ->withConsecutive(
-                [
-                    $this->identicalTo(self::$phpcsFile),
-                    $this->equalTo($target + 2),
-                    $this->equalTo($target + 5),
-                    $this->equalTo(1),
-                ],
-                [
-                    $this->identicalTo(self::$phpcsFile),
-                    $this->equalTo($target + 10),
-                    $this->equalTo($target + 13),
-                    $this->equalTo(2),
-                ],
-                [
-                    $this->identicalTo(self::$phpcsFile),
-                    $this->equalTo($target + 18),
-                    $this->equalTo($target + 21),
-                    $this->equalTo(3),
-                ]
-            );
+        $this->setExpectationWithConsecutiveArgs(
+            $mockObj,
+            $this->exactly(3),
+            'processKey',
+            [
+                [self::$phpcsFile, $target + 2, $target + 5, 1],
+                [self::$phpcsFile, $target + 10, $target + 13, 2],
+                [self::$phpcsFile, $target + 18, $target + 21, 3],
+            ]
+        );
 
-        $mockObj->expects($this->exactly(3))
-            ->method('processArrow')
-            ->withConsecutive(
-                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 6), $this->equalTo(1)],
-                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 14), $this->equalTo(2)],
-                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 22), $this->equalTo(3)]
-            );
+        $this->setExpectationWithConsecutiveArgs(
+            $mockObj,
+            $this->exactly(3),
+            'processArrow',
+            [
+                [self::$phpcsFile, $target + 6, 1],
+                [self::$phpcsFile, $target + 14, 2],
+                [self::$phpcsFile, $target + 22, 3],
+            ]
+        );
 
-        $mockObj->expects($this->exactly(3))
-            ->method('processValue')
-            ->withConsecutive(
-                [
-                    $this->identicalTo(self::$phpcsFile),
-                    $this->equalTo($target + 7),
-                    $this->equalTo($target + 8),
-                    $this->equalTo(1),
-                ],
-                [
-                    $this->identicalTo(self::$phpcsFile),
-                    $this->equalTo($target + 15),
-                    $this->equalTo($target + 16),
-                    $this->equalTo(2),
-                ],
-                [
-                    $this->identicalTo(self::$phpcsFile),
-                    $this->equalTo($target + 23),
-                    $this->equalTo($target + 24),
-                    $this->equalTo(3),
-                ]
-            )
-            ->will($this->onConsecutiveCalls(null, null, true)); // Testing short-circuiting the loop.
+        $this->setExpectationWithConsecutiveArgs(
+            $mockObj,
+            $this->exactly(3),
+            'processValue',
+            [
+                [self::$phpcsFile, $target + 7, $target + 8, 1],
+                [self::$phpcsFile, $target + 15, $target + 16, 2],
+                [self::$phpcsFile, $target + 23, $target + 24, 3],
+            ]
+        )->will($this->onConsecutiveCalls(null, null, true)); // Testing short-circuiting the loop.
 
-        $mockObj->expects($this->exactly(2))
-            ->method('processComma')
-            ->withConsecutive(
-                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 9), $this->equalTo(1)],
-                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 17), $this->equalTo(2)]
-            );
+        $this->setExpectationWithConsecutiveArgs(
+            $mockObj,
+            $this->exactly(2),
+            'processComma',
+            [
+                [self::$phpcsFile, $target + 9, 1],
+                [self::$phpcsFile, $target + 17, 2],
+            ]
+        );
 
         $mockObj->process(self::$phpcsFile, $target);
 
@@ -300,22 +277,15 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
                 $this->identicalTo($target + 22)
             );
 
-        $mockObj->expects($this->exactly(2))
-            ->method('processKey')
-            ->withConsecutive(
-                [
-                    $this->identicalTo(self::$phpcsFile),
-                    $this->equalTo($target + 1),
-                    $this->equalTo($target + 4),
-                    $this->equalTo(1),
-                ],
-                [
-                    $this->identicalTo(self::$phpcsFile),
-                    $this->equalTo($target + 13),
-                    $this->equalTo($target + 16),
-                    $this->equalTo(3),
-                ]
-            );
+        $this->setExpectationWithConsecutiveArgs(
+            $mockObj,
+            $this->exactly(2),
+            'processKey',
+            [
+                [self::$phpcsFile, $target + 1, $target + 4, 1],
+                [self::$phpcsFile, $target + 13, $target + 16, 3],
+            ]
+        );
 
         $mockObj->expects($this->once())
             ->method('processNoKey')
@@ -325,43 +295,37 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
                 $this->identicalTo(2)
             );
 
-        $mockObj->expects($this->exactly(2))
-            ->method('processArrow')
-            ->withConsecutive(
-                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 5), $this->equalTo(1)],
-                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 17), $this->equalTo(3)]
-            );
+        $this->setExpectationWithConsecutiveArgs(
+            $mockObj,
+            $this->exactly(2),
+            'processArrow',
+            [
+                [self::$phpcsFile, $target + 5, 1],
+                [self::$phpcsFile, $target + 17, 3],
+            ]
+        );
 
-        $mockObj->expects($this->exactly(3))
-            ->method('processValue')
-            ->withConsecutive(
-                [
-                    $this->identicalTo(self::$phpcsFile),
-                    $this->equalTo($target + 6),
-                    $this->equalTo($target + 7),
-                    $this->equalTo(1),
-                ],
-                [
-                    $this->identicalTo(self::$phpcsFile),
-                    $this->equalTo($target + 9),
-                    $this->equalTo($target + 11),
-                    $this->equalTo(2),
-                ],
-                [
-                    $this->identicalTo(self::$phpcsFile),
-                    $this->equalTo($target + 18),
-                    $this->equalTo($target + 19),
-                    $this->equalTo(3),
-                ]
-            );
+        $this->setExpectationWithConsecutiveArgs(
+            $mockObj,
+            $this->exactly(3),
+            'processValue',
+            [
+                [self::$phpcsFile, $target + 6, $target + 7, 1],
+                [self::$phpcsFile, $target + 9, $target + 11, 2],
+                [self::$phpcsFile, $target + 18, $target + 19, 3],
+            ]
+        );
 
-        $mockObj->expects($this->exactly(3))
-            ->method('processComma')
-            ->withConsecutive(
-                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 8), $this->equalTo(1)],
-                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 12), $this->equalTo(2)],
-                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 20), $this->equalTo(3)]
-            );
+        $this->setExpectationWithConsecutiveArgs(
+            $mockObj,
+            $this->exactly(3),
+            'processComma',
+            [
+                [self::$phpcsFile, $target + 8, 1],
+                [self::$phpcsFile, $target + 12, 2],
+                [self::$phpcsFile, $target + 20, 3],
+            ]
+        );
 
         $mockObj->process(self::$phpcsFile, $target);
 

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
@@ -51,9 +51,7 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
     {
         $target = $this->getTargetToken('/* testShortList */', Collections::arrayOpenTokensBC());
 
-        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
-            ->setMethods($this->methodsToMock)
-            ->getMockForAbstractClass();
+        $mockObj = $this->getMockedClassUnderTest();
 
         $mockObj->expects($this->never())
             ->method('processOpenClose');
@@ -86,9 +84,7 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
     {
         $target = $this->getTargetToken('/* testEmptyArray */', Collections::arrayOpenTokensBC());
 
-        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
-            ->setMethods($this->methodsToMock)
-            ->getMockForAbstractClass();
+        $mockObj = $this->getMockedClassUnderTest();
 
         $mockObj->expects($this->once())
             ->method('processOpenClose');
@@ -124,9 +120,7 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
             Collections::arrayOpenTokensBC()
         );
 
-        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
-            ->setMethods($this->methodsToMock)
-            ->getMockForAbstractClass();
+        $mockObj = $this->getMockedClassUnderTest();
 
         $mockObj->expects($this->once())
             ->method('processOpenClose')
@@ -187,9 +181,7 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
             Collections::arrayOpenTokensBC()
         );
 
-        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
-            ->setMethods($this->methodsToMock)
-            ->getMockForAbstractClass();
+        $mockObj = $this->getMockedClassUnderTest();
 
         $mockObj->expects($this->once())
             ->method('processOpenClose')
@@ -265,9 +257,7 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
             Collections::arrayOpenTokensBC()
         );
 
-        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
-            ->setMethods($this->methodsToMock)
-            ->getMockForAbstractClass();
+        $mockObj = $this->getMockedClassUnderTest();
 
         $mockObj->expects($this->once())
             ->method('processOpenClose')
@@ -346,9 +336,7 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
     {
         $target = $this->getTargetToken('/* testEmptyArrayItem */', Collections::arrayOpenTokensBC());
 
-        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
-            ->setMethods($this->methodsToMock)
-            ->getMockForAbstractClass();
+        $mockObj = $this->getMockedClassUnderTest();
 
         $mockObj->expects($this->once())
             ->method('processOpenClose');
@@ -377,9 +365,7 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
     {
         $target = $this->getTargetToken('/* testShortCircuit */', Collections::arrayOpenTokensBC());
 
-        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
-            ->setMethods($this->methodsToMock)
-            ->getMockForAbstractClass();
+        $mockObj = $this->getMockedClassUnderTest();
 
         $mockObj->expects($this->once())
             ->method('processOpenClose')
@@ -412,9 +398,7 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
     {
         $target = $this->getTargetToken('/* testShortCircuit */', Collections::arrayOpenTokensBC());
 
-        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
-            ->setMethods($this->methodsToMock)
-            ->getMockForAbstractClass();
+        $mockObj = $this->getMockedClassUnderTest();
 
         $mockObj->expects($this->once())
             ->method('processOpenClose');
@@ -447,9 +431,7 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
     {
         $target = $this->getTargetToken('/* testShortCircuit */', Collections::arrayOpenTokensBC());
 
-        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
-            ->setMethods($this->methodsToMock)
-            ->getMockForAbstractClass();
+        $mockObj = $this->getMockedClassUnderTest();
 
         $mockObj->expects($this->once())
             ->method('processOpenClose');
@@ -482,9 +464,7 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
     {
         $target = $this->getTargetToken('/* testShortCircuit */', Collections::arrayOpenTokensBC());
 
-        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
-            ->setMethods($this->methodsToMock)
-            ->getMockForAbstractClass();
+        $mockObj = $this->getMockedClassUnderTest();
 
         $mockObj->expects($this->once())
             ->method('processOpenClose');
@@ -517,9 +497,7 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
     {
         $target = $this->getTargetToken('/* testShortCircuit */', Collections::arrayOpenTokensBC());
 
-        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
-            ->setMethods($this->methodsToMock)
-            ->getMockForAbstractClass();
+        $mockObj = $this->getMockedClassUnderTest();
 
         $mockObj->expects($this->once())
             ->method('processOpenClose');
@@ -552,9 +530,7 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
     {
         $target = $this->getTargetToken('/* testShortCircuit */', Collections::arrayOpenTokensBC());
 
-        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
-            ->setMethods($this->methodsToMock)
-            ->getMockForAbstractClass();
+        $mockObj = $this->getMockedClassUnderTest();
 
         $mockObj->expects($this->once())
             ->method('processOpenClose');
@@ -587,9 +563,7 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
     {
         $target = $this->getTargetToken('/* testLiveCoding */', Collections::arrayOpenTokensBC());
 
-        $mockObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff')
-            ->setMethods($this->methodsToMock)
-            ->getMockForAbstractClass();
+        $mockObj = $this->getMockedClassUnderTest();
 
         $mockObj->expects($this->never())
             ->method('processOpenClose');
@@ -610,5 +584,31 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
             ->method('processComma');
 
         $mockObj->process(self::$phpcsFile, $target);
+    }
+
+    /**
+     * Helper method to retrieve a mock object for the abstract class.
+     *
+     * The `setMethods()` method was silently deprecated in PHPUnit 9 and removed in PHPUnit 10.
+     *
+     * Note: direct access to the `getMockBuilder()` method is soft deprecated as of PHPUnit 10,
+     * and expected to be hard deprecated in PHPUnit 11 and removed in PHPUnit 12.
+     * Dealing with that is something for a later iteration of the test suite.
+     *
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    private function getMockedClassUnderTest()
+    {
+        $mockedObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff');
+
+        if (\method_exists($mockedObj, 'onlyMethods')) {
+            // PHPUnit 8+.
+            return $mockedObj->onlyMethods($this->methodsToMock)
+                ->getMockForAbstractClass();
+        }
+
+        // PHPUnit < 8.
+        return $mockedObj->setMethods($this->methodsToMock)
+            ->getMockForAbstractClass();
     }
 }

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
@@ -132,8 +132,8 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
             ->method('processOpenClose')
             ->with(
                 $this->identicalTo(self::$phpcsFile),
-                $this->equalTo($target),
-                $this->equalTo($target + 5)
+                $this->identicalTo($target),
+                $this->identicalTo($target + 5)
             );
 
         $mockObj->expects($this->exactly(2))
@@ -164,8 +164,8 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
             ->method('processComma')
             ->with(
                 $this->identicalTo(self::$phpcsFile),
-                $this->equalTo($target + 2),
-                $this->equalTo(1)
+                $this->identicalTo($target + 2),
+                $this->identicalTo(1)
             );
 
         $mockObj->process(self::$phpcsFile, $target);
@@ -199,8 +199,8 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
             ->method('processOpenClose')
             ->with(
                 $this->identicalTo(self::$phpcsFile),
-                $this->equalTo($target + 1),
-                $this->equalTo($target + 35)
+                $this->identicalTo($target + 1),
+                $this->identicalTo($target + 35)
             );
 
         $mockObj->expects($this->exactly(3))
@@ -296,8 +296,8 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
             ->method('processOpenClose')
             ->with(
                 $this->identicalTo(self::$phpcsFile),
-                $this->equalTo($target),
-                $this->equalTo($target + 22)
+                $this->identicalTo($target),
+                $this->identicalTo($target + 22)
             );
 
         $mockObj->expects($this->exactly(2))
@@ -319,8 +319,10 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
 
         $mockObj->expects($this->once())
             ->method('processNoKey')
-            ->withConsecutive(
-                [$this->identicalTo(self::$phpcsFile), $this->equalTo($target + 9), $this->equalTo(2)]
+            ->with(
+                $this->identicalTo(self::$phpcsFile),
+                $this->identicalTo($target + 9),
+                $this->identicalTo(2)
             );
 
         $mockObj->expects($this->exactly(2))

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.php
@@ -71,7 +71,7 @@ final class GetActualArrayKeyTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetActualArrayKey()
+    public static function dataGetActualArrayKey()
     {
         return [
             'unsupported-key-types' => [

--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
@@ -102,7 +102,7 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataExtendedClass()
+    public static function dataExtendedClass()
     {
         return [
             [

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
@@ -100,7 +100,7 @@ class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataImplementedInterface()
+    public static function dataImplementedInterface()
     {
         return [
             [

--- a/Tests/BackCompat/BCFile/GetClassPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetClassPropertiesTest.php
@@ -61,7 +61,7 @@ class GetClassPropertiesTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataNotAClassException()
+    public static function dataNotAClassException()
     {
         return [
             'interface'  => [
@@ -106,7 +106,7 @@ class GetClassPropertiesTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetClassProperties()
+    public static function dataGetClassProperties()
     {
         return [
             'no-properties' => [

--- a/Tests/BackCompat/BCFile/GetDeclarationNameJSTest.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameJSTest.php
@@ -69,7 +69,7 @@ class GetDeclarationNameJSTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetDeclarationNameNull()
+    public static function dataGetDeclarationNameNull()
     {
         return [
             'closure' => [
@@ -108,7 +108,7 @@ class GetDeclarationNameJSTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetDeclarationName()
+    public static function dataGetDeclarationName()
     {
         return [
             'function' => [

--- a/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
@@ -62,7 +62,7 @@ class GetDeclarationNameTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetDeclarationNameNull()
+    public static function dataGetDeclarationNameNull()
     {
         return [
             'closure' => [
@@ -121,7 +121,7 @@ class GetDeclarationNameTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetDeclarationName()
+    public static function dataGetDeclarationName()
     {
         return [
             'function' => [

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -80,7 +80,7 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetMemberProperties()
+    public static function dataGetMemberProperties()
     {
         $php8Names = parent::usesPhp8NameTokens();
 
@@ -1073,7 +1073,7 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataNotClassProperty()
+    public static function dataNotClassProperty()
     {
         return [
             ['/* testMethodParam */'],

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -63,7 +63,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataUnexpectedTokenException()
+    public static function dataUnexpectedTokenException()
     {
         return [
             'interface' => [
@@ -105,7 +105,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataInvalidUse()
+    public static function dataInvalidUse()
     {
         return [
             'ImportUse'      => ['/* testImportUse */'],
@@ -141,7 +141,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataNoParams()
+    public static function dataNoParams()
     {
         return [
             'FunctionNoParams'   => ['/* testFunctionNoParams */'],

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -60,7 +60,7 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataNotAFunctionException()
+    public static function dataNotAFunctionException()
     {
         return [
             'return' => [

--- a/Tests/BackCompat/BCFile/GetTokensAsStringTest.php
+++ b/Tests/BackCompat/BCFile/GetTokensAsStringTest.php
@@ -116,7 +116,7 @@ final class GetTokensAsStringTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetTokensAsString()
+    public static function dataGetTokensAsString()
     {
         $php8Names = parent::usesPhp8NameTokens();
 
@@ -289,7 +289,7 @@ final class GetTokensAsStringTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetOrigContent()
+    public static function dataGetOrigContent()
     {
         return [
             'use-with-comments' => [

--- a/Tests/BackCompat/BCFile/IsReferenceTest.php
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.php
@@ -85,7 +85,7 @@ class IsReferenceTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataIsReference()
+    public static function dataIsReference()
     {
         return [
             'issue-1971-list-first-in-file' => [

--- a/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
+++ b/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
@@ -469,7 +469,7 @@ final class UnchangedTokenArraysTest extends TestCase
      *
      * @return array
      */
-    public function dataUnchangedTokenArrays()
+    public static function dataUnchangedTokenArrays()
     {
         $phpunitProp = [
             'backupGlobals'                     => true,
@@ -484,7 +484,7 @@ final class UnchangedTokenArraysTest extends TestCase
         ];
 
         $data        = [];
-        $tokenArrays = \get_object_vars($this);
+        $tokenArrays = \get_class_vars(__CLASS__);
         foreach ($tokenArrays as $name => $expected) {
             if (isset($phpunitProp[$name])) {
                 continue;

--- a/Tests/BackCompat/Helper/ConfigDataTest.php
+++ b/Tests/BackCompat/Helper/ConfigDataTest.php
@@ -12,8 +12,7 @@ namespace PHPCSUtils\Tests\BackCompat\Helper;
 
 use PHP_CodeSniffer\Config;
 use PHPCSUtils\BackCompat\Helper;
-use PHPUnit\Framework\TestCase;
-use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Test class.
@@ -27,7 +26,6 @@ use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
  */
 final class ConfigDataTest extends TestCase
 {
-    use ExpectException;
 
     /**
      * Test the getConfigData() and setConfigData() method when used in a cross-version compatible manner.

--- a/Tests/ExpectWithConsecutiveArgs.php
+++ b/Tests/ExpectWithConsecutiveArgs.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests;
+
+/**
+ * PHPUnit cross-version compatibility helper.
+ *
+ * Provides a work-around for testing arguments passed to a method in a mocked object.
+ * Previously, the `InvocationMocker->withConsecutive()` method could be used to test
+ * this, but that method was removed in PHPUnit 10.0.
+ *
+ * @since 1.0.7
+ */
+trait ExpectWithConsecutiveArgs
+{
+
+    /**
+     * PHPUnit cross-version helper method to test the arguments passed to a method in a mocked object.
+     *
+     * @param object $mockObject   The object mock.
+     * @param object $countMatcher Matcher for number of time the method is expected to be called.
+     * @param string $methodName   The name of the method on which to set the expectations.
+     * @param array  $expectedArgs Multi-dimentional array of arguments expected to be passed in consecutive calls.
+     *
+     * @return object Expectation object.
+     */
+    final public function setExpectationWithConsecutiveArgs($mockObject, $countMatcher, $methodName, $expectedArgs)
+    {
+        $methodExpectation = $mockObject->expects($countMatcher)
+            ->method($methodName);
+
+        if (\method_exists($methodExpectation, 'withConsecutive')) {
+            // PHPUnit 4.x - 9.x.
+
+            $expectationsArray = [];
+            foreach ($expectedArgs as $key => $series) {
+                foreach ($series as $arg) {
+                    $expectationsArray[$key][] = $this->identicalTo($arg);
+                }
+            }
+
+            return \call_user_func_array([$methodExpectation, 'withConsecutive'], $expectationsArray);
+        }
+
+        // PHPUnit 10+.
+        return $methodExpectation->willReturnCallback(
+            function () use (&$expectedArgs, $countMatcher, $methodName) {
+                $actualArgs = \func_get_args();
+                $expected   = \array_shift($expectedArgs);
+
+                $this->assertCount(
+                    \count($expected),
+                    $actualArgs,
+                    \sprintf(
+                        'Actual number of arguments received does not match expected for call %d to method %s',
+                        $countMatcher->numberOfInvocations(),
+                        $methodName
+                    )
+                );
+
+                $this->assertSame(
+                    $expected,
+                    $actualArgs,
+                    \sprintf(
+                        'Arguments received do not match expected arguments for call %d to method %s',
+                        $countMatcher->numberOfInvocations(),
+                        $methodName
+                    )
+                );
+            }
+        );
+    }
+}

--- a/Tests/Fixers/SpacesFixer/SpacesFixerNewlineTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerNewlineTest.php
@@ -50,7 +50,7 @@ final class SpacesFixerNewlineTest extends SpacesFixerTestCase
      *
      * @var array
      */
-    protected $compliantCases = [
+    protected static $compliantCases = [
         'newline-and-trailing-spaces',
         'multiple-newlines-and-spaces',
         'comment-and-new line',

--- a/Tests/Fixers/SpacesFixer/SpacesFixerNoSpaceTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerNoSpaceTest.php
@@ -50,7 +50,7 @@ final class SpacesFixerNoSpaceTest extends SpacesFixerTestCase
      *
      * @var array
      */
-    protected $compliantCases = ['no-space'];
+    protected static $compliantCases = ['no-space'];
 
     /**
      * Full path to the fixed version of the test case file associated with this test class.

--- a/Tests/Fixers/SpacesFixer/SpacesFixerOneSpaceTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerOneSpaceTest.php
@@ -50,7 +50,7 @@ final class SpacesFixerOneSpaceTest extends SpacesFixerTestCase
      *
      * @var array
      */
-    protected $compliantCases = [
+    protected static $compliantCases = [
         'one-space',
         'comment-and-space',
     ];

--- a/Tests/Fixers/SpacesFixer/SpacesFixerTestCase.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerTestCase.php
@@ -71,7 +71,7 @@ abstract class SpacesFixerTestCase extends UtilityMethodTestCase
      *
      * @var array
      */
-    protected $compliantCases = [];
+    protected static $compliantCases = [];
 
     /**
      * Full path to the fixed version of the test case file associated with this test class.
@@ -156,12 +156,12 @@ abstract class SpacesFixerTestCase extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataCheckAndFixNoError()
+    public static function dataCheckAndFixNoError()
     {
         $data     = [];
-        $baseData = $this->getAllData();
+        $baseData = self::getAllData();
 
-        foreach ($this->compliantCases as $caseName) {
+        foreach (static::$compliantCases as $caseName) {
             if (isset($baseData[$caseName])) {
                 $data[$caseName] = $baseData[$caseName];
             }
@@ -244,11 +244,11 @@ abstract class SpacesFixerTestCase extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataCheckAndFix()
+    public static function dataCheckAndFix()
     {
-        $data = $this->getAllData();
+        $data = self::getAllData();
 
-        foreach ($this->compliantCases as $caseName) {
+        foreach (static::$compliantCases as $caseName) {
             unset($data[$caseName]);
         }
 
@@ -303,7 +303,7 @@ abstract class SpacesFixerTestCase extends UtilityMethodTestCase
      *
      * @return array
      */
-    protected function getAllData()
+    protected static function getAllData()
     {
         return [
             'no-space' => [

--- a/Tests/Fixers/SpacesFixer/SpacesFixerTwoSpaceTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerTwoSpaceTest.php
@@ -52,7 +52,7 @@ final class SpacesFixerTwoSpaceTest extends SpacesFixerTestCase
      *
      * @var array
      */
-    protected $compliantCases = ['two-spaces'];
+    protected static $compliantCases = ['two-spaces'];
 
     /**
      * Full path to the fixed version of the test case file associated with this test class.

--- a/Tests/Fixers/SpacesFixer/TrailingCommentHandlingNewlineTest.php
+++ b/Tests/Fixers/SpacesFixer/TrailingCommentHandlingNewlineTest.php
@@ -156,7 +156,7 @@ final class TrailingCommentHandlingNewlineTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataCheckAndFixNoError()
+    public static function dataCheckAndFixNoError()
     {
         return [
             'correct-newline-before' => [

--- a/Tests/Fixers/SpacesFixer/TrailingCommentHandlingTest.php
+++ b/Tests/Fixers/SpacesFixer/TrailingCommentHandlingTest.php
@@ -182,7 +182,7 @@ final class TrailingCommentHandlingTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataCheckAndFix()
+    public static function dataCheckAndFix()
     {
         return [
             'trailing-comment-not-fixable' => [

--- a/Tests/Internal/Cache/GetClearTest.php
+++ b/Tests/Internal/Cache/GetClearTest.php
@@ -282,7 +282,7 @@ final class GetClearTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataEveryTypeOfInput()
+    public static function dataEveryTypeOfInput()
     {
         $allTypes = TypeProviderHelper::getAll();
         $data     = [];

--- a/Tests/Internal/Cache/SetTest.php
+++ b/Tests/Internal/Cache/SetTest.php
@@ -95,7 +95,7 @@ final class SetTest extends UtilityMethodTestCase
      */
     public function testSetAcceptsEveryTypeOfInput($input)
     {
-        $id = $this->getName();
+        $id = \base_convert(\rand((int) 10e16, (int) 10e20), 10, 36);
         Cache::set(self::$phpcsFile, __METHOD__, $id, $input);
 
         $this->assertTrue(

--- a/Tests/Internal/Cache/SetTest.php
+++ b/Tests/Internal/Cache/SetTest.php
@@ -115,7 +115,7 @@ final class SetTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataEveryTypeOfInput()
+    public static function dataEveryTypeOfInput()
     {
         return TypeProviderHelper::getAll();
     }
@@ -157,7 +157,7 @@ final class SetTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataSetAcceptsIntAndStringIdKeys()
+    public static function dataSetAcceptsIntAndStringIdKeys()
     {
         return [
             'ID: int zero' => [

--- a/Tests/Internal/IsShortArrayOrList/ConstructorTest.php
+++ b/Tests/Internal/IsShortArrayOrList/ConstructorTest.php
@@ -64,7 +64,7 @@ final class ConstructorTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataNotOpenBracket()
+    public static function dataNotOpenBracket()
     {
         return [
             'long-array' => [
@@ -115,7 +115,7 @@ final class ConstructorTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataSupportedBrackets()
+    public static function dataSupportedBrackets()
     {
         return [
             'short-array-open-bracket' => [

--- a/Tests/Internal/IsShortArrayOrList/IsInForeachTest.php
+++ b/Tests/Internal/IsShortArrayOrList/IsInForeachTest.php
@@ -69,7 +69,7 @@ final class IsInForeachTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataIsInForeachResolved()
+    public static function dataIsInForeachResolved()
     {
         return [
             'resolved: short array in foreach' => [
@@ -114,7 +114,7 @@ final class IsInForeachTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataIsInForeachNestedResolvedViaOuter()
+    public static function dataIsInForeachNestedResolvedViaOuter()
     {
         return [
             'resolved-on-outer: short array in foreach nested at start' => [
@@ -159,7 +159,7 @@ final class IsInForeachTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataIsInForeachUndetermined()
+    public static function dataIsInForeachUndetermined()
     {
         return [
             'undetermined: short array in function call in foreach' => [

--- a/Tests/Internal/IsShortArrayOrList/IsShortArrayBracketBC1Test.php
+++ b/Tests/Internal/IsShortArrayOrList/IsShortArrayBracketBC1Test.php
@@ -52,7 +52,7 @@ final class IsShortArrayBracketBC1Test extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataIsShortArrayBracket()
+    public static function dataIsShortArrayBracket()
     {
         return [
             'issue-1971-list-first-in-file' => [

--- a/Tests/Internal/IsShortArrayOrList/IsShortArrayBracketBC2Test.php
+++ b/Tests/Internal/IsShortArrayOrList/IsShortArrayBracketBC2Test.php
@@ -52,7 +52,7 @@ final class IsShortArrayBracketBC2Test extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataIsShortArrayBracket()
+    public static function dataIsShortArrayBracket()
     {
         return [
             // Make sure the utility method does not throw false positives for a short array at the start of a file.

--- a/Tests/Internal/IsShortArrayOrList/IsShortArrayBracketBC3Test.php
+++ b/Tests/Internal/IsShortArrayOrList/IsShortArrayBracketBC3Test.php
@@ -52,7 +52,7 @@ final class IsShortArrayBracketBC3Test extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataIsShortArrayBracket()
+    public static function dataIsShortArrayBracket()
     {
         return [
             'issue-1971-short-array-first-in-file' => [

--- a/Tests/Internal/IsShortArrayOrList/IsShortArrayBracketBC4Test.php
+++ b/Tests/Internal/IsShortArrayOrList/IsShortArrayBracketBC4Test.php
@@ -52,7 +52,7 @@ final class IsShortArrayBracketBC4Test extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataIsShortArrayBracket()
+    public static function dataIsShortArrayBracket()
     {
         return [
             'issue-1971-short-list-first-in-file' => [

--- a/Tests/Internal/IsShortArrayOrList/IsShortArrayBracketBC5Test.php
+++ b/Tests/Internal/IsShortArrayOrList/IsShortArrayBracketBC5Test.php
@@ -52,7 +52,7 @@ final class IsShortArrayBracketBC5Test extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataIsShortArrayBracket()
+    public static function dataIsShortArrayBracket()
     {
         return [
             'issue-1971-short-list-first-in-file' => [

--- a/Tests/Internal/IsShortArrayOrList/IsShortArrayBracketBC6Test.php
+++ b/Tests/Internal/IsShortArrayOrList/IsShortArrayBracketBC6Test.php
@@ -52,7 +52,7 @@ final class IsShortArrayBracketBC6Test extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataIsShortArrayBracket()
+    public static function dataIsShortArrayBracket()
     {
         return [
             'issue-1971-short-list-first-in-file' => [

--- a/Tests/Internal/IsShortArrayOrList/IsShortArrayOrListTest.php
+++ b/Tests/Internal/IsShortArrayOrList/IsShortArrayOrListTest.php
@@ -54,7 +54,7 @@ final class IsShortArrayOrListTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataIsShortArrayOrList()
+    public static function dataIsShortArrayOrList()
     {
         return [
             'short-array-comparison-no-assignment' => [

--- a/Tests/Internal/IsShortArrayOrList/IsSquareBracketTest.php
+++ b/Tests/Internal/IsShortArrayOrList/IsSquareBracketTest.php
@@ -63,7 +63,7 @@ final class IsSquareBracketTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataSquareBrackets()
+    public static function dataSquareBrackets()
     {
         return [
             'array-assignment-no-key' => [

--- a/Tests/Internal/IsShortArrayOrList/SolveTest.php
+++ b/Tests/Internal/IsShortArrayOrList/SolveTest.php
@@ -50,7 +50,7 @@ final class SolveTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataSolve()
+    public static function dataSolve()
     {
         return [
             'real square brackets' => [

--- a/Tests/Internal/IsShortArrayOrList/WalkInsideTest.php
+++ b/Tests/Internal/IsShortArrayOrList/WalkInsideTest.php
@@ -49,7 +49,7 @@ final class WalkInsideTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataWalkInsideUndetermined()
+    public static function dataWalkInsideUndetermined()
     {
         return [
             'nested-short-array-empty' => [
@@ -134,7 +134,7 @@ final class WalkInsideTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataWalkInsideResolved()
+    public static function dataWalkInsideResolved()
     {
         return [
             'nested-short-array-no-vars-or-nested-null' => [
@@ -276,7 +276,7 @@ final class WalkInsideTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataRecursionLimit()
+    public static function dataRecursionLimit()
     {
         return [
             'nested-short-array-with-nested-short-array-recursion-4' => [

--- a/Tests/Internal/IsShortArrayOrList/WalkOutsideTest.php
+++ b/Tests/Internal/IsShortArrayOrList/WalkOutsideTest.php
@@ -52,7 +52,7 @@ final class WalkOutsideTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataWalkOutside()
+    public static function dataWalkOutside()
     {
         return [
             'nested-short-array-start-of-file' => [
@@ -188,7 +188,7 @@ final class WalkOutsideTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataReuseCacheFromAdjacent()
+    public static function dataReuseCacheFromAdjacent()
     {
         return [
             'nested-short-array' => [

--- a/Tests/Internal/IsShortArrayOrListWithCache/CachingTest.php
+++ b/Tests/Internal/IsShortArrayOrListWithCache/CachingTest.php
@@ -69,7 +69,7 @@ final class CachingTest extends IsShortArrayOrListWithCacheTestCase
      *
      * @return array
      */
-    public function dataResultIsCached()
+    public static function dataResultIsCached()
     {
         return [
             'short array' => [

--- a/Tests/Internal/IsShortArrayOrListWithCache/EntryPointsTest.php
+++ b/Tests/Internal/IsShortArrayOrListWithCache/EntryPointsTest.php
@@ -136,7 +136,7 @@ final class EntryPointsTest extends IsShortArrayOrListWithCacheTestCase
      *
      * @return array
      */
-    public function dataEntryPoints()
+    public static function dataEntryPoints()
     {
         return [
             'not a square bracket' => [

--- a/Tests/Internal/IsShortArrayOrListWithCache/IsValidStackPtrTest.php
+++ b/Tests/Internal/IsShortArrayOrListWithCache/IsValidStackPtrTest.php
@@ -68,7 +68,7 @@ final class IsValidStackPtrTest extends IsShortArrayOrListWithCacheTestCase
      *
      * @return array
      */
-    public function dataNotBracket()
+    public static function dataNotBracket()
     {
         return [
             'long-array' => [
@@ -109,7 +109,7 @@ final class IsValidStackPtrTest extends IsShortArrayOrListWithCacheTestCase
      *
      * @return array
      */
-    public function dataValidBracket()
+    public static function dataValidBracket()
     {
         return [
             'open square bracket' => [

--- a/Tests/Internal/IsShortArrayOrListWithCache/ProcessTest.php
+++ b/Tests/Internal/IsShortArrayOrListWithCache/ProcessTest.php
@@ -61,7 +61,7 @@ final class ProcessTest extends IsShortArrayOrListWithCacheTestCase
      *
      * @return array
      */
-    public function dataSupportedBrackets()
+    public static function dataSupportedBrackets()
     {
         return [
             'short array open bracket' => [

--- a/Tests/Internal/NoFileCache/GetClearTest.php
+++ b/Tests/Internal/NoFileCache/GetClearTest.php
@@ -234,7 +234,7 @@ final class GetClearTest extends TestCase
      *
      * @return array
      */
-    public function dataEveryTypeOfInput()
+    public static function dataEveryTypeOfInput()
     {
         $allTypes = TypeProviderHelper::getAll();
         $data     = [];

--- a/Tests/Internal/NoFileCache/SetTest.php
+++ b/Tests/Internal/NoFileCache/SetTest.php
@@ -89,7 +89,7 @@ final class SetTest extends TestCase
      */
     public function testSetAcceptsEveryTypeOfInput($input)
     {
-        $id = $this->getName();
+        $id = \base_convert(\rand((int) 10e16, (int) 10e20), 10, 36);
         NoFileCache::set(__METHOD__, $id, $input);
 
         $this->assertTrue(

--- a/Tests/Internal/NoFileCache/SetTest.php
+++ b/Tests/Internal/NoFileCache/SetTest.php
@@ -109,7 +109,7 @@ final class SetTest extends TestCase
      *
      * @return array
      */
-    public function dataEveryTypeOfInput()
+    public static function dataEveryTypeOfInput()
     {
         return TypeProviderHelper::getAll();
     }
@@ -151,7 +151,7 @@ final class SetTest extends TestCase
      *
      * @return array
      */
-    public function dataSetAcceptsIntAndStringIdKeys()
+    public static function dataSetAcceptsIntAndStringIdKeys()
     {
         return [
             'ID: int zero' => [

--- a/Tests/PolyfilledTestCase.php
+++ b/Tests/PolyfilledTestCase.php
@@ -14,6 +14,7 @@
 namespace PHPCSUtils\Tests;
 
 use PHPCSUtils\Tests\AssertAttributeSame;
+use PHPCSUtils\Tests\ExpectWithConsecutiveArgs;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 use Yoast\PHPUnitPolyfills\Autoload;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
@@ -52,8 +53,9 @@ if (\version_compare(Autoload::VERSION, '2.0.0', '>=')) {
      */
     abstract class PolyfilledTestCase extends UtilityMethodTestCase
     {
-        // PHPCSUtils native helper.
+        // PHPCSUtils native helpers.
         use AssertAttributeSame;
+        use ExpectWithConsecutiveArgs;
 
         // PHPUnit Polyfills.
         use AssertClosedResource;
@@ -90,6 +92,7 @@ if (\version_compare(Autoload::VERSION, '2.0.0', '>=')) {
     {
         // PHPCSUtils native helper.
         use AssertAttributeSame;
+        use ExpectWithConsecutiveArgs;
 
         // PHPUnit Polyfills.
         use AssertClosedResource;

--- a/Tests/PolyfilledTestCase.php
+++ b/Tests/PolyfilledTestCase.php
@@ -6,20 +6,27 @@
  * @copyright 2019-2020 PHPCSUtils Contributors
  * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
  * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ *
+ * @phpcs:disable PSR1.Classes.ClassDeclaration.MultipleClasses
+ * @phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
  */
 
 namespace PHPCSUtils\Tests;
 
 use PHPCSUtils\Tests\AssertAttributeSame;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use Yoast\PHPUnitPolyfills\Autoload;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertEqualsSpecializations;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertFileDirectory;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertFileEqualsSpecializations;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertIgnoringLineEndings;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertIsList;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertNumericType;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertObjectEquals;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertObjectProperty;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
 use Yoast\PHPUnitPolyfills\Polyfills\EqualToSpecializations;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
@@ -27,39 +34,77 @@ use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionObject;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
-/**
- * Abstract utilty method base test case which includes all available polyfills.
- *
- * This test case includes all polyfills from the PHPUnit Polyfill library to make them
- * available to the tests.
- *
- * Generally speaking, this testcase only needs to be used when the concrete test class will
- * use functionality which has changed in PHPUnit cross-version.
- * In all other cases, the `UtilityMethodTestCase` can be extended directly.
- *
- * {@internal The list of included polyfill traits should be reviewed after each new
- * release of the PHPUnit Polyfill library.}
- *
- * @since 1.0.0
- */
-abstract class PolyfilledTestCase extends UtilityMethodTestCase
-{
-    // PHPCSUtils native helper.
-    use AssertAttributeSame;
+if (\version_compare(Autoload::VERSION, '2.0.0', '>=')) {
+    /**
+     * Abstract utility method base test case which includes all available polyfills (PHPUnit Polyfills 2.x compaible).
+     *
+     * This test case includes all polyfills from the PHPUnit Polyfill library to make them
+     * available to the tests.
+     *
+     * Generally speaking, this testcase only needs to be used when the concrete test class will
+     * use functionality which has changed in PHPUnit cross-version.
+     * In all other cases, the `UtilityMethodTestCase` can be extended directly.
+     *
+     * {@internal The list of included polyfill traits should be reviewed after each new
+     * release of the PHPUnit Polyfill library.}
+     *
+     * @since 1.0.0
+     */
+    abstract class PolyfilledTestCase extends UtilityMethodTestCase
+    {
+        // PHPCSUtils native helper.
+        use AssertAttributeSame;
 
-    // PHPUnit Polyfills.
-    use AssertClosedResource;
-    use AssertEqualsSpecializations;
-    use AssertFileDirectory;
-    use AssertFileEqualsSpecializations;
-    use AssertionRenames;
-    use AssertIsType;
-    use AssertNumericType;
-    use AssertObjectEquals;
-    use AssertStringContains;
-    use EqualToSpecializations;
-    use ExpectException;
-    use ExpectExceptionMessageMatches;
-    use ExpectExceptionObject;
-    use ExpectPHPException;
+        // PHPUnit Polyfills.
+        use AssertClosedResource;
+        use AssertEqualsSpecializations;
+        use AssertFileEqualsSpecializations;
+        use AssertIgnoringLineEndings;
+        use AssertionRenames;
+        use AssertIsList;
+        use AssertIsType;
+        use AssertObjectEquals;
+        use AssertObjectProperty;
+        use AssertStringContains;
+        use EqualToSpecializations;
+        use ExpectExceptionMessageMatches;
+        use ExpectExceptionObject;
+    }
+} else {
+    /**
+     * Abstract utility method base test case which includes all available polyfills (PHPUnit Polyfills 1.x compaible).
+     *
+     * This test case includes all polyfills from the PHPUnit Polyfill library to make them
+     * available to the tests.
+     *
+     * Generally speaking, this testcase only needs to be used when the concrete test class will
+     * use functionality which has changed in PHPUnit cross-version.
+     * In all other cases, the `UtilityMethodTestCase` can be extended directly.
+     *
+     * {@internal The list of included polyfill traits should be reviewed after each new
+     * release of the PHPUnit Polyfill library.}
+     *
+     * @since 1.0.0
+     */
+    abstract class PolyfilledTestCase extends UtilityMethodTestCase
+    {
+        // PHPCSUtils native helper.
+        use AssertAttributeSame;
+
+        // PHPUnit Polyfills.
+        use AssertClosedResource;
+        use AssertEqualsSpecializations;
+        use AssertFileDirectory;
+        use AssertFileEqualsSpecializations;
+        use AssertionRenames;
+        use AssertIsType;
+        use AssertNumericType;
+        use AssertObjectEquals;
+        use AssertStringContains;
+        use EqualToSpecializations;
+        use ExpectException;
+        use ExpectExceptionMessageMatches;
+        use ExpectExceptionObject;
+        use ExpectPHPException;
+    }
 }

--- a/Tests/TestUtils/UtilityMethodTestCase/GetTargetTokenTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/GetTargetTokenTest.php
@@ -67,7 +67,7 @@ final class GetTargetTokenTest extends PolyfilledTestCase
      *
      * @return array
      */
-    public function dataGetTargetToken()
+    public static function dataGetTargetToken()
     {
         return [
             'single-token-type' => [

--- a/Tests/Tokens/Collections/PropertyBasedTokenArraysTest.php
+++ b/Tests/Tokens/Collections/PropertyBasedTokenArraysTest.php
@@ -52,7 +52,7 @@ final class PropertyBasedTokenArraysTest extends TestCase
      *
      * @return array
      */
-    public function dataPropertyBasedTokenArrays()
+    public static function dataPropertyBasedTokenArrays()
     {
         $names = [
             'alternativeControlStructureSyntaxes',

--- a/Tests/Tokens/TokenHelper/TokenExistsTest.php
+++ b/Tests/Tokens/TokenHelper/TokenExistsTest.php
@@ -62,7 +62,7 @@ final class TokenExistsTest extends TestCase
      *
      * @return array
      */
-    public function dataTokenExists()
+    public static function dataTokenExists()
     {
         return [
             'Token which doesn\'t exist either way' => [

--- a/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
+++ b/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
@@ -138,7 +138,7 @@ final class GetDoubleArrowPtrTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetDoubleArrowPtr()
+    public static function dataGetDoubleArrowPtr()
     {
         return [
             'test-no-arrow' => [

--- a/Tests/Utils/Arrays/GetOpenCloseTest.php
+++ b/Tests/Utils/Arrays/GetOpenCloseTest.php
@@ -58,7 +58,7 @@ final class GetOpenCloseTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataNotArrayOpenToken()
+    public static function dataNotArrayOpenToken()
     {
         return [
             'short-list' => [
@@ -118,7 +118,7 @@ final class GetOpenCloseTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetOpenClose()
+    public static function dataGetOpenClose()
     {
         return [
             'long-array' => [

--- a/Tests/Utils/Conditions/GetConditionTest.php
+++ b/Tests/Utils/Conditions/GetConditionTest.php
@@ -150,7 +150,7 @@ final class GetConditionTest extends BCFile_GetConditionTest
      *
      * @return array
      */
-    public function dataGetFirstCondition()
+    public static function dataGetFirstCondition()
     {
         $data = [];
         foreach (self::$testTargets as $marker) {
@@ -195,7 +195,7 @@ final class GetConditionTest extends BCFile_GetConditionTest
      *
      * @return array
      */
-    public function dataGetLastCondition()
+    public static function dataGetLastCondition()
     {
         return [
             'testSeriouslyNestedMethod' => [

--- a/Tests/Utils/Context/InAttributeTest.php
+++ b/Tests/Utils/Context/InAttributeTest.php
@@ -58,7 +58,7 @@ final class InAttributeTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataNotInAttribute()
+    public static function dataNotInAttribute()
     {
         return [
             'code nowhere near an attribute [1]' => [
@@ -122,7 +122,7 @@ final class InAttributeTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataInAttribute()
+    public static function dataInAttribute()
     {
         return [
             'single line attribute - attribute name' => [

--- a/Tests/Utils/Context/InEmptyTest.php
+++ b/Tests/Utils/Context/InEmptyTest.php
@@ -58,7 +58,7 @@ final class InEmptyTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataInEmpty()
+    public static function dataInEmpty()
     {
         return [
             'method-called-empty' => [

--- a/Tests/Utils/Context/InForConditionTest.php
+++ b/Tests/Utils/Context/InForConditionTest.php
@@ -57,7 +57,7 @@ final class InForConditionTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataNotInFor()
+    public static function dataNotInFor()
     {
         return [
             'no-parenthesis'                   => ['/* testNoParentheses */'],
@@ -103,7 +103,7 @@ final class InForConditionTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataInForCondition()
+    public static function dataInForCondition()
     {
         return [
             'expr1' => [

--- a/Tests/Utils/Context/InForeachConditionTest.php
+++ b/Tests/Utils/Context/InForeachConditionTest.php
@@ -57,7 +57,7 @@ final class InForeachConditionTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataNotInForeach()
+    public static function dataNotInForeach()
     {
         return [
             'no-parenthesis'                       => ['/* testNoParentheses */'],
@@ -102,7 +102,7 @@ final class InForeachConditionTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataInForeachCondition()
+    public static function dataInForeachCondition()
     {
         return [
             'before' => [

--- a/Tests/Utils/Context/InIssetTest.php
+++ b/Tests/Utils/Context/InIssetTest.php
@@ -58,7 +58,7 @@ final class InIssetTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataInIsset()
+    public static function dataInIsset()
     {
         return [
             'method-called-isset' => [

--- a/Tests/Utils/Context/InUnsetTest.php
+++ b/Tests/Utils/Context/InUnsetTest.php
@@ -58,7 +58,7 @@ final class InUnsetTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataInUnset()
+    public static function dataInUnset()
     {
         return [
             'method-called-unset' => [

--- a/Tests/Utils/ControlStructures/GetCaughtExceptionsTest.php
+++ b/Tests/Utils/ControlStructures/GetCaughtExceptionsTest.php
@@ -93,7 +93,7 @@ final class GetCaughtExceptionsTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetCaughtExceptions()
+    public static function dataGetCaughtExceptions()
     {
         $php8Names = parent::usesPhp8NameTokens();
 

--- a/Tests/Utils/ControlStructures/HasBodyTest.php
+++ b/Tests/Utils/ControlStructures/HasBodyTest.php
@@ -78,7 +78,7 @@ final class HasBodyTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataHasBody()
+    public static function dataHasBody()
     {
         return [
             'if-without-body' => [

--- a/Tests/Utils/ControlStructures/IsElseIfTest.php
+++ b/Tests/Utils/ControlStructures/IsElseIfTest.php
@@ -70,7 +70,7 @@ final class IsElseIfTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataIsElseIf()
+    public static function dataIsElseIf()
     {
         return [
             'if' => [

--- a/Tests/Utils/FunctionDeclarations/IsMagicFunctionNameTest.php
+++ b/Tests/Utils/FunctionDeclarations/IsMagicFunctionNameTest.php
@@ -46,7 +46,7 @@ final class IsMagicFunctionNameTest extends TestCase
      *
      * @return array
      */
-    public function dataIsMagicFunctionName()
+    public static function dataIsMagicFunctionName()
     {
         return [
             'lowercase' => ['__autoload'],
@@ -76,7 +76,7 @@ final class IsMagicFunctionNameTest extends TestCase
      *
      * @return array
      */
-    public function dataIsNotMagicFunctionName()
+    public static function dataIsNotMagicFunctionName()
     {
         return [
             'no_underscore'           => ['noDoubleUnderscore'],

--- a/Tests/Utils/FunctionDeclarations/IsMagicMethodNameTest.php
+++ b/Tests/Utils/FunctionDeclarations/IsMagicMethodNameTest.php
@@ -63,7 +63,7 @@ final class IsMagicMethodNameTest extends TestCase
      *
      * @return array
      */
-    public function dataIsMagicMethodName()
+    public static function dataIsMagicMethodName()
     {
         return [
             // Normal case.
@@ -144,7 +144,7 @@ final class IsMagicMethodNameTest extends TestCase
      *
      * @return array
      */
-    public function dataIsNotMagicMethodName()
+    public static function dataIsNotMagicMethodName()
     {
         return [
             'no_underscore'         => ['construct'],

--- a/Tests/Utils/FunctionDeclarations/IsPHPDoubleUnderscoreMethodNameTest.php
+++ b/Tests/Utils/FunctionDeclarations/IsPHPDoubleUnderscoreMethodNameTest.php
@@ -64,7 +64,7 @@ final class IsPHPDoubleUnderscoreMethodNameTest extends TestCase
      *
      * @return array
      */
-    public function dataIsPHPDoubleUnderscoreMethodName()
+    public static function dataIsPHPDoubleUnderscoreMethodName()
     {
         return [
             // Normal case.
@@ -135,7 +135,7 @@ final class IsPHPDoubleUnderscoreMethodNameTest extends TestCase
      *
      * @return array
      */
-    public function dataIsNotPHPDoubleUnderscoreMethodName()
+    public static function dataIsNotPHPDoubleUnderscoreMethodName()
     {
         return [
             'no_underscore'           => ['getLastResponseHeaders'],

--- a/Tests/Utils/FunctionDeclarations/SpecialFunctionsTest.php
+++ b/Tests/Utils/FunctionDeclarations/SpecialFunctionsTest.php
@@ -162,7 +162,7 @@ final class SpecialFunctionsTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataItsAKindOfMagic()
+    public static function dataItsAKindOfMagic()
     {
         return [
             'MagicMethodInClass' => [

--- a/Tests/Utils/GetTokensAsString/GetTokensAsStringTest.php
+++ b/Tests/Utils/GetTokensAsString/GetTokensAsStringTest.php
@@ -241,7 +241,7 @@ final class GetTokensAsStringTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetTokensAsString()
+    public static function dataGetTokensAsString()
     {
         return [
             'namespace' => [

--- a/Tests/Utils/Lists/GetAssignmentsTest.php
+++ b/Tests/Utils/Lists/GetAssignmentsTest.php
@@ -64,7 +64,7 @@ final class GetAssignmentsTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataNotListToken()
+    public static function dataNotListToken()
     {
         return [
             'not-a-list' => [
@@ -128,7 +128,7 @@ final class GetAssignmentsTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetAssignments()
+    public static function dataGetAssignments()
     {
         return [
             'long-list-empty' => [

--- a/Tests/Utils/Lists/GetOpenCloseTest.php
+++ b/Tests/Utils/Lists/GetOpenCloseTest.php
@@ -58,7 +58,7 @@ final class GetOpenCloseTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataNotListOpenToken()
+    public static function dataNotListOpenToken()
     {
         return [
             'short-array' => [
@@ -118,7 +118,7 @@ final class GetOpenCloseTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetOpenClose()
+    public static function dataGetOpenClose()
     {
         return [
             'long-list' => [

--- a/Tests/Utils/MessageHelper/AddMessageTest.php
+++ b/Tests/Utils/MessageHelper/AddMessageTest.php
@@ -86,7 +86,7 @@ final class AddMessageTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataAddMessage()
+    public static function dataAddMessage()
     {
         return [
             'add-error' => [
@@ -152,7 +152,7 @@ final class AddMessageTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataAddFixableMessage()
+    public static function dataAddFixableMessage()
     {
         return [
             'add-fixable-error' => [

--- a/Tests/Utils/MessageHelper/ShowEscapeCharsTest.php
+++ b/Tests/Utils/MessageHelper/ShowEscapeCharsTest.php
@@ -47,7 +47,7 @@ final class ShowEscapeCharsTest extends TestCase
      *
      * @return array
      */
-    public function dataShowEscapeChars()
+    public static function dataShowEscapeChars()
     {
         return [
             'no-escape-chars' => [

--- a/Tests/Utils/MessageHelper/StringToErrorcodeTest.php
+++ b/Tests/Utils/MessageHelper/StringToErrorcodeTest.php
@@ -47,7 +47,7 @@ final class StringToErrorcodeTest extends TestCase
      *
      * @return array
      */
-    public function dataStringToErrorCode()
+    public static function dataStringToErrorCode()
     {
         return [
             'no-special-chars' => [
@@ -99,7 +99,7 @@ final class StringToErrorcodeTest extends TestCase
      *
      * @return array
      */
-    public function dataStringToErrorCodeWithCaseChange()
+    public static function dataStringToErrorCodeWithCaseChange()
     {
         return [
             'no-special-chars' => [

--- a/Tests/Utils/Namespaces/DetermineNamespaceTest.php
+++ b/Tests/Utils/Namespaces/DetermineNamespaceTest.php
@@ -86,7 +86,7 @@ final class DetermineNamespaceTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataDetermineNamespace()
+    public static function dataDetermineNamespace()
     {
         return [
             'no-namespace' => [

--- a/Tests/Utils/Namespaces/GetDeclaredNameTest.php
+++ b/Tests/Utils/Namespaces/GetDeclaredNameTest.php
@@ -96,7 +96,7 @@ final class GetDeclaredNameTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetDeclaredName()
+    public static function dataGetDeclaredName()
     {
         return [
             'global-namespace-curlies' => [

--- a/Tests/Utils/Namespaces/NamespaceTypeTest.php
+++ b/Tests/Utils/Namespaces/NamespaceTypeTest.php
@@ -111,7 +111,7 @@ final class NamespaceTypeTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataNamespaceType()
+    public static function dataNamespaceType()
     {
         return [
             'namespace-declaration' => [

--- a/Tests/Utils/NamingConventions/IsEqualTest.php
+++ b/Tests/Utils/NamingConventions/IsEqualTest.php
@@ -48,7 +48,7 @@ final class IsEqualTest extends TestCase
      *
      * @return array
      */
-    public function dataIsEqual()
+    public static function dataIsEqual()
     {
         return [
             'a-z-0-9-only-same-case' => [

--- a/Tests/Utils/NamingConventions/IsValidIdentifierNameTest.php
+++ b/Tests/Utils/NamingConventions/IsValidIdentifierNameTest.php
@@ -47,7 +47,7 @@ final class IsValidIdentifierNameTest extends TestCase
      *
      * @return array
      */
-    public function dataIsValidIdentifierName()
+    public static function dataIsValidIdentifierName()
     {
         return [
             // Valid names.

--- a/Tests/Utils/Numbers/GetCompleteNumberTest.php
+++ b/Tests/Utils/Numbers/GetCompleteNumberTest.php
@@ -70,7 +70,7 @@ final class GetCompleteNumberTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetCompleteNumber()
+    public static function dataGetCompleteNumber()
     {
         /*
          * Disabling the hexnumeric string detection for the rest of the file.

--- a/Tests/Utils/Numbers/GetDecimalValueTest.php
+++ b/Tests/Utils/Numbers/GetDecimalValueTest.php
@@ -47,7 +47,7 @@ final class GetDecimalValueTest extends TestCase
      *
      * @return array
      */
-    public function dataGetDecimalValue()
+    public static function dataGetDecimalValue()
     {
         return [
             // Decimal integers.
@@ -110,7 +110,7 @@ final class GetDecimalValueTest extends TestCase
      *
      * @return array
      */
-    public function dataGetDecimalValueInvalid()
+    public static function dataGetDecimalValueInvalid()
     {
         return [
             'not-a-string-bool'                             => [true],

--- a/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.php
@@ -53,7 +53,7 @@ final class FindExtendedClassNameDiffTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataFindExtendedClassName()
+    public static function dataFindExtendedClassName()
     {
         return [
             'phpcs-annotation-and-comments' => [

--- a/Tests/Utils/ObjectDeclarations/FindExtendedInterfaceNamesTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedInterfaceNamesTest.php
@@ -73,7 +73,7 @@ final class FindExtendedInterfaceNamesTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataFindExtendedInterfaceNames()
+    public static function dataFindExtendedInterfaceNames()
     {
         return [
             'not-extended' => [

--- a/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.php
@@ -53,7 +53,7 @@ final class FindImplementedInterfaceNamesDiffTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataFindImplementedInterfaceNames()
+    public static function dataFindImplementedInterfaceNames()
     {
         return [
             'phpcs-annotation-and-comments' => [

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
@@ -76,7 +76,7 @@ final class GetClassPropertiesDiffTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetClassProperties()
+    public static function dataGetClassProperties()
     {
         return [
             'phpcs-annotation' => [

--- a/Tests/Utils/ObjectDeclarations/GetNameDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameDiffTest.php
@@ -63,7 +63,7 @@ final class GetNameDiffTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetNameNull()
+    public static function dataGetNameNull()
     {
         return [
             'live-coding' => [
@@ -102,7 +102,7 @@ final class GetNameDiffTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetName()
+    public static function dataGetName()
     {
         return [
             'trait-name-starts-with-number' => [

--- a/Tests/Utils/Operators/IsShortTernaryTest.php
+++ b/Tests/Utils/Operators/IsShortTernaryTest.php
@@ -74,7 +74,7 @@ final class IsShortTernaryTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataIsShortTernary()
+    public static function dataIsShortTernary()
     {
         return [
             'long-ternary' => [

--- a/Tests/Utils/Operators/IsUnaryPlusMinusJSTest.php
+++ b/Tests/Utils/Operators/IsUnaryPlusMinusJSTest.php
@@ -38,7 +38,7 @@ final class IsUnaryPlusMinusJSTest extends IsUnaryPlusMinusTestCase
      *
      * @return array
      */
-    public function dataIsUnaryPlusMinus()
+    public static function dataIsUnaryPlusMinus()
     {
         return [
             'non-unary-plus' => [

--- a/Tests/Utils/Operators/IsUnaryPlusMinusTest.php
+++ b/Tests/Utils/Operators/IsUnaryPlusMinusTest.php
@@ -31,7 +31,7 @@ final class IsUnaryPlusMinusTest extends IsUnaryPlusMinusTestCase
      *
      * @return array
      */
-    public function dataIsUnaryPlusMinus()
+    public static function dataIsUnaryPlusMinus()
     {
         return [
             'non-unary-plus' => [

--- a/Tests/Utils/Operators/IsUnaryPlusMinusTestCase.php
+++ b/Tests/Utils/Operators/IsUnaryPlusMinusTestCase.php
@@ -73,5 +73,5 @@ abstract class IsUnaryPlusMinusTestCase extends UtilityMethodTestCase
      *
      * @return array
      */
-    abstract public function dataIsUnaryPlusMinus();
+    abstract public static function dataIsUnaryPlusMinus();
 }

--- a/Tests/Utils/Orthography/FirstCharTest.php
+++ b/Tests/Utils/Orthography/FirstCharTest.php
@@ -65,7 +65,7 @@ final class FirstCharTest extends TestCase
      *
      * @return array
      */
-    public function dataFirstChar()
+    public static function dataFirstChar()
     {
         $data = [
             // Quotes should be stripped before passing the string.

--- a/Tests/Utils/Orthography/IsLastCharPunctuationTest.php
+++ b/Tests/Utils/Orthography/IsLastCharPunctuationTest.php
@@ -54,7 +54,7 @@ final class IsLastCharPunctuationTest extends TestCase
      *
      * @return array
      */
-    public function dataIsLastCharPunctuation()
+    public static function dataIsLastCharPunctuation()
     {
         return [
             // Quotes should be stripped before passing the string.

--- a/Tests/Utils/Parentheses/ParenthesesTest.php
+++ b/Tests/Utils/Parentheses/ParenthesesTest.php
@@ -620,7 +620,7 @@ final class ParenthesesTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataWalkParentheses()
+    public static function dataWalkParentheses()
     {
         $data = [
             'testIfWithArray-$a' => [
@@ -973,7 +973,7 @@ final class ParenthesesTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataHasOwner()
+    public static function dataHasOwner()
     {
         return [
             'testIfWithArray-$a' => [
@@ -1217,7 +1217,7 @@ final class ParenthesesTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataFirstOwnerIn()
+    public static function dataFirstOwnerIn()
     {
         return [
             'testElseIfWithClosure-$a-elseif' => [
@@ -1308,7 +1308,7 @@ final class ParenthesesTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataLastOwnerIn()
+    public static function dataLastOwnerIn()
     {
         return [
             'testElseIfWithClosure-$a-closure' => [

--- a/Tests/Utils/PassedParameters/GetParameterCountTest.php
+++ b/Tests/Utils/PassedParameters/GetParameterCountTest.php
@@ -60,7 +60,7 @@ final class GetParameterCountTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetParameterCount()
+    public static function dataGetParameterCount()
     {
         $php8Names = parent::usesPhp8NameTokens();
 

--- a/Tests/Utils/PassedParameters/GetParameterFromStackTest.php
+++ b/Tests/Utils/PassedParameters/GetParameterFromStackTest.php
@@ -73,7 +73,7 @@ final class GetParameterFromStackTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetParameterNonFunctionCallNoParamName()
+    public static function dataGetParameterNonFunctionCallNoParamName()
     {
         return [
             'isset' => [
@@ -175,7 +175,7 @@ final class GetParameterFromStackTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetParameterFunctionCallWithParamName()
+    public static function dataGetParameterFunctionCallWithParamName()
     {
         return [
             'all-named-non-standard-order' => [
@@ -284,7 +284,7 @@ final class GetParameterFromStackTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetParameterFromStack()
+    public static function dataGetParameterFromStack()
     {
         return [
             'all-params-all-positional' => [
@@ -450,7 +450,7 @@ final class GetParameterFromStackTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetParameterFromStackNamedAfterVariadic()
+    public static function dataGetParameterFromStackNamedAfterVariadic()
     {
         return [
             'first param, positional' => [

--- a/Tests/Utils/PassedParameters/GetParametersNamedTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersNamedTest.php
@@ -77,7 +77,7 @@ final class GetParametersNamedTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetParameters()
+    public static function dataGetParameters()
     {
         $php8Names = parent::usesPhp8NameTokens();
 

--- a/Tests/Utils/PassedParameters/GetParametersSkipShortArrayCheckTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersSkipShortArrayCheckTest.php
@@ -113,7 +113,7 @@ final class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase
      *
      * @return array
      */
-    public function dataTestCases()
+    public static function dataTestCases()
     {
         return [
             'no-params' => [

--- a/Tests/Utils/PassedParameters/GetParametersTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersTest.php
@@ -88,7 +88,7 @@ final class GetParametersTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetParameters()
+    public static function dataGetParameters()
     {
         return [
             'function-call' => [
@@ -725,7 +725,7 @@ final class GetParametersTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetParameter()
+    public static function dataGetParameter()
     {
         return [
             'function-call-param-4' => [

--- a/Tests/Utils/PassedParameters/GetParametersWithLimitTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersWithLimitTest.php
@@ -73,7 +73,7 @@ final class GetParametersWithLimitTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetParametersWithIneffectiveLimit()
+    public static function dataGetParametersWithIneffectiveLimit()
     {
         return [
             'invalid-limit-wrong-type-null'       => [null],
@@ -133,7 +133,7 @@ final class GetParametersWithLimitTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetParametersWithLimit()
+    public static function dataGetParametersWithLimit()
     {
         return [
             'function-call' => [

--- a/Tests/Utils/PassedParameters/HasParametersTest.php
+++ b/Tests/Utils/PassedParameters/HasParametersTest.php
@@ -83,7 +83,7 @@ final class HasParametersTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataNotACallToConstructor()
+    public static function dataNotACallToConstructor()
     {
         return [
             'parent' => [
@@ -146,7 +146,7 @@ final class HasParametersTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataHasParameters()
+    public static function dataHasParameters()
     {
         $php8Names = parent::usesPhp8NameTokens();
 

--- a/Tests/Utils/Scopes/IsOOConstantTest.php
+++ b/Tests/Utils/Scopes/IsOOConstantTest.php
@@ -78,7 +78,7 @@ final class IsOOConstantTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataIsOOConstant()
+    public static function dataIsOOConstant()
     {
         return [
             'global-const' => [

--- a/Tests/Utils/Scopes/IsOOMethodTest.php
+++ b/Tests/Utils/Scopes/IsOOMethodTest.php
@@ -78,7 +78,7 @@ final class IsOOMethodTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataIsOOMethod()
+    public static function dataIsOOMethod()
     {
         return [
             'global-function' => [

--- a/Tests/Utils/Scopes/IsOOPropertyTest.php
+++ b/Tests/Utils/Scopes/IsOOPropertyTest.php
@@ -78,7 +78,7 @@ final class IsOOPropertyTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataIsOOProperty()
+    public static function dataIsOOProperty()
     {
         return [
             'global-var' => [

--- a/Tests/Utils/TextStrings/GetCompleteTextStringTest.php
+++ b/Tests/Utils/TextStrings/GetCompleteTextStringTest.php
@@ -107,7 +107,7 @@ final class GetCompleteTextStringTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataExceptions()
+    public static function dataExceptions()
     {
         return [
             'getCompleteTextString'      => ['getCompleteTextString'],
@@ -144,7 +144,7 @@ final class GetCompleteTextStringTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetCompleteTextString()
+    public static function dataGetCompleteTextString()
     {
         return [
             'single-line-constant-encapsed-string' => [

--- a/Tests/Utils/TextStrings/GetEndOfCompleteTextStringTest.php
+++ b/Tests/Utils/TextStrings/GetEndOfCompleteTextStringTest.php
@@ -55,7 +55,7 @@ final class GetEndOfCompleteTextStringTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetEndOfDoubleQuotedString()
+    public static function dataGetEndOfDoubleQuotedString()
     {
         return [
             'Simple embedded variable 1' => [

--- a/Tests/Utils/TextStrings/InterpolatedVariablesTest.php
+++ b/Tests/Utils/TextStrings/InterpolatedVariablesTest.php
@@ -33,7 +33,7 @@ final class InterpolatedVariablesTest extends TestCase
      *
      * @var array<string>
      */
-    private $embeds = [
+    private static $embeds = [
         // Simple.
         '$foo',
         '{$foo}',
@@ -125,7 +125,7 @@ final class InterpolatedVariablesTest extends TestCase
      *
      * @var array<string, string>
      */
-    private $phrases = [
+    private static $phrases = [
         'single line'                                => "%s this is nonsense %s\tbut that's not the point %s",
         'single line, embed followed by non-space 1' => '%s- dash %s+ plus %s',
         'single line, embed followed by non-space 2' => '%s. dash %s= plus %s',
@@ -197,10 +197,10 @@ final class InterpolatedVariablesTest extends TestCase
      *
      * @return array
      */
-    public function dataEmbedsInPhrases()
+    public static function dataEmbedsInPhrases()
     {
         $data = [];
-        foreach ($this->embeds as $embed) {
+        foreach (self::$embeds as $embed) {
             $data[$embed . '| Plain embed (heredoc)'] = [
                 'input'    => $embed,
                 'expected' => [
@@ -217,64 +217,64 @@ final class InterpolatedVariablesTest extends TestCase
             ];
 
             // Plain, no double quotes (heredoc).
-            $phraseKey      = \array_rand($this->phrases);
+            $phraseKey      = \array_rand(self::$phrases);
             $dataKey        = $embed . '| Embed at start of plain phrase in: ' . $phraseKey;
             $data[$dataKey] =  [
-                'input'    => \sprintf($this->phrases[$phraseKey], $embed, '', ''),
+                'input'    => \sprintf(self::$phrases[$phraseKey], $embed, '', ''),
                 'expected' => [
                     'get'      => [$embed],
-                    'stripped' => \sprintf($this->phrases[$phraseKey], '', '', ''),
+                    'stripped' => \sprintf(self::$phrases[$phraseKey], '', '', ''),
                 ],
             ];
 
-            $phraseKey      = \array_rand($this->phrases);
+            $phraseKey      = \array_rand(self::$phrases);
             $dataKey        = $embed . '| Embed in middle of plain phrase in: ' . $phraseKey;
             $data[$dataKey] =  [
-                'input'    => \sprintf($this->phrases[$phraseKey], '', $embed, ''),
+                'input'    => \sprintf(self::$phrases[$phraseKey], '', $embed, ''),
                 'expected' => [
                     'get'      => [$embed],
-                    'stripped' => \sprintf($this->phrases[$phraseKey], '', '', ''),
+                    'stripped' => \sprintf(self::$phrases[$phraseKey], '', '', ''),
                 ],
             ];
 
-            $phraseKey      = \array_rand($this->phrases);
+            $phraseKey      = \array_rand(self::$phrases);
             $dataKey        = $embed . '| Embed at end of plain phrase in: ' . $phraseKey;
             $data[$dataKey] =  [
-                'input'    => \sprintf($this->phrases[$phraseKey], '', '', $embed),
+                'input'    => \sprintf(self::$phrases[$phraseKey], '', '', $embed),
                 'expected' => [
                     'get'      => [$embed],
-                    'stripped' => \sprintf($this->phrases[$phraseKey], '', '', ''),
+                    'stripped' => \sprintf(self::$phrases[$phraseKey], '', '', ''),
                 ],
             ];
 
             // Phrase in double quotes.
-            $phraseKey      = \array_rand($this->phrases);
+            $phraseKey      = \array_rand(self::$phrases);
             $dataKey        = $embed . '| Embed at start of quoted phrase in: ' . $phraseKey;
             $data[$dataKey] =  [
-                'input'    => '"' . \sprintf($this->phrases[$phraseKey], $embed, '', '') . '"',
+                'input'    => '"' . \sprintf(self::$phrases[$phraseKey], $embed, '', '') . '"',
                 'expected' => [
                     'get'      => [$embed],
-                    'stripped' => '"' . \sprintf($this->phrases[$phraseKey], '', '', '') . '"',
+                    'stripped' => '"' . \sprintf(self::$phrases[$phraseKey], '', '', '') . '"',
                 ],
             ];
 
-            $phraseKey      = \array_rand($this->phrases);
+            $phraseKey      = \array_rand(self::$phrases);
             $dataKey        = $embed . '| Embed in middle of quoted phrase in: ' . $phraseKey;
             $data[$dataKey] =  [
-                'input'    => '"' . \sprintf($this->phrases[$phraseKey], '', $embed, '') . '"',
+                'input'    => '"' . \sprintf(self::$phrases[$phraseKey], '', $embed, '') . '"',
                 'expected' => [
                     'get'      => [$embed],
-                    'stripped' => '"' . \sprintf($this->phrases[$phraseKey], '', '', '') . '"',
+                    'stripped' => '"' . \sprintf(self::$phrases[$phraseKey], '', '', '') . '"',
                 ],
             ];
 
-            $phraseKey      = \array_rand($this->phrases);
+            $phraseKey      = \array_rand(self::$phrases);
             $dataKey        = $embed . '| Embed at end of quoted phrase in: ' . $phraseKey;
             $data[$dataKey] =  [
-                'input'    => '"' . \sprintf($this->phrases[$phraseKey], '', '', $embed) . '"',
+                'input'    => '"' . \sprintf(self::$phrases[$phraseKey], '', '', $embed) . '"',
                 'expected' => [
                     'get'      => [$embed],
-                    'stripped' => '"' . \sprintf($this->phrases[$phraseKey], '', '', '') . '"',
+                    'stripped' => '"' . \sprintf(self::$phrases[$phraseKey], '', '', '') . '"',
                 ],
             ];
         }
@@ -290,7 +290,7 @@ final class InterpolatedVariablesTest extends TestCase
      *
      * @return array
      */
-    public function dataEscaping()
+    public static function dataEscaping()
     {
         $embedAtEnd   = '"Foo: %s%s"';
         $embedAtStart = '%s%s Foo'; // Not, no double quotes!
@@ -361,7 +361,7 @@ final class InterpolatedVariablesTest extends TestCase
      *
      * @return array
      */
-    public function dataSpecificCases()
+    public static function dataSpecificCases()
     {
         return [
             // No embeds.

--- a/Tests/Utils/TextStrings/StripQuotesTest.php
+++ b/Tests/Utils/TextStrings/StripQuotesTest.php
@@ -47,7 +47,7 @@ final class StripQuotesTest extends TestCase
      *
      * @return array
      */
-    public function dataStripQuotes()
+    public static function dataStripQuotes()
     {
         return [
             'simple-string-double-quotes' => [

--- a/Tests/Utils/UseStatements/SplitAndMergeImportUseStatementTest.php
+++ b/Tests/Utils/UseStatements/SplitAndMergeImportUseStatementTest.php
@@ -52,7 +52,7 @@ final class SplitAndMergeImportUseStatementTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataSplitAndMergeImportUseStatement()
+    public static function dataSplitAndMergeImportUseStatement()
     {
         $data = [
             'name-plain' => [

--- a/Tests/Utils/UseStatements/SplitImportUseStatementTest.php
+++ b/Tests/Utils/UseStatements/SplitImportUseStatementTest.php
@@ -75,7 +75,7 @@ final class SplitImportUseStatementTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataNonImportUseTokenPassed()
+    public static function dataNonImportUseTokenPassed()
     {
         return [
             'closure-use' => ['/* testClosureUse */'],
@@ -107,7 +107,7 @@ final class SplitImportUseStatementTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataSplitImportUseStatement()
+    public static function dataSplitImportUseStatement()
     {
         return [
             'plain' => [

--- a/Tests/Utils/UseStatements/UseTypeTest.php
+++ b/Tests/Utils/UseStatements/UseTypeTest.php
@@ -118,7 +118,7 @@ final class UseTypeTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataUseType()
+    public static function dataUseType()
     {
         return [
             'import-1' => [

--- a/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
@@ -65,7 +65,7 @@ final class GetMemberPropertiesDiffTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataNotClassPropertyException()
+    public static function dataNotClassPropertyException()
     {
         return [
             'interface property' => ['/* testInterfaceProperty */'],
@@ -105,7 +105,7 @@ final class GetMemberPropertiesDiffTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataGetMemberProperties()
+    public static function dataGetMemberProperties()
     {
         return [
             'php8.2-pseudo-type-true' => [

--- a/Tests/Utils/Variables/GetMemberPropertiesTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesTest.php
@@ -63,7 +63,7 @@ final class GetMemberPropertiesTest extends BCFile_GetMemberPropertiesTest
      *
      * @return array
      */
-    public function dataGetMemberProperties()
+    public static function dataGetMemberProperties()
     {
         $data = parent::dataGetMemberProperties();
 

--- a/Tests/Utils/Variables/IsPHPReservedVarNameTest.php
+++ b/Tests/Utils/Variables/IsPHPReservedVarNameTest.php
@@ -46,7 +46,7 @@ final class IsPHPReservedVarNameTest extends TestCase
      *
      * @return array
      */
-    public function dataIsPHPReservedVarName()
+    public static function dataIsPHPReservedVarName()
     {
         return [
             // With dollar sign.
@@ -118,7 +118,7 @@ final class IsPHPReservedVarNameTest extends TestCase
      *
      * @return array
      */
-    public function dataIsPHPReservedVarNameFalse()
+    public static function dataIsPHPReservedVarNameFalse()
     {
         return [
             // Different case.

--- a/Tests/Utils/Variables/IsSuperglobalTest.php
+++ b/Tests/Utils/Variables/IsSuperglobalTest.php
@@ -64,7 +64,7 @@ final class IsSuperglobalTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataIsSuperglobal()
+    public static function dataIsSuperglobal()
     {
         return [
             'not-a-variable' => [
@@ -157,7 +157,7 @@ final class IsSuperglobalTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataIsSuperglobalName()
+    public static function dataIsSuperglobalName()
     {
         return [
             '$_SERVER'  => ['$_SERVER'],
@@ -193,7 +193,7 @@ final class IsSuperglobalTest extends UtilityMethodTestCase
      *
      * @return array
      */
-    public function dataIsSuperglobalNameFalse()
+    public static function dataIsSuperglobalNameFalse()
     {
         return [
             'non-reserved-var'                    => ['$not_a_superglobal'],

--- a/Tests/Xtra/Messages/HasNewLineSupportTest.php
+++ b/Tests/Xtra/Messages/HasNewLineSupportTest.php
@@ -77,9 +77,6 @@ EOD;
         // Make sure space on empty line is included (often removed by file editor).
         $expected = \str_replace("|\n", "| \n", $expected);
 
-        $this->expectOutputString($expected);
-        $this->setOutputCallback([$this, 'normalizeOutput']);
-
         /*
          * Create the error.
          */
@@ -102,12 +99,17 @@ EOD;
         $reportClass         = new Full();
         $reportData          = $reporter->prepareFileReport(self::$phpcsFile);
 
+        \ob_start();
         $reportClass->generateFileReport(
             $reportData,
             self::$phpcsFile,
             self::$phpcsFile->config->showSources,
             $config->reportWidth
         );
+        $output = \ob_get_contents();
+        \ob_end_clean();
+
+        $this->assertSame($expected, $this->normalizeOutput($output));
     }
 
     /**

--- a/Tests/Xtra/Tokens/TokenNameTest.php
+++ b/Tests/Xtra/Tokens/TokenNameTest.php
@@ -50,7 +50,7 @@ final class TokenNameTest extends TestCase
      *
      * @return array
      */
-    public function dataTokenName()
+    public static function dataTokenName()
     {
         return [
             'PHP native token: T_ECHO' => [

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "phpcsstandards/phpcsdevcs": "^1.1.6",
         "php-parallel-lint/php-parallel-lint": "^1.3.2",
         "php-parallel-lint/php-console-highlighter": "^1.0",
-        "yoast/phpunit-polyfills": "^1.0.5"
+        "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -66,11 +66,20 @@
         "test": [
             "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
         ],
+        "test10": [
+            "@php ./vendor/phpunit/phpunit/phpunit -c phpunit10.xml.dist --no-coverage"
+        ],
         "coverage": [
             "@php ./vendor/phpunit/phpunit/phpunit"
         ],
+        "coverage10": [
+            "@php ./vendor/phpunit/phpunit/phpunit -c phpunit10.xml.dist"
+        ],
         "coverage-local": [
             "@php ./vendor/phpunit/phpunit/phpunit --coverage-html ./build/coverage-html"
+        ],
+        "coverage-local10": [
+            "@php ./vendor/phpunit/phpunit/phpunit -c phpunit10.xml.dist --coverage-html ./build/coverage-html"
         ]
     },
     "config": {

--- a/phpunit10.xml.dist
+++ b/phpunit10.xml.dist
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/10.1/phpunit.xsd"
+        backupGlobals="true"
+        bootstrap="./Tests/bootstrap.php"
+        beStrictAboutTestsThatDoNotTestAnything="true"
+        colors="true"
+        displayDetailsOnTestsThatTriggerErrors="true"
+        displayDetailsOnTestsThatTriggerWarnings="true"
+        displayDetailsOnTestsThatTriggerNotices="true"
+        displayDetailsOnTestsThatTriggerDeprecations="true"
+        displayDetailsOnIncompleteTests="true"
+        displayDetailsOnSkippedTests="true"
+        failOnWarning="true"
+        failOnNotice="true"
+        failOnDeprecation="true"
+        requireCoverageMetadata="true"
+    >
+    <testsuites>
+        <testsuite name="RunFirst">
+            <!--
+            Run caching tests separately as they will clear the caches.
+            -->
+            <file>./Tests/Internal/Cache/GetClearTest.php</file>
+            <file>./Tests/Internal/Cache/SetTest.php</file>
+            <file>./Tests/Internal/NoFileCache/GetClearTest.php</file>
+            <file>./Tests/Internal/NoFileCache/SetTest.php</file>
+
+            <!--
+            A number of tests need process isolation to allow for recording code coverage on
+            the setting of function local static variables.
+            However, using process isolation runs into trouble with PHPUnit 4.x/PHPCS 2.6.0.
+            Executing these specific tests in a separate testsuite, which is run
+            before the full test suite, will allow for the code coverage for these methods
+            to be recorded properly, while still allowing the tests to run on all supported
+            PHP/PHPUnit/PHPCS combinations.
+            -->
+            <file>./Tests/Utils/Namespaces/NamespaceTypeTest.php</file>
+        </testsuite>
+        <testsuite name="PHPCSUtils">
+            <directory suffix="Test.php">./Tests/</directory>
+
+            <exclude>Tests/Internal/Cache/GetClearTest.php</exclude>
+            <exclude>Tests/Internal/Cache/SetTest.php</exclude>
+            <exclude>Tests/Internal/NoFileCache/GetClearTest.php</exclude>
+            <exclude>Tests/Internal/NoFileCache/SetTest.php</exclude>
+
+            <exclude>Tests/Utils/Namespaces/NamespaceTypeTest.php</exclude>
+        </testsuite>
+    </testsuites>
+
+    <groups>
+        <exclude>
+            <group>compareWithPHPCS</group>
+            <!-- Extra tests are basically testing PHPCS itself, not PHPCSUtils. -->
+            <group>xtra</group>
+        </exclude>
+    </groups>
+
+    <source>
+        <include>
+            <!-- Not recording coverage for PHPCS23Utils as there is nothing directly testable. -->
+            <directory suffix=".php">./PHPCSUtils/</directory>
+        </include>
+    </source>
+
+    <coverage includeUncoveredFiles="true" ignoreDeprecatedCodeUnits="true">
+        <report>
+            <clover outputFile="build/logs/clover.xml"/>
+            <text outputFile="php://stdout" showOnlySummary="true"/>
+        </report>
+    </coverage>
+
+</phpunit>


### PR DESCRIPTION
### Composer: update the PHPUnit Polyfills

A PHPUnit 10 compatible version of the PHPUnit Polyfills has been released, so let's start using it.

Ref:
* https://github.com/Yoast/PHPUnit-Polyfills/releases/tag/2.0.0

### Tests/PolyfilledTestCase: make compatible with PHPUnit Polyfills 2.x

As the available traits are different between the 1.x and 2.x versions of the PHPUnit Polyfills, two different class definitions are needed.

This change uses the available PHPUnit Polyfills version number to load the correct class.

### Tests/ConfigDataTest: switch to the PHPUnit Polyfills TestCase

### Tests: make dataproviders static

As of PHPUnit 10, data providers are (again) expected to be `static` methods.

This updates the test suite to respect that.

Includes removing the use of `$this` from select data providers.

Refs:
* https://github.com/sebastianbergmann/phpunit/commit/9caafe2d49b33a21f87db248a8ad6ca7c7bdac09
* sebastianbergmann/phpunit#5100

### Tests/SpacerFixer: make data providers static for compatibility with PHPUnit 10

### Tests/InterpolatedVariablesTest: make data providers static for compatibility with PHPUnit 10

### Tests/[NoFile]Cache/SetTest: remove use of the remove PHPUnit `TestCase::getName()` method

... in favour of just using a randomly generated ID for the cache.

### Tests/HasNewLineSupportTest: work round removal of the `setOutputCallback()` method

PHPUnit 10.0 removed the `TestCase::setOutputCallback()` method without replacement.

Refs:
* sebastianbergmann/phpunit#5319

### Tests/AbstractArrayDeclarationSniffTest: various tweaks and improvements

### Tests: add new ExpectWithConsecutiveArgs helper trait

... to provide a work-around for the removal of the `InvocationMocker->withConsecutive()` method, which was removed without replacement in PHPUnit 10.0.

Refs:
* sebastianbergmann/phpunit#4026
* sebastianbergmann/phpunit#4255
* sebastianbergmann/phpunit#4564

### Tests/AbstractArrayDeclarationSniffTest: implement use of the `ExpectWithConsecutiveArgs` helper

### Tests/AbstractArrayDeclarationSniffTest: work around for `MockBuilder::setMethods()` removal

Please note:
* The `getMockBuilder()` class is also deprecated now, so replacing with another method call on the `MockBuilder` class will only work in the short/medium term and in a future iteration, this will have to be refactored again.
* Also the `getMockForAbstractClass method is also deprecated and expected to be removed in PHPUnit 12.

Refs:
* sebastianbergmann/phpunit#3687#issuecomment-492537584
* sebastianbergmann/phpunit#3770
* sebastianbergmann/phpunit#3769
* sebastianbergmann/phpunit#4775

### PHPUnit: add separate configuration for PHPUnit 10

PHPUnit 10 makes significant changes to the configuration file.
While there is a `--migrate-configuration` option available in PHPUnit, that doesn't get us a well enough converted configuration file, so instead use a separate `phpunit10.xml.dist` file for running the tests on PHPUnit 10 with an optimal configuration.

Includes
* Adding separate scripts to the `composer.json` file to make this more obvious for contributors.
* Updating the GH Actions workflows to take the new configuration file into account when appropriate.
* Selectively not using the `--repeat` option, which was [removed without replacement](sebastianbergmann/phpunit#5174) in PHPUnit 10.