### PR TITLE
GH Actions: special case Dependabot PRs for Coveralls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -363,10 +363,21 @@ jobs:
         if: ${{ success() }}
         run: composer global require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
 
-      - name: Upload coverage results to Coveralls
-        if: ${{ success() }}
+      - name: Upload coverage results to Coveralls (normal)
+        if: ${{ success() && github.actor != 'dependabot[bot]' }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+          COVERALLS_PARALLEL: true
+          COVERALLS_FLAG_NAME: php-${{ matrix.php }}-phpcs-${{ matrix.phpcs_version }}
+        run: php-coveralls -v -x build/logs/clover.xml
+
+      # Dependabot does not have access to secrets, other than the GH token.
+      # Ref: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
+      # Ref: https://github.com/lemurheavy/coveralls-public/issues/1721
+      - name: Upload coverage results to Coveralls (Dependabot)
+        if: ${{ success() && github.actor == 'dependabot[bot]' }}
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: php-${{ matrix.php }}-phpcs-${{ matrix.phpcs_version }}
         run: php-coveralls -v -x build/logs/clover.xml
@@ -378,8 +389,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Coveralls Finished
+      - name: Coveralls Finished (normal)
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.COVERALLS_TOKEN }}
+          parallel-finished: true
+
+      # Dependabot does not have access to secrets, other than the GH token.
+      # Ref: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
+      # Ref: https://github.com/lemurheavy/coveralls-public/issues/1721
+      - name: Coveralls Finished (Dependabot)
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true


### PR DESCRIPTION
Follow up on PR #468.

Turns out Dependabot PRs do not have access to secrets with the exception of (read-only) access to the `GITHUB_TOKEN`.

As the coverage test runs and the Coveralls status are required builds, this blocks Dependabot PRs from being merged without overruling the required statuses.

As I'd like to avoid that situation, I'm special casing Dependabot PRs for the token selection.

Unfortunately using a condition like `${{ github.actor != 'dependabot[bot]' || secrets.COVERALLS_TOKEN && secrets.GITHUB_TOKEN }}` won't work when it involves secrets, so we need to use duplicate steps to get round this.

Refs:
* https://github.com/lemurheavy/coveralls-public/issues/1721
* https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events