### PR TITLE
UtilityMethodTestCase: performance improvement

### DIFF
--- a/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+++ b/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
@@ -18,6 +18,7 @@ use PHPCSUtils\Exceptions\TestMarkerNotFound;
 use PHPCSUtils\Exceptions\TestTargetNotFound;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use ReflectionProperty;
 
 /**
  * Base class for use when testing utility methods for PHP_CodeSniffer.
@@ -208,9 +209,22 @@ abstract class UtilityMethodTestCase extends TestCase
 
         $contents = \file_get_contents($caseFile);
 
+        /*
+         * Set the static properties in the Config class to specific values for performance
+         * and to clear out values from other tests.
+         */
+        self::setStaticConfigProperty('executablePaths', []);
+
+        // Set to values which prevent the test-runner user's `CodeSniffer.conf` file
+        // from being read and influencing the tests. Also prevent an `exec()` call to stty.
+        self::setStaticConfigProperty('configData', ['report_width' => 80]);
+        self::setStaticConfigProperty('configDataFile', '');
+
         $config = new \PHP_CodeSniffer\Config();
 
         /*
+         * Set to a usable value to circumvent Config trying to find a phpcs.xml config file.
+         *
          * We just need to provide a standard so PHPCS will tokenize the file.
          * The standard itself doesn't actually matter for testing utility methods,
          * so use the smallest one to get the fastest results.
@@ -298,6 +312,27 @@ abstract class UtilityMethodTestCase extends TestCase
         self::$tabWidth      = 4;
         self::$phpcsFile     = null;
         self::$selectedSniff = ['Dummy.Dummy.Dummy'];
+
+        // Reset the static properties in the Config class to their defaults to prevent tests influencing each other.
+        self::setStaticConfigProperty('executablePaths', []);
+        self::setStaticConfigProperty('configData', null);
+        self::setStaticConfigProperty('configDataFile', null);
+    }
+
+    /**
+     * Helper function to set the value of a private static property on the PHPCS Config class.
+     *
+     * @param string $name  The name of the property to set.
+     * @param mixed  $value The value to set the property to.
+     *
+     * @return void
+     */
+    public static function setStaticConfigProperty($name, $value)
+    {
+        $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
+        $property->setAccessible(true);
+        $property->setValue(null, $value);
+        $property->setAccessible(false);
     }
 
     /**


### PR DESCRIPTION
PR squizlabs/PHP_CodeSniffer#3831 / PHPCSStandards/PHP_CodeSniffer#61 in PHPCS itself makes a change to improve the performance of the `Config` class.

This commit lets the `UtilityMethodTestCase` take advantage of that performance improvement by explicitly passing the `report_width` to prevent a call to `shell_exec('stty ...')` from being made and slowing down the tests.

While not benchmarked properly, with the test runs for PHPCSUtils on my local machine on Windows, the difference this change makes is significant and noticable:
* Before: **2.5 minutes**.
* After: **1 second**.

This advantage can only be seen with PHPCS 3.8.0 or higher, but the change does not negatively impact test runs against PHPCS < 3.8.0, so there is no need to raise the minimum PHPCS version.