### PR TITLE
Release 1.0.8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 5 # Set to 0 to (temporarily) disable.
     versioning-strategy: widen
     commit-message:
@@ -20,7 +20,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "GH Actions:"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -349,19 +349,18 @@ jobs:
           PHPCS_VERSION: ${{ matrix.phpcs_version }}
           PHPCSUTILS_USE_CACHE: false
 
-      # Uploading the results with PHP Coveralls v1 won't work from GH Actions, so switch the PHP version.
-      # Also PHP Coveralls itself (still) isn't fully compatible with PHP 8.0+.
-      - name: Switch to PHP 7.4
-        if: ${{ success() && matrix.php != '7.4' }}
+      # PHP Coveralls v2 (which supports GH Actions) has a PHP 5.5 minimum, so switch the PHP version.
+      - name: Switch to PHP latest
+        if: ${{ success() && matrix.php == '5.4' }}
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 'latest'
           coverage: none
 
-      # Global install is used to prevent a conflict with the local composer.lock in PHP 8.0+.
+      # Global install is used to prevent a conflict with the local composer.lock.
       - name: Install Coveralls
         if: ${{ success() }}
-        run: composer global require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
+        run: composer global require php-coveralls/php-coveralls:"^2.6.0" --no-interaction
 
       - name: Upload coverage results to Coveralls (normal)
         if: ${{ success() && github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -363,10 +363,21 @@ jobs:
         if: ${{ success() }}
         run: composer global require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
 
-      - name: Upload coverage results to Coveralls
-        if: ${{ success() }}
+      - name: Upload coverage results to Coveralls (normal)
+        if: ${{ success() && github.actor != 'dependabot[bot]' }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+          COVERALLS_PARALLEL: true
+          COVERALLS_FLAG_NAME: php-${{ matrix.php }}-phpcs-${{ matrix.phpcs_version }}
+        run: php-coveralls -v -x build/logs/clover.xml
+
+      # Dependabot does not have access to secrets, other than the GH token.
+      # Ref: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
+      # Ref: https://github.com/lemurheavy/coveralls-public/issues/1721
+      - name: Upload coverage results to Coveralls (Dependabot)
+        if: ${{ success() && github.actor == 'dependabot[bot]' }}
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: php-${{ matrix.php }}-phpcs-${{ matrix.phpcs_version }}
         run: php-coveralls -v -x build/logs/clover.xml
@@ -378,8 +389,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Coveralls Finished
+      - name: Coveralls Finished (normal)
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.COVERALLS_TOKEN }}
+          parallel-finished: true
+
+      # Dependabot does not have access to secrets, other than the GH token.
+      # Ref: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
+      # Ref: https://github.com/lemurheavy/coveralls-public/issues/1721
+      - name: Coveralls Finished (Dependabot)
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -129,7 +129,7 @@ jobs:
           destination: ./docs/_site
 
       - name: Upload GH Pages artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
           path: ./docs/_site
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ _Nothing yet._
 
 #### Utils
 
-* The `Arrays::getDoubleArrowPtr()` method could previously get confused over a double arrow in a keyed lists used as an array value. [#485]
+* The `Arrays::getDoubleArrowPtr()` method could previously get confused over a double arrow in a keyed list used as an array value. [#485]
 
 [#485]: https://github.com/PHPCSStandards/PHPCSUtils/pull/485
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ This projects adheres to [Keep a CHANGELOG](https://keepachangelog.com/) and use
 _Nothing yet._
 
 
+## [1.0.8] - 2023-07-17
+
+### Changed
+
+#### PHPCS BackCompat
+
+* `BCFile::getDeclarationName()`: sync with PHPCS 3.8.0 - support for functions called `self`, `parent` or `static` which return by reference. [#494]
+
+#### Other
+
+* Various housekeeping and minor documentation improvements.
+
+### Fixed
+
+#### Fixers
+
+* The [`SpacesFixer`] will no longer throw an (incorrect) exception when the second pointer passed is a comment token and this comment token is the last content in a file. [#493]
+
+[#493]: https://github.com/PHPCSStandards/PHPCSUtils/pull/493
+[#494]: https://github.com/PHPCSStandards/PHPCSUtils/pull/494
+
+
 ## [1.0.7] - 2023-07-10
 
 ### Changed
@@ -906,6 +928,7 @@ This initial alpha release contains the following utility classes:
 
 
 [Unreleased]:   https://github.com/PHPCSStandards/PHPCSUtils/compare/stable...HEAD
+[1.0.8]:        https://github.com/PHPCSStandards/PHPCSUtils/compare/1.0.7...1.0.8
 [1.0.7]:        https://github.com/PHPCSStandards/PHPCSUtils/compare/1.0.6...1.0.7
 [1.0.6]:        https://github.com/PHPCSStandards/PHPCSUtils/compare/1.0.5...1.0.6
 [1.0.5]:        https://github.com/PHPCSStandards/PHPCSUtils/compare/1.0.4...1.0.5

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -50,6 +50,7 @@ use PHPCSUtils\Tokens\Collections;
  * any affected utility functions:
  * - `readonly` classes.
  * - Constructor property promotion with `readonly` without visibility.
+ * - OO methods called `self`, `parent` or `static`.
  *
  * Most functions in this class will have a related twin-function in the relevant
  * class in the `PHPCSUtils\Utils` namespace.
@@ -75,7 +76,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.7.1.
+     * - PHPCS 3.8.0: OO methods called `self`, `parent` or `static` are now correctly recognized.
      *
      * @see \PHP_CodeSniffer\Files\File::getDeclarationName() Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::getName()   PHPCSUtils native improved version.
@@ -97,7 +98,44 @@ final class BCFile
      */
     public static function getDeclarationName(File $phpcsFile, $stackPtr)
     {
-        return $phpcsFile->getDeclarationName($stackPtr);
+        $tokens    = $phpcsFile->getTokens();
+        $tokenCode = $tokens[$stackPtr]['code'];
+
+        if ($tokenCode === T_ANON_CLASS || $tokenCode === T_CLOSURE) {
+            return null;
+        }
+
+        if ($tokenCode !== T_FUNCTION
+            && $tokenCode !== T_CLASS
+            && $tokenCode !== T_INTERFACE
+            && $tokenCode !== T_TRAIT
+            && $tokenCode !== T_ENUM
+        ) {
+            throw new RuntimeException('Token type "' . $tokens[$stackPtr]['type'] . '" is not T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT or T_ENUM');
+        }
+
+        if ($tokenCode === T_FUNCTION
+            && strtolower($tokens[$stackPtr]['content']) !== 'function'
+        ) {
+            // This is a function declared without the "function" keyword.
+            // So this token is the function name.
+            return $tokens[$stackPtr]['content'];
+        }
+
+        $content = null;
+        for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
+            if ($tokens[$i]['code'] === T_STRING
+                // BC: PHPCS < 3.8.0.
+                || $tokens[$i]['code'] === T_SELF
+                || $tokens[$i]['code'] === T_PARENT
+                || $tokens[$i]['code'] === T_STATIC
+            ) {
+                $content = $tokens[$i]['content'];
+                break;
+            }
+        }
+
+        return $content;
     }
 
     /**

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -48,7 +48,8 @@ use PHPCSUtils\Tokens\Collections;
  *
  * Additionally, this class works round the following tokenizer issues for
  * any affected utility functions:
- * - None at this time.
+ * - `readonly` classes.
+ * - Constructor property promotion with `readonly` without visibility.
  *
  * Most functions in this class will have a related twin-function in the relevant
  * class in the `PHPCSUtils\Utils` namespace.

--- a/PHPCSUtils/Fixers/SpacesFixer.php
+++ b/PHPCSUtils/Fixers/SpacesFixer.php
@@ -133,7 +133,7 @@ final class SpacesFixer
         }
 
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($ptrA + 1), null, true);
-        if ($nextNonEmpty < $ptrB) {
+        if ($nextNonEmpty !== false && $nextNonEmpty < $ptrB) {
             throw new RuntimeException(
                 'The $stackPtr and the $secondPtr token must be adjacent tokens separated only'
                     . ' by whitespace and/or comments'

--- a/Tests/BackCompat/BCFile/GetDeclarationNameTest.inc
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameTest.inc
@@ -88,6 +88,15 @@ enum Suit: int implements Colorful, CardGame {}
 /* testFunctionReturnByRefWithReservedKeywordEach */
 function &each() {}
 
+/* testFunctionReturnByRefWithReservedKeywordParent */
+function &parent() {}
+
+/* testFunctionReturnByRefWithReservedKeywordSelf */
+function &self() {}
+
+/* testFunctionReturnByRefWithReservedKeywordStatic */
+function &static() {}
+
 /* testLiveCoding */
 // Intentional parse error. This has to be the last test in the file.
 function // Comment.

--- a/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
@@ -196,6 +196,18 @@ class GetDeclarationNameTest extends UtilityMethodTestCase
                 '/* testFunctionReturnByRefWithReservedKeywordEach */',
                 'each',
             ],
+            'function-return-by-reference-with-reserved-keyword-parent' => [
+                '/* testFunctionReturnByRefWithReservedKeywordParent */',
+                'parent',
+            ],
+            'function-return-by-reference-with-reserved-keyword-self' => [
+                '/* testFunctionReturnByRefWithReservedKeywordSelf */',
+                'self',
+            ],
+            'function-return-by-reference-with-reserved-keyword-static' => [
+                '/* testFunctionReturnByRefWithReservedKeywordStatic */',
+                'static',
+            ],
         ];
     }
 }

--- a/Tests/Fixers/SpacesFixer/SpacesFixerAtEOFTest.inc
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerAtEOFTest.inc
@@ -1,0 +1,4 @@
+<?php
+
+/* testCommentAtEndOfFile */
+echo $foo;    // Comment.

--- a/Tests/Fixers/SpacesFixer/SpacesFixerAtEOFTest.inc.fixed
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerAtEOFTest.inc.fixed
@@ -1,0 +1,4 @@
+<?php
+
+/* testCommentAtEndOfFile */
+echo $foo; // Comment.

--- a/Tests/Fixers/SpacesFixer/SpacesFixerAtEOFTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerAtEOFTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Fixers\SpacesFixer;
+
+use PHPCSUtils\Fixers\SpacesFixer;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+
+/**
+ * Tests for the \PHPCSUtils\Fixers\SpacesFixer::checkAndFix() method.
+ *
+ * @covers \PHPCSUtils\Fixers\SpacesFixer::checkAndFix
+ *
+ * @group fixers
+ *
+ * @since 1.0.8
+ */
+final class SpacesFixerAtEOFTest extends UtilityMethodTestCase
+{
+
+    /**
+     * Expected number of spaces to use for these tests.
+     *
+     * @var int|string
+     */
+    const SPACES = 1;
+
+    /**
+     * Dummy error message phrase to use for the test.
+     *
+     * @var string
+     */
+    const MSG = 'Expected: %s. Found: %s';
+
+    /**
+     * Dummy error code to use for the test.
+     *
+     * Using the dummy full error code to force it to record.
+     *
+     * @var string
+     */
+    const CODE = 'PHPCSUtils.SpacesFixer.Test.Found';
+
+    /**
+     * Test marker.
+     *
+     * @var string
+     */
+    const TESTMARKER = '/* testCommentAtEndOfFile */';
+
+    /**
+     * Set the name of a sniff to pass to PHPCS to limit the run (and force it to record errors).
+     *
+     * @var array
+     */
+    protected static $selectedSniff = ['PHPCSUtils.SpacesFixer.Test'];
+
+    /**
+     * Test that violations are correctly reported when there is no non-empty token after the second stack pointer.
+     *
+     * @return void
+     */
+    public function testCheckAndFix()
+    {
+        $stackPtr  = $this->getTargetToken(self::TESTMARKER, \T_SEMICOLON);
+        $secondPtr = $this->getTargetToken(self::TESTMARKER, \T_COMMENT);
+
+        SpacesFixer::checkAndFix(
+            self::$phpcsFile,
+            $stackPtr,
+            $secondPtr,
+            self::SPACES,
+            self::MSG,
+            self::CODE
+        );
+
+        $result = self::$phpcsFile->getErrors();
+        $tokens = self::$phpcsFile->getTokens();
+
+        if (isset($result[$tokens[$stackPtr]['line']][$tokens[$stackPtr]['column']]) === false) {
+            $this->fail('Expected 1 violation. None found.');
+        }
+
+        $messages = $result[$tokens[$stackPtr]['line']][$tokens[$stackPtr]['column']];
+
+        // Expect one violation.
+        $this->assertCount(1, $messages, 'Expected 1 violation, found: ' . \count($messages));
+
+        /*
+         * Test the violation details.
+         */
+        $this->assertSame(self::CODE, $messages[0]['source'], 'Error code comparison failed');
+
+        $this->assertSame(true, $messages[0]['fixable'], 'Fixability comparison failed');
+    }
+
+    /**
+     * Test that the fixes are correctly made when there is no non-empty token after the second stack pointer.
+     *
+     * @return void
+     */
+    public function testFixesMade()
+    {
+        self::$phpcsFile->fixer->startFile(self::$phpcsFile);
+        self::$phpcsFile->fixer->enabled = true;
+
+        $stackPtr  = $this->getTargetToken(self::TESTMARKER, \T_SEMICOLON);
+        $secondPtr = $this->getTargetToken(self::TESTMARKER, \T_COMMENT);
+
+        SpacesFixer::checkAndFix(
+            self::$phpcsFile,
+            $stackPtr,
+            $secondPtr,
+            self::SPACES,
+            self::MSG,
+            self::CODE
+        );
+
+        $fixedFile = self::$phpcsFile->getFilename() . '.fixed';
+        $result    = self::$phpcsFile->fixer->getContents();
+
+        $this->assertStringEqualsFile(
+            $fixedFile,
+            $result,
+            \sprintf(
+                'Fixed version of %s does not match expected version in %s',
+                \basename(self::$caseFile),
+                \basename($fixedFile)
+            )
+        );
+    }
+}

--- a/Tests/Utils/ObjectDeclarations/GetNameDiffTest.inc
+++ b/Tests/Utils/ObjectDeclarations/GetNameDiffTest.inc
@@ -12,15 +12,6 @@ interface switch{ // Intentional parse error.
     public function someFunction();
 }
 
-/* testFunctionReturnByRefWithReservedKeywordParent */
-function &parent() {}
-
-/* testFunctionReturnByRefWithReservedKeywordSelf */
-function &self() {}
-
-/* testFunctionReturnByRefWithReservedKeywordStatic */
-function &static() {}
-
 /* testLiveCoding */
 // Intentional parse error. Redundancy testing.
 abstract class

--- a/Tests/Utils/ObjectDeclarations/GetNameDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameDiffTest.php
@@ -117,18 +117,6 @@ final class GetNameDiffTest extends UtilityMethodTestCase
                 'testMarker' => '/* testInvalidInterfaceName */',
                 'expected'   => 'switch',
             ],
-            'function-return-by-reference-with-reserved-keyword-parent' => [
-                '/* testFunctionReturnByRefWithReservedKeywordParent */',
-                'parent',
-            ],
-            'function-return-by-reference-with-reserved-keyword-self' => [
-                '/* testFunctionReturnByRefWithReservedKeywordSelf */',
-                'self',
-            ],
-            'function-return-by-reference-with-reserved-keyword-static' => [
-                '/* testFunctionReturnByRefWithReservedKeywordStatic */',
-                'static',
-            ],
         ];
     }
 }


### PR DESCRIPTION
## Release checklist

### General

- [x] Verify, and if necessary, update the version constraints for dependencies in the `composer.json` - _N/A_
- [x] Verify that any new functions have type declarations whenever possible. -  _N/A_
- [x] Add changelog for the release - PR #495
    :pencil2: Remember to add a release link at the bottom!

### Release

- [x] Merge this PR
- [x] Make sure all CI builds are green.
- [x] Tag and create a release (careful, GH defaults to `develop`!) & copy & paste the changelog to it.
    :pencil2: Don't forget to copy the link collection from the bottom of the changelog!
- [x] Make sure all CI builds are green.
- [x] Verify that the website regenerated correctly.
- [x] Close the milestone
- [x] Open a new milestone for the next release
- [x] If any open PRs/issues which were milestoned for this release did not make it into the release, update their milestone.
- [x] Fast-forward `develop` to be equal to `stable`

### Publicize

- [ ] Tweet about the release.
- [ ] Inform the primary dependants of this repo (PHPCSExtra, WordPressCS, PHPCompatibility and VariableAnalysis) about the release.
