### PR TITLE
GH Actions: update doc generation workflow

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -68,7 +68,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           # Use a version known to be safe for last phpDocumentor release.
-          php-version: '8.0'
+          php-version: '8.1'
           ini-file: 'development'
           coverage: none
           # Install the latest phpDocumentor release as a PHAR.


### PR DESCRIPTION
phpDocumentor 3.4.0 has been released and has a minimum supported PHP version of PHP 8.1.

This updates the workflow to take that into account.

Ref: https://github.com/phpDocumentor/phpDocumentor/releases/tag/v3.4.0