### PR TITLE
PassedParameters: fix type in docs

### DIFF
--- a/PHPCSUtils/Utils/PassedParameters.php
+++ b/PHPCSUtils/Utils/PassedParameters.php
@@ -453,17 +453,17 @@ final class PassedParameters
      *
      * @since 1.0.0
      *
-     * @param array<int, array<string, int|string>> $parameters  The output of a previous call to
-     *                                                           {@see PassedParameters::getParameters()}.
-     * @param int                                   $paramOffset The 1-based index position of the parameter
-     *                                                           to retrieve.
-     * @param string|string[]                       $paramNames  Either the name of the target parameter to retrieve
-     *                                                           as a string or an array of names for the same target
-     *                                                           parameter.
-     *                                                           An array of names is supported to allow for functions
-     *                                                           for which the parameter names have undergone name
-     *                                                           changes over time.
-     *                                                           The name will take precedence over the offset.
+     * @param array<int|string, array<string, int|string>> $parameters  The output of a previous call to
+     *                                                                  {@see PassedParameters::getParameters()}.
+     * @param int                                          $paramOffset The 1-based index position of the parameter
+     *                                                                  to retrieve.
+     * @param string|string[]                              $paramNames  Either the name of the target parameter to retrieve
+     *                                                                  as a string or an array of names for the same target
+     *                                                                  parameter.
+     *                                                                  An array of names is supported to allow for functions
+     *                                                                  for which the parameter names have undergone name
+     *                                                                  changes over time.
+     *                                                                  The name will take precedence over the offset.
      *
      * @return array<string, int|string>|false Array with information on the parameter at the specified offset,
      *                                         or with the specified name.


### PR DESCRIPTION
Follow up on #528, which should have updated this one too.

Depending on whether named parameters are used or not, the keys for the return array from `getParameters()` - and therefore the expected input array for `getParametersFromStack()` - can be a mix of integers and strings.