### PR TITLE
GH Actions: switch to Coveralls action runner to upload reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -349,37 +349,14 @@ jobs:
           PHPCS_VERSION: ${{ matrix.phpcs_version }}
           PHPCSUTILS_USE_CACHE: false
 
-      # PHP Coveralls v2 (which supports GH Actions) has a PHP 5.5 minimum, so switch the PHP version.
-      - name: Switch to PHP latest
-        if: ${{ success() && matrix.php == '5.4' }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 'latest'
-          coverage: none
-
-      # Global install is used to prevent a conflict with the local composer.lock.
-      - name: Install Coveralls
+      - name: Upload coverage results to Coveralls
         if: ${{ success() }}
-        run: composer global require php-coveralls/php-coveralls:"^2.6.0" --no-interaction
-
-      - name: Upload coverage results to Coveralls (normal)
-        if: ${{ success() && github.actor != 'dependabot[bot]' }}
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
-          COVERALLS_PARALLEL: true
-          COVERALLS_FLAG_NAME: php-${{ matrix.php }}-phpcs-${{ matrix.phpcs_version }}
-        run: php-coveralls -v -x build/logs/clover.xml
-
-      # Dependabot does not have access to secrets, other than the GH token.
-      # Ref: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
-      # Ref: https://github.com/lemurheavy/coveralls-public/issues/1721
-      - name: Upload coverage results to Coveralls (Dependabot)
-        if: ${{ success() && github.actor == 'dependabot[bot]' }}
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_PARALLEL: true
-          COVERALLS_FLAG_NAME: php-${{ matrix.php }}-phpcs-${{ matrix.phpcs_version }}
-        run: php-coveralls -v -x build/logs/clover.xml
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.COVERALLS_TOKEN }}
+          format: clover
+          flag-name: php-${{ matrix.php }}-phpcs-${{ matrix.phpcs_version }}
+          parallel: true
 
   coveralls-finish:
     needs: coverage
@@ -388,19 +365,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Coveralls Finished (normal)
-        if: ${{ github.actor != 'dependabot[bot]' }}
+      - name: Coveralls Finished
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.COVERALLS_TOKEN }}
-          parallel-finished: true
-
-      # Dependabot does not have access to secrets, other than the GH token.
-      # Ref: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
-      # Ref: https://github.com/lemurheavy/coveralls-public/issues/1721
-      - name: Coveralls Finished (Dependabot)
-        if: ${{ github.actor == 'dependabot[bot]' }}
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true


### PR DESCRIPTION
Simplify the code coverage workflow by removing the dependency on the `php-coveralls/php-coveralls` package and switching to the `coverallsapp/github-action` action runner, which, as of the release of the [0.6.5 version of the Coverage Reporter](https://github.com/coverallsapp/coverage-reporter/releases/tag/v0.6.5) now natively supports the Clover format.

It is not yet clear whether this also fixes the issues with Dependabot and PRs from forks. If not, the `github-token: ${{ secrets.COVERALLS_TOKEN }}` should be removed in favour of allowing the GitHub native token to be used.