### PR TITLE
[NoFile]Cache/SetTest: pass correct type to base_convert()

### DIFF
--- a/Tests/Internal/Cache/SetTest.php
+++ b/Tests/Internal/Cache/SetTest.php
@@ -95,7 +95,7 @@ final class SetTest extends UtilityMethodTestCase
      */
     public function testSetAcceptsEveryTypeOfInput($input)
     {
-        $id = \base_convert(\rand((int) 10e16, (int) 10e20), 10, 36);
+        $id = \base_convert((string) \rand((int) 10e16, (int) 10e20), 10, 36);
         Cache::set(self::$phpcsFile, __METHOD__, $id, $input);
 
         $this->assertTrue(

--- a/Tests/Internal/NoFileCache/SetTest.php
+++ b/Tests/Internal/NoFileCache/SetTest.php
@@ -89,7 +89,7 @@ final class SetTest extends TestCase
      */
     public function testSetAcceptsEveryTypeOfInput($input)
     {
-        $id = \base_convert(\rand((int) 10e16, (int) 10e20), 10, 36);
+        $id = \base_convert((string) \rand((int) 10e16, (int) 10e20), 10, 36);
         NoFileCache::set(__METHOD__, $id, $input);
 
         $this->assertTrue(


### PR DESCRIPTION
The PHP native `base_convert()` function expects a string as the first parameter. While this is not really a problem, as without `strict_types`, PHP will just juggle the type from `int` to `string`, it is still good to be explicit.

Ref: https://www.php.net/manual/en/function.base-convert.php