### PR TITLE
Composer: raise the minimum supported PHPCS version to 3.9.0 and remove work-arounds

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -76,7 +76,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - PHPCS 3.8.0: OO methods called `self`, `parent` or `static` are now correctly recognized.
+     * - The upstream method has received no significant updates since PHPCS 3.9.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getDeclarationName() Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::getName()   PHPCSUtils native improved version.
@@ -98,44 +98,7 @@ final class BCFile
      */
     public static function getDeclarationName(File $phpcsFile, $stackPtr)
     {
-        $tokens    = $phpcsFile->getTokens();
-        $tokenCode = $tokens[$stackPtr]['code'];
-
-        if ($tokenCode === T_ANON_CLASS || $tokenCode === T_CLOSURE) {
-            return null;
-        }
-
-        if ($tokenCode !== T_FUNCTION
-            && $tokenCode !== T_CLASS
-            && $tokenCode !== T_INTERFACE
-            && $tokenCode !== T_TRAIT
-            && $tokenCode !== T_ENUM
-        ) {
-            throw new RuntimeException('Token type "' . $tokens[$stackPtr]['type'] . '" is not T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT or T_ENUM');
-        }
-
-        if ($tokenCode === T_FUNCTION
-            && strtolower($tokens[$stackPtr]['content']) !== 'function'
-        ) {
-            // This is a function declared without the "function" keyword.
-            // So this token is the function name.
-            return $tokens[$stackPtr]['content'];
-        }
-
-        $content = null;
-        for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
-            if ($tokens[$i]['code'] === T_STRING
-                // BC: PHPCS < 3.8.0.
-                || $tokens[$i]['code'] === T_SELF
-                || $tokens[$i]['code'] === T_PARENT
-                || $tokens[$i]['code'] === T_STATIC
-            ) {
-                $content = $tokens[$i]['content'];
-                break;
-            }
-        }
-
-        return $content;
+        return $phpcsFile->getDeclarationName($stackPtr);
     }
 
     /**

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -545,13 +545,12 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.3.0.
-     * - PHPCS 3.8.0: Added support for PHP 8.2 `readonly` classes.
+     * - The upstream method has received no significant updates since PHPCS 3.9.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getClassProperties()          Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::getClassProperties() PHPCSUtils native improved version.
      *
      * @since 1.0.0
-     * @since 1.0.6 Sync with PHPCS 3.8.0, support for readonly classes. PHPCS#3686.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
      * @param int                         $stackPtr  The position in the stack of the `T_CLASS`
@@ -564,50 +563,7 @@ final class BCFile
      */
     public static function getClassProperties(File $phpcsFile, $stackPtr)
     {
-        $tokens = $phpcsFile->getTokens();
-
-        if ($tokens[$stackPtr]['code'] !== T_CLASS) {
-            throw new RuntimeException('$stackPtr must be of type T_CLASS');
-        }
-
-        $valid = [
-            T_FINAL       => T_FINAL,
-            T_ABSTRACT    => T_ABSTRACT,
-            T_READONLY    => T_READONLY,
-            T_WHITESPACE  => T_WHITESPACE,
-            T_COMMENT     => T_COMMENT,
-            T_DOC_COMMENT => T_DOC_COMMENT,
-        ];
-
-        $isAbstract = false;
-        $isFinal    = false;
-        $isReadonly = false;
-
-        for ($i = ($stackPtr - 1); $i > 0; $i--) {
-            if (isset($valid[$tokens[$i]['code']]) === false) {
-                break;
-            }
-
-            switch ($tokens[$i]['code']) {
-                case T_ABSTRACT:
-                    $isAbstract = true;
-                    break;
-
-                case T_FINAL:
-                    $isFinal = true;
-                    break;
-
-                case T_READONLY:
-                    $isReadonly = true;
-                    break;
-            }
-        }
-
-        return [
-            'is_abstract' => $isAbstract,
-            'is_final'    => $isFinal,
-            'is_readonly' => $isReadonly,
-        ];
+        return $phpcsFile->getClassProperties($stackPtr);
     }
 
     /**

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -499,7 +499,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.8.0.
+     * - The upstream method has received no significant updates since PHPCS 3.9.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodProperties()      Original source.
      * @see \PHPCSUtils\Utils\FunctionDeclarations::getProperties() PHPCSUtils native improved version.
@@ -544,7 +544,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.8.0.
+     * - The upstream method has received no significant updates since PHPCS 3.9.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getMemberProperties() Original source.
      * @see \PHPCSUtils\Utils\Variables::getMemberProperties() PHPCSUtils native improved version.
@@ -654,7 +654,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.8.0.
+     * - The upstream method has received no significant updates since PHPCS 3.9.0.
      *
      * @see \PHP_CodeSniffer\Files\File::isReference() Original source.
      * @see \PHPCSUtils\Utils\Operators::isReference() PHPCSUtils native improved version.
@@ -680,7 +680,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.8.0.
+     * - The upstream method has received no significant updates since PHPCS 3.9.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getTokensAsString() Original source.
      * @see \PHPCSUtils\Utils\GetTokensAsString              Related set of functions.
@@ -709,7 +709,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.1.0.
-     * - The upstream method has received no significant updates since PHPCS 3.8.0.
+     * - The upstream method has received no significant updates since PHPCS 3.9.0.
      *
      * @see \PHP_CodeSniffer\Files\File::findStartOfStatement() Original source.
      *
@@ -733,7 +733,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.1.0.
-     * - The upstream method has received no significant updates since PHPCS 3.8.0.
+     * - The upstream method has received no significant updates since PHPCS 3.9.0.
      *
      * @see \PHP_CodeSniffer\Files\File::findEndOfStatement() Original source.
      *
@@ -757,7 +757,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.8.0.
+     * - The upstream method has received no significant updates since PHPCS 3.9.0.
      *
      * @see \PHP_CodeSniffer\Files\File::hasCondition()  Original source.
      * @see \PHPCSUtils\Utils\Conditions::hasCondition() PHPCSUtils native alternative.
@@ -782,7 +782,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.3.0.
-     * - The upstream method has received no significant updates since PHPCS 3.8.0.
+     * - The upstream method has received no significant updates since PHPCS 3.9.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getCondition()  Original source.
      * @see \PHPCSUtils\Utils\Conditions::getCondition() More versatile alternative.
@@ -813,7 +813,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.2.0.
-     * - The upstream method has received no significant updates since PHPCS 3.8.0.
+     * - The upstream method has received no significant updates since PHPCS 3.9.0.
      *
      * @see \PHP_CodeSniffer\Files\File::findExtendedClassName()          Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::findExtendedClassName() PHPCSUtils native improved version.
@@ -838,7 +838,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.7.0.
-     * - The upstream method has received no significant updates since PHPCS 3.8.0.
+     * - The upstream method has received no significant updates since PHPCS 3.9.0.
      *
      * @see \PHP_CodeSniffer\Files\File::findImplementedInterfaceNames()          Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::findImplementedInterfaceNames() PHPCSUtils native improved version.

--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -74,7 +74,7 @@ final class BCTokens
 
     /**
      * Handle calls to (undeclared) methods for token arrays which haven't received any
-     * changes since PHPCS 3.8.0.
+     * changes since PHPCS 3.9.0.
      *
      * @since 1.0.0
      *

--- a/PHPCSUtils/Internal/IsShortArrayOrList.php
+++ b/PHPCSUtils/Internal/IsShortArrayOrList.php
@@ -161,7 +161,7 @@ final class IsShortArrayOrList
      *
      * @var string
      */
-    private $phpcsVersion;
+    private $phpcsVersion; // @phpstan-ignore-line
 
     /**
      * Tokens which can open a short array or short list (PHPCS cross-version compatible).
@@ -362,27 +362,7 @@ final class IsShortArrayOrList
     private function isShortArrayBracket()
     {
         if ($this->tokens[$this->opener]['code'] === \T_OPEN_SQUARE_BRACKET) {
-            if (\version_compare($this->phpcsVersion, '3.7.2', '>=') === true) {
-                // These will just be properly tokenized, plain square brackets. No need for further checks.
-                return false;
-            }
-
-            /*
-             * BC: Work around a bug in the tokenizer of PHPCS < 3.7.2, where a `[` would be
-             * tokenized as T_OPEN_SQUARE_BRACKET instead of T_OPEN_SHORT_ARRAY if it was
-             * preceded by the close parenthesis of a non-braced control structure.
-             *
-             * @link https://github.com/squizlabs/PHP_CodeSniffer/issues/3632
-             */
-            if ($this->tokens[$this->beforeOpener]['code'] === \T_CLOSE_PARENTHESIS
-                && isset($this->tokens[$this->beforeOpener]['parenthesis_owner']) === true
-                // phpcs:ignore Generic.Files.LineLength.TooLong
-                && isset(Tokens::$scopeOpeners[$this->tokens[$this->tokens[$this->beforeOpener]['parenthesis_owner']]['code']]) === true
-            ) {
-                return true;
-            }
-
-            // These are really just plain square brackets.
+            // Currently there are no known issues with the tokenization in PHPCS 3.9.0 and higher.
             return false;
         }
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Whether you need to split an `array` into the individual items, are trying to de
 
 Includes improved versions of the PHPCS native utility functions and plenty of new utility functions.
 
-These functions are compatible with PHPCS 3.8.0 up to PHPCS `master`.
+These functions are compatible with PHPCS 3.9.0 up to PHPCS `master`.
 
 ### A collection of static properties and methods for often-used token groups
 
@@ -66,7 +66,7 @@ Supports PHPUnit 4.x up to 9.x.
 
 Normally to use the latest version of PHP_CodeSniffer native utility functions, you would have to raise the minimum requirements of your external PHPCS standard.
 
-Now you won't have to anymore. This package allows you to use the latest version of those utility functions in all PHP_CodeSniffer versions from PHPCS 3.8.0 and up.
+Now you won't have to anymore. This package allows you to use the latest version of those utility functions in all PHP_CodeSniffer versions from PHPCS 3.9.0 and up.
 
 ### Fully documented
 
@@ -78,7 +78,7 @@ To see detailed information about all the available abstract sniffs, utility fun
 ## Minimum Requirements
 
 * PHP 5.4 or higher.
-* [PHP_CodeSniffer] 3.8.0+.
+* [PHP_CodeSniffer] 3.9.0+.
 * Recommended PHP extensions for optimal functionality:
     - PCRE with Unicode support (normally enabled by default)
 

--- a/Tests/BackCompat/Helper/GetVersionTest.php
+++ b/Tests/BackCompat/Helper/GetVersionTest.php
@@ -47,7 +47,7 @@ final class GetVersionTest extends TestCase
         }
 
         if ($expected === 'lowest') {
-            $expected = '3.8.0';
+            $expected = '3.9.0';
         }
 
         $result = Helper::getVersion();

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.8.0 || 4.0.x-dev@dev",
+        "squizlabs/php_codesniffer" : "^3.9.0 || 4.0.x-dev@dev",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0"
     },
     "require-dev" : {


### PR DESCRIPTION
### Composer: raise the minimum supported PHPCS version to 3.9.0

... to benefit from the syntax support for PHP 8.3 which has been added to PHPCS itself.

Includes updating references to the PHPCS version whenever relevant throughout the codebase.

### BCFile::getDeclarationName(): defer to upstream

No BC-layer is needed at this time with a minimum supported PHPCS version of PHPCS 3.9.0.

### BCFile::getClassProperties(): defer to upstream

No BC-layer is needed at this time with a minimum supported PHPCS version of PHPCS 3.9.0.

### IsShortArrayOrList::isShortArrayBracket(): remove BC layer

... which is no longer needed now support for PHPCS < 3.9.0 has been dropped.