### PR TITLE
Dependabot: switch to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 5 # Set to 0 to (temporarily) disable.
     versioning-strategy: widen
     commit-message:
@@ -20,7 +20,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "GH Actions:"


### PR DESCRIPTION
No need to check on a daily basis. ("daily" was only really used to be able to test the setup)

Follow up on #298 in which I explicitly stated:

> Once the configuration has been "finalized" (I use that term loosely), this should be changed to run the Dependabot check only once a week.