### PR TITLE
Tests: data set keys should match parameter names

### DIFF
--- a/Tests/BackCompat/BCFile/IsReferenceTest.php
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.php
@@ -64,16 +64,16 @@ class IsReferenceTest extends UtilityMethodTestCase
      *
      * @dataProvider dataIsReference
      *
-     * @param string $identifier Comment which precedes the test case.
+     * @param string $testMarker Comment which precedes the test case.
      * @param bool   $expected   Expected function output.
      *
      * @return void
      */
-    public function testIsReference($identifier, $expected)
+    public function testIsReference($testMarker, $expected)
     {
         $testClass = static::TEST_CLASS;
 
-        $bitwiseAnd = $this->getTargetToken($identifier, T_BITWISE_AND);
+        $bitwiseAnd = $this->getTargetToken($testMarker, T_BITWISE_AND);
         $result     = $testClass::isReference(self::$phpcsFile, $bitwiseAnd);
         $this->assertSame($expected, $result);
     }

--- a/Tests/Fixers/SpacesFixer/SpacesFixerTestCase.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerTestCase.php
@@ -164,6 +164,7 @@ abstract class SpacesFixerTestCase extends UtilityMethodTestCase
         foreach (static::$compliantCases as $caseName) {
             if (isset($baseData[$caseName])) {
                 $data[$caseName] = $baseData[$caseName];
+                unset($data[$caseName]['type']);
             }
         }
 

--- a/Tests/Internal/Cache/GetClearTest.php
+++ b/Tests/Internal/Cache/GetClearTest.php
@@ -401,7 +401,7 @@ final class GetClearTest extends UtilityMethodTestCase
     /**
      * Test that previously cached data is no longer available when the cache has been cleared.
      *
-     * @dataProvider dataEveryTypeOfInput
+     * @dataProvider dataClearCache
      *
      * @covers ::clear
      *
@@ -415,5 +415,23 @@ final class GetClearTest extends UtilityMethodTestCase
 
         $this->assertFalse(Cache::isCached(self::$phpcsFile, 'Utility1', $id));
         $this->assertFalse(Cache::isCached(self::$phpcsFile, 'Utility2', $id));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testClearCache() For the array format.
+     *
+     * @return array
+     */
+    public static function dataClearCache()
+    {
+        $data = self::dataEveryTypeOfInput();
+
+        foreach ($data as $name => $dataset) {
+            unset($data[$name]['expected']);
+        }
+
+        return $data;
     }
 }

--- a/Tests/Internal/NoFileCache/GetClearTest.php
+++ b/Tests/Internal/NoFileCache/GetClearTest.php
@@ -265,7 +265,7 @@ final class GetClearTest extends TestCase
     /**
      * Test that previously cached data is no longer available when the cache has been cleared.
      *
-     * @dataProvider dataEveryTypeOfInput
+     * @dataProvider dataClearCache
      *
      * @covers ::clear
      *
@@ -279,5 +279,23 @@ final class GetClearTest extends TestCase
 
         $this->assertFalse(NoFileCache::isCached('Utility1', $id));
         $this->assertFalse(NoFileCache::isCached('Utility2', $id));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testClearCache() For the array format.
+     *
+     * @return array
+     */
+    public static function dataClearCache()
+    {
+        $data = self::dataEveryTypeOfInput();
+
+        foreach ($data as $name => $dataset) {
+            unset($data[$name]['expected']);
+        }
+
+        return $data;
     }
 }

--- a/Tests/Utils/PassedParameters/GetParametersSkipShortArrayCheckTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersSkipShortArrayCheckTest.php
@@ -35,7 +35,7 @@ final class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase
      *
      * Also verify that for valid constructs, the method still behaves like normal.
      *
-     * @dataProvider dataTestCases
+     * @dataProvider dataHasParametersDontSkipShortArrayCheck
      *
      * @param string     $testMarker      The comment which prefaces the target token in the test file.
      * @param int|string $targetType      The type of token to look for.
@@ -59,19 +59,36 @@ final class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase
     }
 
     /**
+     * Data provider.
+     *
+     * @see testHasParametersDontSkipShortArrayCheck() For the array format.
+     *
+     * @return array
+     */
+    public static function dataHasParametersDontSkipShortArrayCheck()
+    {
+        $data = self::dataTestCases();
+
+        foreach ($data as $name => $dataset) {
+            unset($data[$name]['expected']);
+        }
+
+        return $data;
+    }
+
+    /**
      * Test retrieving the parameter details for valid and invalid constructs when the
      * `$isShortArray` parameter is set to TRUE.
      *
-     * @dataProvider dataTestCases
+     * @dataProvider dataGetParametersSkipShortArrayCheck
      *
      * @param string     $testMarker The comment which prefaces the target token in the test file.
      * @param int|string $targetType The type of token to look for.
-     * @param bool       $ignore     Not used in this test.
      * @param array      $expected   The expected return value.
      *
      * @return void
      */
-    public function testGetParametersSkipShortArrayCheck($testMarker, $targetType, $ignore, $expected)
+    public function testGetParametersSkipShortArrayCheck($testMarker, $targetType, $expected)
     {
         /*
          * Expect an exception on PHPCS versions when square brackets will never be a short array.
@@ -108,6 +125,24 @@ final class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase
     /**
      * Data provider.
      *
+     * @see testGetParametersSkipShortArrayCheck() For the array format.
+     *
+     * @return array
+     */
+    public static function dataGetParametersSkipShortArrayCheck()
+    {
+        $data = self::dataTestCases();
+
+        foreach ($data as $name => $dataset) {
+            unset($data[$name]['expectException']);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Data provider.
+     *
      * @see testGetParametersSkipShortArrayCheck()     For the array format.
      * @see testHasParametersDontSkipShortArrayCheck() For the array format.
      *
@@ -117,16 +152,16 @@ final class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase
     {
         return [
             'no-params' => [
-                'testMarker' => '/* testNoParams */',
-                'targetType' => \T_OPEN_SHORT_ARRAY,
-                'ignore'     => false,
-                'expected'   => [],
+                'testMarker'      => '/* testNoParams */',
+                'targetType'      => \T_OPEN_SHORT_ARRAY,
+                'expectException' => false,
+                'expected'        => [],
             ],
             'long-array' => [
-                'testMarker' => '/* testLongArray */',
-                'targetType' => \T_ARRAY,
-                'ignore'     => false,
-                'expected'   => [
+                'testMarker'      => '/* testLongArray */',
+                'targetType'      => \T_ARRAY,
+                'expectException' => false,
+                'expected'        => [
                     1 => [
                         'start' => 2,
                         'end'   => 3,
@@ -140,10 +175,10 @@ final class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase
                 ],
             ],
             'short-array' => [
-                'testMarker' => '/* testShortArray */',
-                'targetType' => \T_OPEN_SHORT_ARRAY,
-                'ignore'     => false,
-                'expected'   => [
+                'testMarker'      => '/* testShortArray */',
+                'targetType'      => \T_OPEN_SHORT_ARRAY,
+                'expectException' => false,
+                'expected'        => [
                     1 => [
                         'start' => 1,
                         'end'   => 6,
@@ -157,10 +192,10 @@ final class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase
                 ],
             ],
             'short-list' => [
-                'testMarker' => '/* testShortList */',
-                'targetType' => \T_OPEN_SHORT_ARRAY,
-                'ignore'     => true,
-                'expected'   => [
+                'testMarker'      => '/* testShortList */',
+                'targetType'      => \T_OPEN_SHORT_ARRAY,
+                'expectException' => true,
+                'expected'        => [
                     1 => [
                         'start' => 1,
                         'end'   => 6,
@@ -180,10 +215,10 @@ final class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase
              * class for those PHPCS versions.
              */
             'array-assign' => [
-                'testMarker' => '/* testArrayAssign */',
-                'targetType' => \T_OPEN_SQUARE_BRACKET,
-                'ignore'     => true,
-                'expected'   => [],
+                'testMarker'      => '/* testArrayAssign */',
+                'targetType'      => \T_OPEN_SQUARE_BRACKET,
+                'expectException' => true,
+                'expected'        => [],
             ],
             /*
              * This test will result in an (expected) Exception when run on PHPCS versions which
@@ -192,10 +227,10 @@ final class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase
              * class for those PHPCS versions.
              */
             'array-access' => [
-                'testMarker' => '/* testArrayAccess */',
-                'targetType' => \T_OPEN_SQUARE_BRACKET,
-                'ignore'     => true,
-                'expected'   => [
+                'testMarker'      => '/* testArrayAccess */',
+                'targetType'      => \T_OPEN_SQUARE_BRACKET,
+                'expectException' => true,
+                'expected'        => [
                     1 => [
                         'start' => 1,
                         'end'   => 4,
@@ -204,10 +239,10 @@ final class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase
                 ],
             ],
             'short-list-with-empties-before' => [
-                'testMarker' => '/* testShortListWithEmptyItemsBefore */',
-                'targetType' => \T_OPEN_SHORT_ARRAY,
-                'ignore'     => true,
-                'expected'   => [
+                'testMarker'      => '/* testShortListWithEmptyItemsBefore */',
+                'targetType'      => \T_OPEN_SHORT_ARRAY,
+                'expectException' => true,
+                'expected'        => [
                     1 => [
                         'start' => 1,
                         'end'   => 0,
@@ -226,10 +261,10 @@ final class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase
                 ],
             ],
             'short-list-with-empties-after' => [
-                'testMarker' => '/* testShortListWithEmptyItemsAfter */',
-                'targetType' => \T_OPEN_SHORT_ARRAY,
-                'ignore'     => true,
-                'expected'   => [
+                'testMarker'      => '/* testShortListWithEmptyItemsAfter */',
+                'targetType'      => \T_OPEN_SHORT_ARRAY,
+                'expectException' => true,
+                'expected'        => [
                     1 => [
                         'start' => 1,
                         'end'   => 1,
@@ -243,10 +278,10 @@ final class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase
                 ],
             ],
             'short-list-with-all-empties' => [
-                'testMarker' => '/* testShortListWithAllEmptyItems */',
-                'targetType' => \T_OPEN_SHORT_ARRAY,
-                'ignore'     => true,
-                'expected'   => [
+                'testMarker'      => '/* testShortListWithAllEmptyItems */',
+                'targetType'      => \T_OPEN_SHORT_ARRAY,
+                'expectException' => true,
+                'expected'        => [
                     1 => [
                         'start' => 1,
                         'end'   => 0,


### PR DESCRIPTION
Initially to prevent issues with a few PHPUnit versions which were around in the early days of PHP 8.0, where these would accidentally be seen as parameter names.

So, as a best practice, when using keys in data sets, the keys should match the parameter names of the receiving test method.

And if a "super-"dataprovider is used and individual tests only need a subset of the keys from the data provider, add dedicated dataprovider for the individual test to remove the unneeded keys.

An ulterior reason to make this change is that PHPUnit 11 will always treat the keys as parameter names, so this can be seen as a preparation step for allowing for PHPUnit 11 support.