### PR TITLE
Arrays::getDoubleArrowPtr(): allow for (keyed) lists in array values

### DIFF
--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -39,6 +39,7 @@ final class Arrays
         \T_OPEN_SHORT_ARRAY => \T_OPEN_SHORT_ARRAY,
 
         // Inline function, control structures and other things to skip over.
+        \T_LIST             => \T_LIST,
         \T_FN               => \T_FN,
         \T_MATCH            => \T_MATCH,
         \T_ATTRIBUTE        => \T_ATTRIBUTE,
@@ -205,6 +206,14 @@ final class Arrays
                 && isset($tokens[$doubleArrow]['attribute_closer'])
             ) {
                 $doubleArrow = $tokens[$doubleArrow]['attribute_closer'];
+                continue;
+            }
+
+            // Skip over potentially keyed long lists.
+            if ($tokens[$doubleArrow]['code'] === \T_LIST
+                && isset($tokens[$doubleArrow]['parenthesis_closer'])
+            ) {
+                $doubleArrow = $tokens[$doubleArrow]['parenthesis_closer'];
                 continue;
             }
 

--- a/Tests/Utils/Arrays/GetDoubleArrowPtrTest.inc
+++ b/Tests/Utils/Arrays/GetDoubleArrowPtrTest.inc
@@ -104,6 +104,12 @@ $array = [
         FOO     => BAR,
         default => [0 => 10],
     } => 'value',
+    
+    /* testNoArrowKeyedLongListInValue */
+    list( 'key1' => $a, 'key2' => $b ) = $array,
+
+    /* testNoArrowKeyedShortListInValue */
+    [ 'key1' => $a, 'key2' => $b ] = $array,
 
     /* testNoArrowValueClosureWithAttribute */
     #[MyAttribute([0 => 'value'])] function() { /* do something */ }(),

--- a/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
+++ b/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
@@ -234,6 +234,16 @@ final class GetDoubleArrowPtrTest extends UtilityMethodTestCase
                 'expected'   => 38,
             ],
 
+            // Safeguard that PHP 7.2 keyed lists in values are handled correctly.
+            'test-no-arrow-value-keyed-long-list' => [
+                'testMarker' => '/* testNoArrowKeyedLongListInValue */',
+                'expected'   => false,
+            ],
+            'test-no-arrow-value-keyed-short-list' => [
+                'testMarker' => '/* testNoArrowKeyedShortListInValue */',
+                'expected'   => false,
+            ],
+
             // Safeguard that double arrows in PHP 8.0 attributes are disregarded.
             'test-no-arrow-value-closure-with-attached-attribute-containing-arrow' => [
                 'testMarker' => '/* testNoArrowValueClosureWithAttribute */',


### PR DESCRIPTION
PHP 7.2 introduced keyed lists, but the `Arrays::getDoubleArrowPtr()` method did not take this into account correctly.

Keyed short lists were already handled correctly as they tokenize the same as short arrays. Keyed long lists were not.

Fixed now.

Includes tests.