### PR TITLE
Tokens\Collections: add new ternaryOperators() token array

### DIFF
--- a/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
+++ b/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
@@ -118,8 +118,6 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
         \T_DNUMBER                  => \T_DNUMBER,
         \T_CONSTANT_ENCAPSED_STRING => \T_CONSTANT_ENCAPSED_STRING,
         \T_STRING_CONCAT            => \T_STRING_CONCAT,
-        \T_INLINE_THEN              => \T_INLINE_THEN,
-        \T_INLINE_ELSE              => \T_INLINE_ELSE,
         \T_BOOLEAN_NOT              => \T_BOOLEAN_NOT,
     ];
 
@@ -143,6 +141,7 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
         $this->acceptedTokens += Tokens::$castTokens;
         $this->acceptedTokens += Tokens::$bracketTokens;
         $this->acceptedTokens += Tokens::$heredocTokens;
+        $this->acceptedTokens += Collections::ternaryOperators();
     }
 
     /**

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -55,6 +55,7 @@ use PHPCSUtils\Exceptions\InvalidTokenArray;
  *                                                                 declaration.
  * @method static array shortArrayTokens()                         Tokens which are used for short arrays.
  * @method static array shortListTokens()                          Tokens which are used for short lists.
+ * @method static array ternaryOperators()                         Tokens which represent ternary operators.
  * @method static array textStringStartTokens()                    Tokens which can start a - potentially multi-line -
  *                                                                 text string.
  */
@@ -518,6 +519,18 @@ final class Collections
     private static $shortListTokens = [
         \T_OPEN_SHORT_ARRAY  => \T_OPEN_SHORT_ARRAY,
         \T_CLOSE_SHORT_ARRAY => \T_CLOSE_SHORT_ARRAY,
+    ];
+
+    /**
+     * Tokens which represent ternary operators.
+     *
+     * @since 1.1.0 Use the {@see Collections::ternaryOperators()} method for access.
+     *
+     * @var array<int|string, int|string>
+     */
+    private static $ternaryOperators = [
+        \T_INLINE_THEN => \T_INLINE_THEN,
+        \T_INLINE_ELSE => \T_INLINE_ELSE,
     ];
 
     /**

--- a/PHPCSUtils/Utils/Operators.php
+++ b/PHPCSUtils/Utils/Operators.php
@@ -52,8 +52,6 @@ final class Operators
         \T_OPEN_SHORT_ARRAY    => true,
         \T_OPEN_CURLY_BRACKET  => true,
         \T_COLON               => true,
-        \T_INLINE_THEN         => true,
-        \T_INLINE_ELSE         => true,
         \T_CASE                => true,
         \T_FN_ARROW            => true,
         \T_MATCH_ARROW         => true,
@@ -206,6 +204,7 @@ final class Operators
             || isset(Tokens::$booleanOperators[$tokens[$prev]['code']]) === true
             || isset(Tokens::$assignmentTokens[$tokens[$prev]['code']]) === true
             || isset(Tokens::$castTokens[$tokens[$prev]['code']]) === true
+            || isset(Collections::ternaryOperators()[$tokens[$prev]['code']]) === true
             || isset(self::$extraUnaryIndicators[$tokens[$prev]['code']]) === true
         ) {
             return true;

--- a/Tests/Tokens/Collections/PropertyBasedTokenArraysTest.php
+++ b/Tests/Tokens/Collections/PropertyBasedTokenArraysTest.php
@@ -75,6 +75,7 @@ final class PropertyBasedTokenArraysTest extends TestCase
             'propertyModifierKeywords',
             'shortArrayTokens',
             'shortListTokens',
+            'ternaryOperators',
             'textStringStartTokens',
         ];
 


### PR DESCRIPTION
### Tokens\Collections: add new ternaryOperators() token array

... containing the ternary operator tokens.

### Implement use of the new Collections::ternaryOperators() token array 