### PR TITLE
Tests/AddMessageTest: remove work-around for PHPCS 2.x support

### DIFF
--- a/Tests/Utils/MessageHelper/AddMessageTest.php
+++ b/Tests/Utils/MessageHelper/AddMessageTest.php
@@ -232,9 +232,6 @@ final class AddMessageTest extends UtilityMethodTestCase
 
         $violation = $messages[0];
 
-        // PHPCS 2.x places `unknownSniff.` before the actual error code for utility tests with a dummy error code.
-        $violation['source'] = \str_replace('unknownSniff.', '', $violation['source']);
-
         /*
          * Test the violation details.
          */


### PR DESCRIPTION
... which is no longer needed now support for PHPCS 2.x has been dropped.