### PR TITLE
Update for PHPUnit Polyfills 1.1.0

### DIFF
--- a/Tests/PolyfilledTestCase.php
+++ b/Tests/PolyfilledTestCase.php
@@ -103,6 +103,7 @@ if (\version_compare(Autoload::VERSION, '2.0.0', '>=')) {
         use AssertIsType;
         use AssertNumericType;
         use AssertObjectEquals;
+        use AssertObjectProperty;
         use AssertStringContains;
         use EqualToSpecializations;
         use ExpectException;

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "phpcsstandards/phpcsdevcs": "^1.1.6",
         "php-parallel-lint/php-parallel-lint": "^1.3.2",
         "php-parallel-lint/php-console-highlighter": "^1.0",
-        "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
+        "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
The Polyfills 1.1.0 backport a trait which was made available in the 2.0.0 version.

This updates the `PolyfilledTestCase` to take that into account and updates the minimum supported version in Composer.

Ref: https://github.com/Yoast/PHPUnit-Polyfills/releases/tag/1.1.0