### PR TITLE
GH Actions: update for the release of PHP 8.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,11 +30,11 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', '7.0', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['5.4', '7.0', '7.4', '8.0', '8.3', '8.4']
 
     name: "Lint: PHP ${{ matrix.php }}"
 
-    continue-on-error: ${{ matrix.php == '8.3' }}
+    continue-on-error: ${{ matrix.php == '8.4' }}
 
     steps:
       - name: Checkout code
@@ -49,7 +49,7 @@ jobs:
           tools: cs2pr
 
       - name: Install Composer dependencies - normal
-        if: ${{ matrix.php < 8.3 }}
+        if: ${{ matrix.php < 8.4 }}
         uses: "ramsey/composer-install@v2"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
@@ -57,7 +57,7 @@ jobs:
 
       # For the PHP "nightly", we need to install with ignore platform reqs as not all dependencies allow it yet.
       - name: Install Composer dependencies - with ignore platform
-        if: ${{ matrix.php >= 8.3 }}
+        if: ${{ matrix.php >= 8.4 }}
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-req=php+
@@ -91,7 +91,7 @@ jobs:
         # IMPORTANT: test runs shouldn't fail because of PHPCS being incompatible with a PHP version.
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
-        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
         phpcs_version: ['lowest', 'dev-master']
         risky: [false]
         experimental: [false]
@@ -109,7 +109,7 @@ jobs:
             extensions: ':iconv' # Run with iconv disabled.
 
           # Experimental builds. These are allowed to fail.
-          - php: '8.3'
+          - php: '8.4'
             phpcs_version: 'dev-master'
             risky: false
             experimental: true
@@ -135,12 +135,12 @@ jobs:
             risky: true
             experimental: true
 
-          - php: '8.2'
+          - php: '8.3'
             phpcs_version: 'lowest'
             risky: true
             experimental: true
 
-          - php: '8.2'
+          - php: '8.3'
             phpcs_version: 'dev-master'
             risky: true
             experimental: true
@@ -183,7 +183,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies - normal
-        if: ${{ matrix.php < 8.3 }}
+        if: ${{ matrix.php < 8.4 }}
         uses: "ramsey/composer-install@v2"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
@@ -191,7 +191,7 @@ jobs:
 
       # For PHP "nightly", we need to install with ignore platform reqs as not all dependencies allow it yet.
       - name: Install Composer dependencies - with ignore platform
-        if: ${{ matrix.php >= 8.3 }}
+        if: ${{ matrix.php >= 8.4 }}
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-req=php+
@@ -266,9 +266,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: '8.2'
+          - php: '8.3'
             phpcs_version: 'dev-master'
-          - php: '8.2'
+          - php: '8.3'
             phpcs_version: 'lowest'
             extensions: ':iconv' # Run one build with iconv disabled.
           - php: '5.4'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Minimum PHP Version](https://img.shields.io/packagist/php-v/phpcsstandards/phpcsutils.svg?maxAge=3600)][phpcsutils-packagist]
 [![CS Build Status](https://github.com/PHPCSStandards/PHPCSUtils/actions/workflows/basics.yml/badge.svg?branch=develop)](https://github.com/PHPCSStandards/PHPCSUtils/actions/workflows/basics.yml)
 [![Test Build Status](https://github.com/PHPCSStandards/PHPCSUtils/actions/workflows/test.yml/badge.svg?branch=develop)][phpcsutils-tests-gha]
-[![Tested on PHP 5.4 to 8.2](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2-brightgreen.svg?maxAge=2419200)][phpcsutils-tests-gha]
+[![Tested on PHP 5.4 to 8.3](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3-brightgreen.svg?maxAge=2419200)][phpcsutils-tests-gha]
 [![Coverage Status](https://coveralls.io/repos/github/PHPCSStandards/PHPCSUtils/badge.svg?branch=develop)](https://coveralls.io/github/PHPCSStandards/PHPCSUtils?branch=develop)
 
 [![Docs website](https://github.com/PHPCSStandards/PHPCSUtils/actions/workflows/update-docs.yml/badge.svg)][phpcsutils-web]


### PR DESCRIPTION
... which is expected later today.

* Builds against PHP 8.3 are no longer allowed to fail.
* Update PHP version on which code coverage is run (high should now be 8.3).
* Add _allowed to fail_ build against PHP 8.4.
* Update the "tested against" badge in the README.