### PR TITLE
:sparkles: New `PHPCSUtils\TestUtils\ConfigDouble` class

### DIFF
--- a/PHPCSUtils/TestUtils/ConfigDouble.php
+++ b/PHPCSUtils/TestUtils/ConfigDouble.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\TestUtils;
+
+use PHP_CodeSniffer\Config;
+use PHPCSUtils\BackCompat\Helper;
+use ReflectionProperty;
+
+/**
+ * Config class for use in the tests.
+ *
+ * The PHP_CodeSniffer Config class contains a number of static properties.
+ * As the value of these static properties will be retained between instantiations of the class,
+ * config values set in one test can influence the results for another test, which makes tests unstable.
+ *
+ * This class is a "double" of the Config class which prevents this from happening.
+ * In _most_ cases, tests should be using this class instead of the "normal" Config,
+ * with the exception of select tests for the PHPCS Config class itself.
+ *
+ * @since 1.1.0
+ */
+final class ConfigDouble extends Config
+{
+
+    /**
+     * The PHPCS version the tests are being run on.
+     *
+     * @since 1.1.0
+     *
+     * @var string
+     */
+    private $phpcsVersion = '0';
+
+    /**
+     * Whether or not the setting of a standard should be skipped.
+     *
+     * @since 1.1.0
+     *
+     * @var bool
+     */
+    private $skipSettingStandard = false;
+
+    /**
+     * Creates a clean Config object and populates it with command line values.
+     *
+     * @since 1.1.0
+     *
+     * @param array<string> $cliArgs                An array of values gathered from CLI args.
+     * @param bool          $skipSettingStandard    Whether to skip setting a standard to prevent
+     *                                              the Config class trying to auto-discover a ruleset file.
+     *                                              Should only be set to `true` for tests which actually test
+     *                                              the ruleset auto-discovery.
+     *                                              Note: there is no need to set this to `true` when a standard
+     *                                              is being passed via the `$cliArgs`. Those settings will always
+     *                                              respected.
+     *                                              Defaults to `false`. Will result in the standard being set
+     *                                              to "PSR1" if not provided via `$cliArgs`.
+     * @param bool          $skipSettingReportWidth Whether to skip setting a report-width to prevent
+     *                                              the Config class trying to auto-discover the screen width.
+     *                                              Should only be set to `true` for tests which actually test
+     *                                              the screen width auto-discovery.
+     *                                              Note: there is no need to set this to `true` when a report-width
+     *                                              is being passed via the `$cliArgs`. Those settings will always
+     *                                              respected.
+     *                                              Defaults to `false`. Will result in the reportWidth being set
+     *                                              to "80" if not provided via `$cliArgs`.
+     *
+     * @return void
+     */
+    public function __construct(array $cliArgs = [], $skipSettingStandard = false, $skipSettingReportWidth = false)
+    {
+        $this->skipSettingStandard = $skipSettingStandard;
+        $this->phpcsVersion        = Helper::getVersion();
+
+        $this->resetSelectProperties();
+        $this->preventReadingCodeSnifferConfFile();
+
+        parent::__construct($cliArgs);
+
+        if ($skipSettingReportWidth !== true) {
+            $this->preventAutoDiscoveryScreenWidth();
+        }
+    }
+
+    /**
+     * Sets the command line values and optionally prevents a file system search for a custom ruleset.
+     *
+     * {@internal Note: `array` type declaration can't be added as the parent class does not have a type declaration
+     * for the parameter in the original method.}
+     *
+     * @since 1.1.0
+     *
+     * @param array<string> $args An array of command line arguments to set.
+     *
+     * @return void
+     */
+    public function setCommandLineValues($args)
+    {
+        parent::setCommandLineValues($args);
+
+        if ($this->skipSettingStandard !== true) {
+            $this->preventSearchingForRuleset();
+        }
+    }
+
+    /**
+     * Reset a few properties on the Config class to their default values.
+     *
+     * @since 1.1.0
+     *
+     * @return void
+     */
+    private function resetSelectProperties()
+    {
+        $this->setStaticConfigProperty('overriddenDefaults', []);
+        $this->setStaticConfigProperty('executablePaths', []);
+    }
+
+    /**
+     * Prevent the values in a potentially available user-specific `CodeSniffer.conf` file
+     * from influencing the tests.
+     *
+     * This also prevents some file system calls which can influence the test runtime.
+     *
+     * @since 1.1.0
+     *
+     * @return void
+     */
+    private function preventReadingCodeSnifferConfFile()
+    {
+        $this->setStaticConfigProperty('configData', []);
+        $this->setStaticConfigProperty('configDataFile', '');
+    }
+
+    /**
+     * Prevent searching for a custom ruleset by setting a standard, but only if the test
+     * being run doesn't set a standard itself.
+     *
+     * This also prevents some file system calls which can influence the test runtime.
+     *
+     * The standard being set is the smallest one available so the ruleset initialization
+     * will be the fastest possible.
+     *
+     * @since 1.1.0
+     *
+     * @return void
+     */
+    private function preventSearchingForRuleset()
+    {
+        $overriddenDefaults = $this->getStaticConfigProperty('overriddenDefaults');
+        if (isset($overriddenDefaults['standards']) === false) {
+            $this->standards                 = ['PSR1'];
+            $overriddenDefaults['standards'] = true;
+        }
+
+        self::setStaticConfigProperty('overriddenDefaults', $overriddenDefaults);
+    }
+
+    /**
+     * Prevent a call to stty to figure out the screen width, but only if the test being run
+     * doesn't set a report width itself.
+     *
+     * @since 1.1.0
+     *
+     * @return void
+     */
+    private function preventAutoDiscoveryScreenWidth()
+    {
+        $settings = $this->getSettings();
+        if ($settings['reportWidth'] === 'auto') {
+            $this->reportWidth = self::DEFAULT_REPORT_WIDTH;
+        }
+    }
+
+    /**
+     * Helper function to retrieve the value of a private static property on the Config class.
+     *
+     * Note: As of PHPCS 4.0, the "overriddenDefaults" property is no longer static, but this method
+     * will still handle this property.
+     *
+     * @since 1.1.0
+     *
+     * @param string $name The name of the property to retrieve.
+     *
+     * @return mixed
+     */
+    public function getStaticConfigProperty($name)
+    {
+        $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
+        $property->setAccessible(true);
+
+        if ($name === 'overriddenDefaults' && \version_compare($this->phpcsVersion, '3.99.99', '>')) {
+            return $property->getValue($this);
+        }
+
+        return $property->getValue();
+    }
+
+    /**
+     * Helper function to set the value of a private static property on the Config class.
+     *
+     * Note: As of PHPCS 4.0, the "overriddenDefaults" property is no longer static, but this method
+     * will still handle this property.
+     *
+     * @since 1.1.0
+     *
+     * @param string $name  The name of the property to set.
+     * @param mixed  $value The value to set the property to.
+     *
+     * @return void
+     */
+    public function setStaticConfigProperty($name, $value)
+    {
+        $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
+        $property->setAccessible(true);
+
+        if ($name === 'overriddenDefaults' && \version_compare($this->phpcsVersion, '3.99.99', '>')) {
+            $property->setValue($this, $value);
+        } else {
+            $property->setValue(null, $value);
+        }
+
+        $property->setAccessible(false);
+    }
+}

--- a/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+++ b/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
@@ -10,7 +10,6 @@
 
 namespace PHPCSUtils\TestUtils;
 
-use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Exceptions\TokenizerException;
 use PHP_CodeSniffer\Files\DummyFile;
 use PHP_CodeSniffer\Files\File;
@@ -19,6 +18,7 @@ use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Exceptions\TestFileNotFound;
 use PHPCSUtils\Exceptions\TestMarkerNotFound;
 use PHPCSUtils\Exceptions\TestTargetNotFound;
+use PHPCSUtils\TestUtils\ConfigDouble;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionProperty;
@@ -212,31 +212,10 @@ abstract class UtilityMethodTestCase extends TestCase
 
         $contents = \file_get_contents($caseFile);
 
-        /*
-         * Set the static properties in the Config class to specific values for performance
-         * and to clear out values from other tests.
-         */
-        self::setStaticConfigProperty('executablePaths', []);
-
-        // Set to values which prevent the test-runner user's `CodeSniffer.conf` file
-        // from being read and influencing the tests. Also prevent an `exec()` call to stty.
-        self::setStaticConfigProperty('configData', ['report_width' => 80]);
-        self::setStaticConfigProperty('configDataFile', '');
-
-        $config = new Config();
+        $config = new ConfigDouble();
 
         /*
-         * Set to a usable value to circumvent Config trying to find a phpcs.xml config file.
-         *
-         * We just need to provide a standard so PHPCS will tokenize the file.
-         * The standard itself doesn't actually matter for testing utility methods,
-         * so use the smallest one to get the fastest results.
-         */
-        $config->standards = ['PSR1'];
-
-        /*
-         * Limiting the run to just one sniff will make it, yet again, slightly faster.
-         * Picked the simplest/fastest sniff available which is registered in PSR1.
+         * Limiting the run to just one (dummy) sniff will make it, yet again, slightly faster.
          */
         $config->sniffs = static::$selectedSniff;
 
@@ -315,17 +294,15 @@ abstract class UtilityMethodTestCase extends TestCase
         self::$tabWidth      = 4;
         self::$phpcsFile     = null;
         self::$selectedSniff = ['Dummy.Dummy.Dummy'];
-
-        // Reset the static properties in the Config class to their defaults to prevent tests influencing each other.
-        self::setStaticConfigProperty('executablePaths', []);
-        self::setStaticConfigProperty('configData', null);
-        self::setStaticConfigProperty('configDataFile', null);
     }
 
     /**
      * Helper function to set the value of a private static property on the PHPCS Config class.
      *
-     * @since 1.0.9
+     * @since      1.0.9
+     * @deprecated 1.1.0 Use the `PHPCSUtils\TestUtils\ConfigDouble::setStaticConfigProperty()` method instead.
+     *
+     * @codeCoverageIgnore
      *
      * @param string $name  The name of the property to set.
      * @param mixed  $value The value to set the property to.

--- a/Tests/TestUtils/ConfigDouble/ConfigDoubleTest.php
+++ b/Tests/TestUtils/ConfigDouble/ConfigDoubleTest.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\TestUtils\ConfigDouble;
+
+use PHPCSUtils\TestUtils\ConfigDouble;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Tests for the \PHPCSUtils\TestUtils\ConfigDouble class.
+ *
+ * @coversDefaultClass \PHPCSUtils\TestUtils\ConfigDouble
+ *
+ * @group testutils
+ *
+ * @since 1.1.0
+ */
+final class ConfigDoubleTest extends TestCase
+{
+
+    /**
+     * Verify that the static properties in the Config class get cleared between instances.
+     *
+     * @covers ::resetSelectProperties
+     * @covers ::getStaticConfigProperty
+     * @covers ::setStaticConfigProperty
+     *
+     * @return void
+     */
+    public function testOverriddenDefaultsGetCleared()
+    {
+        $configA = new ConfigDouble(['--standard=PSR12', '--severity=2', '-sp']);
+
+        // Verify that the CLI args initialized the "overriddenDefaults" property and that the settings took effect.
+        $this->assertCount(
+            5,
+            $configA->getStaticConfigProperty('overriddenDefaults'),
+            'Initialize: expected overriddenDefaults entry count does not match'
+        );
+        $this->assertSame(['PSR12'], $configA->standards, 'Initialize: standards was not set to PSR12');
+        $this->assertSame(2, $configA->warningSeverity, 'Initialize: warningSeverity was not set to 2');
+        $this->assertSame(2, $configA->errorSeverity, 'Initialize: errorSeverity was not set to 2');
+        $this->assertTrue($configA->showSources, 'Initialize: showSources was not set to "true"');
+        $this->assertTrue($configA->showProgress, 'Initialize: showProgress was not set to "true"');
+
+        $configB = new ConfigDouble();
+
+        // Verify that the "overriddenDefaults" do not persist to the next Config instance.
+        $this->assertLessThanOrEqual(
+            2, // Standards should be the only thing set, though files _may_ also be set.
+            \count($configB->getStaticConfigProperty('overriddenDefaults')),
+            'Reset did not wipe overriddenDefaults. Found: '
+                . \var_export($configB->getStaticConfigProperty('overriddenDefaults'), true)
+        );
+        $this->assertSame(['PSR1'], $configB->standards, 'Ruleset search prevention did not set standard to PSR1');
+        $this->assertSame(5, $configB->warningSeverity, 'Reset did not wipe warningSeverity');
+        $this->assertSame(5, $configB->errorSeverity, 'Reset did not wipe errorSeverity');
+        $this->assertFalse($configB->showSources, 'Reset did not wipe showSources');
+        $this->assertFalse($configB->showProgress, 'Reset did not wipe showProgress');
+    }
+
+    /**
+     * Verify that when no standard is given, the default standard (PEAR) is overridden with the smaller PSR1.
+     *
+     * Additionally verifies that `standards` is added to the "overriddenDefaults" array, which is what prevents
+     * the file system search for a ruleset.
+     *
+     * @covers ::setCommandLineValues
+     * @covers ::preventSearchingForRuleset
+     *
+     * @return void
+     */
+    public function testDefaultStandardIsOverridden()
+    {
+        $config = new ConfigDouble();
+
+        $this->assertSame(['PSR1'], $config->standards, 'Standards was not set to PSR1');
+
+        $overriddenDefaults = $config->getStaticConfigProperty('overriddenDefaults');
+        $this->assertArrayHasKey('standards', $overriddenDefaults, 'Standards was not added to overriddenDefaults');
+        $this->assertTrue($overriddenDefaults['standards'], 'Standards was not marked as overridden');
+    }
+
+    /**
+     * Verify that if a standard is set via the Config $args, that the Double doesn't override this to PSR1.
+     *
+     * @covers ::setCommandLineValues
+     * @covers ::preventSearchingForRuleset
+     *
+     * @return void
+     */
+    public function testStandardSetViaArgsIsRespected()
+    {
+        $config = new ConfigDouble(['--standard=Squiz']);
+
+        $this->assertSame(['Squiz'], $config->standards, 'Standards was not set to Squiz');
+
+        $overriddenDefaults = $config->getStaticConfigProperty('overriddenDefaults');
+        $this->assertArrayHasKey('standards', $overriddenDefaults, 'Standards was not added to overriddenDefaults');
+        $this->assertTrue($overriddenDefaults['standards'], 'Standards was not marked as overridden');
+    }
+
+    /**
+     * Test that the `$skipSettingStandard` option prevents the standard being set by the double.
+     *
+     * @covers ::__construct
+     * @covers ::setCommandLineValues
+     *
+     * @return void
+     */
+    public function testStandardOverrideIsSkippedOnRequest()
+    {
+        $config = new ConfigDouble([], true);
+
+        $this->assertNotSame(['PSR1'], $config->standards, 'Standards was still overloaded to be PSR1');
+
+        // This will normally be `phpcs.xml.dist`, but the contributor running the tests may have an overload file in place.
+        $this->assertStringContainsString('phpcs.xml', $config->standards[0], 'Standards auto-discovery did not take place');
+
+        $overriddenDefaults = $config->getStaticConfigProperty('overriddenDefaults');
+        $this->assertArrayNotHasKey('standards', $overriddenDefaults, 'Standards was still added to overriddenDefaults');
+    }
+
+    /**
+     * Verify that the reportWidth will be set to the default width when implicitly set to "auto".
+     *
+     * @covers ::preventAutoDiscoveryScreenWidth
+     *
+     * @return void
+     */
+    public function testDefaultReportWidthAutoIsOverridden()
+    {
+        $config = new ConfigDouble();
+
+        $this->assertSame(80, $config->reportWidth, 'Report width was not set to 80');
+    }
+
+    /**
+     * Verify that the reportWidth will be set to the default width when explicitly set to "auto".
+     *
+     * @covers ::preventAutoDiscoveryScreenWidth
+     *
+     * @return void
+     */
+    public function testReportWidthSetToAutoViaArgsIsOverridden()
+    {
+        $config = new ConfigDouble(['--report-width=auto']);
+
+        $this->assertSame(80, $config->reportWidth, 'Report width was not set to 80');
+
+        $overriddenDefaults = $config->getStaticConfigProperty('overriddenDefaults');
+        $this->assertArrayHasKey('reportWidth', $overriddenDefaults, 'reportWidth was not added to overriddenDefaults');
+        $this->assertTrue($overriddenDefaults['reportWidth'], 'reportWidth was not marked as overridden');
+    }
+
+    /**
+     * Verify that if a reportWidth is set via the Config $args, that the Double doesn't override this to the default width.
+     *
+     * @covers ::preventAutoDiscoveryScreenWidth
+     *
+     * @return void
+     */
+    public function testReportWidthSetToIntViaArgsIsRespected()
+    {
+        $config = new ConfigDouble(['--report-width=1250']);
+
+        $this->assertSame(1250, $config->reportWidth, 'Report width was not set to 1250');
+
+        $overriddenDefaults = $config->getStaticConfigProperty('overriddenDefaults');
+        $this->assertArrayHasKey('reportWidth', $overriddenDefaults, 'reportWidth was not added to overriddenDefaults');
+        $this->assertTrue($overriddenDefaults['reportWidth'], 'reportWidth was not marked as overridden');
+    }
+
+    /**
+     * Test that the `$skipSettingReportWidth` option prevents the report width being set by the double.
+     *
+     * @covers ::__construct
+     *
+     * @return void
+     */
+    public function testReportWidthOverrideIsSkippedOnRequest()
+    {
+        $config = new ConfigDouble([], false, true);
+
+        // Can't test the exact value as "auto" will resolve differently depending on the machine running the tests.
+        $this->assertIsInt($config->reportWidth, 'Report width is not an integer');
+        $this->assertGreaterThan(0, $config->reportWidth, 'Report width is not greater than 0');
+
+        if (\getenv('CI') === false) {
+            // Not entirely stable as an contributors screen _may_ actually be 80 wide,
+            // though in this modern age this is unlikely.
+            // Skipping for CI as GH Actions **will** identify the screen width as 80 wide.
+            $this->assertNotSame(80, $config->reportWidth, 'Report width has still been set to 80');
+        }
+    }
+}

--- a/Tests/TestUtils/ConfigDouble/PreventReadingCodeSnifferConfFileTest.php
+++ b/Tests/TestUtils/ConfigDouble/PreventReadingCodeSnifferConfFileTest.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\TestUtils\ConfigDouble;
+
+use Exception;
+use PHPCSUtils\TestUtils\ConfigDouble;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the \PHPCSUtils\TestUtils\ConfigDouble class.
+ *
+ * @covers \PHPCSUtils\TestUtils\ConfigDouble::preventReadingCodeSnifferConfFile
+ *
+ * @group testutils
+ *
+ * @since 1.1.0
+ */
+final class PreventReadingCodeSnifferConfFileTest extends TestCase
+{
+
+    /**
+     * Location of the applicable CodeSniffer.conf file.
+     *
+     * @var string
+     */
+    private static $pathToConfFile = '';
+
+    /**
+     * Backup of the contents of the contributor's CodeSniffer.conf file.
+     *
+     * @var string
+     */
+    private static $originalConfFile = '';
+
+    /**
+     * The contents for the CodeSniffer.conf file to be used in the test.
+     *
+     * @var string
+     */
+    private static $testConfFileContents = <<<'EOD'
+<?php
+$phpCodeSnifferConfig = array (
+    'report_width' => '150',
+    'php_version'  => '70000',
+    'php_path'     => 'path/to/php.exe',
+    'colors'       => '1',
+);
+EOD;
+
+    /**
+     * Skip message for when the tests need to be skipped due to errors while setting up.
+     *
+     * Note: "set up before class" methods can "mark a test as skipped", while "set up" methods can.
+     * This property is used to pass any potential errors encountered during "set up before class"
+     * to the "set up" method.
+     *
+     * @var string
+     */
+    private static $skip = '';
+
+    /**
+     * Create a backup of the CodeSniffer.conf file and create the CodeSniffer.conf file to be used in the test.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function backupCodeSnifferConf()
+    {
+        // Get the PHPCS dir from an environment variable (if set).
+        $phpcsDir = \getenv('PHPCS_DIR');
+
+        // This may be a Composer install.
+        if ($phpcsDir === false && \is_dir(__DIR__ . '/../../../vendor')) {
+            $vendorDir = __DIR__ . '/../../../vendor';
+            if (\is_dir($vendorDir . '/squizlabs/php_codesniffer')) {
+                $phpcsDir = $vendorDir . '/squizlabs/php_codesniffer';
+            }
+        }
+
+        if ($phpcsDir === false) {
+            self::$skip = 'Could not determine path to the PHPCS instance being used to run the tests.';
+            return;
+        }
+
+        $phpcsDir             = \realpath($phpcsDir);
+        self::$pathToConfFile = $phpcsDir . '/CodeSniffer.conf';
+
+        // Safeguard the contributors CodeSniffer.conf file.
+        if (\file_exists(self::$pathToConfFile)) {
+            if (\copy(self::$pathToConfFile, self::$pathToConfFile . '.bak') === false) {
+                self::$skip = 'Making a backup of the CodeSniffer.conf file failed.'
+                    . ' Skipping the test to prevent damaging the contributors setup.';
+                return;
+            }
+
+            self::$originalConfFile = \file_get_contents(self::$pathToConfFile);
+        }
+
+        if (\file_put_contents(self::$pathToConfFile, self::$testConfFileContents) === false) {
+            self::$skip = 'Failed to create the CodeSniffer.conf file for the test.';
+            return;
+        }
+    }
+
+    /**
+     * Skip the tests if the "set up before class" ran into trouble.
+     *
+     * @before
+     *
+     * @return void
+     */
+    protected function maybeSkip()
+    {
+        if (self::$skip !== '') {
+            $this->markTestSkipped(self::$skip);
+        }
+    }
+
+    /**
+     * Restore the original CodeSniffer.conf file.
+     *
+     * @afterClass
+     *
+     * @return void
+     */
+    public static function restoreCodeSnifferConf()
+    {
+        if (self::$pathToConfFile === '' || self::$originalConfFile === '') {
+            return;
+        }
+
+        if (\file_put_contents(self::$pathToConfFile, self::$originalConfFile) === false) {
+            throw new Exception(
+                \sprintf(
+                    'Failed to restore the CodeSniffer.conf file. There is a backup of the original file available in %s.'
+                    . ' Please restore the file manually.',
+                    self::$pathToConfFile . '.bak'
+                )
+            );
+        }
+    }
+
+    /**
+     * Verify that config values set in a user `CodeSniffer.conf` file are disregarded when using the Double class.
+     *
+     * @dataProvider dataConfigDoesNotGetTakenFromConfFile
+     *
+     * @param string $name          The configuration setting name.
+     * @param mixed  $expectedValue The expected value for the setting.
+     *
+     * @return void
+     */
+    public function testConfigDoesNotGetTakenFromConfFile($name, $expectedValue)
+    {
+        $config = new ConfigDouble();
+
+        $this->assertSame($expectedValue, $config->$name);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testConfigDoesNotGetTakenFromConfFile()
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public static function dataConfigDoesNotGetTakenFromConfFile()
+    {
+        return [
+            'report-width' => [
+                'name'          => 'reportWidth',
+                'expectedValue' => 80,
+            ],
+            'standard' => [
+                'name'          => 'standards',
+                'expectedValue' => ['PSR1'],
+            ],
+            'colors' => [
+                'name'          => 'colors',
+                'expectedValue' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Verify that config values set in a user `CodeSniffer.conf` file are disregarded when using the Double class.
+     *
+     * @return void
+     */
+    public function testConfigDoesNotGetTakenFromConfFileForExecutablePaths()
+    {
+        $config = new ConfigDouble();
+
+        $this->assertSame(\PHP_BINARY, $config->getExecutablePath('php'));
+    }
+
+    /**
+     * Verify that config values set in a user `CodeSniffer.conf` file are disregarded when using the Double class.
+     *
+     * @return void
+     */
+    public function testConfigDoesNotGetTakenFromConfFileForConfigData()
+    {
+        $config = new ConfigDouble();
+
+        $this->assertNull($config->getConfigData('php_version'));
+    }
+}


### PR DESCRIPTION
### New `PHPCSUtils\TestUtils\ConfigDouble` class

The PHP_CodeSniffer native `Config` class contains a number of static properties.
As the value of these static properties will be retained between instantiations of the class, config values set in one test can influence the results for another test, which makes tests unstable.

This commit introduces a test "double" of the `Config` class which prevents this from happening.
In _most_ cases, tests should be using this class instead of the "normal" Config, with the exception of select tests for the PHPCS Config class itself.

Includes tests covering the new class.

### UtilityMethodTestCase: implement use of the new `PHPCSUtils\TestUtils\ConfigDouble` class

Start using the new `ConfigDouble` class in the `UtilityMethodTestCase` class.

Note: this includes deprecating the `UtilityMethodTestCase::setStaticConfigProperty()` method, which was introduced, but not publicized, in PHPCSUtils 1.0.9 in favour of handling the same in the `ConfigDouble` class.