### PR TITLE
Tests/GetMemberPropertiesTest: sync with upstream

### DIFF
--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.inc
@@ -213,6 +213,7 @@ $anon = class() {
 
     /* testPHP8UnionTypesIllegalTypes */
     // Intentional fatal error - types which are not allowed for properties, but that's not the concern of the method.
+    // Note: static is also not allowed as a type, but using static for a property type is not supported by the tokenizer.
     public callable|static|void $unionTypesIllegalTypes;
 
     /* testPHP8UnionTypesNullable */

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -63,10 +63,11 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
         $variable = $this->getTargetToken($identifier, T_VARIABLE);
         $result   = $testClass::getMemberProperties(self::$phpcsFile, $variable);
 
-        if (isset($expected['type_token']) && $expected['type_token'] !== false) {
+        // Convert offsets to absolute positions in the token stream.
+        if (isset($expected['type_token']) && \is_int($expected['type_token']) === true) {
             $expected['type_token'] += $variable;
         }
-        if (isset($expected['type_end_token']) && $expected['type_end_token'] !== false) {
+        if (isset($expected['type_end_token']) && \is_int($expected['type_end_token']) === true) {
             $expected['type_end_token'] += $variable;
         }
 
@@ -75,6 +76,10 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
 
     /**
      * Data provider.
+     *
+     * Note: the `expected - type_token` and `expected - type_end_token` indexes should
+     * contain either `false` (no type) or the _offset_ of the type start/end token in
+     * relation to the `T_VARIABLE` token which is passed to the getMemberProperties() method.
      *
      * @see testGetMemberProperties()
      *
@@ -106,8 +111,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => '?int',
-                    'type_token'      => -2, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -2,
+                    'type_end_token'  => -2,
                     'nullable_type'   => true,
                 ],
             ],
@@ -132,8 +137,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'string',
-                    'type_token'      => -2, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -2,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -158,8 +163,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'bool',
-                    'type_token'      => -2, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -2,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -184,8 +189,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'array',
-                    'type_token'      => -2, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -2,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -210,8 +215,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => true,
                     'is_readonly'     => false,
                     'type'            => '?string',
-                    'type_token'      => -2, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -2,
+                    'type_end_token'  => -2,
                     'nullable_type'   => true,
                 ],
             ],
@@ -340,8 +345,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'float',
-                    'type_token'      => -6, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -6, // Offset from the T_VARIABLE token.
+                    'type_token'      => -6,
+                    'type_end_token'  => -6,
                     'nullable_type'   => false,
                 ],
             ],
@@ -353,8 +358,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'float',
-                    'type_token'      => -13, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -13, // Offset from the T_VARIABLE token.
+                    'type_token'      => -13,
+                    'type_end_token'  => -13,
                     'nullable_type'   => false,
                 ],
             ],
@@ -366,8 +371,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => true,
                     'is_readonly'     => false,
                     'type'            => '?string',
-                    'type_token'      => -6, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -6, // Offset from the T_VARIABLE token.
+                    'type_token'      => -6,
+                    'type_end_token'  => -6,
                     'nullable_type'   => true,
                 ],
             ],
@@ -379,8 +384,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => true,
                     'is_readonly'     => false,
                     'type'            => '?string',
-                    'type_token'      => -17, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -17, // Offset from the T_VARIABLE token.
+                    'type_token'      => -17,
+                    'type_end_token'  => -17,
                     'nullable_type'   => true,
                 ],
             ],
@@ -522,8 +527,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => '?array',
-                    'type_token'      => -2, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -2,
+                    'type_end_token'  => -2,
                     'nullable_type'   => true,
                 ],
             ],
@@ -535,8 +540,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => '\MyNamespace\MyClass',
-                    'type_token'      => ($php8Names === true) ? -2 : -5, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => ($php8Names === true) ? -2 : -5,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -548,8 +553,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => '?ClassName',
-                    'type_token'      => -2, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -2,
+                    'type_end_token'  => -2,
                     'nullable_type'   => true,
                 ],
             ],
@@ -561,8 +566,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => '?Folder\ClassName',
-                    'type_token'      => ($php8Names === true) ? -2 : -4, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => ($php8Names === true) ? -2 : -4,
+                    'type_end_token'  => -2,
                     'nullable_type'   => true,
                 ],
             ],
@@ -574,8 +579,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => '\MyNamespace\MyClass\Foo',
-                    'type_token'      => ($php8Names === true) ? -15 : -18, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => ($php8Names === true) ? -15 : -18,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -630,8 +635,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => true,
                     'is_readonly'     => false,
                     'type'            => 'miXed',
-                    'type_token'      => -2, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -2,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -643,8 +648,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => '?mixed',
-                    'type_token'      => -2, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -2,
+                    'type_end_token'  => -2,
                     'nullable_type'   => true,
                 ],
             ],
@@ -656,8 +661,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => '?namespace\Name',
-                    'type_token'      => ($php8Names === true) ? -2 : -4, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => ($php8Names === true) ? -2 : -4,
+                    'type_end_token'  => -2,
                     'nullable_type'   => true,
                 ],
             ],
@@ -669,8 +674,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'int|float',
-                    'type_token'      => -4, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -4,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -682,8 +687,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'MyClassA|\Package\MyClassB',
-                    'type_token'      => ($php8Names === true) ? -4 : -7, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => ($php8Names === true) ? -4 : -7,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -695,8 +700,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'array|bool|int|float|NULL|object|string',
-                    'type_token'      => -14, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -14,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -708,8 +713,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'false|mixed|self|parent|iterable|Resource',
-                    'type_token'      => -12, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -12,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -722,8 +727,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_readonly'     => false,
                     // Missing static, but that's OK as not an allowed syntax.
                     'type'            => 'callable|void',
-                    'type_token'      => -6, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -6,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -735,8 +740,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => '?int|float',
-                    'type_token'      => -4, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -4,
+                    'type_end_token'  => -2,
                     'nullable_type'   => true,
                 ],
             ],
@@ -748,8 +753,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'null',
-                    'type_token'      => -2, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -2,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -761,8 +766,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'false',
-                    'type_token'      => -2, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -2,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -774,8 +779,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'bool|FALSE',
-                    'type_token'      => -4, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -4,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -787,8 +792,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'object|ClassName',
-                    'type_token'      => -4, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -4,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -800,8 +805,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'iterable|array|Traversable',
-                    'type_token'      => -6, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -6,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -813,8 +818,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'int|string|INT',
-                    'type_token'      => -10, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -10,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -826,8 +831,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => true,
                     'type'            => 'int',
-                    'type_token'      => -2, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -2,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -839,8 +844,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => true,
                     'type'            => '?array',
-                    'type_token'      => -2, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -2,
+                    'type_end_token'  => -2,
                     'nullable_type'   => true,
                 ],
             ],
@@ -852,8 +857,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => true,
                     'type'            => 'string|int',
-                    'type_token'      => -4, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -4,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -865,8 +870,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => true,
                     'type'            => 'string|null',
-                    'type_token'      => -4, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -4,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -878,8 +883,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => true,
                     'type'            => 'string|int',
-                    'type_token'      => -4, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -4,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -891,8 +896,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => true,
                     'type'            => '\InterfaceA|\Sub\InterfaceB|false',
-                    'type_token'      => ($php8Names === true) ? -7 : -11, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -3, // Offset from the T_VARIABLE token.
+                    'type_token'      => ($php8Names === true) ? -7 : -11,
+                    'type_end_token'  => -3,
                     'nullable_type'   => false,
                 ],
             ],
@@ -904,8 +909,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => true,
                     'is_readonly'     => true,
                     'type'            => '?string',
-                    'type_token'      => -2, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -2,
+                    'type_end_token'  => -2,
                     'nullable_type'   => true,
                 ],
             ],
@@ -930,8 +935,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'string',
-                    'type_token'      => -2, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -2,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -943,8 +948,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => '?int|float',
-                    'type_token'      => -4, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -4,
+                    'type_end_token'  => -2,
                     'nullable_type'   => true,
                 ],
             ],
@@ -956,8 +961,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'mixed',
-                    'type_token'      => -2, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -2,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -973,8 +978,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'Foo&Bar',
-                    'type_token'      => -4, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -4,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -986,8 +991,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'Foo&Bar&Baz',
-                    'type_token'      => -6, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -6,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -999,8 +1004,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'int&string',
-                    'type_token'      => -4, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -4,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -1012,8 +1017,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => '?Foo&Bar',
-                    'type_token'      => -4, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -4,
+                    'type_end_token'  => -2,
                     'nullable_type'   => true,
                 ],
             ],
@@ -1026,8 +1031,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'int|string',
-                    'type_token'      => -8, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -8,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -1039,8 +1044,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => '\Foo&Bar',
-                    'type_token'      => ($php8Names === true) ? -8 : -9, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => ($php8Names === true) ? -8 : -9,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -1052,8 +1057,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'true',
-                    'type_token'      => -2, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -2,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -1065,8 +1070,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => true,
                     'is_readonly'     => false,
                     'type'            => '?true',
-                    'type_token'      => -2, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -2,
+                    'type_end_token'  => -2,
                     'nullable_type'   => true,
                 ],
             ],
@@ -1078,8 +1083,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => false,
                     'type'            => 'int|string|true',
-                    'type_token'      => -6, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -6,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],
@@ -1091,8 +1096,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'is_static'       => false,
                     'is_readonly'     => true,
                     'type'            => 'true|FALSE',
-                    'type_token'      => -4, // Offset from the T_VARIABLE token.
-                    'type_end_token'  => -2, // Offset from the T_VARIABLE token.
+                    'type_token'      => -4,
+                    'type_end_token'  => -2,
                     'nullable_type'   => false,
                 ],
             ],

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -51,8 +51,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
      *
      * @dataProvider dataGetMemberProperties
      *
-     * @param string $identifier Comment which precedes the test case.
-     * @param array  $expected   Expected function output.
+     * @param string                         $identifier Comment which precedes the test case.
+     * @param array<string, string|int|bool> $expected   Expected function output.
      *
      * @return void
      */
@@ -78,7 +78,7 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
      *
      * @see testGetMemberProperties()
      *
-     * @return array
+     * @return array<string, array<string|array<string, string|int|bool>>>
      */
     public static function dataGetMemberProperties()
     {
@@ -86,8 +86,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
 
         return [
             'var-modifier' => [
-                '/* testVar */',
-                [
+                'identifier' => '/* testVar */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => false,
                     'is_static'       => false,
@@ -99,8 +99,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'var-modifier-and-type' => [
-                '/* testVarType */',
-                [
+                'identifier' => '/* testVarType */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => false,
                     'is_static'       => false,
@@ -112,8 +112,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'public-modifier' => [
-                '/* testPublic */',
-                [
+                'identifier' => '/* testPublic */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -125,8 +125,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'public-modifier-and-type' => [
-                '/* testPublicType */',
-                [
+                'identifier' => '/* testPublicType */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -138,8 +138,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'protected-modifier' => [
-                '/* testProtected */',
-                [
+                'identifier' => '/* testProtected */',
+                'expected'   => [
                     'scope'           => 'protected',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -151,8 +151,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'protected-modifier-and-type' => [
-                '/* testProtectedType */',
-                [
+                'identifier' => '/* testProtectedType */',
+                'expected'   => [
                     'scope'           => 'protected',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -164,8 +164,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'private-modifier' => [
-                '/* testPrivate */',
-                [
+                'identifier' => '/* testPrivate */',
+                'expected'   => [
                     'scope'           => 'private',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -177,8 +177,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'private-modifier-and-type' => [
-                '/* testPrivateType */',
-                [
+                'identifier' => '/* testPrivateType */',
+                'expected'   => [
                     'scope'           => 'private',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -190,8 +190,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'static-modifier' => [
-                '/* testStatic */',
-                [
+                'identifier' => '/* testStatic */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => false,
                     'is_static'       => true,
@@ -203,8 +203,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'static-modifier-and-type' => [
-                '/* testStaticType */',
-                [
+                'identifier' => '/* testStaticType */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => false,
                     'is_static'       => true,
@@ -216,8 +216,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'static-and-var-modifier' => [
-                '/* testStaticVar */',
-                [
+                'identifier' => '/* testStaticVar */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => false,
                     'is_static'       => true,
@@ -229,8 +229,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'var-and-static-modifier' => [
-                '/* testVarStatic */',
-                [
+                'identifier' => '/* testVarStatic */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => false,
                     'is_static'       => true,
@@ -242,8 +242,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'public-static-modifiers' => [
-                '/* testPublicStatic */',
-                [
+                'identifier' => '/* testPublicStatic */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => true,
@@ -255,8 +255,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'protected-static-modifiers' => [
-                '/* testProtectedStatic */',
-                [
+                'identifier' => '/* testProtectedStatic */',
+                'expected'   => [
                     'scope'           => 'protected',
                     'scope_specified' => true,
                     'is_static'       => true,
@@ -268,8 +268,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'private-static-modifiers' => [
-                '/* testPrivateStatic */',
-                [
+                'identifier' => '/* testPrivateStatic */',
+                'expected'   => [
                     'scope'           => 'private',
                     'scope_specified' => true,
                     'is_static'       => true,
@@ -281,8 +281,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'no-modifier' => [
-                '/* testNoPrefix */',
-                [
+                'identifier' => '/* testNoPrefix */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => false,
                     'is_static'       => false,
@@ -294,8 +294,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'public-and-static-modifier-with-docblock' => [
-                '/* testPublicStaticWithDocblock */',
-                [
+                'identifier' => '/* testPublicStaticWithDocblock */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => true,
@@ -307,8 +307,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'protected-and-static-modifier-with-docblock' => [
-                '/* testProtectedStaticWithDocblock */',
-                [
+                'identifier' => '/* testProtectedStaticWithDocblock */',
+                'expected'   => [
                     'scope'           => 'protected',
                     'scope_specified' => true,
                     'is_static'       => true,
@@ -320,8 +320,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'private-and-static-modifier-with-docblock' => [
-                '/* testPrivateStaticWithDocblock */',
-                [
+                'identifier' => '/* testPrivateStaticWithDocblock */',
+                'expected'   => [
                     'scope'           => 'private',
                     'scope_specified' => true,
                     'is_static'       => true,
@@ -333,8 +333,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'property-group-simple-type-prop-1' => [
-                '/* testGroupType 1 */',
-                [
+                'identifier' => '/* testGroupType 1 */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -346,8 +346,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'property-group-simple-type-prop-2' => [
-                '/* testGroupType 2 */',
-                [
+                'identifier' => '/* testGroupType 2 */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -359,8 +359,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'property-group-nullable-type-prop-1' => [
-                '/* testGroupNullableType 1 */',
-                [
+                'identifier' => '/* testGroupNullableType 1 */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => true,
@@ -372,8 +372,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'property-group-nullable-type-prop-2' => [
-                '/* testGroupNullableType 2 */',
-                [
+                'identifier' => '/* testGroupNullableType 2 */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => true,
@@ -385,8 +385,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'property-group-protected-static-prop-1' => [
-                '/* testGroupProtectedStatic 1 */',
-                [
+                'identifier' => '/* testGroupProtectedStatic 1 */',
+                'expected'   => [
                     'scope'           => 'protected',
                     'scope_specified' => true,
                     'is_static'       => true,
@@ -398,8 +398,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'property-group-protected-static-prop-2' => [
-                '/* testGroupProtectedStatic 2 */',
-                [
+                'identifier' => '/* testGroupProtectedStatic 2 */',
+                'expected'   => [
                     'scope'           => 'protected',
                     'scope_specified' => true,
                     'is_static'       => true,
@@ -411,8 +411,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'property-group-protected-static-prop-3' => [
-                '/* testGroupProtectedStatic 3 */',
-                [
+                'identifier' => '/* testGroupProtectedStatic 3 */',
+                'expected'   => [
                     'scope'           => 'protected',
                     'scope_specified' => true,
                     'is_static'       => true,
@@ -424,8 +424,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'property-group-private-prop-1' => [
-                '/* testGroupPrivate 1 */',
-                [
+                'identifier' => '/* testGroupPrivate 1 */',
+                'expected'   => [
                     'scope'           => 'private',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -437,8 +437,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'property-group-private-prop-2' => [
-                '/* testGroupPrivate 2 */',
-                [
+                'identifier' => '/* testGroupPrivate 2 */',
+                'expected'   => [
                     'scope'           => 'private',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -450,8 +450,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'property-group-private-prop-3' => [
-                '/* testGroupPrivate 3 */',
-                [
+                'identifier' => '/* testGroupPrivate 3 */',
+                'expected'   => [
                     'scope'           => 'private',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -463,8 +463,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'property-group-private-prop-4' => [
-                '/* testGroupPrivate 4 */',
-                [
+                'identifier' => '/* testGroupPrivate 4 */',
+                'expected'   => [
                     'scope'           => 'private',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -476,8 +476,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'property-group-private-prop-5' => [
-                '/* testGroupPrivate 5 */',
-                [
+                'identifier' => '/* testGroupPrivate 5 */',
+                'expected'   => [
                     'scope'           => 'private',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -489,8 +489,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'property-group-private-prop-6' => [
-                '/* testGroupPrivate 6 */',
-                [
+                'identifier' => '/* testGroupPrivate 6 */',
+                'expected'   => [
                     'scope'           => 'private',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -502,8 +502,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'property-group-private-prop-7' => [
-                '/* testGroupPrivate 7 */',
-                [
+                'identifier' => '/* testGroupPrivate 7 */',
+                'expected'   => [
                     'scope'           => 'private',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -515,8 +515,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'messy-nullable-type' => [
-                '/* testMessyNullableType */',
-                [
+                'identifier' => '/* testMessyNullableType */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -528,8 +528,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'fqn-type' => [
-                '/* testNamespaceType */',
-                [
+                'identifier' => '/* testNamespaceType */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -541,8 +541,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'nullable-classname-type' => [
-                '/* testNullableNamespaceType 1 */',
-                [
+                'identifier' => '/* testNullableNamespaceType 1 */',
+                'expected'   => [
                     'scope'           => 'private',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -554,8 +554,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'nullable-namespace-relative-class-type' => [
-                '/* testNullableNamespaceType 2 */',
-                [
+                'identifier' => '/* testNullableNamespaceType 2 */',
+                'expected'   => [
                     'scope'           => 'protected',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -567,8 +567,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'multiline-namespaced-type' => [
-                '/* testMultilineNamespaceType */',
-                [
+                'identifier' => '/* testMultilineNamespaceType */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -580,8 +580,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'property-after-method' => [
-                '/* testPropertyAfterMethod */',
-                [
+                'identifier' => '/* testPropertyAfterMethod */',
+                'expected'   => [
                     'scope'           => 'private',
                     'scope_specified' => true,
                     'is_static'       => true,
@@ -593,12 +593,12 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'invalid-property-in-interface' => [
-                '/* testInterfaceProperty */',
-                [],
+                'identifier' => '/* testInterfaceProperty */',
+                'expected'   => [],
             ],
             'property-in-nested-class-1' => [
-                '/* testNestedProperty 1 */',
-                [
+                'identifier' => '/* testNestedProperty 1 */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -610,8 +610,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'property-in-nested-class-2' => [
-                '/* testNestedProperty 2 */',
-                [
+                'identifier' => '/* testNestedProperty 2 */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -623,8 +623,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8-mixed-type' => [
-                '/* testPHP8MixedTypeHint */',
-                [
+                'identifier' => '/* testPHP8MixedTypeHint */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => true,
@@ -636,8 +636,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8-nullable-mixed-type' => [
-                '/* testPHP8MixedTypeHintNullable */',
-                [
+                'identifier' => '/* testPHP8MixedTypeHintNullable */',
+                'expected'   => [
                     'scope'           => 'private',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -649,8 +649,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'namespace-operator-type-declaration' => [
-                '/* testNamespaceOperatorTypeHint */',
-                [
+                'identifier' => '/* testNamespaceOperatorTypeHint */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -662,8 +662,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8-union-types-simple' => [
-                '/* testPHP8UnionTypesSimple */',
-                [
+                'identifier' => '/* testPHP8UnionTypesSimple */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -675,8 +675,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8-union-types-two-classes' => [
-                '/* testPHP8UnionTypesTwoClasses */',
-                [
+                'identifier' => '/* testPHP8UnionTypesTwoClasses */',
+                'expected'   => [
                     'scope'           => 'private',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -688,8 +688,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8-union-types-all-base-types' => [
-                '/* testPHP8UnionTypesAllBaseTypes */',
-                [
+                'identifier' => '/* testPHP8UnionTypesAllBaseTypes */',
+                'expected'   => [
                     'scope'           => 'protected',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -701,8 +701,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8-union-types-all-pseudo-types' => [
-                '/* testPHP8UnionTypesAllPseudoTypes */',
-                [
+                'identifier' => '/* testPHP8UnionTypesAllPseudoTypes */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => false,
                     'is_static'       => false,
@@ -714,8 +714,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8-union-types-illegal-types' => [
-                '/* testPHP8UnionTypesIllegalTypes */',
-                [
+                'identifier' => '/* testPHP8UnionTypesIllegalTypes */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -728,8 +728,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8-union-types-nullable' => [
-                '/* testPHP8UnionTypesNullable */',
-                [
+                'identifier' => '/* testPHP8UnionTypesNullable */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -741,8 +741,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8-union-types-pseudo-type-null' => [
-                '/* testPHP8PseudoTypeNull */',
-                [
+                'identifier' => '/* testPHP8PseudoTypeNull */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -754,8 +754,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8-union-types-pseudo-type-false' => [
-                '/* testPHP8PseudoTypeFalse */',
-                [
+                'identifier' => '/* testPHP8PseudoTypeFalse */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -767,8 +767,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8-union-types-pseudo-type-false-and-bool' => [
-                '/* testPHP8PseudoTypeFalseAndBool */',
-                [
+                'identifier' => '/* testPHP8PseudoTypeFalseAndBool */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -780,8 +780,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8-union-types-object-and-class' => [
-                '/* testPHP8ObjectAndClass */',
-                [
+                'identifier' => '/* testPHP8ObjectAndClass */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -793,8 +793,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8-union-types-pseudo-type-iterable-and-array' => [
-                '/* testPHP8PseudoTypeIterableAndArray */',
-                [
+                'identifier' => '/* testPHP8PseudoTypeIterableAndArray */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -806,8 +806,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8-union-types-duplicate-type-with-whitespace-and-comments' => [
-                '/* testPHP8DuplicateTypeInUnionWhitespaceAndComment */',
-                [
+                'identifier' => '/* testPHP8DuplicateTypeInUnionWhitespaceAndComment */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -819,8 +819,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8.1-readonly-property' => [
-                '/* testPHP81Readonly */',
-                [
+                'identifier' => '/* testPHP81Readonly */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -832,8 +832,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8.1-readonly-property-with-nullable-type' => [
-                '/* testPHP81ReadonlyWithNullableType */',
-                [
+                'identifier' => '/* testPHP81ReadonlyWithNullableType */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -845,8 +845,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8.1-readonly-property-with-union-type' => [
-                '/* testPHP81ReadonlyWithUnionType */',
-                [
+                'identifier' => '/* testPHP81ReadonlyWithUnionType */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -858,8 +858,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8.1-readonly-property-with-union-type-with-null' => [
-                '/* testPHP81ReadonlyWithUnionTypeWithNull */',
-                [
+                'identifier' => '/* testPHP81ReadonlyWithUnionTypeWithNull */',
+                'expected'   => [
                     'scope'           => 'protected',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -871,8 +871,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8.1-readonly-property-with-union-type-no-visibility' => [
-                '/* testPHP81OnlyReadonlyWithUnionType */',
-                [
+                'identifier' => '/* testPHP81OnlyReadonlyWithUnionType */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => false,
                     'is_static'       => false,
@@ -884,8 +884,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8.1-readonly-property-with-multi-union-type-no-visibility' => [
-                '/* testPHP81OnlyReadonlyWithUnionTypeMultiple */',
-                [
+                'identifier' => '/* testPHP81OnlyReadonlyWithUnionTypeMultiple */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => false,
                     'is_static'       => false,
@@ -897,8 +897,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8.1-readonly-and-static-property' => [
-                '/* testPHP81ReadonlyAndStatic */',
-                [
+                'identifier' => '/* testPHP81ReadonlyAndStatic */',
+                'expected'   => [
                     'scope'           => 'private',
                     'scope_specified' => true,
                     'is_static'       => true,
@@ -910,8 +910,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8.1-readonly-mixed-case-keyword' => [
-                '/* testPHP81ReadonlyMixedCase */',
-                [
+                'identifier' => '/* testPHP81ReadonlyMixedCase */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => true,
@@ -923,8 +923,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8-property-with-single-attribute' => [
-                '/* testPHP8PropertySingleAttribute */',
-                [
+                'identifier' => '/* testPHP8PropertySingleAttribute */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -936,8 +936,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8-property-with-multiple-attributes' => [
-                '/* testPHP8PropertyMultipleAttributes */',
-                [
+                'identifier' => '/* testPHP8PropertyMultipleAttributes */',
+                'expected'   => [
                     'scope'           => 'protected',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -949,8 +949,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8-property-with-multiline-attribute' => [
-                '/* testPHP8PropertyMultilineAttribute */',
-                [
+                'identifier' => '/* testPHP8PropertyMultilineAttribute */',
+                'expected'   => [
                     'scope'           => 'private',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -962,12 +962,12 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'invalid-property-in-enum' => [
-                '/* testEnumProperty */',
-                [],
+                'identifier' => '/* testEnumProperty */',
+                'expected'   => [],
             ],
             'php8.1-single-intersection-type' => [
-                '/* testPHP81IntersectionTypes */',
-                [
+                'identifier' => '/* testPHP81IntersectionTypes */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -979,8 +979,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8.1-multi-intersection-type' => [
-                '/* testPHP81MoreIntersectionTypes */',
-                [
+                'identifier' => '/* testPHP81MoreIntersectionTypes */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -992,8 +992,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8.1-illegal-intersection-type' => [
-                '/* testPHP81IllegalIntersectionTypes */',
-                [
+                'identifier' => '/* testPHP81IllegalIntersectionTypes */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -1005,8 +1005,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8.1-nullable-intersection-type' => [
-                '/* testPHP81NullableIntersectionType */',
-                [
+                'identifier' => '/* testPHP81NullableIntersectionType */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -1019,8 +1019,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
             ],
 
             'php8.0-union-type-with-whitespace-and-comment' => [
-                '/* testUnionTypeWithWhitespaceAndComment */',
-                [
+                'identifier' => '/* testUnionTypeWithWhitespaceAndComment */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -1032,8 +1032,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8.1-intersection-type-with-whitespace-and-comment' => [
-                '/* testIntersectionTypeWithWhitespaceAndComment */',
-                [
+                'identifier' => '/* testIntersectionTypeWithWhitespaceAndComment */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -1045,8 +1045,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8.2-pseudo-type-true' => [
-                '/* testPHP82PseudoTypeTrue */',
-                [
+                'identifier' => '/* testPHP82PseudoTypeTrue */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -1058,8 +1058,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8.2-pseudo-type-true-nullable' => [
-                '/* testPHP82NullablePseudoTypeTrue */',
-                [
+                'identifier' => '/* testPHP82NullablePseudoTypeTrue */',
+                'expected'   => [
                     'scope'           => 'protected',
                     'scope_specified' => true,
                     'is_static'       => true,
@@ -1071,8 +1071,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8.2-pseudo-type-true-in-union' => [
-                '/* testPHP82PseudoTypeTrueInUnion */',
-                [
+                'identifier' => '/* testPHP82PseudoTypeTrueInUnion */',
+                'expected'   => [
                     'scope'           => 'private',
                     'scope_specified' => true,
                     'is_static'       => false,
@@ -1084,8 +1084,8 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                 ],
             ],
             'php8.2-pseudo-type-invalid-true-false-union' => [
-                '/* testPHP82PseudoTypeFalseAndTrue */',
-                [
+                'identifier' => '/* testPHP82PseudoTypeFalseAndTrue */',
+                'expected'   => [
                     'scope'           => 'public',
                     'scope_specified' => false,
                     'is_static'       => false,
@@ -1123,18 +1123,18 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
      *
      * @see testNotClassPropertyException()
      *
-     * @return array
+     * @return array<string, array<string>>
      */
     public static function dataNotClassProperty()
     {
         return [
-            ['/* testMethodParam */'],
-            ['/* testImportedGlobal */'],
-            ['/* testLocalVariable */'],
-            ['/* testGlobalVariable */'],
-            ['/* testNestedMethodParam 1 */'],
-            ['/* testNestedMethodParam 2 */'],
-            ['/* testEnumMethodParamNotProperty */'],
+            'method parameter'                                       => ['/* testMethodParam */'],
+            'variable import using global keyword'                   => ['/* testImportedGlobal */'],
+            'function local variable'                                => ['/* testLocalVariable */'],
+            'global variable'                                        => ['/* testGlobalVariable */'],
+            'method parameter in anon class nested in ternary'       => ['/* testNestedMethodParam 1 */'],
+            'method parameter in anon class nested in function call' => ['/* testNestedMethodParam 2 */'],
+            'method parameter in enum'                               => ['/* testEnumMethodParamNotProperty */'],
         ];
     }
 

--- a/Tests/Utils/Variables/GetMemberPropertiesTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesTest.php
@@ -92,10 +92,10 @@ final class GetMemberPropertiesTest extends BCFile_GetMemberPropertiesTest
 
         $variable = $this->getTargetToken($identifier, \T_VARIABLE);
 
-        if (isset($expected['type_token']) && $expected['type_token'] !== false) {
+        if (isset($expected['type_token']) && \is_int($expected['type_token']) === true) {
             $expected['type_token'] += $variable;
         }
-        if (isset($expected['type_end_token']) && $expected['type_end_token'] !== false) {
+        if (isset($expected['type_end_token']) && \is_int($expected['type_end_token']) === true) {
             $expected['type_end_token'] += $variable;
         }
 

--- a/Tests/Utils/Variables/GetMemberPropertiesTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesTest.php
@@ -63,21 +63,17 @@ final class GetMemberPropertiesTest extends BCFile_GetMemberPropertiesTest
      *
      * @see testGetMemberProperties()
      *
-     * @return array
+     * @return array<string, array<string|array<string, string|int|bool>>>
      */
     public static function dataGetMemberProperties()
     {
         $data = parent::dataGetMemberProperties();
 
         /*
-         * Remove the data set related to the invalid interface/enum properties.
+         * Remove the data sets related to the invalid interface/enum properties.
          * These will now throw an exception instead.
          */
-        foreach ($data as $key => $value) {
-            if ($value[0] === '/* testInterfaceProperty */' || $value[0] === '/* testEnumProperty */') {
-                unset($data[$key]);
-            }
-        }
+        unset($data['invalid-property-in-interface'], $data['invalid-property-in-enum']);
 
         return $data;
     }
@@ -91,8 +87,8 @@ final class GetMemberPropertiesTest extends BCFile_GetMemberPropertiesTest
     {
         $methodName = 'PHPCSUtils\\Utils\\Variables::getMemberProperties';
         $cases      = self::dataGetMemberProperties();
-        $identifier = $cases['php8.2-pseudo-type-true-in-union'][0];
-        $expected   = $cases['php8.2-pseudo-type-true-in-union'][1];
+        $identifier = $cases['php8.2-pseudo-type-true-in-union']['identifier'];
+        $expected   = $cases['php8.2-pseudo-type-true-in-union']['expected'];
 
         $variable = $this->getTargetToken($identifier, \T_VARIABLE);
 


### PR DESCRIPTION
Sister-PR to PHPCSStandards/PHP_CodeSniffer#221

### Tests/GetMemberPropertiesTest: sync with upstream [1] - use named items in data sets

These tests, for the most part, already had data set names in PHPCSUtils.

This commit adds the parameter name for each item in the data set, this time in an effort to make it more straight forward to update and add tests as it will be more obvious what each key in the data set signifies.

Includes updating references to individual items in data sets in the sister-test class for the `Variables::getMemberProperties()` method.

Includes fixing the data types in the docblocks and making them more specific, where relevant.

### Tests/GetMemberPropertiesTest: sync with upstream [2] - minor docs and stability tweak

* Use the more stable `is_int()` instead of a comparison against `false` for the offset calculation safeguard.
* Add some guidance to the data provider docblock about the use of offsets and remove the inline trailing comma's about the same.