### PR TITLE
Tests/FindExtendedClassNameTest: sync with upstream

### DIFF
--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.inc
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.inc
@@ -3,7 +3,8 @@
 /* testNotAClass */
 function notAClass() {}
 
-class testFECNClass {}
+/* testNonExtendedClass */
+class testFECNNonExtendedClass {}
 
 /* testExtendsUnqualifiedClass */
 class testFECNExtendedClass extends testFECNClass {}
@@ -11,8 +12,8 @@ class testFECNExtendedClass extends testFECNClass {}
 /* testExtendsFullyQualifiedClass */
 class testFECNNamespacedClass extends \PHP_CodeSniffer\Tests\Core\File\testFECNClass {}
 
-/* testNonExtendedClass */
-class testFECNNonExtendedClass {}
+/* testExtendsPartiallyQualifiedClass */
+class testFECNQualifiedClass extends Core\File\RelativeClass {}
 
 /* testNonExtendedInterface */
 interface testFECNInterface {}
@@ -23,6 +24,9 @@ interface testInterfaceThatExtendsInterface extends testFECNInterface{}
 /* testInterfaceExtendsFullyQualifiedInterface */
 interface testInterfaceThatExtendsFQCNInterface extends \PHP_CodeSniffer\Tests\Core\File\testFECNInterface{}
 
+/* testExtendedAnonClass */
+$anon = new class( $a, $b ) extends testFECNExtendedAnonClass {};
+
 /* testNestedExtendedClass */
 class testFECNNestedExtendedClass {
     public function someMethod() {
@@ -31,17 +35,11 @@ class testFECNNestedExtendedClass {
     }
 }
 
-/* testExtendsPartiallyQualifiedClass */
-class testFECNQualifiedClass extends Core\File\RelativeClass {}
-
 /* testClassThatExtendsAndImplements */
 class testFECNClassThatExtendsAndImplements extends testFECNClass implements InterfaceA, InterfaceB {}
 
 /* testClassThatImplementsAndExtends */
 class testFECNClassThatImplementsAndExtends implements InterfaceA, InterfaceB extends testFECNClass {}
-
-/* testExtendedAnonClass */
-$anon = new class( $a, $b ) extends testFECNExtendedAnonClass {};
 
 /* testInterfaceMultiExtends */
 interface Multi extends \Package\FooInterface, \BarInterface {};

--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.inc
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.inc
@@ -5,22 +5,22 @@ function notAClass() {}
 
 class testFECNClass {}
 
-/* testExtendedClass */
+/* testExtendsUnqualifiedClass */
 class testFECNExtendedClass extends testFECNClass {}
 
-/* testNamespacedClass */
+/* testExtendsFullyQualifiedClass */
 class testFECNNamespacedClass extends \PHP_CodeSniffer\Tests\Core\File\testFECNClass {}
 
 /* testNonExtendedClass */
 class testFECNNonExtendedClass {}
 
-/* testInterface */
+/* testNonExtendedInterface */
 interface testFECNInterface {}
 
-/* testInterfaceThatExtendsInterface */
+/* testInterfaceExtendsUnqualifiedInterface */
 interface testInterfaceThatExtendsInterface extends testFECNInterface{}
 
-/* testInterfaceThatExtendsFQCNInterface */
+/* testInterfaceExtendsFullyQualifiedInterface */
 interface testInterfaceThatExtendsFQCNInterface extends \PHP_CodeSniffer\Tests\Core\File\testFECNInterface{}
 
 /* testNestedExtendedClass */
@@ -31,7 +31,7 @@ class testFECNNestedExtendedClass {
     }
 }
 
-/* testNamespaceRelativeQualifiedClass */
+/* testExtendsPartiallyQualifiedClass */
 class testFECNQualifiedClass extends Core\File\RelativeClass {}
 
 /* testClassThatExtendsAndImplements */

--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
@@ -81,8 +81,8 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
      *
      * @dataProvider dataExtendedClass
      *
-     * @param string $identifier Comment which precedes the test case.
-     * @param bool   $expected   Expected function output.
+     * @param string       $identifier Comment which precedes the test case.
+     * @param string|false $expected   Expected function output.
      *
      * @return void
      */
@@ -100,70 +100,70 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
      *
      * @see testFindExtendedClassName()
      *
-     * @return array
+     * @return array<string, array<string, string|false>>
      */
     public static function dataExtendedClass()
     {
         return [
-            [
-                '/* testExtendsUnqualifiedClass */',
-                'testFECNClass',
+            'class extends unqualified class' => [
+                'identifier' => '/* testExtendsUnqualifiedClass */',
+                'expected'   => 'testFECNClass',
             ],
-            [
-                '/* testExtendsFullyQualifiedClass */',
-                '\PHP_CodeSniffer\Tests\Core\File\testFECNClass',
+            'class extends fully qualified class' => [
+                'identifier' => '/* testExtendsFullyQualifiedClass */',
+                'expected'   => '\PHP_CodeSniffer\Tests\Core\File\testFECNClass',
             ],
-            [
-                '/* testNonExtendedClass */',
-                false,
+            'class does not extend' => [
+                'identifier' => '/* testNonExtendedClass */',
+                'expected'   => false,
             ],
-            [
-                '/* testNonExtendedInterface */',
-                false,
+            'interface does not extend' => [
+                'identifier' => '/* testNonExtendedInterface */',
+                'expected'   => false,
             ],
-            [
-                '/* testInterfaceExtendsUnqualifiedInterface */',
-                'testFECNInterface',
+            'interface extends unqualified interface' => [
+                'identifier' => '/* testInterfaceExtendsUnqualifiedInterface */',
+                'expected'   => 'testFECNInterface',
             ],
-            [
-                '/* testInterfaceExtendsFullyQualifiedInterface */',
-                '\PHP_CodeSniffer\Tests\Core\File\testFECNInterface',
+            'interface extends fully qualified interface' => [
+                'identifier' => '/* testInterfaceExtendsFullyQualifiedInterface */',
+                'expected'   => '\PHP_CodeSniffer\Tests\Core\File\testFECNInterface',
             ],
-            [
-                '/* testNestedExtendedClass */',
-                false,
+            'class does not extend but contains anon class which extends' => [
+                'identifier' => '/* testNestedExtendedClass */',
+                'expected'   => false,
             ],
-            [
-                '/* testNestedExtendedAnonClass */',
-                'testFECNAnonClass',
+            'anon class extends, nested in non-extended class' => [
+                'identifier' => '/* testNestedExtendedAnonClass */',
+                'expected'   => 'testFECNAnonClass',
             ],
-            [
-                '/* testExtendsPartiallyQualifiedClass */',
-                'Core\File\RelativeClass',
+            'class extends partially qualified class' => [
+                'identifier' => '/* testExtendsPartiallyQualifiedClass */',
+                'expected'   => 'Core\File\RelativeClass',
             ],
-            [
-                '/* testClassThatExtendsAndImplements */',
-                'testFECNClass',
+            'class extends and implements' => [
+                'identifier' => '/* testClassThatExtendsAndImplements */',
+                'expected'   => 'testFECNClass',
             ],
-            [
-                '/* testClassThatImplementsAndExtends */',
-                'testFECNClass',
+            'class implements and extends' => [
+                'identifier' => '/* testClassThatImplementsAndExtends */',
+                'expected'   => 'testFECNClass',
             ],
-            [
-                '/* testExtendedAnonClass */',
-                'testFECNExtendedAnonClass',
+            'anon class extends unqualified class' => [
+                'identifier' => '/* testExtendedAnonClass */',
+                'expected'   => 'testFECNExtendedAnonClass',
             ],
-            [
-                '/* testInterfaceMultiExtends */',
-                '\Package\FooInterface',
+            'interface extends multiple interfaces (not supported)' => [
+                'identifier' => '/* testInterfaceMultiExtends */',
+                'expected'   => '\Package\FooInterface',
             ],
-            [
-                '/* testMissingExtendsName */',
-                false,
+            'parse error - extends keyword, but no class name' => [
+                'identifier' => '/* testMissingExtendsName */',
+                'expected'   => false,
             ],
-            [
-                '/* testParseError */',
-                false,
+            'parse error - live coding - no curly braces' => [
+                'identifier' => '/* testParseError */',
+                'expected'   => false,
             ],
         ];
     }

--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
@@ -106,11 +106,11 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
     {
         return [
             [
-                '/* testExtendedClass */',
+                '/* testExtendsUnqualifiedClass */',
                 'testFECNClass',
             ],
             [
-                '/* testNamespacedClass */',
+                '/* testExtendsFullyQualifiedClass */',
                 '\PHP_CodeSniffer\Tests\Core\File\testFECNClass',
             ],
             [
@@ -118,15 +118,15 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
                 false,
             ],
             [
-                '/* testInterface */',
+                '/* testNonExtendedInterface */',
                 false,
             ],
             [
-                '/* testInterfaceThatExtendsInterface */',
+                '/* testInterfaceExtendsUnqualifiedInterface */',
                 'testFECNInterface',
             ],
             [
-                '/* testInterfaceThatExtendsFQCNInterface */',
+                '/* testInterfaceExtendsFullyQualifiedInterface */',
                 '\PHP_CodeSniffer\Tests\Core\File\testFECNInterface',
             ],
             [
@@ -138,7 +138,7 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
                 'testFECNAnonClass',
             ],
             [
-                '/* testNamespaceRelativeQualifiedClass */',
+                '/* testExtendsPartiallyQualifiedClass */',
                 'Core\File\RelativeClass',
             ],
             [

--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
@@ -105,6 +105,10 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
     public static function dataExtendedClass()
     {
         return [
+            'class does not extend' => [
+                'identifier' => '/* testNonExtendedClass */',
+                'expected'   => false,
+            ],
             'class extends unqualified class' => [
                 'identifier' => '/* testExtendsUnqualifiedClass */',
                 'expected'   => 'testFECNClass',
@@ -113,9 +117,9 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
                 'identifier' => '/* testExtendsFullyQualifiedClass */',
                 'expected'   => '\PHP_CodeSniffer\Tests\Core\File\testFECNClass',
             ],
-            'class does not extend' => [
-                'identifier' => '/* testNonExtendedClass */',
-                'expected'   => false,
+            'class extends partially qualified class' => [
+                'identifier' => '/* testExtendsPartiallyQualifiedClass */',
+                'expected'   => 'Core\File\RelativeClass',
             ],
             'interface does not extend' => [
                 'identifier' => '/* testNonExtendedInterface */',
@@ -129,6 +133,10 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
                 'identifier' => '/* testInterfaceExtendsFullyQualifiedInterface */',
                 'expected'   => '\PHP_CodeSniffer\Tests\Core\File\testFECNInterface',
             ],
+            'anon class extends unqualified class' => [
+                'identifier' => '/* testExtendedAnonClass */',
+                'expected'   => 'testFECNExtendedAnonClass',
+            ],
             'class does not extend but contains anon class which extends' => [
                 'identifier' => '/* testNestedExtendedClass */',
                 'expected'   => false,
@@ -137,10 +145,6 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
                 'identifier' => '/* testNestedExtendedAnonClass */',
                 'expected'   => 'testFECNAnonClass',
             ],
-            'class extends partially qualified class' => [
-                'identifier' => '/* testExtendsPartiallyQualifiedClass */',
-                'expected'   => 'Core\File\RelativeClass',
-            ],
             'class extends and implements' => [
                 'identifier' => '/* testClassThatExtendsAndImplements */',
                 'expected'   => 'testFECNClass',
@@ -148,10 +152,6 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
             'class implements and extends' => [
                 'identifier' => '/* testClassThatImplementsAndExtends */',
                 'expected'   => 'testFECNClass',
-            ],
-            'anon class extends unqualified class' => [
-                'identifier' => '/* testExtendedAnonClass */',
-                'expected'   => 'testFECNExtendedAnonClass',
             ],
             'interface extends multiple interfaces (not supported)' => [
                 'identifier' => '/* testInterfaceMultiExtends */',

--- a/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.php
@@ -34,8 +34,8 @@ final class FindExtendedClassNameDiffTest extends UtilityMethodTestCase
      *
      * @dataProvider dataFindExtendedClassName
      *
-     * @param string $testMarker The comment which prefaces the target token in the test file.
-     * @param bool   $expected   Expected function output.
+     * @param string       $testMarker The comment which prefaces the target token in the test file.
+     * @param string|false $expected   Expected function output.
      *
      * @return void
      */


### PR DESCRIPTION
Sister-PR to PHPCSStandards/PHP_CodeSniffer#212

### Tests/FindExtendedClassNameTest: sync with upstream [1] - improve test markers

Make the test marker names more descriptive

### Tests/FindExtendedClassNameTest: sync with upstream [2] - use named data sets

With non-named data sets, when a test fails, PHPUnit will display the number of the test which failed.

With tests which have a _lot_ of data sets, this makes it _interesting_ (and time-consuming) to debug those, as one now has to figure out which of the data sets in the data provider corresponds to that number.

Using named data sets makes debugging failing tests more straight forward as PHPUnit will display the data set name instead of the number.

Aside from adding the data set name, this commit also adds the parameter name for each item in the data set, this time in an effort to make it more straight forward to update and add tests as it will be more obvious what each key in the data set signifies.

Includes fixing the data types in the docblocks and making them more specific, where relevant.

### Tests/FindExtendedClassNameTest: sync with upstream [3] - more logical test order

This cleans up the test case file a little by removing some code which isn't actually used in the tests and moves some tests