### PR TITLE
Tests/FindImplementedInterfaceNamesTest: sync with upstream

### DIFF
--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.inc
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.inc
@@ -5,22 +5,22 @@ function notAClass() {}
 
 interface testFIINInterface2 {}
 
-/* testInterface */
+/* testPlainInterface */
 interface testFIINInterface {}
 
-/* testImplementedClass */
+/* testClassImplementsSingle */
 class testFIINImplementedClass implements testFIINInterface {}
 
-/* testMultiImplementedClass */
+/* testClassImplementsMultiple */
 class testFIINMultiImplementedClass implements testFIINInterface, testFIINInterface2 {}
 
-/* testNamespacedClass */
+/* testImplementsFullyQualified */
 class testFIINNamespacedClass implements \PHP_CodeSniffer\Tests\Core\File\testFIINInterface {}
 
 /* testNonImplementedClass */
 class testFIINNonImplementedClass {}
 
-/* testNamespaceRelativeQualifiedClass */
+/* testImplementsPartiallyQualified */
 class testFIINQualifiedClass implements Core\File\RelativeInterface {}
 
 /* testClassThatExtendsAndImplements */
@@ -32,13 +32,13 @@ class testFECNClassThatImplementsAndExtends implements \InterfaceA, InterfaceB e
 /* testBackedEnumWithoutImplements */
 enum Suit:string {}
 
-/* testEnumImplements */
+/* testEnumImplementsSingle */
 enum Suit implements Colorful {}
 
-/* testBackedEnumImplements */
+/* testBackedEnumImplementsMulti */
 enum Suit: string implements Colorful, \Deck {}
 
-/* testAnonClassImplements */
+/* testAnonClassImplementsSingle */
 $anon = class() implements testFIINInterface {}
 
 /* testMissingImplementsName */

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.inc
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.inc
@@ -3,10 +3,11 @@
 /* testNotAClass */
 function notAClass() {}
 
-interface testFIINInterface2 {}
-
 /* testPlainInterface */
 interface testFIINInterface {}
+
+/* testNonImplementedClass */
+class testFIINNonImplementedClass {}
 
 /* testClassImplementsSingle */
 class testFIINImplementedClass implements testFIINInterface {}
@@ -16,9 +17,6 @@ class testFIINMultiImplementedClass implements testFIINInterface, testFIINInterf
 
 /* testImplementsFullyQualified */
 class testFIINNamespacedClass implements \PHP_CodeSniffer\Tests\Core\File\testFIINInterface {}
-
-/* testNonImplementedClass */
-class testFIINNonImplementedClass {}
 
 /* testImplementsPartiallyQualified */
 class testFIINQualifiedClass implements Core\File\RelativeInterface {}

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
@@ -103,6 +103,14 @@ class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
     public static function dataImplementedInterface()
     {
         return [
+            'interface declaration, no implements' => [
+                'identifier' => '/* testPlainInterface */',
+                'expected'   => false,
+            ],
+            'class does not implement' => [
+                'identifier' => '/* testNonImplementedClass */',
+                'expected'   => false,
+            ],
             'class implements single interface, unqualified' => [
                 'identifier' => '/* testClassImplementsSingle */',
                 'expected'   => ['testFIINInterface'],
@@ -117,14 +125,6 @@ class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
             'class implements single interface, fully qualified' => [
                 'identifier' => '/* testImplementsFullyQualified */',
                 'expected'   => ['\PHP_CodeSniffer\Tests\Core\File\testFIINInterface'],
-            ],
-            'class does not implement' => [
-                'identifier' => '/* testNonImplementedClass */',
-                'expected'   => false,
-            ],
-            'interface declaration, no implements' => [
-                'identifier' => '/* testPlainInterface */',
-                'expected'   => false,
             ],
             'class implements single interface, partially qualified' => [
                 'identifier' => '/* testImplementsPartiallyQualified */',

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
@@ -104,18 +104,18 @@ class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
     {
         return [
             [
-                '/* testImplementedClass */',
+                '/* testClassImplementsSingle */',
                 ['testFIINInterface'],
             ],
             [
-                '/* testMultiImplementedClass */',
+                '/* testClassImplementsMultiple */',
                 [
                     'testFIINInterface',
                     'testFIINInterface2',
                 ],
             ],
             [
-                '/* testNamespacedClass */',
+                '/* testImplementsFullyQualified */',
                 ['\PHP_CodeSniffer\Tests\Core\File\testFIINInterface'],
             ],
             [
@@ -123,11 +123,11 @@ class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
                 false,
             ],
             [
-                '/* testInterface */',
+                '/* testPlainInterface */',
                 false,
             ],
             [
-                '/* testNamespaceRelativeQualifiedClass */',
+                '/* testImplementsPartiallyQualified */',
                 ['Core\File\RelativeInterface'],
             ],
             [
@@ -149,18 +149,18 @@ class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
                 false,
             ],
             [
-                '/* testEnumImplements */',
+                '/* testEnumImplementsSingle */',
                 ['Colorful'],
             ],
             [
-                '/* testBackedEnumImplements */',
+                '/* testBackedEnumImplementsMulti */',
                 [
                     'Colorful',
                     '\Deck',
                 ],
             ],
             [
-                '/* testAnonClassImplements */',
+                '/* testAnonClassImplementsSingle */',
                 ['testFIINInterface'],
             ],
             [

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
@@ -79,8 +79,8 @@ class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
      *
      * @dataProvider dataImplementedInterface
      *
-     * @param string $identifier Comment which precedes the test case.
-     * @param bool   $expected   Expected function output.
+     * @param string              $identifier Comment which precedes the test case.
+     * @param array<string>|false $expected   Expected function output.
      *
      * @return void
      */
@@ -98,78 +98,78 @@ class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
      *
      * @see testFindImplementedInterfaceNames()
      *
-     * @return array
+     * @return array<string, array<string, string|array<string>>>
      */
     public static function dataImplementedInterface()
     {
         return [
-            [
-                '/* testClassImplementsSingle */',
-                ['testFIINInterface'],
+            'class implements single interface, unqualified' => [
+                'identifier' => '/* testClassImplementsSingle */',
+                'expected'   => ['testFIINInterface'],
             ],
-            [
-                '/* testClassImplementsMultiple */',
-                [
+            'class implements multiple interfaces' => [
+                'identifier' => '/* testClassImplementsMultiple */',
+                'expected'   => [
                     'testFIINInterface',
                     'testFIINInterface2',
                 ],
             ],
-            [
-                '/* testImplementsFullyQualified */',
-                ['\PHP_CodeSniffer\Tests\Core\File\testFIINInterface'],
+            'class implements single interface, fully qualified' => [
+                'identifier' => '/* testImplementsFullyQualified */',
+                'expected'   => ['\PHP_CodeSniffer\Tests\Core\File\testFIINInterface'],
             ],
-            [
-                '/* testNonImplementedClass */',
-                false,
+            'class does not implement' => [
+                'identifier' => '/* testNonImplementedClass */',
+                'expected'   => false,
             ],
-            [
-                '/* testPlainInterface */',
-                false,
+            'interface declaration, no implements' => [
+                'identifier' => '/* testPlainInterface */',
+                'expected'   => false,
             ],
-            [
-                '/* testImplementsPartiallyQualified */',
-                ['Core\File\RelativeInterface'],
+            'class implements single interface, partially qualified' => [
+                'identifier' => '/* testImplementsPartiallyQualified */',
+                'expected'   => ['Core\File\RelativeInterface'],
             ],
-            [
-                '/* testClassThatExtendsAndImplements */',
-                [
+            'class extends and implements' => [
+                'identifier' => '/* testClassThatExtendsAndImplements */',
+                'expected'   => [
                     'InterfaceA',
                     '\NameSpaced\Cat\InterfaceB',
                 ],
             ],
-            [
-                '/* testClassThatImplementsAndExtends */',
-                [
+            'class implements and extends' => [
+                'identifier' => '/* testClassThatImplementsAndExtends */',
+                'expected'   => [
                     '\InterfaceA',
                     'InterfaceB',
                 ],
             ],
-            [
-                '/* testBackedEnumWithoutImplements */',
-                false,
+            'enum does not implement' => [
+                'identifier' => '/* testBackedEnumWithoutImplements */',
+                'expected'   => false,
             ],
-            [
-                '/* testEnumImplementsSingle */',
-                ['Colorful'],
+            'enum implements single interface, unqualified' => [
+                'identifier' => '/* testEnumImplementsSingle */',
+                'expected'   => ['Colorful'],
             ],
-            [
-                '/* testBackedEnumImplementsMulti */',
-                [
+            'enum implements multiple interfaces, unqualified + fully qualified' => [
+                'identifier' => '/* testBackedEnumImplementsMulti */',
+                'expected'   => [
                     'Colorful',
                     '\Deck',
                 ],
             ],
-            [
-                '/* testAnonClassImplementsSingle */',
-                ['testFIINInterface'],
+            'anon class implements single interface, unqualified' => [
+                'identifier' => '/* testAnonClassImplementsSingle */',
+                'expected'   => ['testFIINInterface'],
             ],
-            [
-                '/* testMissingImplementsName */',
-                false,
+            'parse error - implements keyword, but no interface name' => [
+                'identifier' => '/* testMissingImplementsName */',
+                'expected'   => false,
             ],
-            [
-                '/* testParseError */',
-                false,
+            'parse error - live coding - no curly braces' => [
+                'identifier' => '/* testParseError */',
+                'expected'   => false,
             ],
         ];
     }

--- a/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.php
@@ -34,8 +34,8 @@ final class FindImplementedInterfaceNamesDiffTest extends UtilityMethodTestCase
      *
      * @dataProvider dataFindImplementedInterfaceNames
      *
-     * @param string $testMarker The comment which prefaces the target token in the test file.
-     * @param bool   $expected   Expected function output.
+     * @param string              $testMarker The comment which prefaces the target token in the test file.
+     * @param array<string>|false $expected   Expected function output.
      *
      * @return void
      */
@@ -51,7 +51,7 @@ final class FindImplementedInterfaceNamesDiffTest extends UtilityMethodTestCase
      *
      * @see testFindImplementedInterfaceNames() For the array format.
      *
-     * @return array
+     * @return array<string, array<string, string|array<string>|false>>
      */
     public static function dataFindImplementedInterfaceNames()
     {


### PR DESCRIPTION
Sister-PR to PHPCSStandards/PHP_CodeSniffer#213

### Tests/FindImplementedInterfaceNamesTest: sync with upstream [1] - improve test markers

Make the test marker names more descriptive

### Tests/FindImplementedInterfaceNamesTest: sync with upstream [2] - use named data sets

With non-named data sets, when a test fails, PHPUnit will display the number of the test which failed.

With tests which have a _lot_ of data sets, this makes it _interesting_ (and time-consuming) to debug those, as one now has to figure out which of the data sets in the data provider corresponds to that number.

Using named data sets makes debugging failing tests more straight forward as PHPUnit will display the data set name instead of the number.

Aside from adding the data set name, this commit also adds the parameter name for each item in the data set, this time in an effort to make it more straight forward to update and add tests as it will be more obvious what each key in the data set signifies.

Includes fixing the data types in the docblocks and making them more specific, where relevant.

### Tests/FindImplementedInterfaceNamesTest: sync with upstream [3] - more logical test order

This cleans up the test case file a little by removing some code which isn't actually used in the tests and moves some tests up.
