### PR TITLE
Tests: remove redundant `@group` annotations

### DIFF
--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\Tokens\Collections;
  *
  * @covers \PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff
  *
- * @group abstracts
- *
  * @since 1.0.0
  */
 final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.php
@@ -20,8 +20,6 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @covers \PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff::getActualArrayKey
  *
- * @group abstracts
- *
  * @since 1.0.0
  */
 final class GetActualArrayKeyTest extends UtilityMethodTestCase

--- a/Tests/BackCompat/Helper/ConfigDataTest.php
+++ b/Tests/BackCompat/Helper/ConfigDataTest.php
@@ -20,8 +20,6 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  * @covers \PHPCSUtils\BackCompat\Helper::setConfigData
  * @covers \PHPCSUtils\BackCompat\Helper::getConfigData
  *
- * @group helper
- *
  * @since 1.0.0
  */
 final class ConfigDataTest extends TestCase

--- a/Tests/BackCompat/Helper/GetCommandLineDataTest.php
+++ b/Tests/BackCompat/Helper/GetCommandLineDataTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @coversDefaultClass \PHPCSUtils\BackCompat\Helper
  *
- * @group helper
- *
  * @since 1.0.0
  */
 final class GetCommandLineDataTest extends UtilityMethodTestCase

--- a/Tests/BackCompat/Helper/GetVersionTest.php
+++ b/Tests/BackCompat/Helper/GetVersionTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\BackCompat\Helper::getVersion
  *
- * @group helper
- *
  * @since 1.0.0
  */
 final class GetVersionTest extends TestCase

--- a/Tests/Fixers/SpacesFixer/SpacesFixerAtEOFTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerAtEOFTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @covers \PHPCSUtils\Fixers\SpacesFixer::checkAndFix
  *
- * @group fixers
- *
  * @since 1.0.8
  */
 final class SpacesFixerAtEOFTest extends UtilityMethodTestCase

--- a/Tests/Fixers/SpacesFixer/SpacesFixerExceptionsTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerExceptionsTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @covers \PHPCSUtils\Fixers\SpacesFixer::checkAndFix
  *
- * @group fixers
- *
  * @since 1.0.0
  */
 final class SpacesFixerExceptionsTest extends UtilityMethodTestCase

--- a/Tests/Fixers/SpacesFixer/SpacesFixerNewlineTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerNewlineTest.php
@@ -17,8 +17,6 @@ use PHPCSUtils\Tests\Fixers\SpacesFixer\SpacesFixerTestCase;
  *
  * @covers \PHPCSUtils\Fixers\SpacesFixer::checkAndFix
  *
- * @group fixers
- *
  * @since 1.0.0
  */
 final class SpacesFixerNewlineTest extends SpacesFixerTestCase

--- a/Tests/Fixers/SpacesFixer/SpacesFixerNoSpaceTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerNoSpaceTest.php
@@ -17,8 +17,6 @@ use PHPCSUtils\Tests\Fixers\SpacesFixer\SpacesFixerTestCase;
  *
  * @covers \PHPCSUtils\Fixers\SpacesFixer::checkAndFix
  *
- * @group fixers
- *
  * @since 1.0.0
  */
 final class SpacesFixerNoSpaceTest extends SpacesFixerTestCase

--- a/Tests/Fixers/SpacesFixer/SpacesFixerOneSpaceTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerOneSpaceTest.php
@@ -17,8 +17,6 @@ use PHPCSUtils\Tests\Fixers\SpacesFixer\SpacesFixerTestCase;
  *
  * @covers \PHPCSUtils\Fixers\SpacesFixer::checkAndFix
  *
- * @group fixers
- *
  * @since 1.0.0
  */
 final class SpacesFixerOneSpaceTest extends SpacesFixerTestCase

--- a/Tests/Fixers/SpacesFixer/SpacesFixerTwoSpaceTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerTwoSpaceTest.php
@@ -17,8 +17,6 @@ use PHPCSUtils\Tests\Fixers\SpacesFixer\SpacesFixerTestCase;
  *
  * @covers \PHPCSUtils\Fixers\SpacesFixer::checkAndFix
  *
- * @group fixers
- *
  * @since 1.0.0
  */
 final class SpacesFixerTwoSpaceTest extends SpacesFixerTestCase

--- a/Tests/Fixers/SpacesFixer/TrailingCommentHandlingNewlineTest.php
+++ b/Tests/Fixers/SpacesFixer/TrailingCommentHandlingNewlineTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @covers \PHPCSUtils\Fixers\SpacesFixer::checkAndFix
  *
- * @group fixers
- *
  * @since 1.0.0
  */
 final class TrailingCommentHandlingNewlineTest extends UtilityMethodTestCase

--- a/Tests/Fixers/SpacesFixer/TrailingCommentHandlingTest.php
+++ b/Tests/Fixers/SpacesFixer/TrailingCommentHandlingTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @covers \PHPCSUtils\Fixers\SpacesFixer::checkAndFix
  *
- * @group fixers
- *
  * @since 1.0.0
  */
 final class TrailingCommentHandlingTest extends UtilityMethodTestCase

--- a/Tests/TestUtils/UtilityMethodTestCase/ExpectPhpcsExceptionTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/ExpectPhpcsExceptionTest.php
@@ -19,8 +19,6 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @covers \PHPCSUtils\TestUtils\UtilityMethodTestCase::expectPhpcsException
  *
- * @group testutils
- *
  * @since 1.0.0
  */
 final class ExpectPhpcsExceptionTest extends UtilityMethodTestCase

--- a/Tests/TestUtils/UtilityMethodTestCase/FailedToTokenizeTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/FailedToTokenizeTest.php
@@ -17,8 +17,6 @@ use PHPCSUtils\Tests\PolyfilledTestCase;
  *
  * @covers \PHPCSUtils\TestUtils\UtilityMethodTestCase::setUpTestFile
  *
- * @group testutils
- *
  * @since 1.0.0
  */
 final class FailedToTokenizeTest extends PolyfilledTestCase

--- a/Tests/TestUtils/UtilityMethodTestCase/GetTargetTokenFileNotFoundTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/GetTargetTokenFileNotFoundTest.php
@@ -17,8 +17,6 @@ use PHPCSUtils\Tests\PolyfilledTestCase;
  *
  * @covers \PHPCSUtils\TestUtils\UtilityMethodTestCase::getTargetToken
  *
- * @group testutils
- *
  * @since 1.0.0
  */
 final class GetTargetTokenFileNotFoundTest extends PolyfilledTestCase

--- a/Tests/TestUtils/UtilityMethodTestCase/GetTargetTokenTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/GetTargetTokenTest.php
@@ -17,8 +17,6 @@ use PHPCSUtils\Tests\PolyfilledTestCase;
  *
  * @covers \PHPCSUtils\TestUtils\UtilityMethodTestCase::getTargetToken
  *
- * @group testutils
- *
  * @since 1.0.0
  */
 final class GetTargetTokenTest extends PolyfilledTestCase

--- a/Tests/TestUtils/UtilityMethodTestCase/MissingCaseFileTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/MissingCaseFileTest.php
@@ -17,8 +17,6 @@ use PHPCSUtils\Tests\PolyfilledTestCase;
  *
  * @covers \PHPCSUtils\TestUtils\UtilityMethodTestCase::setUpTestFile
  *
- * @group testutils
- *
  * @since 1.0.0
  */
 final class MissingCaseFileTest extends PolyfilledTestCase

--- a/Tests/TestUtils/UtilityMethodTestCase/SkipJSCSSTestsOnPHPCS4Test.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/SkipJSCSSTestsOnPHPCS4Test.php
@@ -17,8 +17,6 @@ use PHPCSUtils\Tests\PolyfilledTestCase;
  *
  * @covers \PHPCSUtils\TestUtils\UtilityMethodTestCase::skipJSCSSTestsOnPHPCS4
  *
- * @group testutils
- *
  * @since 1.0.0
  */
 final class SkipJSCSSTestsOnPHPCS4Test extends PolyfilledTestCase

--- a/Tests/TestUtils/UtilityMethodTestCase/UtilityMethodTestCaseTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/UtilityMethodTestCaseTest.php
@@ -17,8 +17,6 @@ use PHPCSUtils\Tests\PolyfilledTestCase;
  *
  * @covers \PHPCSUtils\TestUtils\UtilityMethodTestCase
  *
- * @group testutils
- *
  * @since 1.0.0
  */
 final class UtilityMethodTestCaseTest extends PolyfilledTestCase

--- a/Tests/Tokens/Collections/ArrayOpenTokensBCTest.php
+++ b/Tests/Tokens/Collections/ArrayOpenTokensBCTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Tokens\Collections::arrayOpenTokensBC
  *
- * @group collections
- *
  * @since 1.0.2
  */
 final class ArrayOpenTokensBCTest extends TestCase

--- a/Tests/Tokens/Collections/ArrayTokensBCTest.php
+++ b/Tests/Tokens/Collections/ArrayTokensBCTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Tokens\Collections::arrayTokensBC
  *
- * @group collections
- *
  * @since 1.0.2
  */
 final class ArrayTokensBCTest extends TestCase

--- a/Tests/Tokens/Collections/FunctionCallTokensTest.php
+++ b/Tests/Tokens/Collections/FunctionCallTokensTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Tokens\Collections::functionCallTokens
  *
- * @group collections
- *
  * @since 1.0.0
  */
 final class FunctionCallTokensTest extends TestCase

--- a/Tests/Tokens/Collections/ListOpenTokensBCTest.php
+++ b/Tests/Tokens/Collections/ListOpenTokensBCTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Tokens\Collections::listOpenTokensBC
  *
- * @group collections
- *
  * @since 1.0.2
  */
 final class ListOpenTokensBCTest extends TestCase

--- a/Tests/Tokens/Collections/ListTokensBCTest.php
+++ b/Tests/Tokens/Collections/ListTokensBCTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Tokens\Collections::listTokensBC
  *
- * @group collections
- *
  * @since 1.0.2
  */
 final class ListTokensBCTest extends TestCase

--- a/Tests/Tokens/Collections/NamespacedNameTokensTest.php
+++ b/Tests/Tokens/Collections/NamespacedNameTokensTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Tokens\Collections::namespacedNameTokens
  *
- * @group collections
- *
  * @since 1.0.0
  */
 final class NamespacedNameTokensTest extends TestCase

--- a/Tests/Tokens/Collections/ParameterPassingTokensTest.php
+++ b/Tests/Tokens/Collections/ParameterPassingTokensTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Tokens\Collections::parameterPassingTokens
  *
- * @group collections
- *
  * @since 1.0.0
  */
 final class ParameterPassingTokensTest extends TestCase

--- a/Tests/Tokens/Collections/ParameterTypeTokensTest.php
+++ b/Tests/Tokens/Collections/ParameterTypeTokensTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Tokens\Collections::parameterTypeTokens
  *
- * @group collections
- *
  * @since 1.0.0
  */
 final class ParameterTypeTokensTest extends TestCase

--- a/Tests/Tokens/Collections/PropertyBasedTokenArraysTest.php
+++ b/Tests/Tokens/Collections/PropertyBasedTokenArraysTest.php
@@ -19,8 +19,6 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  *
  * @covers \PHPCSUtils\Tokens\Collections::__callStatic
  *
- * @group collections
- *
  * @since 1.0.0
  */
 final class PropertyBasedTokenArraysTest extends TestCase

--- a/Tests/Tokens/Collections/PropertyTypeTokensTest.php
+++ b/Tests/Tokens/Collections/PropertyTypeTokensTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Tokens\Collections::propertyTypeTokens
  *
- * @group collections
- *
  * @since 1.0.0
  */
 final class PropertyTypeTokensTest extends TestCase

--- a/Tests/Tokens/Collections/ReturnTypeTokensTest.php
+++ b/Tests/Tokens/Collections/ReturnTypeTokensTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Tokens\Collections::returnTypeTokens
  *
- * @group collections
- *
  * @since 1.0.0
  */
 final class ReturnTypeTokensTest extends TestCase

--- a/Tests/Tokens/Collections/ShortArrayListOpenTokensBCTest.php
+++ b/Tests/Tokens/Collections/ShortArrayListOpenTokensBCTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Tokens\Collections::shortArrayListOpenTokensBC
  *
- * @group collections
- *
  * @since 1.0.2
  */
 final class ShortArrayListOpenTokensBCTest extends TestCase

--- a/Tests/Tokens/Collections/ShortArrayTokensBCTest.php
+++ b/Tests/Tokens/Collections/ShortArrayTokensBCTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Tokens\Collections::shortArrayTokensBC
  *
- * @group collections
- *
  * @since 1.0.2
  */
 final class ShortArrayTokensBCTest extends TestCase

--- a/Tests/Tokens/Collections/ShortListTokensBCTest.php
+++ b/Tests/Tokens/Collections/ShortListTokensBCTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Tokens\Collections::shortListTokensBC
  *
- * @group collections
- *
  * @since 1.0.2
  */
 final class ShortListTokensBCTest extends TestCase

--- a/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
+++ b/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
@@ -20,8 +20,6 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @covers \PHPCSUtils\Utils\Arrays::getDoubleArrowPtr
  *
- * @group arrays
- *
  * @since 1.0.0
  */
 final class GetDoubleArrowPtrTest extends UtilityMethodTestCase

--- a/Tests/Utils/Arrays/GetOpenCloseTest.php
+++ b/Tests/Utils/Arrays/GetOpenCloseTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\Utils\Arrays;
  *
  * @covers \PHPCSUtils\Utils\Arrays::getOpenClose
  *
- * @group arrays
- *
  * @since 1.0.0
  */
 final class GetOpenCloseTest extends UtilityMethodTestCase

--- a/Tests/Utils/Context/InAttributeTest.php
+++ b/Tests/Utils/Context/InAttributeTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\Utils\Context;
  *
  * @covers \PHPCSUtils\Utils\Context::inAttribute
  *
- * @group context
- *
  * @since 1.0.0
  */
 final class InAttributeTest extends UtilityMethodTestCase

--- a/Tests/Utils/Context/InEmptyTest.php
+++ b/Tests/Utils/Context/InEmptyTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\Utils\Context;
  *
  * @covers \PHPCSUtils\Utils\Context::inEmpty
  *
- * @group context
- *
  * @since 1.0.0
  */
 final class InEmptyTest extends UtilityMethodTestCase

--- a/Tests/Utils/Context/InForConditionTest.php
+++ b/Tests/Utils/Context/InForConditionTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\Utils\Context;
  *
  * @covers \PHPCSUtils\Utils\Context::inForCondition
  *
- * @group context
- *
  * @since 1.0.0
  */
 final class InForConditionTest extends UtilityMethodTestCase

--- a/Tests/Utils/Context/InForeachConditionTest.php
+++ b/Tests/Utils/Context/InForeachConditionTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\Utils\Context;
  *
  * @covers \PHPCSUtils\Utils\Context::inForeachCondition
  *
- * @group context
- *
  * @since 1.0.0
  */
 final class InForeachConditionTest extends UtilityMethodTestCase

--- a/Tests/Utils/Context/InIssetTest.php
+++ b/Tests/Utils/Context/InIssetTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\Utils\Context;
  *
  * @covers \PHPCSUtils\Utils\Context::inIsset
  *
- * @group context
- *
  * @since 1.0.0
  */
 final class InIssetTest extends UtilityMethodTestCase

--- a/Tests/Utils/Context/InUnsetTest.php
+++ b/Tests/Utils/Context/InUnsetTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\Utils\Context;
  *
  * @covers \PHPCSUtils\Utils\Context::inUnset
  *
- * @group context
- *
  * @since 1.0.0
  */
 final class InUnsetTest extends UtilityMethodTestCase

--- a/Tests/Utils/ControlStructures/GetCaughtExceptionsTest.php
+++ b/Tests/Utils/ControlStructures/GetCaughtExceptionsTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\Utils\ControlStructures;
  *
  * @covers \PHPCSUtils\Utils\ControlStructures::getCaughtExceptions
  *
- * @group controlstructures
- *
  * @since 1.0.0
  */
 final class GetCaughtExceptionsTest extends UtilityMethodTestCase

--- a/Tests/Utils/ControlStructures/HasBodyParseError1Test.php
+++ b/Tests/Utils/ControlStructures/HasBodyParseError1Test.php
@@ -18,8 +18,6 @@ use PHPCSUtils\Utils\ControlStructures;
  *
  * @covers \PHPCSUtils\Utils\ControlStructures::hasBody
  *
- * @group controlstructures
- *
  * @since 1.0.0
  */
 final class HasBodyParseError1Test extends UtilityMethodTestCase

--- a/Tests/Utils/ControlStructures/HasBodyParseError2Test.php
+++ b/Tests/Utils/ControlStructures/HasBodyParseError2Test.php
@@ -18,8 +18,6 @@ use PHPCSUtils\Utils\ControlStructures;
  *
  * @covers \PHPCSUtils\Utils\ControlStructures::hasBody
  *
- * @group controlstructures
- *
  * @since 1.0.0
  */
 final class HasBodyParseError2Test extends UtilityMethodTestCase

--- a/Tests/Utils/ControlStructures/HasBodyTest.php
+++ b/Tests/Utils/ControlStructures/HasBodyTest.php
@@ -19,8 +19,6 @@ use PHPCSUtils\Utils\ControlStructures;
  *
  * @covers \PHPCSUtils\Utils\ControlStructures::hasBody
  *
- * @group controlstructures
- *
  * @since 1.0.0
  */
 final class HasBodyTest extends UtilityMethodTestCase

--- a/Tests/Utils/ControlStructures/IsElseIfTest.php
+++ b/Tests/Utils/ControlStructures/IsElseIfTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\Utils\ControlStructures;
  *
  * @covers \PHPCSUtils\Utils\ControlStructures::isElseIf
  *
- * @group controlstructures
- *
  * @since 1.0.0
  */
 final class IsElseIfTest extends UtilityMethodTestCase

--- a/Tests/Utils/Lists/GetAssignmentsTest.php
+++ b/Tests/Utils/Lists/GetAssignmentsTest.php
@@ -20,8 +20,6 @@ use PHPCSUtils\Utils\Lists;
  *
  * @covers \PHPCSUtils\Utils\Lists::getAssignments
  *
- * @group lists
- *
  * @since 1.0.0
  */
 final class GetAssignmentsTest extends UtilityMethodTestCase

--- a/Tests/Utils/Lists/GetOpenCloseTest.php
+++ b/Tests/Utils/Lists/GetOpenCloseTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\Utils\Lists;
  *
  * @covers \PHPCSUtils\Utils\Lists::getOpenClose
  *
- * @group lists
- *
  * @since 1.0.0
  */
 final class GetOpenCloseTest extends UtilityMethodTestCase

--- a/Tests/Utils/MessageHelper/AddMessageTest.php
+++ b/Tests/Utils/MessageHelper/AddMessageTest.php
@@ -22,8 +22,6 @@ use PHPCSUtils\Utils\MessageHelper;
  *
  * @coversDefaultClass \PHPCSUtils\Utils\MessageHelper
  *
- * @group messagehelper
- *
  * @since 1.0.0
  */
 final class AddMessageTest extends UtilityMethodTestCase

--- a/Tests/Utils/MessageHelper/ShowEscapeCharsTest.php
+++ b/Tests/Utils/MessageHelper/ShowEscapeCharsTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Utils\MessageHelper::showEscapeChars
  *
- * @group messagehelper
- *
  * @since 1.0.0
  */
 final class ShowEscapeCharsTest extends TestCase

--- a/Tests/Utils/MessageHelper/StringToErrorcodeTest.php
+++ b/Tests/Utils/MessageHelper/StringToErrorcodeTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Utils\MessageHelper::stringToErrorcode
  *
- * @group messagehelper
- *
  * @since 1.0.0
  */
 final class StringToErrorcodeTest extends TestCase

--- a/Tests/Utils/Namespaces/DetermineNamespaceTest.php
+++ b/Tests/Utils/Namespaces/DetermineNamespaceTest.php
@@ -21,8 +21,6 @@ use PHPCSUtils\Utils\Namespaces;
  * @covers \PHPCSUtils\Utils\Namespaces::findNamespacePtr
  * @covers \PHPCSUtils\Utils\Namespaces::determineNamespace
  *
- * @group namespaces
- *
  * @since 1.0.0
  */
 final class DetermineNamespaceTest extends UtilityMethodTestCase

--- a/Tests/Utils/Namespaces/GetDeclaredNameTest.php
+++ b/Tests/Utils/Namespaces/GetDeclaredNameTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\Utils\Namespaces;
  *
  * @covers \PHPCSUtils\Utils\Namespaces::getDeclaredName
  *
- * @group namespaces
- *
  * @since 1.0.0
  */
 final class GetDeclaredNameTest extends UtilityMethodTestCase

--- a/Tests/Utils/Namespaces/NamespaceTypeTest.php
+++ b/Tests/Utils/Namespaces/NamespaceTypeTest.php
@@ -22,8 +22,6 @@ use PHPCSUtils\Utils\Namespaces;
  * @covers \PHPCSUtils\Utils\Namespaces::isOperator
  * @covers \PHPCSUtils\Utils\Namespaces::getType
  *
- * @group namespaces
- *
  * @since 1.0.0
  */
 final class NamespaceTypeTest extends UtilityMethodTestCase

--- a/Tests/Utils/NamingConventions/IsEqualTest.php
+++ b/Tests/Utils/NamingConventions/IsEqualTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Utils\NamingConventions::isEqual
  *
- * @group namingconventions
- *
  * @since 1.0.0
  */
 final class IsEqualTest extends TestCase

--- a/Tests/Utils/NamingConventions/IsValidIdentifierNameTest.php
+++ b/Tests/Utils/NamingConventions/IsValidIdentifierNameTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Utils\NamingConventions::isValidIdentifierName
  *
- * @group namingconventions
- *
  * @since 1.0.0
  */
 final class IsValidIdentifierNameTest extends TestCase

--- a/Tests/Utils/Numbers/GetCompleteNumberTest.php
+++ b/Tests/Utils/Numbers/GetCompleteNumberTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\Utils\Numbers;
  *
  * @covers \PHPCSUtils\Utils\Numbers::getCompleteNumber
  *
- * @group numbers
- *
  * @since 1.0.0
  */
 final class GetCompleteNumberTest extends UtilityMethodTestCase

--- a/Tests/Utils/Numbers/GetDecimalValueTest.php
+++ b/Tests/Utils/Numbers/GetDecimalValueTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Utils\Numbers::getDecimalValue
  *
- * @group numbers
- *
  * @since 1.0.0
  */
 final class GetDecimalValueTest extends TestCase

--- a/Tests/Utils/Numbers/NumberTypesTest.php
+++ b/Tests/Utils/Numbers/NumberTypesTest.php
@@ -22,8 +22,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @coversDefaultClass \PHPCSUtils\Utils\Numbers
  *
- * @group numbers
- *
  * @since 1.0.0
  */
 final class NumberTypesTest extends TestCase

--- a/Tests/Utils/Orthography/FirstCharTest.php
+++ b/Tests/Utils/Orthography/FirstCharTest.php
@@ -20,8 +20,6 @@ use PHPUnit\Framework\TestCase;
  * @covers \PHPCSUtils\Utils\Orthography::isFirstCharCapitalized
  * @covers \PHPCSUtils\Utils\Orthography::isFirstCharLowercase
  *
- * @group orthography
- *
  * @since 1.0.0
  */
 final class FirstCharTest extends TestCase

--- a/Tests/Utils/Orthography/IsLastCharPunctuationTest.php
+++ b/Tests/Utils/Orthography/IsLastCharPunctuationTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Utils\Orthography::isLastCharPunctuation
  *
- * @group orthography
- *
  * @since 1.0.0
  */
 final class IsLastCharPunctuationTest extends TestCase

--- a/Tests/Utils/Parentheses/ParenthesesTest.php
+++ b/Tests/Utils/Parentheses/ParenthesesTest.php
@@ -19,8 +19,6 @@ use PHPCSUtils\Utils\Parentheses;
  *
  * @covers \PHPCSUtils\Utils\Parentheses
  *
- * @group parentheses
- *
  * @since 1.0.0
  */
 final class ParenthesesTest extends UtilityMethodTestCase

--- a/Tests/Utils/PassedParameters/GetParameterCountTest.php
+++ b/Tests/Utils/PassedParameters/GetParameterCountTest.php
@@ -21,8 +21,6 @@ use PHPCSUtils\Utils\PassedParameters;
  * @covers \PHPCSUtils\Utils\PassedParameters::getParameters
  * @covers \PHPCSUtils\Utils\PassedParameters::hasParameters
  *
- * @group passedparameters
- *
  * @since 1.0.0
  */
 final class GetParameterCountTest extends UtilityMethodTestCase

--- a/Tests/Utils/PassedParameters/GetParameterFromStackTest.php
+++ b/Tests/Utils/PassedParameters/GetParameterFromStackTest.php
@@ -21,8 +21,6 @@ use PHPCSUtils\Utils\PassedParameters;
  * @covers \PHPCSUtils\Utils\PassedParameters::getParameter
  * @covers \PHPCSUtils\Utils\PassedParameters::getParameterFromStack
  *
- * @group passedparameters
- *
  * @since 1.0.0
  */
 final class GetParameterFromStackTest extends UtilityMethodTestCase

--- a/Tests/Utils/PassedParameters/GetParametersNamedTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersNamedTest.php
@@ -23,8 +23,6 @@ use PHPCSUtils\Utils\PassedParameters;
  * @covers \PHPCSUtils\Utils\PassedParameters::getParameterFromStack
  * @covers \PHPCSUtils\Utils\PassedParameters::hasParameters
  *
- * @group passedparameters
- *
  * @since 1.0.0
  */
 final class GetParametersNamedTest extends UtilityMethodTestCase

--- a/Tests/Utils/PassedParameters/GetParametersSkipShortArrayCheckTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersSkipShortArrayCheckTest.php
@@ -22,8 +22,6 @@ use PHPCSUtils\Utils\PassedParameters;
  * @covers \PHPCSUtils\Utils\PassedParameters::hasParameters
  * @covers \PHPCSUtils\Utils\PassedParameters::getParameters
  *
- * @group passedparameters
- *
  * @since 1.0.0
  */
 final class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase

--- a/Tests/Utils/PassedParameters/GetParametersTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersTest.php
@@ -23,8 +23,6 @@ use PHPCSUtils\Utils\PassedParameters;
  * @covers \PHPCSUtils\Utils\PassedParameters::getParameterFromStack
  * @covers \PHPCSUtils\Utils\PassedParameters::hasParameters
  *
- * @group passedparameters
- *
  * @since 1.0.0
  */
 final class GetParametersTest extends UtilityMethodTestCase

--- a/Tests/Utils/PassedParameters/GetParametersWithLimitTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersWithLimitTest.php
@@ -20,8 +20,6 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @covers \PHPCSUtils\Utils\PassedParameters::getParameters
  *
- * @group passedparameters
- *
  * @since 1.0.0
  */
 final class GetParametersWithLimitTest extends UtilityMethodTestCase

--- a/Tests/Utils/PassedParameters/HasParametersTest.php
+++ b/Tests/Utils/PassedParameters/HasParametersTest.php
@@ -19,8 +19,6 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @covers \PHPCSUtils\Utils\PassedParameters::hasParameters
  *
- * @group passedparameters
- *
  * @since 1.0.0
  */
 final class HasParametersTest extends UtilityMethodTestCase

--- a/Tests/Utils/Scopes/IsOOConstantTest.php
+++ b/Tests/Utils/Scopes/IsOOConstantTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\Utils\Scopes;
  *
  * @coversDefaultClass \PHPCSUtils\Utils\Scopes
  *
- * @group scopes
- *
  * @since 1.0.0
  */
 final class IsOOConstantTest extends UtilityMethodTestCase

--- a/Tests/Utils/Scopes/IsOOMethodTest.php
+++ b/Tests/Utils/Scopes/IsOOMethodTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\Utils\Scopes;
  *
  * @coversDefaultClass \PHPCSUtils\Utils\Scopes
  *
- * @group scopes
- *
  * @since 1.0.0
  */
 final class IsOOMethodTest extends UtilityMethodTestCase

--- a/Tests/Utils/Scopes/IsOOPropertyTest.php
+++ b/Tests/Utils/Scopes/IsOOPropertyTest.php
@@ -18,8 +18,6 @@ use PHPCSUtils\Utils\Scopes;
  *
  * @coversDefaultClass \PHPCSUtils\Utils\Scopes
  *
- * @group scopes
- *
  * @since 1.0.0
  */
 final class IsOOPropertyTest extends UtilityMethodTestCase

--- a/Tests/Utils/TextStrings/GetCompleteTextStringTest.php
+++ b/Tests/Utils/TextStrings/GetCompleteTextStringTest.php
@@ -21,8 +21,6 @@ use PHPCSUtils\Utils\TextStrings;
  * @covers \PHPCSUtils\Utils\TextStrings::getCompleteTextString
  * @covers \PHPCSUtils\Utils\TextStrings::getEndOfCompleteTextString
  *
- * @group textstrings
- *
  * @since 1.0.0
  */
 final class GetCompleteTextStringTest extends UtilityMethodTestCase

--- a/Tests/Utils/TextStrings/GetEndOfCompleteTextStringTest.php
+++ b/Tests/Utils/TextStrings/GetEndOfCompleteTextStringTest.php
@@ -22,8 +22,6 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * @covers \PHPCSUtils\Utils\TextStrings::getEndOfCompleteTextString
  *
- * @group textstrings
- *
  * @since 1.0.0
  */
 final class GetEndOfCompleteTextStringTest extends UtilityMethodTestCase

--- a/Tests/Utils/TextStrings/InterpolatedVariablesTest.php
+++ b/Tests/Utils/TextStrings/InterpolatedVariablesTest.php
@@ -21,8 +21,6 @@ use PHPUnit\Framework\TestCase;
  * @covers \PHPCSUtils\Utils\TextStrings::stripEmbeds
  * @covers \PHPCSUtils\Utils\TextStrings::getStripEmbeds
  *
- * @group textstrings
- *
  * @since 1.0.0
  */
 final class InterpolatedVariablesTest extends TestCase

--- a/Tests/Utils/TextStrings/StripQuotesTest.php
+++ b/Tests/Utils/TextStrings/StripQuotesTest.php
@@ -18,8 +18,6 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \PHPCSUtils\Utils\TextStrings::stripQuotes
  *
- * @group textstrings
- *
  * @since 1.0.0
  */
 final class StripQuotesTest extends TestCase

--- a/Tests/Utils/UseStatements/SplitAndMergeImportUseStatementTest.php
+++ b/Tests/Utils/UseStatements/SplitAndMergeImportUseStatementTest.php
@@ -20,8 +20,6 @@ use PHPCSUtils\Utils\UseStatements;
  * @covers \PHPCSUtils\Utils\UseStatements::splitAndMergeImportUseStatement
  * @covers \PHPCSUtils\Utils\UseStatements::mergeImportUseStatements
  *
- * @group usestatements
- *
  * @since 1.0.0
  */
 final class SplitAndMergeImportUseStatementTest extends UtilityMethodTestCase

--- a/Tests/Utils/UseStatements/SplitImportUseStatementTest.php
+++ b/Tests/Utils/UseStatements/SplitImportUseStatementTest.php
@@ -19,8 +19,6 @@ use PHPCSUtils\Utils\UseStatements;
  *
  * @covers \PHPCSUtils\Utils\UseStatements::splitImportUseStatement
  *
- * @group usestatements
- *
  * @since 1.0.0
  */
 final class SplitImportUseStatementTest extends UtilityMethodTestCase

--- a/Tests/Utils/UseStatements/UseTypeTest.php
+++ b/Tests/Utils/UseStatements/UseTypeTest.php
@@ -24,8 +24,6 @@ use PHPCSUtils\Utils\UseStatements;
  * @covers \PHPCSUtils\Utils\UseStatements::isClosureUse
  * @covers \PHPCSUtils\Utils\UseStatements::getType
  *
- * @group usestatements
- *
  * @since 1.0.0
  */
 final class UseTypeTest extends UtilityMethodTestCase


### PR DESCRIPTION
The `@group` annotations were initially added to:
- allow for running closely related BCFile tests + Utils tests in one go;
- for running other closely related tests together;
- and for selectively excluding some unstable tests from CI test runs.

For everything else they should be regarded as redundant as the PHPUnit native `--filter` argument can sufficiently handle with running a group of tests from a single directory/namespace in modern PHPUnit versions (and who still runs locally on older ones ?).

This commit removes `@group` tags which are not needed based on that reasoning.