### PR TITLE
Tests/FindStartOfStatementTest: sync with upstream - minor improvements

### DIFF
--- a/Tests/BackCompat/BCFile/FindStartOfStatementTest.inc
+++ b/Tests/BackCompat/BCFile/FindStartOfStatementTest.inc
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * PHPCS native tests.
- */
-
 /* testSimpleAssignment */
 $a = false;
 
@@ -125,11 +121,6 @@ return 0;
 ?>
 <h1>Test</h1>
 <?= '<h2>', foo(), '</h2>';
-
-?><?php
-/*
- * PHPCSUtils native extra tests.
- */
 
 $value = [
     /* testPrecededByArrowFunctionInArray - Expected */

--- a/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
@@ -485,9 +485,9 @@ final class FindStartOfStatementTest extends UtilityMethodTestCase
      *
      * @dataProvider dataFindStartInsideSwitchCaseDefaultStatements
      *
-     * @param string           $testMarker     The comment which prefaces the target token in the test file.
-     * @param array|string|int $targets        The token to search for after the test marker.
-     * @param string|int       $expectedTarget Token code of the expected start of statement stack pointer.
+     * @param string     $testMarker     The comment which prefaces the target token in the test file.
+     * @param int|string $targets        The token to search for after the test marker.
+     * @param string|int $expectedTarget Token code of the expected start of statement stack pointer.
      *
      * @return void
      */
@@ -504,7 +504,7 @@ final class FindStartOfStatementTest extends UtilityMethodTestCase
     /**
      * Data provider.
      *
-     * @return array
+     * @return array<string, array<string, int|string>>
      */
     public static function dataFindStartInsideSwitchCaseDefaultStatements()
     {


### PR DESCRIPTION
* Remove PHPCS/PHPCSUtils markers in the test case file as all tests for this method are now in both repos.
* Improve type specificity in the docblocks.

Sister-PR to PHPCSStandards/PHP_CodeSniffer#214