### PR TITLE
Docs: various `@var`/`@param`/`@return` tag improvements

### DIFF
--- a/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
+++ b/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
@@ -42,7 +42,7 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @var array
+     * @var array<int, array<string, mixed>>
      */
     protected $tokens;
 
@@ -79,7 +79,7 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @var array
+     * @var array<int, array<string, int|string>>
      */
     protected $arrayItems;
 
@@ -108,7 +108,7 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
      *
      * @since 1.0.0
      *
-     * @var array
+     * @var array<int|string, int|string>
      */
     private $acceptedTokens = [
         \T_NULL                     => \T_NULL,
@@ -152,7 +152,7 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
      *
      * @codeCoverageIgnore
      *
-     * @return array
+     * @return array<int|string>
      */
     public function register()
     {

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -201,7 +201,7 @@ final class BCFile
      * @param int                         $stackPtr  The position in the stack of the function token
      *                                               to acquire the parameters for.
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified `$stackPtr` is not of
      *                                                      type `T_FUNCTION`, `T_CLOSURE`, `T_USE`,
@@ -509,7 +509,7 @@ final class BCFile
      * @param int                         $stackPtr  The position in the stack of the function token to
      *                                               acquire the properties for.
      *
-     * @return array
+     * @return array<string, mixed>
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
      *                                                      `T_FUNCTION`, `T_CLOSURE`, or `T_FN` token.
@@ -554,7 +554,7 @@ final class BCFile
      * @param int                         $stackPtr  The position in the stack of the `T_VARIABLE` token to
      *                                               acquire the properties for.
      *
-     * @return array
+     * @return array<string, mixed>
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
      *                                                      `T_VARIABLE` token, or if the position is not
@@ -573,7 +573,7 @@ final class BCFile
      * array(
      *   'is_abstract' => boolean, // TRUE if the abstract keyword was found.
      *   'is_final'    => boolean, // TRUE if the final keyword was found.
-     *   'is_readonly' => false, // TRUE if the readonly keyword was found.
+     *   'is_readonly' => boolean, // TRUE if the readonly keyword was found.
      * );
      * ```
      *
@@ -593,7 +593,7 @@ final class BCFile
      * @param int                         $stackPtr  The position in the stack of the `T_CLASS`
      *                                               token to acquire the properties for.
      *
-     * @return array
+     * @return array<string, bool>
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
      *                                                      `T_CLASS` token.
@@ -714,9 +714,9 @@ final class BCFile
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $start     The position to start searching from in the token stack.
-     * @param int|string|array            $ignore    Token types that should not be considered stop points.
+     * @param \PHP_CodeSniffer\Files\File  $phpcsFile The file being scanned.
+     * @param int                          $start     The position to start searching from in the token stack.
+     * @param int|string|array<int|string> $ignore    Token types that should not be considered stop points.
      *
      * @return int
      */
@@ -738,9 +738,9 @@ final class BCFile
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $start     The position to start searching from in the token stack.
-     * @param int|string|array            $ignore    Token types that should not be considered stop points.
+     * @param \PHP_CodeSniffer\Files\File  $phpcsFile The file being scanned.
+     * @param int                          $start     The position to start searching from in the token stack.
+     * @param int|string|array<int|string> $ignore    Token types that should not be considered stop points.
      *
      * @return int
      */
@@ -763,9 +763,9 @@ final class BCFile
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the token we are checking.
-     * @param int|string|array            $types     The type(s) of tokens to search for.
+     * @param \PHP_CodeSniffer\Files\File  $phpcsFile The file being scanned.
+     * @param int                          $stackPtr  The position of the token we are checking.
+     * @param int|string|array<int|string> $types     The type(s) of tokens to search for.
      *
      * @return bool
      */
@@ -847,8 +847,8 @@ final class BCFile
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The stack position of the class or enum token.
      *
-     * @return array|false Array with names of the implemented interfaces or `FALSE` on
-     *                     error or if there are no implemented interface names.
+     * @return string[]|false Array with names of the implemented interfaces or `FALSE` on
+     *                        error or if there are no implemented interface names.
      */
     public static function findImplementedInterfaceNames(File $phpcsFile, $stackPtr)
     {

--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -78,11 +78,11 @@ final class BCTokens
      *
      * @since 1.0.0
      *
-     * @param string $name The name of the method which has been called.
-     * @param array  $args Any arguments passed to the method.
-     *                     Unused as none of the methods take arguments.
+     * @param string       $name The name of the method which has been called.
+     * @param array<mixed> $args Any arguments passed to the method.
+     *                           Unused as none of the methods take arguments.
      *
-     * @return array <int|string> => <int|string> Token array
+     * @return array<int|string, int|string> Token array
      *
      * @throws \PHPCSUtils\Exceptions\InvalidTokenArray When an invalid token array is requested.
      */
@@ -110,7 +110,7 @@ final class BCTokens
      *
      * @since 1.0.0
      *
-     * @return array <int|string> => <int|string> Token array.
+     * @return array<int|string, int|string> Token array.
      */
     public static function functionNameTokens()
     {

--- a/PHPCSUtils/BackCompat/Helper.php
+++ b/PHPCSUtils/BackCompat/Helper.php
@@ -52,7 +52,7 @@ final class Helper
      * @since 1.0.0
      *
      * @param string                  $key    The name of the config value.
-     * @param string|null             $value  The value to set. If `null`, the config entry
+     * @param mixed                   $value  The value to set. If `null`, the config entry
      *                                        is deleted, reverting it to the default value.
      * @param bool                    $temp   Set this config data temporarily for this script run.
      *                                        This will not write the config data to the config file.

--- a/PHPCSUtils/Exceptions/TestTargetNotFound.php
+++ b/PHPCSUtils/Exceptions/TestTargetNotFound.php
@@ -29,7 +29,7 @@ final class TestTargetNotFound extends OutOfBoundsException
      * @param string $content The (optional) target token content.
      * @param string $file    The file in which the target token was not found.
      *
-     * @return \PHPCSUtils\Exceptions\TestMarkerNotFound
+     * @return \PHPCSUtils\Exceptions\TestTargetNotFound
      */
     public static function create($marker, $content, $file)
     {

--- a/PHPCSUtils/Internal/Cache.php
+++ b/PHPCSUtils/Internal/Cache.php
@@ -68,7 +68,8 @@ final class Cache
      *
      * @since 1.0.0
      *
-     * @var array<int, array<string, array>> Format: $cache[$loop][$fileName][$key][$id] = mixed $value;
+     * @var array<int, array<string, array<string, array<string|int, mixed>>>>
+     *            Format: $cache[$loop][$fileName][$key][$id] = mixed $value;
      */
     private static $cache = [];
 
@@ -144,7 +145,7 @@ final class Cache
      * @param string                      $key       The key to identify a particular set of results.
      *                                               It is recommended to pass __METHOD__ to this parameter.
      *
-     * @return array
+     * @return array<string|int, mixed>
      */
     public static function getForFile(File $phpcsFile, $key)
     {

--- a/PHPCSUtils/Internal/IsShortArrayOrList.php
+++ b/PHPCSUtils/Internal/IsShortArrayOrList.php
@@ -114,7 +114,7 @@ final class IsShortArrayOrList
      *
      * @since 1.0.0
      *
-     * @var array
+     * @var array<int, array<string, mixed>>
      */
     private $tokens;
 
@@ -168,7 +168,7 @@ final class IsShortArrayOrList
      *
      * @since 1.0.0
      *
-     * @return array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private $openBrackets;
 

--- a/PHPCSUtils/Internal/IsShortArrayOrListWithCache.php
+++ b/PHPCSUtils/Internal/IsShortArrayOrListWithCache.php
@@ -58,7 +58,7 @@ final class IsShortArrayOrListWithCache
      *
      * @since 1.0.0
      *
-     * @var array
+     * @var array<int, array<string, mixed>>
      */
     private $tokens;
 

--- a/PHPCSUtils/Internal/NoFileCache.php
+++ b/PHPCSUtils/Internal/NoFileCache.php
@@ -116,7 +116,7 @@ final class NoFileCache
      * @param string $key The key to identify a particular set of results.
      *                    It is recommended to pass `__METHOD__` to this parameter.
      *
-     * @return array
+     * @return array<int|string, mixed>
      */
     public static function getForKey($key)
     {

--- a/PHPCSUtils/Internal/StableCollections.php
+++ b/PHPCSUtils/Internal/StableCollections.php
@@ -46,7 +46,7 @@ final class StableCollections
      *
      * @since 1.0.2
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     public static $shortArrayListOpenTokensBC = [
         \T_OPEN_SHORT_ARRAY    => \T_OPEN_SHORT_ARRAY,
@@ -64,7 +64,7 @@ final class StableCollections
      *
      * @since 1.0.2
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     public static $shortArrayListTokensBC = [
         \T_OPEN_SHORT_ARRAY     => \T_OPEN_SHORT_ARRAY,

--- a/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+++ b/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
@@ -154,7 +154,7 @@ abstract class UtilityMethodTestCase extends TestCase
      *
      * @since 1.0.0
      *
-     * @var \PHP_CodeSniffer\Files\File
+     * @var \PHP_CodeSniffer\Files\File|null
      */
     protected static $phpcsFile;
 
@@ -168,7 +168,7 @@ abstract class UtilityMethodTestCase extends TestCase
      *
      * @since 1.0.0
      *
-     * @var array
+     * @var string[]
      */
     protected static $selectedSniff = ['Dummy.Dummy.Dummy'];
 
@@ -329,10 +329,10 @@ abstract class UtilityMethodTestCase extends TestCase
      *
      * @since 1.0.0
      *
-     * @param string           $commentString The complete delimiter comment to look for as a string.
-     *                                        This string should include the comment opener and closer.
-     * @param int|string|array $tokenType     The type of token(s) to look for.
-     * @param string           $tokenContent  Optional. The token content for the target token.
+     * @param string                       $commentString The complete delimiter comment to look for as a string.
+     *                                                    This string should include the comment opener and closer.
+     * @param int|string|array<int|string> $tokenType     The type of token(s) to look for.
+     * @param string                       $tokenContent  Optional. The token content for the target token.
      *
      * @return int
      *

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -67,7 +67,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::alternativeControlStructureSyntaxes()} method for access.
      *
-     * @var array <int> => <int>
+     * @var array<int, int>
      */
     private static $alternativeControlStructureSyntaxes = [
         \T_IF      => \T_IF,
@@ -85,7 +85,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::alternativeControlStructureSyntaxClosers()} method for access.
      *
-     * @var array <int> => <int>
+     * @var array<int, int>
      */
     private static $alternativeControlStructureSyntaxClosers = [
         \T_ENDIF      => \T_ENDIF,
@@ -109,7 +109,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::arrayOpenTokensBC()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $arrayOpenTokensBC = [
         \T_ARRAY            => \T_ARRAY,
@@ -128,7 +128,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::arrayTokens()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $arrayTokens = [
         \T_ARRAY             => \T_ARRAY,
@@ -141,7 +141,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::classModifierKeywords()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $classModifierKeywords = [
         \T_FINAL    => \T_FINAL,
@@ -160,7 +160,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::closedScopes()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $closedScopes = [
         \T_CLASS      => \T_CLASS,
@@ -180,7 +180,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::constantModifierKeywords()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $constantModifierKeywords = [
         \T_PUBLIC    => \T_PUBLIC,
@@ -194,7 +194,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::controlStructureTokens()} method for access.
      *
-     * @var array <int> => <int>
+     * @var array<int|string, int|string>
      */
     private static $controlStructureTokens = [
         \T_IF      => \T_IF,
@@ -214,7 +214,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::functionDeclarationTokens()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $functionDeclarationTokens = [
         \T_FUNCTION => \T_FUNCTION,
@@ -227,7 +227,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::incrementDecrementOperators()} method for access.
      *
-     * @var array <int> => <int>
+     * @var array<int, int>
      */
     private static $incrementDecrementOperators = [
         \T_DEC => \T_DEC,
@@ -247,7 +247,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::listOpenTokensBC()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $listOpenTokensBC = [
         \T_LIST             => \T_LIST,
@@ -264,7 +264,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::listTokens()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $listTokens = [
         \T_LIST              => \T_LIST,
@@ -277,7 +277,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::namespaceDeclarationClosers()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $namespaceDeclarationClosers = [
         \T_SEMICOLON          => \T_SEMICOLON,
@@ -298,7 +298,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::nameTokens()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $nameTokens = [
         \T_STRING               => \T_STRING,
@@ -312,7 +312,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::objectOperators()} method for access.
      *
-     * @var array <int> => <int>
+     * @var array<int|string, int|string>
      */
     private static $objectOperators = [
         \T_DOUBLE_COLON             => \T_DOUBLE_COLON,
@@ -325,7 +325,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::ooCanExtend()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $ooCanExtend = [
         \T_CLASS      => \T_CLASS,
@@ -338,7 +338,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::ooCanImplement()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $ooCanImplement = [
         \T_CLASS      => \T_CLASS,
@@ -353,7 +353,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::ooConstantScopes()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $ooConstantScopes = [
         \T_CLASS      => \T_CLASS,
@@ -370,7 +370,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::ooHierarchyKeywords()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $ooHierarchyKeywords = [
         \T_PARENT => \T_PARENT,
@@ -385,7 +385,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::ooPropertyScopes()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $ooPropertyScopes = [
         \T_CLASS      => \T_CLASS,
@@ -398,7 +398,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::parameterTypeTokens()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $parameterTypeTokens = [
         \T_CALLABLE          => \T_CALLABLE,
@@ -416,7 +416,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::phpOpenTags()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int, int>
      */
     private static $phpOpenTags = [
         \T_OPEN_TAG           => \T_OPEN_TAG,
@@ -428,7 +428,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::propertyModifierKeywords()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $propertyModifierKeywords = [
         \T_PUBLIC    => \T_PUBLIC,
@@ -444,7 +444,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::propertyTypeTokens()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $propertyTypeTokens = [
         \T_CALLABLE          => \T_CALLABLE,
@@ -462,7 +462,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::returnTypeTokens()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $returnTypeTokens = [
         \T_CALLABLE          => \T_CALLABLE,
@@ -481,7 +481,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::shortArrayListOpenTokensBC()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $shortArrayListOpenTokensBC = [
         \T_OPEN_SHORT_ARRAY => \T_OPEN_SHORT_ARRAY,
@@ -494,7 +494,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::shortArrayTokens()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $shortArrayTokens = [
         \T_OPEN_SHORT_ARRAY  => \T_OPEN_SHORT_ARRAY,
@@ -508,7 +508,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::shortListTokens()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $shortListTokens = [
         \T_OPEN_SHORT_ARRAY  => \T_OPEN_SHORT_ARRAY,
@@ -520,7 +520,7 @@ final class Collections
      *
      * @since 1.0.0 Use the {@see Collections::textStringStartTokens()} method for access.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $textStringStartTokens = [
         \T_START_HEREDOC            => \T_START_HEREDOC,
@@ -534,11 +534,11 @@ final class Collections
      *
      * @since 1.0.0
      *
-     * @param string $name The name of the method which has been called.
-     * @param array  $args Any arguments passed to the method.
-     *                     Unused as none of the methods take arguments.
+     * @param string       $name The name of the method which has been called.
+     * @param array<mixed> $args Any arguments passed to the method.
+     *                           Unused as none of the methods take arguments.
      *
-     * @return array <int|string> => <int|string> Token array
+     * @return array<int|string, int|string> Token array
      *
      * @throws \PHPCSUtils\Exceptions\InvalidTokenArray When an invalid token array is requested.
      */
@@ -592,7 +592,7 @@ final class Collections
      *
      * @since 1.0.0
      *
-     * @return array <int|string> => <int|string>
+     * @return array<int|string, int|string>
      */
     public static function arrayOpenTokensBC()
     {
@@ -619,7 +619,7 @@ final class Collections
      *
      * @since 1.0.0
      *
-     * @return array <int|string> => <int|string>
+     * @return array<int|string, int|string>
      */
     public static function arrayTokensBC()
     {
@@ -640,7 +640,7 @@ final class Collections
      *
      * @since 1.0.0
      *
-     * @return array <int|string> => <int|string>
+     * @return array<int|string, int|string>
      */
     public static function functionCallTokens()
     {
@@ -669,7 +669,7 @@ final class Collections
      *
      * @since 1.0.0
      *
-     * @return array <int|string> => <int|string>
+     * @return array<int|string, int|string>
      */
     public static function listOpenTokensBC()
     {
@@ -694,7 +694,7 @@ final class Collections
      *
      * @since 1.0.0
      *
-     * @return array <int|string> => <int|string>
+     * @return array<int|string, int|string>
      */
     public static function listTokensBC()
     {
@@ -718,7 +718,7 @@ final class Collections
      *
      * @since 1.0.0
      *
-     * @return array <int|string> => <int|string>
+     * @return array<int|string, int|string>
      */
     public static function namespacedNameTokens()
     {
@@ -739,7 +739,7 @@ final class Collections
      *
      * @since 1.0.0
      *
-     * @return array <int|string> => <int|string>
+     * @return array<int|string, int|string>
      */
     public static function parameterPassingTokens()
     {
@@ -761,7 +761,7 @@ final class Collections
      *
      * @since 1.0.0
      *
-     * @return array <int|string> => <int|string>
+     * @return array<int|string, int|string>
      */
     public static function parameterTypeTokens()
     {
@@ -776,7 +776,7 @@ final class Collections
      *
      * @since 1.0.0
      *
-     * @return array <int|string> => <int|string>
+     * @return array<int|string, int|string>
      */
     public static function propertyTypeTokens()
     {
@@ -791,7 +791,7 @@ final class Collections
      *
      * @since 1.0.0
      *
-     * @return array <int|string> => <int|string>
+     * @return array<int|string, int|string>
      */
     public static function returnTypeTokens()
     {
@@ -811,7 +811,7 @@ final class Collections
      *
      * @since 1.0.0
      *
-     * @return array <int|string> => <int|string>
+     * @return array<int|string, int|string>
      */
     public static function shortArrayListOpenTokensBC()
     {
@@ -836,7 +836,7 @@ final class Collections
      *
      * @since 1.0.0
      *
-     * @return array <int|string> => <int|string>
+     * @return array<int|string, int|string>
      */
     public static function shortArrayTokensBC()
     {
@@ -862,7 +862,7 @@ final class Collections
      *
      * @since 1.0.0
      *
-     * @return array <int|string> => <int|string>
+     * @return array<int|string, int|string>
      */
     public static function shortListTokensBC()
     {

--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -29,7 +29,7 @@ final class Arrays
      *
      * @since 1.0.0
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $doubleArrowTargets = [
         \T_DOUBLE_ARROW     => \T_DOUBLE_ARROW,
@@ -86,15 +86,15 @@ final class Arrays
      *                                                  tokens in an array.
      *                                                  Use with care.
      *
-     * @return array|false An array with the token pointers; or `FALSE` if this is not a
-     *                     (short) array token or if the opener/closer could not be determined.
-     *                     The format of the array return value is:
-     *                     ```php
-     *                     array(
-     *                       'opener' => integer, // Stack pointer to the array open bracket.
-     *                       'closer' => integer, // Stack pointer to the array close bracket.
-     *                     )
-     *                     ```
+     * @return array<string, int>|false An array with the token pointers; or `FALSE` if this is not a
+     *                                  (short) array token or if the opener/closer could not be determined.
+     *                                  The format of the array return value is:
+     *                                  ```php
+     *                                  array(
+     *                                    'opener' => integer, // Stack pointer to the array open bracket.
+     *                                    'closer' => integer, // Stack pointer to the array close bracket.
+     *                                  )
+     *                                  ```
      */
     public static function getOpenClose(File $phpcsFile, $stackPtr, $isShortArray = null)
     {

--- a/PHPCSUtils/Utils/Conditions.php
+++ b/PHPCSUtils/Utils/Conditions.php
@@ -39,12 +39,12 @@ final class Conditions
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the token we are checking.
-     * @param int|string|array            $types     Optional. The type(s) of tokens to search for.
-     * @param bool                        $first     Optional. Whether to search for the first (outermost)
-     *                                               (`true`) or the last (innermost) condition (`false`) of
-     *                                               the specified type(s).
+     * @param \PHP_CodeSniffer\Files\File  $phpcsFile The file being scanned.
+     * @param int                          $stackPtr  The position of the token we are checking.
+     * @param int|string|array<int|string> $types     Optional. The type(s) of tokens to search for.
+     * @param bool                         $first     Optional. Whether to search for the first (outermost)
+     *                                                (`true`) or the last (innermost) condition (`false`) of
+     *                                                the specified type(s).
      *
      * @return int|false Integer stack pointer to the condition; or `FALSE` if the token
      *                   does not have the condition or has no conditions at all.
@@ -103,9 +103,9 @@ final class Conditions
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the token we are checking.
-     * @param int|string|array            $types     The type(s) of tokens to search for.
+     * @param \PHP_CodeSniffer\Files\File  $phpcsFile The file being scanned.
+     * @param int                          $stackPtr  The position of the token we are checking.
+     * @param int|string|array<int|string> $types     The type(s) of tokens to search for.
      *
      * @return bool
      */
@@ -122,9 +122,9 @@ final class Conditions
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
-     * @param int                         $stackPtr  The position of the token we are checking.
-     * @param int|string|array            $types     Optional. The type(s) of tokens to search for.
+     * @param \PHP_CodeSniffer\Files\File  $phpcsFile The file where this token was found.
+     * @param int                          $stackPtr  The position of the token we are checking.
+     * @param int|string|array<int|string> $types     Optional. The type(s) of tokens to search for.
      *
      * @return int|false Integer stack pointer to the condition; or `FALSE` if the token
      *                   does not have the condition or has no conditions at all.
@@ -142,9 +142,9 @@ final class Conditions
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
-     * @param int                         $stackPtr  The position of the token we are checking.
-     * @param int|string|array            $types     Optional. The type(s) of tokens to search for.
+     * @param \PHP_CodeSniffer\Files\File  $phpcsFile The file where this token was found.
+     * @param int                          $stackPtr  The position of the token we are checking.
+     * @param int|string|array<int|string> $types     Optional. The type(s) of tokens to search for.
      *
      * @return int|false Integer stack pointer to the condition; or `FALSE` if the token
      *                   does not have the condition or has no conditions at all.

--- a/PHPCSUtils/Utils/ControlStructures.php
+++ b/PHPCSUtils/Utils/ControlStructures.php
@@ -199,7 +199,8 @@ final class ControlStructures
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of the token we are checking.
      *
-     * @return array Array with information about the caught Exception(s).
+     * @return array<int, array<string, string|int>>
+     *               Array with information about the caught Exception(s).
      *               The returned array will contain the following information for
      *               each caught exception:
      *               ```php

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -43,7 +43,7 @@ final class FunctionDeclarations
      *
      * @since 1.0.0
      *
-     * @var array <string> => <string>
+     * @var array<string, string>
      */
     public static $magicFunctions = [
         '__autoload' => 'autoload',
@@ -59,7 +59,7 @@ final class FunctionDeclarations
      *
      * @since 1.0.0
      *
-     * @var array <string> => <string>
+     * @var array<string, string>
      */
     public static $magicMethods = [
         '__construct'   => 'construct',
@@ -94,7 +94,7 @@ final class FunctionDeclarations
      *
      * @since 1.0.0
      *
-     * @var array <string> => <string>
+     * @var array<string, string>
      */
     public static $methodsDoubleUnderscore = [
         '__dorequest'              => 'SOAPClient',
@@ -160,7 +160,7 @@ final class FunctionDeclarations
      * @param int                         $stackPtr  The position in the stack of the function token to
      *                                               acquire the properties for.
      *
-     * @return array Array with information about a function declaration.
+     * @return array<string, mixed> Array with information about a function declaration.
      *               The format of the return value is:
      *               ```php
      *               array(
@@ -379,7 +379,7 @@ final class FunctionDeclarations
      * @param int                         $stackPtr  The position in the stack of the function token
      *                                               to acquire the parameters for.
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified $stackPtr is not of
      *                                                      type `T_FUNCTION`, `T_CLOSURE` or `T_USE`,

--- a/PHPCSUtils/Utils/Lists.php
+++ b/PHPCSUtils/Utils/Lists.php
@@ -33,7 +33,7 @@ final class Lists
      *
      * @since 1.0.0
      *
-     * @var array
+     * @var array<string, mixed>
      */
     private static $listItemDefaults = [
         'raw'                  => '',
@@ -87,15 +87,15 @@ final class Lists
      *                                                 tokens in a list.
      *                                                 Use with care.
      *
-     * @return array|false An array with the token pointers; or `FALSE` if this is not a (short) list
-     *                     token or if the opener/closer could not be determined.
-     *                     The format of the array return value is:
-     *                     ```php
-     *                     array(
-     *                       'opener' => integer, // Stack pointer to the list open bracket.
-     *                       'closer' => integer, // Stack pointer to the list close bracket.
-     *                     )
-     *                     ```
+     * @return array<string, int>|false An array with the token pointers; or `FALSE` if this is not a (short) list
+     *                                  token or if the opener/closer could not be determined.
+     *                                 The format of the array return value is:
+     *                                 ```php
+     *                                 array(
+     *                                   'opener' => integer, // Stack pointer to the list open bracket.
+     *                                   'closer' => integer, // Stack pointer to the list close bracket.
+     *                                 )
+     *                                 ```
      */
     public static function getOpenClose(File $phpcsFile, $stackPtr, $isShortList = null)
     {
@@ -190,7 +190,8 @@ final class Lists
      * @param int                         $stackPtr  The position in the stack of the function token
      *                                               to acquire the parameters for.
      *
-     * @return array An array with information on each assignment made, including skipped assignments (empty),
+     * @return array<int, array<string, mixed>>
+     *               An array with information on each assignment made, including skipped assignments (empty),
      *               or an empty array if no assignments are made at all (fatal error in PHP >= 7.0).
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified $stackPtr is not of

--- a/PHPCSUtils/Utils/MessageHelper.php
+++ b/PHPCSUtils/Utils/MessageHelper.php
@@ -34,7 +34,7 @@ final class MessageHelper
      *                                               Defaults to true (error).
      * @param string                      $code      The error code for the message.
      *                                               Defaults to 'Found'.
-     * @param array                       $data      Optional input for the data replacements.
+     * @param scalar[]                    $data      Optional input for the data replacements.
      * @param int                         $severity  Optional. Severity level. Defaults to 0 which will
      *                                               translate to the PHPCS default severity level.
      *
@@ -70,7 +70,7 @@ final class MessageHelper
      *                                               Defaults to true (error).
      * @param string                      $code      The error code for the message.
      *                                               Defaults to 'Found'.
-     * @param array                       $data      Optional input for the data replacements.
+     * @param scalar[]                    $data      Optional input for the data replacements.
      * @param int                         $severity  Optional. Severity level. Defaults to 0 which will
      *                                               translate to the PHPCS default severity level.
      *

--- a/PHPCSUtils/Utils/Numbers.php
+++ b/PHPCSUtils/Utils/Numbers.php
@@ -106,7 +106,7 @@ final class Numbers
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position of a T_LNUMBER or T_DNUMBER token.
      *
-     * @return array An array with information about the number.
+     * @return array<string, string|int> An array with information about the number.
      *               The format of the array return value is:
      *               ```php
      *               array(

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -147,7 +147,7 @@ final class ObjectDeclarations
      * @param int                         $stackPtr  The position in the stack of the `T_CLASS`
      *                                               token to acquire the properties for.
      *
-     * @return array Array with implementation properties of a class.
+     * @return array<string, int|bool> Array with implementation properties of a class.
      *               The format of the return value is:
      *               ```php
      *               array(
@@ -272,8 +272,8 @@ final class ObjectDeclarations
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The stack position of the class or enum token.
      *
-     * @return array|false Array with names of the implemented interfaces or `FALSE` on
-     *                     error or if there are no implemented interface names.
+     * @return string[]|false Array with names of the implemented interfaces or `FALSE` on
+     *                        error or if there are no implemented interface names.
      */
     public static function findImplementedInterfaceNames(File $phpcsFile, $stackPtr)
     {
@@ -290,8 +290,8 @@ final class ObjectDeclarations
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
      * @param int                         $stackPtr  The stack position of the interface keyword.
      *
-     * @return array|false Array with names of the extended interfaces or `FALSE` on
-     *                     error or if there are no extended interface names.
+     * @return string[]|false Array with names of the extended interfaces or `FALSE` on
+     *                        error or if there are no extended interface names.
      */
     public static function findExtendedInterfaceNames(File $phpcsFile, $stackPtr)
     {
@@ -309,16 +309,16 @@ final class ObjectDeclarations
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile  The file where this token was found.
-     * @param int                         $stackPtr   The stack position of the
-     *                                                class/interface declaration keyword.
-     * @param int                         $keyword    The token constant for the keyword to examine.
-     *                                                Either `T_EXTENDS` or `T_IMPLEMENTS`.
-     * @param array                       $allowedFor Array of OO types for which use of the keyword
-     *                                                is allowed.
+     * @param \PHP_CodeSniffer\Files\File   $phpcsFile  The file where this token was found.
+     * @param int                           $stackPtr   The stack position of the
+     *                                                  class/interface declaration keyword.
+     * @param int                           $keyword    The token constant for the keyword to examine.
+     *                                                  Either `T_EXTENDS` or `T_IMPLEMENTS`.
+     * @param array<int|string, int|string> $allowedFor Array of OO types for which use of the keyword
+     *                                                  is allowed.
      *
-     * @return array|false Returns an array of names or `FALSE` on error or when the object
-     *                     being declared does not extend/implement another object.
+     * @return string[]|false Returns an array of names or `FALSE` on error or when the object
+     *                        being declared does not extend/implement another object.
      */
     private static function findNames(File $phpcsFile, $stackPtr, $keyword, array $allowedFor)
     {

--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -35,7 +35,7 @@ final class Operators
      *
      * @since 1.0.0
      *
-     * @var array <int|string> => <irrelevant>
+     * @var array<int|string, true> Note: value is irrelevant, only key is used.
      */
     private static $extraUnaryIndicators = [
         \T_STRING_CONCAT       => true,

--- a/PHPCSUtils/Utils/Parentheses.php
+++ b/PHPCSUtils/Utils/Parentheses.php
@@ -34,7 +34,7 @@ final class Parentheses
      *
      * @since 1.0.0
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $extraParenthesesOwners = [
         \T_ISSET => \T_ISSET,
@@ -95,10 +95,10 @@ final class Parentheses
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
-     * @param int                         $stackPtr    The position of `T_OPEN/CLOSE_PARENTHESIS` token.
-     * @param int|string|array            $validOwners Array of token constants for the owners
-     *                                                 which should be considered valid.
+     * @param \PHP_CodeSniffer\Files\File  $phpcsFile   The file where this token was found.
+     * @param int                          $stackPtr    The position of `T_OPEN/CLOSE_PARENTHESIS` token.
+     * @param int|string|array<int|string> $validOwners Array of token constants for the owners
+     *                                                  which should be considered valid.
      *
      * @return bool `TRUE` if the owner is within the list of `$validOwners`; `FALSE` if not and
      *              if the parenthesis does not have a (direct) owner.
@@ -121,10 +121,10 @@ final class Parentheses
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
-     * @param int                         $stackPtr    The position of the token we are checking.
-     * @param int|string|array            $validOwners Array of token constants for the owners
-     *                                                 which should be considered valid.
+     * @param \PHP_CodeSniffer\Files\File  $phpcsFile   The file where this token was found.
+     * @param int                          $stackPtr    The position of the token we are checking.
+     * @param int|string|array<int|string> $validOwners Array of token constants for the owners
+     *                                                  which should be considered valid.
      *
      * @return bool
      */
@@ -143,10 +143,10 @@ final class Parentheses
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
-     * @param int                         $stackPtr    The position of the token we are checking.
-     * @param int|string|array            $validOwners Array of token constants for the owners
-     *                                                 which should be considered valid.
+     * @param \PHP_CodeSniffer\Files\File  $phpcsFile   The file where this token was found.
+     * @param int                          $stackPtr    The position of the token we are checking.
+     * @param int|string|array<int|string> $validOwners Array of token constants for the owners
+     *                                                  which should be considered valid.
      *
      * @return int|false Integer stack pointer to the parentheses opener; or `FALSE` if the token
      *                   does not have parentheses owned by any of the valid owners or if
@@ -167,10 +167,10 @@ final class Parentheses
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
-     * @param int                         $stackPtr    The position of the token we are checking.
-     * @param int|string|array            $validOwners Array of token constants for the owners
-     *                                                 which should be considered valid.
+     * @param \PHP_CodeSniffer\Files\File  $phpcsFile   The file where this token was found.
+     * @param int                          $stackPtr    The position of the token we are checking.
+     * @param int|string|array<int|string> $validOwners Array of token constants for the owners
+     *                                                  which should be considered valid.
      *
      * @return int|false Integer stack pointer to the parentheses closer; or `FALSE` if the token
      *                   does not have parentheses owned by any of the valid owners or if
@@ -197,10 +197,10 @@ final class Parentheses
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
-     * @param int                         $stackPtr    The position of the token we are checking.
-     * @param int|string|array            $validOwners Array of token constants for the owners
-     *                                                 which should be considered valid.
+     * @param \PHP_CodeSniffer\Files\File  $phpcsFile   The file where this token was found.
+     * @param int                          $stackPtr    The position of the token we are checking.
+     * @param int|string|array<int|string> $validOwners Array of token constants for the owners
+     *                                                  which should be considered valid.
      *
      * @return int|false Integer stack pointer to the parentheses owner; or `FALSE` if the token
      *                   does not have parentheses owned by any of the valid owners or if
@@ -226,10 +226,10 @@ final class Parentheses
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
-     * @param int                         $stackPtr    The position of the token we are checking.
-     * @param int|string|array            $validOwners Array of token constants for the owners
-     *                                                 which should be considered valid.
+     * @param \PHP_CodeSniffer\Files\File  $phpcsFile   The file where this token was found.
+     * @param int                          $stackPtr    The position of the token we are checking.
+     * @param int|string|array<int|string> $validOwners Array of token constants for the owners
+     *                                                  which should be considered valid.
      *
      * @return int|false Integer stack pointer to the parentheses opener; or `FALSE` if the token
      *                   does not have parentheses owned by any of the valid owners or if
@@ -250,10 +250,10 @@ final class Parentheses
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
-     * @param int                         $stackPtr    The position of the token we are checking.
-     * @param int|string|array            $validOwners Array of token constants for the owners
-     *                                                 which should be considered valid.
+     * @param \PHP_CodeSniffer\Files\File  $phpcsFile   The file where this token was found.
+     * @param int                          $stackPtr    The position of the token we are checking.
+     * @param int|string|array<int|string> $validOwners Array of token constants for the owners
+     *                                                  which should be considered valid.
      *
      * @return int|false Integer stack pointer to the parentheses closer; or `FALSE` if the token
      *                   does not have parentheses owned by any of the valid owners or if
@@ -280,10 +280,10 @@ final class Parentheses
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
-     * @param int                         $stackPtr    The position of the token we are checking.
-     * @param int|string|array            $validOwners Array of token constants for the owners
-     *                                                 which should be considered valid.
+     * @param \PHP_CodeSniffer\Files\File  $phpcsFile   The file where this token was found.
+     * @param int                          $stackPtr    The position of the token we are checking.
+     * @param int|string|array<int|string> $validOwners Array of token constants for the owners
+     *                                                  which should be considered valid.
      *
      * @return int|false Integer stack pointer to the parentheses owner; or `FALSE` if the token
      *                   does not have parentheses owned by any of the valid owners or if
@@ -305,11 +305,11 @@ final class Parentheses
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
-     * @param int                         $stackPtr    The position in the stack of the
-     *                                                 token to verify.
-     * @param int|string|array            $validOwners Array of token constants for the owners
-     *                                                 which should be considered valid.
+     * @param \PHP_CodeSniffer\Files\File  $phpcsFile   The file where this token was found.
+     * @param int                          $stackPtr    The position in the stack of the
+     *                                                  token to verify.
+     * @param int|string|array<int|string> $validOwners Array of token constants for the owners
+     *                                                  which should be considered valid.
      *
      * @return int|false Integer stack pointer to the valid parentheses owner; or `FALSE` if
      *                   the token was not wrapped in parentheses or if the outermost set
@@ -333,11 +333,11 @@ final class Parentheses
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
-     * @param int                         $stackPtr    The position in the stack of the
-     *                                                 token to verify.
-     * @param int|string|array            $validOwners Array of token constants for the owners
-     *                                                 which should be considered valid.
+     * @param \PHP_CodeSniffer\Files\File  $phpcsFile   The file where this token was found.
+     * @param int                          $stackPtr    The position in the stack of the
+     *                                                  token to verify.
+     * @param int|string|array<int|string> $validOwners Array of token constants for the owners
+     *                                                  which should be considered valid.
      *
      * @return int|false Integer stack pointer to the valid parentheses owner; or `FALSE` if
      *                   the token was not wrapped in parentheses or if the innermost set
@@ -363,13 +363,13 @@ final class Parentheses
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
-     * @param int                         $stackPtr    The position of the token we are checking.
-     * @param int|string|array            $validOwners Optional. Array of token constants for the owners
-     *                                                 which should be considered valid.
-     * @param bool                        $reverse     Optional. Whether to search for the first/outermost
-     *                                                 (`false`) or the last/innermost (`true`) set of
-     *                                                 parentheses with the specified owner(s).
+     * @param \PHP_CodeSniffer\Files\File  $phpcsFile   The file where this token was found.
+     * @param int                          $stackPtr    The position of the token we are checking.
+     * @param int|string|array<int|string> $validOwners Optional. Array of token constants for the owners
+     *                                                  which should be considered valid.
+     * @param bool                         $reverse     Optional. Whether to search for the first/outermost
+     *                                                  (`false`) or the last/innermost (`true`) set of
+     *                                                  parentheses with the specified owner(s).
      *
      * @return int|false Integer stack pointer to the parentheses opener; or `FALSE` if the token
      *                   does not have parentheses owned by any of the valid owners or if

--- a/PHPCSUtils/Utils/PassedParameters.php
+++ b/PHPCSUtils/Utils/PassedParameters.php
@@ -33,7 +33,7 @@ final class PassedParameters
      *
      * @since 1.0.0
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private static $callParsingStopPoints = [
         \T_COMMA                => \T_COMMA,
@@ -170,7 +170,8 @@ final class PassedParameters
      *                                                  Efficiency tweak for when this has already been established,
      *                                                  Use with EXTREME care.
      *
-     * @return array A multi-dimentional array with information on each parameter/array item.
+     * @return array<int, array<string, int|string>>
+     *               A multi-dimentional array with information on each parameter/array item.
      *               The information gathered about each parameter/array item is in the following format:
      *               ```php
      *               1 => array(
@@ -379,11 +380,11 @@ final class PassedParameters
      *                                                 always pass both the offset as well as the parameter
      *                                                 name when examining function calls.
      *
-     * @return array|false Array with information on the parameter/array item at the specified offset,
-     *                     or with the specified name.
-     *                     Or `FALSE` if the specified parameter/array item is not found.
-     *                     See {@see PassedParameters::getParameters()} for the format of the returned
-     *                     (single-dimensional) array.
+     * @return array<string, int|string>|false Array with information on the parameter/array item at the specified
+     *                                         offset, or with the specified name.
+     *                                         Or `FALSE` if the specified parameter/array item is not found.
+     *                                         See {@see PassedParameters::getParameters()} for the format of the
+     *                                         returned (single-dimensional) array.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the token passed is not one of the
      *                                                      accepted types or doesn't exist.
@@ -452,20 +453,23 @@ final class PassedParameters
      *
      * @since 1.0.0
      *
-     * @param array           $parameters  The output of a previous call to {@see PassedParameters::getParameters()}.
-     * @param int             $paramOffset The 1-based index position of the parameter to retrieve.
-     * @param string|string[] $paramNames  Either the name of the target parameter to retrieve
-     *                                     as a string or an array of names for the same target parameter.
-     *                                     An array of names is supported to allow for functions
-     *                                     for which the parameter names have undergone name
-     *                                     changes over time.
-     *                                     The name will take precedence over the offset.
+     * @param array<int, array<string, int|string>> $parameters  The output of a previous call to
+     *                                                           {@see PassedParameters::getParameters()}.
+     * @param int                                   $paramOffset The 1-based index position of the parameter
+     *                                                           to retrieve.
+     * @param string|string[]                       $paramNames  Either the name of the target parameter to retrieve
+     *                                                           as a string or an array of names for the same target
+     *                                                           parameter.
+     *                                                           An array of names is supported to allow for functions
+     *                                                           for which the parameter names have undergone name
+     *                                                           changes over time.
+     *                                                           The name will take precedence over the offset.
      *
-     * @return array|false Array with information on the parameter at the specified offset,
-     *                     or with the specified name.
-     *                     Or `FALSE` if the specified parameter is not found.
-     *                     See {@see PassedParameters::getParameters()} for the format of the returned
-     *                     (single-dimensional) array.
+     * @return array<string, int|string>|false Array with information on the parameter at the specified offset,
+     *                                         or with the specified name.
+     *                                         Or `FALSE` if the specified parameter is not found.
+     *                                         See {@see PassedParameters::getParameters()} for the format of the
+     *                                         returned (single-dimensional) array.
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the `$paramNames` parameter is not passed
      *                                                      and the requested parameter was not passed

--- a/PHPCSUtils/Utils/Scopes.php
+++ b/PHPCSUtils/Utils/Scopes.php
@@ -30,11 +30,11 @@ final class Scopes
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file where this token was found.
-     * @param int                         $stackPtr    The position in the stack of the
-     *                                                 token to verify.
-     * @param int|string|array            $validScopes Array of token constants representing
-     *                                                 the scopes considered valid.
+     * @param \PHP_CodeSniffer\Files\File  $phpcsFile   The file where this token was found.
+     * @param int                          $stackPtr    The position in the stack of the
+     *                                                  token to verify.
+     * @param int|string|array<int|string> $validScopes Array of token constants representing
+     *                                                  the scopes considered valid.
      *
      * @return int|false Integer stack pointer to the valid direct scope; or `FALSE` if
      *                   no valid direct scope was found.

--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -156,7 +156,8 @@ final class UseStatements
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
      * @param int                         $stackPtr  The position in the stack of the `T_USE` token.
      *
-     * @return array A multi-level array containing information about the use statement.
+     * @return array<string, array<string, string>>
+     *               A multi-level array containing information about the use statement.
      *               The first level is `'name'`, `'function'` and `'const'`. These keys will always exist.
      *               If any statements are found for any of these categories, the second level
      *               will contain the alias/name as the key and the full original use name as the
@@ -358,16 +359,18 @@ final class UseStatements
      *
      * @since 1.0.0
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile             The file where this token was found.
-     * @param int                         $stackPtr              The position in the stack of the `T_USE` token.
-     * @param array                       $previousUseStatements The import `use` statements collected so far.
-     *                                                           This should be either the output of a
-     *                                                           previous call to this method or the output of
-     *                                                           an earlier call to the
-     *                                                           {@see UseStatements::splitImportUseStatement()}
-     *                                                           method.
+     * @param \PHP_CodeSniffer\Files\File          $phpcsFile             The file where this token was found.
+     * @param int                                  $stackPtr              The position in the stack of the
+     *                                                                    `T_USE` token.
+     * @param array<string, array<string, string>> $previousUseStatements The import `use` statements collected so far.
+     *                                                                    This should be either the output of a
+     *                                                                    previous call to this method or the output of
+     *                                                                    an earlier call to the
+     *                                                                    {@see UseStatements::splitImportUseStatement()}
+     *                                                                    method.
      *
-     * @return array A multi-level array containing information about the current `use` statement combined with
+     * @return array<string, array<string, string>>
+     *               A multi-level array containing information about the current `use` statement combined with
      *               the previously collected `use` statement information.
      *               See {@see UseStatements::splitImportUseStatement()} for more details about the array format.
      */
@@ -393,19 +396,20 @@ final class UseStatements
      *
      * @since 1.0.0
      *
-     * @param array $previousUseStatements The import `use` statements collected so far.
-     *                                     This should be either the output of a
-     *                                     previous call to this method or the output of
-     *                                     an earlier call to the
-     *                                     {@see UseStatements::splitImportUseStatement()}
-     *                                     method.
-     * @param array $currentUseStatement   The parsed import `use` statements to merge with
-     *                                     the previously collected use statements.
-     *                                     This should be the output of a call to the
-     *                                     {@see UseStatements::splitImportUseStatement()}
-     *                                     method.
+     * @param array<string, array<string, string>> $previousUseStatements The import `use` statements collected so far.
+     *                                                                    This should be either the output of a
+     *                                                                    previous call to this method or the output of
+     *                                                                    an earlier call to the
+     *                                                                    {@see UseStatements::splitImportUseStatement()}
+     *                                                                    method.
+     * @param array<string, array<string, string>> $currentUseStatement   The parsed import `use` statements to merge with
+     *                                                                    the previously collected use statements.
+     *                                                                    This should be the output of a call to the
+     *                                                                    {@see UseStatements::splitImportUseStatement()}
+     *                                                                    method.
      *
-     * @return array A multi-level array containing information about the current `use` statement combined with
+     * @return array<string, array<string, string>>
+     *               A multi-level array containing information about the current `use` statement combined with
      *               the previously collected `use` statement information.
      *               See {@see UseStatements::splitImportUseStatement()} for more details about the array format.
      */

--- a/PHPCSUtils/Utils/Variables.php
+++ b/PHPCSUtils/Utils/Variables.php
@@ -41,7 +41,7 @@ final class Variables
      *
      * @since 1.0.0
      *
-     * @var array <string> => <bool>
+     * @var array<string, bool>
      */
     public static $phpReservedVars = [
         '_SERVER'              => true,
@@ -94,7 +94,7 @@ final class Variables
      * @param int                         $stackPtr  The position in the stack of the `T_VARIABLE` token
      *                                               to acquire the properties for.
      *
-     * @return array Array with information about the class member variable.
+     * @return array<string, mixed> Array with information about the class member variable.
      *               The format of the return value is:
      *               ```php
      *               array(

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
@@ -31,7 +31,7 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
      * Needed for PHPUnit cross-version support as PHPUnit 4.x does not have a
      * `setMethodsExcept()` method yet.
      *
-     * @var array
+     * @var string[]
      */
     public $methodsToMock = [
         'processOpenClose',

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/ArrayDeclarationSniffTestDouble.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/ArrayDeclarationSniffTestDouble.php
@@ -24,7 +24,7 @@ final class ArrayDeclarationSniffTestDouble extends AbstractArrayDeclarationSnif
     /**
      * The token stack for the current file being examined.
      *
-     * @var array
+     * @var array<int, array<string, mixed>>
      */
     public $tokens;
 

--- a/Tests/BackCompat/BCFile/GetConditionTest.php
+++ b/Tests/BackCompat/BCFile/GetConditionTest.php
@@ -44,7 +44,7 @@ class GetConditionTest extends UtilityMethodTestCase
      * - The startPoint token is left out as it is tested separately.
      * - The key is the type of token to look for after the test marker.
      *
-     * @var array <int|string> => <string>
+     * @var array<int|string, string>
      */
     protected static $testTargets = [
         \T_VARIABLE                 => '/* testSeriouslyNestedMethod */',
@@ -92,7 +92,7 @@ class GetConditionTest extends UtilityMethodTestCase
      * This array isn't auto-generated based on the array in Tokens as for these
      * tests we want to have access to the token constant names, not just their values.
      *
-     * @var array <string> => <bool>
+     * @var array<string, bool>
      */
     protected $conditionDefaults = [
         'T_CLASS'      => false,
@@ -124,21 +124,21 @@ class GetConditionTest extends UtilityMethodTestCase
     /**
      * Cache for the test token stack pointers.
      *
-     * @var array <string> => <int>
+     * @var array<string, int>
      */
     protected static $testTokens = [];
 
     /**
      * Cache for the marker token stack pointers.
      *
-     * @var array <string> => <int>
+     * @var array<string, int>
      */
     protected static $markerTokens = [];
 
     /**
      * OO scope tokens array.
      *
-     * @var <int|string> => <int>
+     * @var array<int|string, int>
      */
     protected $ooScopeTokens = [];
 

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -52,7 +52,7 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
      * @dataProvider dataGetMemberProperties
      *
      * @param string $identifier Comment which precedes the test case.
-     * @param bool   $expected   Expected function output.
+     * @param array  $expected   Expected function output.
      *
      * @return void
      */

--- a/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
+++ b/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
@@ -53,7 +53,7 @@ final class UnchangedTokenArraysTest extends TestCase
     /**
      * Tokens that represent equality comparisons.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private $equalityTokens = [
         \T_IS_EQUAL            => \T_IS_EQUAL,
@@ -120,7 +120,7 @@ final class UnchangedTokenArraysTest extends TestCase
     /**
      * Tokens that perform boolean operations.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private $booleanOperators = [
         \T_BOOLEAN_AND => \T_BOOLEAN_AND,
@@ -133,7 +133,7 @@ final class UnchangedTokenArraysTest extends TestCase
     /**
      * Tokens that represent casting.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private $castTokens = [
         \T_INT_CAST    => \T_INT_CAST,
@@ -183,7 +183,7 @@ final class UnchangedTokenArraysTest extends TestCase
     /**
      * Tokens that represent scope modifiers.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private $scopeModifiers = [
         \T_PRIVATE   => \T_PRIVATE,
@@ -194,7 +194,7 @@ final class UnchangedTokenArraysTest extends TestCase
     /**
      * Tokens that can prefix a method name
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private $methodPrefixes = [
         \T_PRIVATE   => \T_PRIVATE,
@@ -208,7 +208,7 @@ final class UnchangedTokenArraysTest extends TestCase
     /**
      * Tokens that open code blocks.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private $blockOpeners = [
         \T_OPEN_CURLY_BRACKET  => \T_OPEN_CURLY_BRACKET,
@@ -276,7 +276,7 @@ final class UnchangedTokenArraysTest extends TestCase
     /**
      * Tokens that represent strings.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private $stringTokens = [
         \T_CONSTANT_ENCAPSED_STRING => \T_CONSTANT_ENCAPSED_STRING,
@@ -299,7 +299,7 @@ final class UnchangedTokenArraysTest extends TestCase
     /**
      * Tokens that represent brackets and parenthesis.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private $bracketTokens = [
         \T_OPEN_CURLY_BRACKET   => \T_OPEN_CURLY_BRACKET,
@@ -313,7 +313,7 @@ final class UnchangedTokenArraysTest extends TestCase
     /**
      * Tokens that include files.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private $includeTokens = [
         \T_REQUIRE_ONCE => \T_REQUIRE_ONCE,
@@ -325,7 +325,7 @@ final class UnchangedTokenArraysTest extends TestCase
     /**
      * Tokens that make up a heredoc string.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      */
     private $heredocTokens = [
         \T_START_HEREDOC => \T_START_HEREDOC,
@@ -352,7 +352,7 @@ final class UnchangedTokenArraysTest extends TestCase
     /**
      * Tokens representing PHP magic constants.
      *
-     * @var array <int|string> => <int|string>
+     * @var array<int|string, int|string>
      *
      * @link https://www.php.net/language.constants.predefined PHP Manual on magic constants
      */

--- a/Tests/Fixers/SpacesFixer/SpacesFixerAtEOFTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerAtEOFTest.php
@@ -58,7 +58,7 @@ final class SpacesFixerAtEOFTest extends UtilityMethodTestCase
     /**
      * Set the name of a sniff to pass to PHPCS to limit the run (and force it to record errors).
      *
-     * @var array
+     * @var string[]
      */
     protected static $selectedSniff = ['PHPCSUtils.SpacesFixer.Test'];
 

--- a/Tests/Fixers/SpacesFixer/SpacesFixerNewlineTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerNewlineTest.php
@@ -48,7 +48,7 @@ final class SpacesFixerNewlineTest extends SpacesFixerTestCase
     /**
      * The names of the test case(s) in compliance.
      *
-     * @var array
+     * @var string[]
      */
     protected static $compliantCases = [
         'newline-and-trailing-spaces',

--- a/Tests/Fixers/SpacesFixer/SpacesFixerNoSpaceTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerNoSpaceTest.php
@@ -48,7 +48,7 @@ final class SpacesFixerNoSpaceTest extends SpacesFixerTestCase
     /**
      * The names of the test case(s) in compliance.
      *
-     * @var array
+     * @var string[]
      */
     protected static $compliantCases = ['no-space'];
 

--- a/Tests/Fixers/SpacesFixer/SpacesFixerOneSpaceTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerOneSpaceTest.php
@@ -48,7 +48,7 @@ final class SpacesFixerOneSpaceTest extends SpacesFixerTestCase
     /**
      * The names of the test case(s) in compliance.
      *
-     * @var array
+     * @var string[]
      */
     protected static $compliantCases = [
         'one-space',

--- a/Tests/Fixers/SpacesFixer/SpacesFixerTestCase.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerTestCase.php
@@ -26,7 +26,7 @@ abstract class SpacesFixerTestCase extends UtilityMethodTestCase
      *
      * Important: this MUST be set in the concrete test class!
      *
-     * @var int|string
+     * @var int|string|null Note: `null` is not an acceptable value for the overloaded constant!
      */
     const SPACES = null;
 
@@ -69,7 +69,7 @@ abstract class SpacesFixerTestCase extends UtilityMethodTestCase
      *
      * Important: this MUST be set in the concrete test class!
      *
-     * @var array
+     * @var string[]
      */
     protected static $compliantCases = [];
 
@@ -85,7 +85,7 @@ abstract class SpacesFixerTestCase extends UtilityMethodTestCase
     /**
      * Set the name of a sniff to pass to PHPCS to limit the run (and force it to record errors).
      *
-     * @var array
+     * @var string[]
      */
     protected static $selectedSniff = ['PHPCSUtils.SpacesFixer.Test'];
 
@@ -301,7 +301,7 @@ abstract class SpacesFixerTestCase extends UtilityMethodTestCase
     /**
      * Helper function holding the base data for the data providers.
      *
-     * @return array
+     * @return array<string, array<string, mixed>>
      */
     protected static function getAllData()
     {

--- a/Tests/Fixers/SpacesFixer/SpacesFixerTwoSpaceTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerTwoSpaceTest.php
@@ -50,7 +50,7 @@ final class SpacesFixerTwoSpaceTest extends SpacesFixerTestCase
     /**
      * The names of the test case(s) in compliance.
      *
-     * @var array
+     * @var string[]
      */
     protected static $compliantCases = ['two-spaces'];
 

--- a/Tests/Fixers/SpacesFixer/TrailingCommentHandlingNewlineTest.php
+++ b/Tests/Fixers/SpacesFixer/TrailingCommentHandlingNewlineTest.php
@@ -65,7 +65,7 @@ final class TrailingCommentHandlingNewlineTest extends UtilityMethodTestCase
     /**
      * Set the name of a sniff to pass to PHPCS to limit the run (and force it to record errors).
      *
-     * @var array
+     * @var string[]
      */
     protected static $selectedSniff = ['PHPCSUtils.SpacesFixer.Test'];
 

--- a/Tests/Fixers/SpacesFixer/TrailingCommentHandlingTest.php
+++ b/Tests/Fixers/SpacesFixer/TrailingCommentHandlingTest.php
@@ -65,7 +65,7 @@ final class TrailingCommentHandlingTest extends UtilityMethodTestCase
     /**
      * Set the name of a sniff to pass to PHPCS to limit the run (and force it to record errors).
      *
-     * @var array
+     * @var string[]
      */
     protected static $selectedSniff = ['PHPCSUtils.SpacesFixer.Test'];
 

--- a/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
+++ b/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
@@ -30,7 +30,7 @@ final class GetDoubleArrowPtrTest extends UtilityMethodTestCase
     /**
      * Cache for the parsed parameters array.
      *
-     * @var array <string> => <int>
+     * @var array<string, array<string, int|string>>
      */
     private static $parameters = [];
 
@@ -106,8 +106,8 @@ final class GetDoubleArrowPtrTest extends UtilityMethodTestCase
      *
      * @dataProvider dataGetDoubleArrowPtr
      *
-     * @param string $testMarker The comment which is part of the target array item in the test file.
-     * @param array  $expected   The expected function call result.
+     * @param string   $testMarker The comment which is part of the target array item in the test file.
+     * @param int|bool $expected   The expected function call result.
      *
      * @return void
      */

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
@@ -124,10 +124,11 @@ final class GetParametersDiffTest extends UtilityMethodTestCase
     /**
      * Test helper to translate token offsets to absolute positions in an "expected" array.
      *
-     * @param string $targetPtr The token pointer to the target token from which the offset is calculated.
-     * @param array  $expected  The expected function output containing offsets.
+     * @param int                              $targetPtr The token pointer to the target token from which
+     *                                                    the offset is calculated.
+     * @param array<int, array<string, mixed>> $expected  The expected function output containing offsets.
      *
-     * @return array
+     * @return array<int, array<string, mixed>>
      */
     private function updateExpectedTokenPositions($targetPtr, $expected)
     {

--- a/Tests/Utils/MessageHelper/AddMessageTest.php
+++ b/Tests/Utils/MessageHelper/AddMessageTest.php
@@ -41,7 +41,7 @@ final class AddMessageTest extends UtilityMethodTestCase
     /**
      * Set the name of a sniff to pass to PHPCS to limit the run (and force it to record errors).
      *
-     * @var array
+     * @var string[]
      */
     protected static $selectedSniff = ['PHPCSUtils.MessageHelper.AddMessageTest'];
 

--- a/Tests/Utils/Numbers/NumberTypesTest.php
+++ b/Tests/Utils/Numbers/NumberTypesTest.php
@@ -36,7 +36,7 @@ final class NumberTypesTest extends TestCase
      * @covers       ::isDecimalInt
      *
      * @param string $input    The input string.
-     * @param string $expected The expected output for the various functions.
+     * @param array  $expected The expected output for the various functions.
      *
      * @return void
      */
@@ -52,7 +52,7 @@ final class NumberTypesTest extends TestCase
      * @covers       ::isHexidecimalInt
      *
      * @param string $input    The input string.
-     * @param string $expected The expected output for the various functions.
+     * @param array  $expected The expected output for the various functions.
      *
      * @return void
      */
@@ -68,7 +68,7 @@ final class NumberTypesTest extends TestCase
      * @covers       ::isBinaryInt
      *
      * @param string $input    The input string.
-     * @param string $expected The expected output for the various functions.
+     * @param array  $expected The expected output for the various functions.
      *
      * @return void
      */
@@ -84,7 +84,7 @@ final class NumberTypesTest extends TestCase
      * @covers       ::isOctalInt
      *
      * @param string $input    The input string.
-     * @param string $expected The expected output for the various functions.
+     * @param array  $expected The expected output for the various functions.
      *
      * @return void
      */
@@ -100,7 +100,7 @@ final class NumberTypesTest extends TestCase
      * @covers       ::isFloat
      *
      * @param string $input    The input string.
-     * @param string $expected The expected output for the various functions.
+     * @param array  $expected The expected output for the various functions.
      *
      * @return void
      */

--- a/Tests/Utils/Parentheses/ParenthesesTest.php
+++ b/Tests/Utils/Parentheses/ParenthesesTest.php
@@ -29,7 +29,7 @@ final class ParenthesesTest extends UtilityMethodTestCase
     /**
      * List of all the test markers with their target token info in the test case file.
      *
-     * @var array
+     * @var array<string, array<string, string|int>>
      */
     public static $testTargets = [
         'testIfWithArray-$a' => [
@@ -194,7 +194,7 @@ final class ParenthesesTest extends UtilityMethodTestCase
     /**
      * Cache for the test token stack pointers.
      *
-     * @var array <string> => <int>
+     * @var array<string, int>
      */
     private static $testTokens = [];
 
@@ -210,7 +210,7 @@ final class ParenthesesTest extends UtilityMethodTestCase
      * This array isn't auto-generated based on the array in Tokens as for these
      * tests we want to have access to the token constant names, not just their values.
      *
-     * @var array <string> => <bool>
+     * @var array<string, bool>
      */
     private $ownerDefaults = [
         'T_ARRAY'      => false,

--- a/Tests/Utils/PassedParameters/GetParameterFromStackTest.php
+++ b/Tests/Utils/PassedParameters/GetParameterFromStackTest.php
@@ -415,7 +415,7 @@ final class GetParameterFromStackTest extends UtilityMethodTestCase
      *
      * @dataProvider dataGetParameterFromStackNamedAfterVariadic
      *
-     * @param string      $offset   The positional offfset to pass.
+     * @param int         $offset   The positional offfset to pass.
      * @param array       $names    The parameter names to pass.
      * @param array|false $expected The expected result array for the parameter.
      *

--- a/Tests/Utils/PassedParameters/GetParametersWithLimitTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersWithLimitTest.php
@@ -92,7 +92,7 @@ final class GetParametersWithLimitTest extends UtilityMethodTestCase
      *
      * @param string     $testMarker The comment which prefaces the target token in the test file.
      * @param int|string $targetType The type of token to look for.
-     * @param array      $limit      The number of parameters to limit this call to.
+     * @param int        $limit      The number of parameters to limit this call to.
      *                               Should match the expected count.
      * @param array      $expected   Optional. The expected return value. Only tested when not empty.
      *

--- a/Tests/Utils/TextStrings/GetCompleteTextStringTest.php
+++ b/Tests/Utils/TextStrings/GetCompleteTextStringTest.php
@@ -31,7 +31,7 @@ final class GetCompleteTextStringTest extends UtilityMethodTestCase
     /**
      * Token types to target for these tests.
      *
-     * @var array
+     * @var array<string|int>
      */
     private $targets = [
         \T_START_HEREDOC,

--- a/Tests/Utils/TextStrings/InterpolatedVariablesTest.php
+++ b/Tests/Utils/TextStrings/InterpolatedVariablesTest.php
@@ -31,7 +31,7 @@ final class InterpolatedVariablesTest extends TestCase
     /**
      * Collection of various variables and other embeds which are valid in double quoted strings.
      *
-     * @var array<string>
+     * @var string[]
      */
     private static $embeds = [
         // Simple.

--- a/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
@@ -79,7 +79,7 @@ final class GetMemberPropertiesDiffTest extends UtilityMethodTestCase
      * @dataProvider dataGetMemberProperties
      *
      * @param string $identifier Comment which precedes the test case.
-     * @param bool   $expected   Expected function output.
+     * @param array  $expected   Expected function output.
      *
      * @return void
      */

--- a/Tests/Xtra/Messages/HasNewLineSupportTest.php
+++ b/Tests/Xtra/Messages/HasNewLineSupportTest.php
@@ -41,7 +41,7 @@ final class HasNewLineSupportTest extends PolyfilledTestCase
     /**
      * Set the name of a sniff to pass to PHPCS to limit the run (and force it to record errors).
      *
-     * @var array
+     * @var string[]
      */
     protected static $selectedSniff = ['PHPCSUtils.Xtra.HasNewLineSupportTest'];
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -50,6 +50,19 @@
 
     <!--
     #############################################################################
+    SNIFF SPECIFIC CONFIGURATION
+    #############################################################################
+    -->
+
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="125" />
+        </properties>
+    </rule>
+
+
+    <!--
+    #############################################################################
     SELECTIVE EXCLUSIONS
     Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
     #############################################################################


### PR DESCRIPTION
Not claiming completeness. This is just another iteration step in improving the documented types.

Includes minor tweak to the PHPCS ruleset to allow for the longer types and still have a var/param/return description.