### PR TITLE
GH Actions/coverage: remove COVERALLS_TOKEN

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -353,7 +353,6 @@ jobs:
         if: ${{ success() }}
         uses: coverallsapp/github-action@v2
         with:
-          github-token: ${{ secrets.COVERALLS_TOKEN }}
           format: clover
           file: build/logs/clover.xml
           flag-name: php-${{ matrix.php }}-phpcs-${{ matrix.phpcs_version }}
@@ -369,5 +368,4 @@ jobs:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@v2
         with:
-          github-token: ${{ secrets.COVERALLS_TOKEN }}
           parallel-finished: true


### PR DESCRIPTION
... to test (confirm) that uploading the coverage results will then work (again) for PRs from outside contributors (forks).

Note: I'm explicitly **_not_** setting the `github-token` to `${{ secrets.GITHUB_TOKEN }}` as the action runner _should_ have access to that token anyhow. Not setting the input should confirm that. If that doesn't work, the GH token can still be added at a later point.

Related to: https://github.com/lemurheavy/coveralls-public/issues/1721