### PR TITLE
Switch to PHPCSStandards/PHP_CodeSniffer & raise minimum supported version

### DIFF
--- a/.github/workflows/update-phpcs-versionnr.yml
+++ b/.github/workflows/update-phpcs-versionnr.yml
@@ -29,7 +29,7 @@ jobs:
         uses: octokit/request-action@v2.x
         id: get_latest_release
         with:
-          route: GET /repos/squizlabs/PHP_CodeSniffer/releases/latest
+          route: GET /repos/PHPCSStandards/PHP_CodeSniffer/releases/latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -29,7 +29,7 @@
  * @author    Klaus Purer <klaus.purer@protonmail.ch>
  *
  * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
 namespace PHPCSUtils\BackCompat;

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -498,7 +498,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.7.1.
+     * - The upstream method has received no significant updates since PHPCS 3.8.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodProperties()      Original source.
      * @see \PHPCSUtils\Utils\FunctionDeclarations::getProperties() PHPCSUtils native improved version.
@@ -543,7 +543,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.7.1.
+     * - The upstream method has received no significant updates since PHPCS 3.8.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getMemberProperties() Original source.
      * @see \PHPCSUtils\Utils\Variables::getMemberProperties() PHPCSUtils native improved version.
@@ -653,7 +653,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.7.1.
+     * - The upstream method has received no significant updates since PHPCS 3.8.0.
      *
      * @see \PHP_CodeSniffer\Files\File::isReference() Original source.
      * @see \PHPCSUtils\Utils\Operators::isReference() PHPCSUtils native improved version.
@@ -679,7 +679,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.7.1.
+     * - The upstream method has received no significant updates since PHPCS 3.8.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getTokensAsString() Original source.
      * @see \PHPCSUtils\Utils\GetTokensAsString              Related set of functions.
@@ -708,7 +708,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.1.0.
-     * - The upstream method has received no significant updates since PHPCS 3.7.1.
+     * - The upstream method has received no significant updates since PHPCS 3.8.0.
      *
      * @see \PHP_CodeSniffer\Files\File::findStartOfStatement() Original source.
      *
@@ -732,7 +732,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.1.0.
-     * - The upstream method has received no significant updates since PHPCS 3.7.1.
+     * - The upstream method has received no significant updates since PHPCS 3.8.0.
      *
      * @see \PHP_CodeSniffer\Files\File::findEndOfStatement() Original source.
      *
@@ -756,7 +756,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.7.1.
+     * - The upstream method has received no significant updates since PHPCS 3.8.0.
      *
      * @see \PHP_CodeSniffer\Files\File::hasCondition()  Original source.
      * @see \PHPCSUtils\Utils\Conditions::hasCondition() PHPCSUtils native alternative.
@@ -781,7 +781,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.3.0.
-     * - The upstream method has received no significant updates since PHPCS 3.7.1.
+     * - The upstream method has received no significant updates since PHPCS 3.8.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getCondition()  Original source.
      * @see \PHPCSUtils\Utils\Conditions::getCondition() More versatile alternative.
@@ -812,7 +812,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.2.0.
-     * - The upstream method has received no significant updates since PHPCS 3.7.1.
+     * - The upstream method has received no significant updates since PHPCS 3.8.0.
      *
      * @see \PHP_CodeSniffer\Files\File::findExtendedClassName()          Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::findExtendedClassName() PHPCSUtils native improved version.
@@ -837,7 +837,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.7.0.
-     * - The upstream method has received no significant updates since PHPCS 3.7.1.
+     * - The upstream method has received no significant updates since PHPCS 3.8.0.
      *
      * @see \PHP_CodeSniffer\Files\File::findImplementedInterfaceNames()          Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::findImplementedInterfaceNames() PHPCSUtils native improved version.

--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -74,7 +74,7 @@ final class BCTokens
 
     /**
      * Handle calls to (undeclared) methods for token arrays which haven't received any
-     * changes since PHPCS 3.7.1.
+     * changes since PHPCS 3.8.0.
      *
      * @since 1.0.0
      *

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -596,13 +596,7 @@ final class Collections
      */
     public static function arrayOpenTokensBC()
     {
-        $tokens = self::$arrayOpenTokensBC;
-
-        if (\version_compare(Helper::getVersion(), '3.7.1', '<=')) {
-            $tokens[\T_OPEN_SQUARE_BRACKET] = \T_OPEN_SQUARE_BRACKET;
-        }
-
-        return $tokens;
+        return self::$arrayOpenTokensBC;
     }
 
     /**
@@ -623,14 +617,7 @@ final class Collections
      */
     public static function arrayTokensBC()
     {
-        $tokens = self::$arrayTokens;
-
-        if (\version_compare(Helper::getVersion(), '3.7.1', '<=')) {
-            $tokens[\T_OPEN_SQUARE_BRACKET]  = \T_OPEN_SQUARE_BRACKET;
-            $tokens[\T_CLOSE_SQUARE_BRACKET] = \T_CLOSE_SQUARE_BRACKET;
-        }
-
-        return $tokens;
+        return self::$arrayTokens;
     }
 
     /**
@@ -673,13 +660,7 @@ final class Collections
      */
     public static function listOpenTokensBC()
     {
-        $tokens = self::$listOpenTokensBC;
-
-        if (\version_compare(Helper::getVersion(), '3.7.1', '<=')) {
-            $tokens[\T_OPEN_SQUARE_BRACKET] = \T_OPEN_SQUARE_BRACKET;
-        }
-
-        return $tokens;
+        return self::$listOpenTokensBC;
     }
 
     /**
@@ -698,14 +679,7 @@ final class Collections
      */
     public static function listTokensBC()
     {
-        $tokens = self::$listTokens;
-
-        if (\version_compare(Helper::getVersion(), '3.7.1', '<=')) {
-            $tokens[\T_OPEN_SQUARE_BRACKET]  = \T_OPEN_SQUARE_BRACKET;
-            $tokens[\T_CLOSE_SQUARE_BRACKET] = \T_CLOSE_SQUARE_BRACKET;
-        }
-
-        return $tokens;
+        return self::$listTokens;
     }
 
     /**
@@ -815,13 +789,7 @@ final class Collections
      */
     public static function shortArrayListOpenTokensBC()
     {
-        $tokens = self::$shortArrayListOpenTokensBC;
-
-        if (\version_compare(Helper::getVersion(), '3.7.1', '<=')) {
-            $tokens[\T_OPEN_SQUARE_BRACKET] = \T_OPEN_SQUARE_BRACKET;
-        }
-
-        return $tokens;
+        return self::$shortArrayListOpenTokensBC;
     }
 
     /**
@@ -840,14 +808,7 @@ final class Collections
      */
     public static function shortArrayTokensBC()
     {
-        $tokens = self::$shortArrayTokens;
-
-        if (\version_compare(Helper::getVersion(), '3.7.1', '<=')) {
-            $tokens[\T_OPEN_SQUARE_BRACKET]  = \T_OPEN_SQUARE_BRACKET;
-            $tokens[\T_CLOSE_SQUARE_BRACKET] = \T_CLOSE_SQUARE_BRACKET;
-        }
-
-        return $tokens;
+        return self::$shortArrayTokens;
     }
 
     /**
@@ -866,13 +827,6 @@ final class Collections
      */
     public static function shortListTokensBC()
     {
-        $tokens = self::$shortListTokens;
-
-        if (\version_compare(Helper::getVersion(), '3.7.1', '<=')) {
-            $tokens[\T_OPEN_SQUARE_BRACKET]  = \T_OPEN_SQUARE_BRACKET;
-            $tokens[\T_CLOSE_SQUARE_BRACKET] = \T_CLOSE_SQUARE_BRACKET;
-        }
-
-        return $tokens;
+        return self::$shortListTokens;
     }
 }

--- a/PHPCSUtils/ruleset.xml
+++ b/PHPCSUtils/ruleset.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCSUtils" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCSUtils" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
     <description>Utility methods for external PHPCS standards.</description>
 </ruleset>

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Whether you need to split an `array` into the individual items, are trying to de
 
 Includes improved versions of the PHPCS native utility functions and plenty of new utility functions.
 
-These functions are compatible with PHPCS 3.7.1 up to PHPCS `master`.
+These functions are compatible with PHPCS 3.8.0 up to PHPCS `master`.
 
 ### A collection of static properties and methods for often-used token groups
 
@@ -66,7 +66,7 @@ Supports PHPUnit 4.x up to 9.x.
 
 Normally to use the latest version of PHP_CodeSniffer native utility functions, you would have to raise the minimum requirements of your external PHPCS standard.
 
-Now you won't have to anymore. This package allows you to use the latest version of those utility functions in all PHP_CodeSniffer versions from PHPCS 3.7.1 and up.
+Now you won't have to anymore. This package allows you to use the latest version of those utility functions in all PHP_CodeSniffer versions from PHPCS 3.8.0 and up.
 
 ### Fully documented
 
@@ -78,7 +78,7 @@ To see detailed information about all the available abstract sniffs, utility fun
 ## Minimum Requirements
 
 * PHP 5.4 or higher.
-* [PHP_CodeSniffer] 3.7.1+.
+* [PHP_CodeSniffer] 3.8.0+.
 * Recommended PHP extensions for optimal functionality:
     - PCRE with Unicode support (normally enabled by default)
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ To use a non-Composer based installation for your sniff development environment,
 
 Your installation instructions for a non-Composer based installation will probably look similar to this:
 
-> * Install [PHP_CodeSniffer] via [your preferred method](https://github.com/squizlabs/PHP_CodeSniffer#installation).
+> * Install [PHP_CodeSniffer] via [your preferred method](https://github.com/PHPCSStandards/PHP_CodeSniffer#installation).
 > * Register the path to PHPCS in your system `$PATH` environment variable to make the `phpcs` command available from anywhere in your file system.
 > * Download the \[latest _YourStandardName_ release\] and unzip/untar it into an arbitrary directory.
 >     You can also choose to clone the repository using git.
@@ -288,7 +288,7 @@ If you are unsure whether the changes you are proposing would be welcome, please
 This code is released under the [GNU Lesser General Public License (LGPLv3)](LICENSE).
 
 
-[PHP_CodeSniffer]:       https://github.com/squizlabs/PHP_CodeSniffer
+[PHP_CodeSniffer]:       https://github.com/PHPCSStandards/PHP_CodeSniffer
 [Composer PHPCS plugin]: https://github.com/PHPCSStandards/composer-installer
 [phpcsutils-repo]:       https://github.com/PHPCSStandards/PHPCSUtils
 [phpcsutils-web]:        https://phpcsutils.com/

--- a/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
@@ -17,7 +17,7 @@
  * @author    Phil Davis <phil@jankaritech.com>
  *
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;

--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
@@ -19,7 +19,7 @@
  * @author    Phil Davis <phil@jankaritech.com>
  *
  * @copyright 2016-2019 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
@@ -18,7 +18,7 @@
  * @author    Phil Davis <phil@jankaritech.com>
  *
  * @copyright 2016-2019 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -17,7 +17,7 @@
  * @author    Phil Davis <phil@jankaritech.com>
  *
  * @copyright 2017-2019 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -18,7 +18,7 @@
  * @author    George Mponos <gmponos@gmail.com>
  *
  * @copyright 2010-2019 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -15,7 +15,7 @@
  * @author    Juliette Reinders Folmer <jrf@phpcodesniffer.info>
  *
  * @copyright 2018-2019 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;

--- a/Tests/BackCompat/BCFile/IsReferenceTest.php
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.php
@@ -17,7 +17,7 @@
  * @author    Phil Davis <phil@jankaritech.com>
  *
  * @copyright 2017-2019 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;

--- a/Tests/BackCompat/Helper/GetVersionTest.php
+++ b/Tests/BackCompat/Helper/GetVersionTest.php
@@ -32,7 +32,7 @@ final class GetVersionTest extends TestCase
      *
      * @var string
      */
-    const DEVMASTER = '3.7.2';
+    const DEVMASTER = '3.8.0';
 
     /**
      * Test the method.
@@ -49,7 +49,7 @@ final class GetVersionTest extends TestCase
         }
 
         if ($expected === 'lowest') {
-            $expected = '3.7.1';
+            $expected = '3.8.0';
         }
 
         $result = Helper::getVersion();

--- a/Tests/Tokens/Collections/ArrayOpenTokensBCTest.php
+++ b/Tests/Tokens/Collections/ArrayOpenTokensBCTest.php
@@ -38,10 +38,6 @@ final class ArrayOpenTokensBCTest extends TestCase
             \T_OPEN_SHORT_ARRAY => \T_OPEN_SHORT_ARRAY,
         ];
 
-        if (\version_compare(Helper::getVersion(), '3.7.1', '<=')) {
-            $expected[\T_OPEN_SQUARE_BRACKET] = \T_OPEN_SQUARE_BRACKET;
-        }
-
         $this->assertSame($expected, Collections::arrayOpenTokensBC());
     }
 }

--- a/Tests/Tokens/Collections/ArrayTokensBCTest.php
+++ b/Tests/Tokens/Collections/ArrayTokensBCTest.php
@@ -39,11 +39,6 @@ final class ArrayTokensBCTest extends TestCase
             \T_CLOSE_SHORT_ARRAY => \T_CLOSE_SHORT_ARRAY,
         ];
 
-        if (\version_compare(Helper::getVersion(), '3.7.1', '<=')) {
-            $expected[\T_OPEN_SQUARE_BRACKET]  = \T_OPEN_SQUARE_BRACKET;
-            $expected[\T_CLOSE_SQUARE_BRACKET] = \T_CLOSE_SQUARE_BRACKET;
-        }
-
         $this->assertSame($expected, Collections::arrayTokensBC());
     }
 }

--- a/Tests/Tokens/Collections/ListOpenTokensBCTest.php
+++ b/Tests/Tokens/Collections/ListOpenTokensBCTest.php
@@ -38,10 +38,6 @@ final class ListOpenTokensBCTest extends TestCase
             \T_OPEN_SHORT_ARRAY => \T_OPEN_SHORT_ARRAY,
         ];
 
-        if (\version_compare(Helper::getVersion(), '3.7.1', '<=')) {
-            $expected[\T_OPEN_SQUARE_BRACKET] = \T_OPEN_SQUARE_BRACKET;
-        }
-
         $this->assertSame($expected, Collections::listOpenTokensBC());
     }
 }

--- a/Tests/Tokens/Collections/ListTokensBCTest.php
+++ b/Tests/Tokens/Collections/ListTokensBCTest.php
@@ -39,11 +39,6 @@ final class ListTokensBCTest extends TestCase
             \T_CLOSE_SHORT_ARRAY => \T_CLOSE_SHORT_ARRAY,
         ];
 
-        if (\version_compare(Helper::getVersion(), '3.7.1', '<=')) {
-            $expected[\T_OPEN_SQUARE_BRACKET]  = \T_OPEN_SQUARE_BRACKET;
-            $expected[\T_CLOSE_SQUARE_BRACKET] = \T_CLOSE_SQUARE_BRACKET;
-        }
-
         $this->assertSame($expected, Collections::listTokensBC());
     }
 }

--- a/Tests/Tokens/Collections/ParameterPassingTokensTest.php
+++ b/Tests/Tokens/Collections/ParameterPassingTokensTest.php
@@ -49,10 +49,6 @@ final class ParameterPassingTokensTest extends TestCase
             \T_OPEN_SHORT_ARRAY     => \T_OPEN_SHORT_ARRAY,
         ];
 
-        if (\version_compare(Helper::getVersion(), '3.7.1', '<=')) {
-            $expected[\T_OPEN_SQUARE_BRACKET] = \T_OPEN_SQUARE_BRACKET;
-        }
-
         $this->assertSame($expected, Collections::parameterPassingTokens());
     }
 }

--- a/Tests/Tokens/Collections/ShortArrayListOpenTokensBCTest.php
+++ b/Tests/Tokens/Collections/ShortArrayListOpenTokensBCTest.php
@@ -37,10 +37,6 @@ final class ShortArrayListOpenTokensBCTest extends TestCase
             \T_OPEN_SHORT_ARRAY => \T_OPEN_SHORT_ARRAY,
         ];
 
-        if (\version_compare(Helper::getVersion(), '3.7.1', '<=')) {
-            $expected[\T_OPEN_SQUARE_BRACKET] = \T_OPEN_SQUARE_BRACKET;
-        }
-
         $this->assertSame($expected, Collections::shortArrayListOpenTokensBC());
     }
 }

--- a/Tests/Tokens/Collections/ShortArrayTokensBCTest.php
+++ b/Tests/Tokens/Collections/ShortArrayTokensBCTest.php
@@ -38,11 +38,6 @@ final class ShortArrayTokensBCTest extends TestCase
             \T_CLOSE_SHORT_ARRAY => \T_CLOSE_SHORT_ARRAY,
         ];
 
-        if (\version_compare(Helper::getVersion(), '3.7.1', '<=')) {
-            $expected[\T_OPEN_SQUARE_BRACKET]  = \T_OPEN_SQUARE_BRACKET;
-            $expected[\T_CLOSE_SQUARE_BRACKET] = \T_CLOSE_SQUARE_BRACKET;
-        }
-
         $this->assertSame($expected, Collections::shortArrayTokensBC());
     }
 }

--- a/Tests/Tokens/Collections/ShortListTokensBCTest.php
+++ b/Tests/Tokens/Collections/ShortListTokensBCTest.php
@@ -38,11 +38,6 @@ final class ShortListTokensBCTest extends TestCase
             \T_CLOSE_SHORT_ARRAY => \T_CLOSE_SHORT_ARRAY,
         ];
 
-        if (\version_compare(Helper::getVersion(), '3.7.1', '<=')) {
-            $expected[\T_OPEN_SQUARE_BRACKET]  = \T_OPEN_SQUARE_BRACKET;
-            $expected[\T_CLOSE_SQUARE_BRACKET] = \T_CLOSE_SQUARE_BRACKET;
-        }
-
         $this->assertSame($expected, Collections::shortListTokensBC());
     }
 }

--- a/Tests/Tokens/TokenHelper/TokenExistsTest.php
+++ b/Tests/Tokens/TokenHelper/TokenExistsTest.php
@@ -58,7 +58,7 @@ final class TokenExistsTest extends TestCase
      * {@internal This dataprovider does not currently contain any tests for
      *            PHP native tokens which may not exist (depending on the PHPCS version).
      *            These tests are not relevant at this time with the current minimum
-     *            PHPCS version of 3.7.1, but this may change again in the future.}
+     *            PHPCS version, but this may change again in the future.}
      *
      * @return array
      */

--- a/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
+++ b/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
@@ -210,7 +210,8 @@ final class GetDoubleArrowPtrTest extends UtilityMethodTestCase
                 'expected'   => 8,
             ],
             // Test specifically for PHPCS 3.5.3 and 3.5.4 in which all "fn" tokens were tokenized as T_FN.
-            // While PHPCS < 3.7.1 is no longer supported, the test remains to safeguard against tokenizer regressions.
+            // While these PHPCS versions are no longer supported, the test remains to safeguard against
+            // tokenizer regressions.
             'test-arrow-access-to-property-named-fn-as-key-phpcs-3.5.3-3.5.4' => [
                 'testMarker' => '/* testKeyPropertyAccessFnPHPCS353-354 */',
                 'expected'   => 12,

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.7.1 || 4.0.x-dev@dev",
+        "squizlabs/php_codesniffer" : "^3.8.0 || 4.0.x-dev@dev",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0"
     },
     "require-dev" : {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,7 +5,7 @@
     <!--
     #############################################################################
     COMMAND LINE ARGUMENTS
-    https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset
+    https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset
     #############################################################################
     -->
 


### PR DESCRIPTION
⚠️  **_This is a DRAFT PR on purpose as it references releases which have not yet been tagged. Once the PHPCS 3.8.0 tag is available ~~(which contains the Composer `replace` directive)~~, this can/should be merged ~~and released ASAP~~._** ⚠️ 

### Switch to PHPCSStandards/PHP_CodeSniffer

The Squizlabs repo has been abandoned. The project continues in a fork in the PHPCSStandards organisation.

Ref:
* squizlabs/PHP_CodeSniffer#3932

### Composer: raise the minimum supported PHPCS version to 3.8.0

... to prevent end-users from running into trouble with the name change.

~~The files in the Composer `vendor/bin` will only be replaced when the `replace...` directive is found and that is only available in the 3.8.0 tag.~~
~~When the files in the Composer `vendor/bin` are not replaced, they will continue to point to the `vendor/squizlabs/php_codesniffer` directory which will no longer exist, leading to fatal "File not found" errors for end-users trying to run PHPCS/PHPCBF.~~

Includes updating references to the PHPCS version whenever relevant throughout the codebase.

**Update**: The Composer package name will not change, so while this PR should still be merged at our convenience (after the 3.8.0 release, expected this Friday), we will not need to do a release to unblock end-users, only because we actually have changes which are useful for end-users.

### Remove work-arounds which were in place for PHPCS < 3.8.0 