### PR TITLE
PassedParameters: fix type in docs

### DIFF
--- a/PHPCSUtils/Utils/PassedParameters.php
+++ b/PHPCSUtils/Utils/PassedParameters.php
@@ -170,7 +170,7 @@ final class PassedParameters
      *                                                  Efficiency tweak for when this has already been established,
      *                                                  Use with EXTREME care.
      *
-     * @return array<int, array<string, int|string>>
+     * @return array<int|string, array<string, int|string>>
      *               A multi-dimentional array with information on each parameter/array item.
      *               The information gathered about each parameter/array item is in the following format:
      *               ```php


### PR DESCRIPTION
Depending on whether named parameters are used or not, the keys for the return array from `getParameters()` can be a mix of integers and strings.