### PR TITLE
Correct error message when path not found

### DIFF
--- a/.github/GHPages/UpdateWebsite.php
+++ b/.github/GHPages/UpdateWebsite.php
@@ -122,7 +122,7 @@ seo:
     {
         $realRoot = \realpath(self::PROJECT_ROOT);
         if ($realRoot === false) {
-            throw new RuntimeException(\sprintf('Failed to find the %s directory.', $realRoot));
+            throw new RuntimeException(\sprintf('Failed to find the %s directory.', self::PROJECT_ROOT));
         }
 
         $this->realRoot = $realRoot . '/';


### PR DESCRIPTION
While reviewing https://github.com/PHPCSStandards/PHPCSUtils/pull/501, I noticed that the error message will inject `false` into the string, not the actual directory that couldn't be found. This pull request fixes that.