### PR TITLE
CS: minor cleanup

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -10,7 +10,6 @@
 
 namespace PHPCSUtils\Tokens;
 
-use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Exceptions\InvalidTokenArray;
 
 /**

--- a/Tests/Tokens/Collections/ArrayOpenTokensBCTest.php
+++ b/Tests/Tokens/Collections/ArrayOpenTokensBCTest.php
@@ -10,7 +10,6 @@
 
 namespace PHPCSUtils\Tests\Tokens\Collections;
 
-use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tokens\Collections;
 use PHPUnit\Framework\TestCase;
 

--- a/Tests/Tokens/Collections/ArrayTokensBCTest.php
+++ b/Tests/Tokens/Collections/ArrayTokensBCTest.php
@@ -10,7 +10,6 @@
 
 namespace PHPCSUtils\Tests\Tokens\Collections;
 
-use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tokens\Collections;
 use PHPUnit\Framework\TestCase;
 

--- a/Tests/Tokens/Collections/ListOpenTokensBCTest.php
+++ b/Tests/Tokens/Collections/ListOpenTokensBCTest.php
@@ -10,7 +10,6 @@
 
 namespace PHPCSUtils\Tests\Tokens\Collections;
 
-use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tokens\Collections;
 use PHPUnit\Framework\TestCase;
 

--- a/Tests/Tokens/Collections/ListTokensBCTest.php
+++ b/Tests/Tokens/Collections/ListTokensBCTest.php
@@ -10,7 +10,6 @@
 
 namespace PHPCSUtils\Tests\Tokens\Collections;
 
-use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tokens\Collections;
 use PHPUnit\Framework\TestCase;
 

--- a/Tests/Tokens/Collections/ParameterPassingTokensTest.php
+++ b/Tests/Tokens/Collections/ParameterPassingTokensTest.php
@@ -10,7 +10,6 @@
 
 namespace PHPCSUtils\Tests\Tokens\Collections;
 
-use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tokens\Collections;
 use PHPUnit\Framework\TestCase;
 

--- a/Tests/Tokens/Collections/ShortArrayListOpenTokensBCTest.php
+++ b/Tests/Tokens/Collections/ShortArrayListOpenTokensBCTest.php
@@ -10,7 +10,6 @@
 
 namespace PHPCSUtils\Tests\Tokens\Collections;
 
-use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tokens\Collections;
 use PHPUnit\Framework\TestCase;
 

--- a/Tests/Tokens/Collections/ShortArrayTokensBCTest.php
+++ b/Tests/Tokens/Collections/ShortArrayTokensBCTest.php
@@ -10,7 +10,6 @@
 
 namespace PHPCSUtils\Tests\Tokens\Collections;
 
-use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tokens\Collections;
 use PHPUnit\Framework\TestCase;
 

--- a/Tests/Tokens/Collections/ShortListTokensBCTest.php
+++ b/Tests/Tokens/Collections/ShortListTokensBCTest.php
@@ -10,7 +10,6 @@
 
 namespace PHPCSUtils\Tests\Tokens\Collections;
 
-use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tokens\Collections;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
Follow up on PR #523 / commit https://github.com/PHPCSStandards/PHPCSUtils/pull/523/commits/2f73b9664a68d99d546adbad8d4f13930354c73a, which removed the use of certain classes, but failed to remove the import `use` statements.