### PR TITLE
✨ New PHPCSUtils\Utils\Constants class + associated token collection

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -190,6 +190,24 @@ final class Collections
     ];
 
     /**
+     * Token types which can be encountered in an OO constant type declaration.
+     *
+     * @since 1.1.0 Use the {@see Collections::constantTypeTokens()} method for access.
+     *
+     * @var array<int|string, int|string>
+     */
+    private static $constantTypeTokens = [
+        \T_CALLABLE               => \T_CALLABLE, // Not allowed in PHP, but in this list to allow for flagging code errors.
+        \T_FALSE                  => \T_FALSE,
+        \T_TRUE                   => \T_TRUE,
+        \T_NULL                   => \T_NULL,
+        \T_TYPE_UNION             => \T_TYPE_UNION,
+        \T_TYPE_INTERSECTION      => \T_TYPE_INTERSECTION,
+        \T_TYPE_OPEN_PARENTHESIS  => \T_TYPE_OPEN_PARENTHESIS,
+        \T_TYPE_CLOSE_PARENTHESIS => \T_TYPE_CLOSE_PARENTHESIS,
+    ];
+
+    /**
      * Control structure tokens.
      *
      * @since 1.0.0 Use the {@see Collections::controlStructureTokens()} method for access.
@@ -636,6 +654,23 @@ final class Collections
     public static function arrayTokensBC()
     {
         return self::$arrayTokens;
+    }
+
+    /**
+     * Token types which can be encountered in OO constant type declaration.
+     *
+     * @since 1.1.0
+     *
+     * @return array<int|string, int|string>
+     */
+    public static function constantTypeTokens()
+    {
+        $tokens = self::$constantTypeTokens;
+        // Self and static are only allowed in enums, but that's not the concern of this method.
+        $tokens += self::$ooHierarchyKeywords;
+        $tokens += self::namespacedNameTokens();
+
+        return $tokens;
     }
 
     /**

--- a/PHPCSUtils/Utils/Constants.php
+++ b/PHPCSUtils/Utils/Constants.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Utils;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\TypeError;
+use PHPCSUtils\Exceptions\UnexpectedTokenType;
+use PHPCSUtils\Exceptions\ValueError;
+use PHPCSUtils\Internal\Cache;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Scopes;
+
+/**
+ * Utility functions for use when examining constants declared using the "const" keyword.
+ *
+ * @since 1.1.0
+ */
+final class Constants
+{
+
+    /**
+     * Retrieve the visibility and implementation properties of an OO constant.
+     *
+     * @since 1.1.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position in the stack of the `T_CONST` token
+     *                                               to acquire the properties for.
+     *
+     * @return array<string, string|int|bool> Array with information about the constant declaration.
+     *         The format of the return value is:
+     *         ```php
+     *         array(
+     *             'scope'           => string,        // Public, private, or protected.
+     *             'scope_token'     => integer|false, // The stack pointer to the scope keyword or
+     *                                                 // FALSE if the scope was not explicitly specified.
+     *             'is_final'        => boolean,       // TRUE if the final keyword was found.
+     *             'final_token'     => integer|false, // The stack pointer to the final keyword
+     *                                                 // or FALSE if the const is not declared final.
+     *             'type'            => string,        // The type of the const (empty if no type specified).
+     *             'type_token'      => integer|false, // The stack pointer to the start of the type
+     *                                                 // or FALSE if there is no type.
+     *             'type_end_token'  => integer|false, // The stack pointer to the end of the type
+     *                                                 // or FALSE if there is no type.
+     *             'nullable_type'   => boolean,       // TRUE if the type is preceded by the
+     *                                                 // nullability operator.
+     *             'name_token'      => integer,       // The stack pointer to the constant name.
+     *                                                 // Note: for group declarations this points to the
+     *                                                 // name of the first constant.
+     *             'equal_token'     => integer,       // The stack pointer to the equal sign.
+     *                                                 // Note: for group declarations this points to the
+     *                                                 // equal sign of the first constant.
+     *         );
+     *         ```
+     *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_CONST` token.
+     * @throws \PHPCSUtils\Exceptions\ValueError          If the specified position is not an OO constant.
+     */
+    public static function getProperties(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (\is_int($stackPtr) === false) {
+            throw TypeError::create(2, '$stackPtr', 'integer', $stackPtr);
+        }
+
+        if (isset($tokens[$stackPtr]) === false) {
+            throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);
+        }
+
+        if ($tokens[$stackPtr]['code'] !== \T_CONST) {
+            throw UnexpectedTokenType::create(2, '$stackPtr', 'T_CONST', $tokens[$stackPtr]['type']);
+        }
+
+        if (Scopes::isOOConstant($phpcsFile, $stackPtr) === false) {
+            throw ValueError::create(2, '$stackPtr', 'must be the pointer to an OO constant');
+        }
+
+        if (Cache::isCached($phpcsFile, __METHOD__, $stackPtr) === true) {
+            return Cache::get($phpcsFile, __METHOD__, $stackPtr);
+        }
+
+        $find          = [\T_EQUAL, \T_SEMICOLON, \T_OPEN_CURLY_BRACKET, \T_CLOSE_CURLY_BRACKET, \T_CLOSE_TAG];
+        $assignmentPtr = $phpcsFile->findNext($find, ($stackPtr + 1));
+        if ($assignmentPtr === false || $tokens[$assignmentPtr]['code'] !== \T_EQUAL) {
+            // Probably a parse error. Don't cache the result.
+            throw ValueError::create(2, '$stackPtr', 'must be the pointer to an OO constant');
+        }
+
+        $namePtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($assignmentPtr - 1), ($stackPtr + 1), true);
+
+        $returnValue = [
+            'scope'          => 'public',
+            'scope_token'    => false,
+            'is_final'       => false,
+            'final_token'    => false,
+            'type'           => '',
+            'type_token'     => false,
+            'type_end_token' => false,
+            'nullable_type'  => false,
+            'name_token'     => $namePtr,
+            'equal_token'    => $assignmentPtr,
+        ];
+
+        for ($i = ($stackPtr - 1);; $i--) {
+            // Skip over potentially large docblocks.
+            if ($tokens[$i]['code'] === \T_DOC_COMMENT_CLOSE_TAG
+                && isset($tokens[$i]['comment_opener'])
+            ) {
+                $i = $tokens[$i]['comment_opener'];
+                continue;
+            }
+
+            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+                continue;
+            }
+
+            switch ($tokens[$i]['code']) {
+                case \T_PUBLIC:
+                    $returnValue['scope']       = 'public';
+                    $returnValue['scope_token'] = $i;
+                    break;
+
+                case \T_PROTECTED:
+                    $returnValue['scope']       = 'protected';
+                    $returnValue['scope_token'] = $i;
+                    break;
+
+                case \T_PRIVATE:
+                    $returnValue['scope']       = 'private';
+                    $returnValue['scope_token'] = $i;
+                    break;
+
+                case \T_FINAL:
+                    $returnValue['is_final']    = true;
+                    $returnValue['final_token'] = $i;
+                    break;
+
+                default:
+                    // Any other token means that the start of the statement has been reached.
+                    break 2;
+            }
+        }
+
+        $type               = '';
+        $typeToken          = false;
+        $typeEndToken       = false;
+        $constantTypeTokens = Collections::constantTypeTokens();
+
+        // Now, let's check for a type.
+        for ($i = ($stackPtr + 1); $i < $namePtr; $i++) {
+            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+                continue;
+            }
+
+            if ($tokens[$i]['code'] === \T_NULLABLE) {
+                $returnValue['nullable_type'] = true;
+                continue;
+            }
+
+            if (isset($constantTypeTokens[$tokens[$i]['code']]) === true) {
+                $typeEndToken = $i;
+                if ($typeToken === false) {
+                    $typeToken = $i;
+                }
+
+                $type .= $tokens[$i]['content'];
+            }
+        }
+
+        if ($type !== '' && $returnValue['nullable_type'] === true) {
+            $type = '?' . $type;
+        }
+
+        $returnValue['type']           = $type;
+        $returnValue['type_token']     = $typeToken;
+        $returnValue['type_end_token'] = $typeEndToken;
+
+        Cache::set($phpcsFile, __METHOD__, $stackPtr, $returnValue);
+        return $returnValue;
+    }
+}

--- a/Tests/Tokens/Collections/ConstantTypeTokensTest.php
+++ b/Tests/Tokens/Collections/ConstantTypeTokensTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Tokens\Collections;
+
+use PHPCSUtils\Tokens\Collections;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Tokens\Collections::constantTypeTokens
+ *
+ * @group collections
+ *
+ * @since 1.1.0
+ */
+final class ConstantTypeTokensTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testConstantTypeTokens()
+    {
+        $expected = [
+            \T_CALLABLE               => \T_CALLABLE,
+            \T_FALSE                  => \T_FALSE,
+            \T_TRUE                   => \T_TRUE,
+            \T_NULL                   => \T_NULL,
+            \T_TYPE_UNION             => \T_TYPE_UNION,
+            \T_TYPE_INTERSECTION      => \T_TYPE_INTERSECTION,
+            \T_TYPE_OPEN_PARENTHESIS  => \T_TYPE_OPEN_PARENTHESIS,
+            \T_TYPE_CLOSE_PARENTHESIS => \T_TYPE_CLOSE_PARENTHESIS,
+            \T_PARENT                 => \T_PARENT,
+            \T_SELF                   => \T_SELF,
+            \T_STATIC                 => \T_STATIC,
+            \T_NS_SEPARATOR           => \T_NS_SEPARATOR,
+            \T_NAMESPACE              => \T_NAMESPACE,
+            \T_STRING                 => \T_STRING,
+            \T_NAME_QUALIFIED         => \T_NAME_QUALIFIED,
+            \T_NAME_FULLY_QUALIFIED   => \T_NAME_FULLY_QUALIFIED,
+            \T_NAME_RELATIVE          => \T_NAME_RELATIVE,
+        ];
+
+        $this->assertSame($expected, Collections::constantTypeTokens());
+    }
+}

--- a/Tests/Utils/Constants/GetPropertiesParseError1Test.inc
+++ b/Tests/Utils/Constants/GetPropertiesParseError1Test.inc
@@ -1,0 +1,6 @@
+<?php
+
+class LiveCodingParseError {
+    /* testParseErrorMissingName */
+    private const = 0;
+}

--- a/Tests/Utils/Constants/GetPropertiesParseError1Test.php
+++ b/Tests/Utils/Constants/GetPropertiesParseError1Test.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Constants;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\Constants;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Constants::getProperties method.
+ *
+ * @covers \PHPCSUtils\Utils\Constants::getProperties
+ *
+ * @group constants
+ *
+ * @since 1.1.0
+ */
+final class GetPropertiesParseError1Test extends UtilityMethodTestCase
+{
+
+    /**
+     * Test the getProperties() method returns false for the name pointer, when the name is missing.
+     *
+     * @return void
+     */
+    public function testGetProperties()
+    {
+        $const    = $this->getTargetToken('/* testParseErrorMissingName */', \T_CONST);
+        $expected = [
+            'scope'           => 'private',
+            'scope_token'     => ($const - 2),
+            'is_final'        => false,
+            'final_token'     => false,
+            'type'            => '',
+            'type_token'      => false,
+            'type_end_token'  => false,
+            'nullable_type'   => false,
+            'name_token'      => false,
+            'equal_token'     => ($const + 2),
+        ];
+        $result   = Constants::getProperties(self::$phpcsFile, $const);
+
+        $this->assertSame($expected, $result);
+    }
+}

--- a/Tests/Utils/Constants/GetPropertiesParseError2Test.inc
+++ b/Tests/Utils/Constants/GetPropertiesParseError2Test.inc
@@ -1,0 +1,6 @@
+<?php
+
+class LiveCodingParseError {
+    /* testParseErrorLiveCoding */
+    final const false
+}

--- a/Tests/Utils/Constants/GetPropertiesParseError2Test.php
+++ b/Tests/Utils/Constants/GetPropertiesParseError2Test.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Constants;
+
+use PHPCSUtils\Tests\PolyfilledTestCase;
+use PHPCSUtils\Utils\Constants;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Constants::getProperties method.
+ *
+ * @covers \PHPCSUtils\Utils\Constants::getProperties
+ *
+ * @group constants
+ *
+ * @since 1.1.0
+ */
+final class GetPropertiesParseError2Test extends PolyfilledTestCase
+{
+
+    /**
+     * Test receiving an exception when encountering a specific parse error.
+     *
+     * @return void
+     */
+    public function testParseError()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\ValueError');
+        $this->expectExceptionMessage('The value of argument #2 ($stackPtr) must be the pointer to an OO constant');
+
+        $const = $this->getTargetToken('/* testParseErrorLiveCoding */', \T_CONST);
+        Constants::getProperties(self::$phpcsFile, $const);
+    }
+}

--- a/Tests/Utils/Constants/GetPropertiesParseError3Test.inc
+++ b/Tests/Utils/Constants/GetPropertiesParseError3Test.inc
@@ -1,0 +1,5 @@
+<?php
+
+class LiveCodingParseError {
+    /* testParseErrorLiveCoding */
+    private const ?int TYPED_INT = 0;

--- a/Tests/Utils/Constants/GetPropertiesParseError3Test.php
+++ b/Tests/Utils/Constants/GetPropertiesParseError3Test.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Constants;
+
+use PHPCSUtils\Tests\PolyfilledTestCase;
+use PHPCSUtils\Utils\Constants;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Constants::getProperties method.
+ *
+ * @covers \PHPCSUtils\Utils\Constants::getProperties
+ *
+ * @group constants
+ *
+ * @since 1.1.0
+ */
+final class GetPropertiesParseError3Test extends PolyfilledTestCase
+{
+
+    /**
+     * Test receiving an exception when encountering a specific parse error.
+     *
+     * @return void
+     */
+    public function testParseError()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\ValueError');
+        $this->expectExceptionMessage('The value of argument #2 ($stackPtr) must be the pointer to an OO constant');
+
+        $const = $this->getTargetToken('/* testParseErrorLiveCoding */', \T_CONST);
+        Constants::getProperties(self::$phpcsFile, $const);
+    }
+}

--- a/Tests/Utils/Constants/GetPropertiesParseError4Test.inc
+++ b/Tests/Utils/Constants/GetPropertiesParseError4Test.inc
@@ -1,0 +1,6 @@
+<?php
+
+class LiveCodingParseError {
+    /* testParseErrorLiveCoding */
+    final const SOMETHING ?><?php = false;
+}

--- a/Tests/Utils/Constants/GetPropertiesParseError4Test.php
+++ b/Tests/Utils/Constants/GetPropertiesParseError4Test.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Constants;
+
+use PHPCSUtils\Tests\PolyfilledTestCase;
+use PHPCSUtils\Utils\Constants;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Constants::getProperties method.
+ *
+ * @covers \PHPCSUtils\Utils\Constants::getProperties
+ *
+ * @group constants
+ *
+ * @since 1.1.0
+ */
+final class GetPropertiesParseError4Test extends PolyfilledTestCase
+{
+
+    /**
+     * Test receiving an exception when encountering a specific parse error.
+     *
+     * @return void
+     */
+    public function testParseError()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\ValueError');
+        $this->expectExceptionMessage('The value of argument #2 ($stackPtr) must be the pointer to an OO constant');
+
+        $const = $this->getTargetToken('/* testParseErrorLiveCoding */', \T_CONST);
+        Constants::getProperties(self::$phpcsFile, $const);
+    }
+}

--- a/Tests/Utils/Constants/GetPropertiesParseError5Test.inc
+++ b/Tests/Utils/Constants/GetPropertiesParseError5Test.inc
@@ -1,0 +1,6 @@
+<?php
+
+class LiveCodingParseError {
+    /* testParseErrorLiveCoding */
+    final const MISSING_ASSIGNMENT;
+}

--- a/Tests/Utils/Constants/GetPropertiesParseError5Test.php
+++ b/Tests/Utils/Constants/GetPropertiesParseError5Test.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Constants;
+
+use PHPCSUtils\Tests\PolyfilledTestCase;
+use PHPCSUtils\Utils\Constants;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Constants::getProperties method.
+ *
+ * @covers \PHPCSUtils\Utils\Constants::getProperties
+ *
+ * @group constants
+ *
+ * @since 1.1.0
+ */
+final class GetPropertiesParseError5Test extends PolyfilledTestCase
+{
+
+    /**
+     * Test receiving an exception when encountering a specific parse error.
+     *
+     * @return void
+     */
+    public function testParseError()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\ValueError');
+        $this->expectExceptionMessage('The value of argument #2 ($stackPtr) must be the pointer to an OO constant');
+
+        $const = $this->getTargetToken('/* testParseErrorLiveCoding */', \T_CONST);
+        Constants::getProperties(self::$phpcsFile, $const);
+    }
+}

--- a/Tests/Utils/Constants/GetPropertiesTest.inc
+++ b/Tests/Utils/Constants/GetPropertiesTest.inc
@@ -1,0 +1,193 @@
+<?php
+
+/* testNotAConstToken */
+define('FOO', true);
+
+/* testGlobalConstantCannotHaveModifiersOrType */
+const GLOBAL_UNTYPED = true;
+
+class ClassWithTypedConstants {
+
+    public function foo() {
+        /* testConstInMethodIsNotOO */
+        const NOT_OO_CONST = true;
+    }
+
+    /* testNoModifiersNoTypesWithDocblock */
+    /**
+     * Comment here.
+     *
+     * @phpcs:ignore Standard.Category.Sniff -- because
+     * @var boolean
+     */
+    const NO_MODIFIERS_UNTYPED = true;
+
+    /* testFinalNoTypesConstAsName */
+    final const CONST = true;
+
+    /* testPublicNoTypes */
+    public const PUBLIC_UNTYPED = true;
+
+    /* testProtectedNoTypesWithComment */
+    protected /*comment*/ const PROTECTED_UNTYPED = true;
+
+    /* testPrivateNoTypesWithCommentAndWhitespace */
+    private
+        /*comment*/
+        const
+        // phpcs:ignore Stnd.Cat.Sniff -- for reasons.
+        PRIVATE_UNTYPED = true;
+
+    /* testFinalPublicNoTypes */
+    final public const FINAL_PUBLIC_UNTYPED = true;
+
+    /* testProtectedFinalNoTypes */
+    protected final const PROTECTED_FINAL_UNTYPED = true;
+
+    /* testTypedTrue */
+    const true TYPED_TRUE = true;
+
+    /* testTypedFalse */
+    final const false TYPED_FALSE = false;
+
+    /* testTypedNull */
+    public const null TYPED_NULL = null;
+
+    /* testTypedBoolWihComment */
+    final protected const/*comment*/bool TYPED_BOOL = false;
+
+    /* testTypedNullableIntWithDocblock */
+    /**
+     * Comment here.
+     *
+     * @phpcs:ignore Standard.Category.Sniff -- because
+     * @var int|null
+     */
+    private const ?int TYPED_INT = 0;
+
+    /* testTypedFloatWithAttribute */
+    #[ConstantWithAttribute]
+    const float TYPED_FLOAT = 0.5;
+
+    /* testTypedNullableStringWithComment */
+    public /*comment*/ final const ?string/*comment*/TYPED_STRING = 'string';
+
+    /* testTypedArray */
+    private final const array TYPED_ARRAY = [];
+
+    /* testTypedObjectWithExtraWhitespace */
+    const
+        object
+        TYPED_OBJECT
+        // comment.
+        =
+        MyClass::getInstance();
+
+    /* testTypedNullableIterableLowercaseName */
+    const ?iterable typed_iterable = [];
+
+    /* testTypedMixed */
+    const mixed TYPED_MIXED = 'string';
+
+    /* testTypedClassUnqualifiedWithComment */
+    const ? /*comment*/ MyClass TYPED_UNQUALIFIED_CLASSNAME = MyClass::getInstance();
+
+    /* testTypedClassFullyQualifiedWithDocblock */
+    /**
+     * Comment here.
+     *
+     * @phpcs:ignore Standard.Category.Sniff -- because
+     * @var MyClass
+     */
+    public const \MyClass TYPED_FULLY_QUALIFIED_CLASSNAME = MyClass::getInstance();
+
+    /* testTypedClassNamespaceRelative */
+    protected const namespace\MyClass TYPED_NAMESPACE_RELATIVE_CLASSNAME = MyClass::getInstance();
+
+    /* testTypedClassPartiallyQualifiedWithMultipleAttributes */
+    #[PropertyWithAttribute(foo: 'bar'), MyAttribute]
+    private const Partial\MyClass TYPED_PARTIALLY_QUALIFIED_CLASSNAME = MyClass::getInstance();
+
+    /* testTypedNullableParentMessy */
+    const /* comment
+         */ ? //comment
+        parent TYPED_PARENT = parent::getInstance();
+
+    /* testMultiConstSingleLine */
+    public const bool NAME_1 = true, NAME_2 = false;
+
+    /* testMultiConstMultiLine */
+    public const ?array
+        // First constant.
+        NAME_1 = [],
+        // Second constant.
+        NAME_2 = [];
+}
+
+enum EnumWithOOHierarchyTypedConstants {
+    // Illegal types in a class, but legal in an enum.
+    /* testEnumConstTypedSelf */
+    final const self TYPED_SELF = self::getInstance();
+
+    /* testEnumConstTypedNullableStatic */
+    const ?static TYPED_STATIC = static::getInstance();
+}
+
+trait TraitWithNullableTypedConstants {
+    // Illegal types - the fact that these are not allowed in PHP is not the concern of this method.
+    /* testTypedNullableCallable */
+    protected const ?callable TYPED_CALLABLE = 'function_name';
+
+    /* testTypedVoid */
+    final public const void TYPED_VOID = null;
+
+    /* testTypedNever */
+    private const never TYPED_NEVER = null;
+}
+
+interface InterfaceWithUnionTypedConstants {
+    /* testTypedUnionTrueNull */
+    const true|null /*comment*/ UNION_TRUE_NULL = true;
+
+    /* testTypedUnionArrayObjectWithMultilineAttribute */
+    #[
+        PropertyWithAttribute(/* comment */ 'baz')
+    ]
+    final const array|object UNION_ARRAY_OBJECT = [];
+
+    /* testTypedUnionStringArrayInt */
+    const string | array | int UNION_STRING_ARRAY_INT = 'array middle';
+
+    /* testTypedUnionFloatBoolArrayIllegalNullable */
+    public final const ?float /*comment*/| bool|array UNION_FLOAT_BOOL_ARRAY = false;
+
+    /* testTypedUnionIterableFalse */
+    const iterable|false UNION_ITERABLE_FALSE = false;
+
+    /* testTypedUnionUnqualifiedNamespaceRelativeWithWhiteSpaceAndComments */
+    final protected const Unqualified /*comment*/ | namespace\Relative UNION_UNQUALIFIED_NSRELATIVE = new Unqualified();
+
+    /* testTypedUnionFullyQualifiedPartiallyQualified */
+    private /*comment*/ const \Fully\Qualified|Partially\Qualified UNION_FQN_PARTIAL = new Partial\Qualified;
+}
+
+$a = ( $foo == $bar ? new stdClass() :
+    new class {
+        /* testTypedIntersectUnqualifiedNamespaceRelative */
+        final const Unqualified&namespace\Relative UNION_UNQUALIFIED_NSRELATIVE = new Unqualified();
+
+        /* testTypedIntersectFullyQualifiedPartiallyQualified */
+        protected const \Fully\Qualified&Partially\Qualified UNION_FQN_PARTIAL = new Partial\Qualified;
+    }
+);
+
+interface DNFTypes {
+    /* testPHP82DNFType */
+    protected const float|(Partially\Qualified&Traversable) DNF_PROTECTED = 1.5;
+
+    /* testPHP82DNFTypeWithWhiteSpaceAndComment */
+    public final const ( Unqualified & namespace\Relative ) /*comment*/ | bool DNF_PUBLIC_FINAL = true;
+
+    /* testPHP82DNFTypeIllegalNullable */
+    const ?(A&\Pck\B)|bool DNF_ILLEGAL_NULLABLE = null;
+}

--- a/Tests/Utils/Constants/GetPropertiesTest.php
+++ b/Tests/Utils/Constants/GetPropertiesTest.php
@@ -1,0 +1,851 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\Constants;
+
+use PHPCSUtils\Internal\Cache;
+use PHPCSUtils\Tests\PolyfilledTestCase;
+use PHPCSUtils\Utils\Constants;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\Constants::getProperties method.
+ *
+ * @covers \PHPCSUtils\Utils\Constants::getProperties
+ *
+ * @group constants
+ *
+ * @since 1.1.0
+ */
+final class GetPropertiesTest extends PolyfilledTestCase
+{
+
+    /**
+     * Test receiving an exception when passing a non-integer token pointer.
+     *
+     * @return void
+     */
+    public function testNonIntegerToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, boolean given');
+
+        Constants::getProperties(self::$phpcsFile, false);
+    }
+
+    /**
+     * Test receiving an exception when passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object, 100000 given'
+        );
+
+        Constants::getProperties(self::$phpcsFile, 100000);
+    }
+
+    /**
+     * Test receiving an expected exception when a non const token is passed.
+     *
+     * @return void
+     */
+    public function testNotAConstException()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type T_CONST;');
+
+        $define = $this->getTargetToken('/* testNotAConstToken */', \T_STRING);
+        Constants::getProperties(self::$phpcsFile, $define);
+    }
+
+    /**
+     * Test receiving an expected exception when a non OO constant is passed.
+     *
+     * @dataProvider dataNotOOConstantException
+     *
+     * @param string $identifier Comment which precedes the test case.
+     *
+     * @return void
+     */
+    public function testNotOOConstantException($identifier)
+    {
+        $this->expectException('PHPCSUtils\Exceptions\ValueError');
+        $this->expectExceptionMessage('The value of argument #2 ($stackPtr) must be the pointer to an OO constant');
+
+        $const = $this->getTargetToken($identifier, \T_CONST);
+        Constants::getProperties(self::$phpcsFile, $const);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNotOOConstantException()
+     *
+     * @return array<string, array<string>>
+     */
+    public static function dataNotOOConstantException()
+    {
+        return [
+            'global constant'                          => ['/* testGlobalConstantCannotHaveModifiersOrType */'],
+            'constant declared in OO method (illegal)' => ['/* testConstInMethodIsNotOO */'],
+        ];
+    }
+
+    /**
+     * Test the getProperties() method.
+     *
+     * @dataProvider dataGetProperties
+     *
+     * @param string                         $identifier Comment which precedes the test case.
+     * @param array<string, string|int|bool> $expected   Expected function output.
+     *
+     * @return void
+     */
+    public function testGetProperties($identifier, $expected)
+    {
+        $const    = $this->getTargetToken($identifier, \T_CONST);
+        $expected = $this->updateExpectedTokenPositions($const, $expected);
+        $result   = Constants::getProperties(self::$phpcsFile, $const);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * Note: all indexes containing token positions should contain either `false` (no position)
+     * or the _offset_ of the token in relation to the `T_CONST` token which is passed
+     * to the getProperties() method.
+     *
+     * @see testGetProperties()
+     *
+     * @return array<string, array<string|array<string, string|int|bool>>>
+     */
+    public static function dataGetProperties()
+    {
+        $php8Names = parent::usesPhp8NameTokens();
+
+        return [
+            'no modifiers, no type, with docblock' => [
+                'identifier' => '/* testNoModifiersNoTypesWithDocblock */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => false,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
+                    'nullable_type'   => false,
+                    'name_token'      => 2,
+                    'equal_token'     => 4,
+                ],
+            ],
+
+            // Testing modifier keyword recognition.
+            'final, no type' => [
+                'identifier' => '/* testFinalNoTypesConstAsName */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => false,
+                    'is_final'        => true,
+                    'final_token'     => -2,
+                    'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
+                    'nullable_type'   => false,
+                    'name_token'      => 2,
+                    'equal_token'     => 4,
+                ],
+            ],
+            'public, no type' => [
+                'identifier' => '/* testPublicNoTypes */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => -2,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
+                    'nullable_type'   => false,
+                    'name_token'      => 2,
+                    'equal_token'     => 4,
+                ],
+            ],
+            'protected, no type, with comment' => [
+                'identifier' => '/* testProtectedNoTypesWithComment */',
+                'expected'   => [
+                    'scope'           => 'protected',
+                    'scope_token'     => -4,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
+                    'nullable_type'   => false,
+                    'name_token'      => 2,
+                    'equal_token'     => 4,
+                ],
+            ],
+            'private, no type, comments and whitespace' => [
+                'identifier' => '/* testPrivateNoTypesWithCommentAndWhitespace */',
+                'expected'   => [
+                    'scope'           => 'private',
+                    'scope_token'     => -6,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
+                    'nullable_type'   => false,
+                    'name_token'      => 5,
+                    'equal_token'     => 7,
+                ],
+            ],
+            'final public, no type' => [
+                'identifier' => '/* testFinalPublicNoTypes */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => -2,
+                    'is_final'        => true,
+                    'final_token'     => -4,
+                    'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
+                    'nullable_type'   => false,
+                    'name_token'      => 2,
+                    'equal_token'     => 4,
+                ],
+            ],
+            'protected final, no type' => [
+                'identifier' => '/* testProtectedFinalNoTypes */',
+                'expected'   => [
+                    'scope'           => 'protected',
+                    'scope_token'     => -4,
+                    'is_final'        => true,
+                    'final_token'     => -2,
+                    'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
+                    'nullable_type'   => false,
+                    'name_token'      => 2,
+                    'equal_token'     => 4,
+                ],
+            ],
+
+            // Testing typed constants.
+            'no modifiers, typed: true' => [
+                'identifier' => '/* testTypedTrue */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => false,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => 'true',
+                    'type_token'      => 2,
+                    'type_end_token'  => 2,
+                    'nullable_type'   => false,
+                    'name_token'      => 4,
+                    'equal_token'     => 6,
+                ],
+            ],
+            'final, typed: false' => [
+                'identifier' => '/* testTypedFalse */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => false,
+                    'is_final'        => true,
+                    'final_token'     => -2,
+                    'type'            => 'false',
+                    'type_token'      => 2,
+                    'type_end_token'  => 2,
+                    'nullable_type'   => false,
+                    'name_token'      => 4,
+                    'equal_token'     => 6,
+                ],
+            ],
+            'public, typed: null' => [
+                'identifier' => '/* testTypedNull */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => -2,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => 'null',
+                    'type_token'      => 2,
+                    'type_end_token'  => 2,
+                    'nullable_type'   => false,
+                    'name_token'      => 4,
+                    'equal_token'     => 6,
+                ],
+            ],
+            'final protected, typed: bool, with comment' => [
+                'identifier' => '/* testTypedBoolWihComment */',
+                'expected'   => [
+                    'scope'           => 'protected',
+                    'scope_token'     => -2,
+                    'is_final'        => true,
+                    'final_token'     => -4,
+                    'type'            => 'bool',
+                    'type_token'      => 2,
+                    'type_end_token'  => 2,
+                    'nullable_type'   => false,
+                    'name_token'      => 4,
+                    'equal_token'     => 6,
+                ],
+            ],
+            'private, typed: ?int, with docblock' => [
+                'identifier' => '/* testTypedNullableIntWithDocblock */',
+                'expected'   => [
+                    'scope'           => 'private',
+                    'scope_token'     => -2,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => '?int',
+                    'type_token'      => 3,
+                    'type_end_token'  => 3,
+                    'nullable_type'   => true,
+                    'name_token'      => 5,
+                    'equal_token'     => 7,
+                ],
+            ],
+            'no modifiers, typed: float, with attribute' => [
+                'identifier' => '/* testTypedFloatWithAttribute */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => false,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => 'float',
+                    'type_token'      => 2,
+                    'type_end_token'  => 2,
+                    'nullable_type'   => false,
+                    'name_token'      => 4,
+                    'equal_token'     => 6,
+                ],
+            ],
+            'public final, typed: ?string, with comment' => [
+                'identifier' => '/* testTypedNullableStringWithComment */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => -6,
+                    'is_final'        => true,
+                    'final_token'     => -2,
+                    'type'            => '?string',
+                    'type_token'      => 3,
+                    'type_end_token'  => 3,
+                    'nullable_type'   => true,
+                    'name_token'      => 5,
+                    'equal_token'     => 7,
+                ],
+            ],
+            'private final, typed: array' => [
+                'identifier' => '/* testTypedArray */',
+                'expected'   => [
+                    'scope'           => 'private',
+                    'scope_token'     => -4,
+                    'is_final'        => true,
+                    'final_token'     => -2,
+                    'type'            => 'array',
+                    'type_token'      => 2,
+                    'type_end_token'  => 2,
+                    'nullable_type'   => false,
+                    'name_token'      => 4,
+                    'equal_token'     => 6,
+                ],
+            ],
+            'no modifiers, typed: object, extra whitespace' => [
+                'identifier' => '/* testTypedObjectWithExtraWhitespace */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => false,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => 'object',
+                    'type_token'      => 3,
+                    'type_end_token'  => 3,
+                    'nullable_type'   => false,
+                    'name_token'      => 6,
+                    'equal_token'     => 11,
+                ],
+            ],
+            'no modifiers, typed: ?iterable, lowercase constant name' => [
+                'identifier' => '/* testTypedNullableIterableLowercaseName */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => false,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => '?iterable',
+                    'type_token'      => 3,
+                    'type_end_token'  => 3,
+                    'nullable_type'   => true,
+                    'name_token'      => 5,
+                    'equal_token'     => 7,
+                ],
+            ],
+            'no modifiers, typed: mixed' => [
+                'identifier' => '/* testTypedMixed */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => false,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => 'mixed',
+                    'type_token'      => 2,
+                    'type_end_token'  => 2,
+                    'nullable_type'   => false,
+                    'name_token'      => 4,
+                    'equal_token'     => 6,
+                ],
+            ],
+            'no modifiers, typed: nullable unqualified name, comment in type' => [
+                'identifier' => '/* testTypedClassUnqualifiedWithComment */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => false,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => '?MyClass',
+                    'type_token'      => 6,
+                    'type_end_token'  => 6,
+                    'nullable_type'   => true,
+                    'name_token'      => 8,
+                    'equal_token'     => 10,
+                ],
+            ],
+            'public, typed: fully qualified name, with docblock' => [
+                'identifier' => '/* testTypedClassFullyQualifiedWithDocblock */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => -2,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => '\MyClass',
+                    'type_token'      => 2,
+                    'type_end_token'  => ($php8Names === true) ? 2 : 3,
+                    'nullable_type'   => false,
+                    'name_token'      => ($php8Names === true) ? 4 : 5,
+                    'equal_token'     => ($php8Names === true) ? 6 : 7,
+                ],
+            ],
+            'protected, typed: namespace relative name' => [
+                'identifier' => '/* testTypedClassNamespaceRelative */',
+                'expected'   => [
+                    'scope'           => 'protected',
+                    'scope_token'     => -2,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => 'namespace\MyClass',
+                    'type_token'      => 2,
+                    'type_end_token'  => ($php8Names === true) ? 2 : 4,
+                    'nullable_type'   => false,
+                    'name_token'      => ($php8Names === true) ? 4 : 6,
+                    'equal_token'     => ($php8Names === true) ? 6 : 8,
+                ],
+            ],
+            'private, typed: partially qualified, with multi-attribute' => [
+                'identifier' => '/* testTypedClassPartiallyQualifiedWithMultipleAttributes */',
+                'expected'   => [
+                    'scope'           => 'private',
+                    'scope_token'     => -2,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => 'Partial\MyClass',
+                    'type_token'      => 2,
+                    'type_end_token'  => ($php8Names === true) ? 2 : 4,
+                    'nullable_type'   => false,
+                    'name_token'      => ($php8Names === true) ? 4 : 6,
+                    'equal_token'     => ($php8Names === true) ? 6 : 8,
+                ],
+            ],
+            'no modifiers, typed: ?parent, with comments, messy' => [
+                'identifier' => '/* testTypedNullableParentMessy */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => false,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => '?parent',
+                    'type_token'      => 9,
+                    'type_end_token'  => 9,
+                    'nullable_type'   => true,
+                    'name_token'      => 11,
+                    'equal_token'     => 13,
+                ],
+            ],
+            'public, typed: bool, multi-constant, single line' => [
+                'identifier' => '/* testMultiConstSingleLine */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => -2,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => 'bool',
+                    'type_token'      => 2,
+                    'type_end_token'  => 2,
+                    'nullable_type'   => false,
+                    'name_token'      => 4,
+                    'equal_token'     => 6,
+                ],
+            ],
+            'public, typed: ?array, multi-constant, multi-line' => [
+                'identifier' => '/* testMultiConstMultiLine */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => -2,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => '?array',
+                    'type_token'      => 3,
+                    'type_end_token'  => 3,
+                    'nullable_type'   => true,
+                    'name_token'      => 8,
+                    'equal_token'     => 10,
+                ],
+            ],
+
+            // Types which are only legal in enums.
+            'final, typed: self' => [
+                'identifier' => '/* testEnumConstTypedSelf */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => false,
+                    'is_final'        => true,
+                    'final_token'     => -2,
+                    'type'            => 'self',
+                    'type_token'      => 2,
+                    'type_end_token'  => 2,
+                    'nullable_type'   => false,
+                    'name_token'      => 4,
+                    'equal_token'     => 6,
+                ],
+            ],
+            'no modifiers, typed: static' => [
+                'identifier' => '/* testEnumConstTypedNullableStatic */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => false,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => '?static',
+                    'type_token'      => 3,
+                    'type_end_token'  => 3,
+                    'nullable_type'   => true,
+                    'name_token'      => 5,
+                    'equal_token'     => 7,
+                ],
+            ],
+
+            // Illegal types, but that's not the concern of this method.
+            'protected, typed: ?callable (not supported in PHP)' => [
+                'identifier' => '/* testTypedNullableCallable */',
+                'expected'   => [
+                    'scope'           => 'protected',
+                    'scope_token'     => -2,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => '?callable',
+                    'type_token'      => 3,
+                    'type_end_token'  => 3,
+                    'nullable_type'   => true,
+                    'name_token'      => 5,
+                    'equal_token'     => 7,
+                ],
+            ],
+            'final public, typed: void (not supported in PHP)' => [
+                'identifier' => '/* testTypedVoid */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => -2,
+                    'is_final'        => true,
+                    'final_token'     => -4,
+                    'type'            => 'void',
+                    'type_token'      => 2,
+                    'type_end_token'  => 2,
+                    'nullable_type'   => false,
+                    'name_token'      => 4,
+                    'equal_token'     => 6,
+                ],
+            ],
+            'private, typed: never (not supported in PHP)' => [
+                'identifier' => '/* testTypedNever */',
+                'expected'   => [
+                    'scope'           => 'private',
+                    'scope_token'     => -2,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => 'never',
+                    'type_token'      => 2,
+                    'type_end_token'  => 2,
+                    'nullable_type'   => false,
+                    'name_token'      => 4,
+                    'equal_token'     => 6,
+                ],
+            ],
+
+            // Union types.
+            'no modifiers, typed: true|null' => [
+                'identifier' => '/* testTypedUnionTrueNull */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => false,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => 'true|null',
+                    'type_token'      => 2,
+                    'type_end_token'  => 4,
+                    'nullable_type'   => false,
+                    'name_token'      => 8,
+                    'equal_token'     => 10,
+                ],
+            ],
+            'final, typed: array|object, with multi-line atribute' => [
+                'identifier' => '/* testTypedUnionArrayObjectWithMultilineAttribute */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => false,
+                    'is_final'        => true,
+                    'final_token'     => -2,
+                    'type'            => 'array|object',
+                    'type_token'      => 2,
+                    'type_end_token'  => 4,
+                    'nullable_type'   => false,
+                    'name_token'      => 6,
+                    'equal_token'     => 8,
+                ],
+            ],
+            'no modifiers, typed: string|array|int, with whitespace in type' => [
+                'identifier' => '/* testTypedUnionStringArrayInt */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => false,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => 'string|array|int',
+                    'type_token'      => 2,
+                    'type_end_token'  => 10,
+                    'nullable_type'   => false,
+                    'name_token'      => 12,
+                    'equal_token'     => 14,
+                ],
+            ],
+            'public final, typed: ?float|bool|array, illegal nullable union type' => [
+                'identifier' => '/* testTypedUnionFloatBoolArrayIllegalNullable */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => -4,
+                    'is_final'        => true,
+                    'final_token'     => -2,
+                    'type'            => '?float|bool|array',
+                    'type_token'      => 3,
+                    'type_end_token'  => 10,
+                    'nullable_type'   => true,
+                    'name_token'      => 12,
+                    'equal_token'     => 14,
+                ],
+            ],
+            'no modifiers, typed: iterable|false' => [
+                'identifier' => '/* testTypedUnionIterableFalse */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => false,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => 'iterable|false',
+                    'type_token'      => 2,
+                    'type_end_token'  => 4,
+                    'nullable_type'   => false,
+                    'name_token'      => 6,
+                    'equal_token'     => 8,
+                ],
+            ],
+            'final protected, typed: Unqualified|namespace\Relative, with whitespace and comments in type' => [
+                'identifier' => '/* testTypedUnionUnqualifiedNamespaceRelativeWithWhiteSpaceAndComments */',
+                'expected'   => [
+                    'scope'           => 'protected',
+                    'scope_token'     => -2,
+                    'is_final'        => true,
+                    'final_token'     => -4,
+                    'type'            => 'Unqualified|namespace\Relative',
+                    'type_token'      => 2,
+                    'type_end_token'  => ($php8Names === true) ? 8 : 10,
+                    'nullable_type'   => false,
+                    'name_token'      => ($php8Names === true) ? 10 : 12,
+                    'equal_token'     => ($php8Names === true) ? 12 : 14,
+                ],
+            ],
+            'private, typed: \Fully\Qualified|Partially\Qualified' => [
+                'identifier' => '/* testTypedUnionFullyQualifiedPartiallyQualified */',
+                'expected'   => [
+                    'scope'           => 'private',
+                    'scope_token'     => -4,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => '\Fully\Qualified|Partially\Qualified',
+                    'type_token'      => 2,
+                    'type_end_token'  => ($php8Names === true) ? 4 : 9,
+                    'nullable_type'   => false,
+                    'name_token'      => ($php8Names === true) ? 6 : 11,
+                    'equal_token'     => ($php8Names === true) ? 8 : 13,
+                ],
+            ],
+
+            // Intersection types.
+            'final, typed: Unqualified|namespace\Relative, with whitespace and comments in type' => [
+                'identifier' => '/* testTypedIntersectUnqualifiedNamespaceRelative */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => false,
+                    'is_final'        => true,
+                    'final_token'     => -2,
+                    'type'            => 'Unqualified&namespace\Relative',
+                    'type_token'      => 2,
+                    'type_end_token'  => ($php8Names === true) ? 4 : 6,
+                    'nullable_type'   => false,
+                    'name_token'      => ($php8Names === true) ? 6 : 8,
+                    'equal_token'     => ($php8Names === true) ? 8 : 10,
+                ],
+            ],
+            'protected, typed: \Fully\Qualified|Partially\Qualified' => [
+                'identifier' => '/* testTypedIntersectFullyQualifiedPartiallyQualified */',
+                'expected'   => [
+                    'scope'           => 'protected',
+                    'scope_token'     => -2,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => '\Fully\Qualified&Partially\Qualified',
+                    'type_token'      => 2,
+                    'type_end_token'  => ($php8Names === true) ? 4 : 9,
+                    'nullable_type'   => false,
+                    'name_token'      => ($php8Names === true) ? 6 : 11,
+                    'equal_token'     => ($php8Names === true) ? 8 : 13,
+                ],
+            ],
+
+            // DNF types.
+            'protected, DNF typed: float|(Partially\Qualified&Traversable)' => [
+                'identifier' => '/* testPHP82DNFType */',
+                'expected'   => [
+                    'scope'           => 'protected',
+                    'scope_token'     => -2,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => 'float|(Partially\Qualified&Traversable)',
+                    'type_token'      => 2,
+                    'type_end_token'  => ($php8Names === true) ? 8 : 10,
+                    'nullable_type'   => false,
+                    'name_token'      => ($php8Names === true) ? 10 : 12,
+                    'equal_token'     => ($php8Names === true) ? 12 : 14,
+                ],
+            ],
+            'public final, DNF typed: (Unqualified&namespace\Relative)|bool, with whitespace and comments in type' => [
+                'identifier' => '/* testPHP82DNFTypeWithWhiteSpaceAndComment */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => -4,
+                    'is_final'        => true,
+                    'final_token'     => -2,
+                    'type'            => '(Unqualified&namespace\Relative)|bool',
+                    'type_token'      => 2,
+                    'type_end_token'  => ($php8Names === true) ? 16 : 18,
+                    'nullable_type'   => false,
+                    'name_token'      => ($php8Names === true) ? 18 : 20,
+                    'equal_token'     => ($php8Names === true) ? 20 : 22,
+                ],
+            ],
+            'no modifiers, DNF typed: ?(A&\Pck\B)|bool, with whitespace and comments in type' => [
+                'identifier' => '/* testPHP82DNFTypeIllegalNullable */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_token'     => false,
+                    'is_final'        => false,
+                    'final_token'     => false,
+                    'type'            => '?(A&\Pck\B)|bool',
+                    'type_token'      => 3,
+                    'type_end_token'  => ($php8Names === true) ? 9 : 12,
+                    'nullable_type'   => true,
+                    'name_token'      => ($php8Names === true) ? 11 : 14,
+                    'equal_token'     => ($php8Names === true) ? 13 : 16,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Verify that the build-in caching is used when caching is enabled.
+     *
+     * @return void
+     */
+    public function testResultIsCached()
+    {
+        $methodName = 'PHPCSUtils\\Utils\\Constants::getProperties';
+        $cases      = self::dataGetProperties();
+        $identifier = $cases['public final, typed: ?float|bool|array, illegal nullable union type']['identifier'];
+        $expected   = $cases['public final, typed: ?float|bool|array, illegal nullable union type']['expected'];
+
+        $const    = $this->getTargetToken($identifier, \T_CONST);
+        $expected = $this->updateExpectedTokenPositions($const, $expected);
+
+        // Verify the caching works.
+        $origStatus     = Cache::$enabled;
+        Cache::$enabled = true;
+
+        $resultFirstRun  = Constants::getProperties(self::$phpcsFile, $const);
+        $isCached        = Cache::isCached(self::$phpcsFile, $methodName, $const);
+        $resultSecondRun = Constants::getProperties(self::$phpcsFile, $const);
+
+        if ($origStatus === false) {
+            Cache::clear();
+        }
+        Cache::$enabled = $origStatus;
+
+        $this->assertSame($expected, $resultFirstRun, 'First result did not match expectation');
+        $this->assertTrue($isCached, 'Cache::isCached() could not find the cached value');
+        $this->assertSame($resultFirstRun, $resultSecondRun, 'Second result did not match first');
+    }
+
+    /**
+     * Test helper to translate token offsets to absolute positions in an "expected" array.
+     *
+     * @param int                            $targetPtr The token pointer to the target token from which
+     *                                                  the offset is calculated.
+     * @param array<string, string|int|bool> $expected  The expected function output containing offsets.
+     *
+     * @return array<string, string|int|bool>
+     */
+    private function updateExpectedTokenPositions($targetPtr, $expected)
+    {
+        if (\is_int($expected['scope_token']) === true) {
+            $expected['scope_token'] += $targetPtr;
+        }
+        if (\is_int($expected['final_token']) === true) {
+            $expected['final_token'] += $targetPtr;
+        }
+        if (\is_int($expected['type_token']) === true) {
+            $expected['type_token'] += $targetPtr;
+        }
+        if (\is_int($expected['type_end_token']) === true) {
+            $expected['type_end_token'] += $targetPtr;
+        }
+        if (\is_int($expected['name_token']) === true) {
+            $expected['name_token'] += $targetPtr;
+        }
+        if (\is_int($expected['equal_token'])) {
+            $expected['equal_token'] += $targetPtr;
+        }
+
+        return $expected;
+    }
+}


### PR DESCRIPTION
### ✨ New Collections::constantTypeTokens() method

PHP 8.3 adds support for typed OO constants.

This collection contains all the tokens which can be encountered in a constant type.

Note: along the same lines as for property/parameter/return type declarations, the collection does not include the `T_NULLABLE` token.

Ref: https://wiki.php.net/rfc/typed_class_constants#supported_types

### ✨ New PHPCSUtils\Utils\Constants class

... to contain utilities methods for analysing constants declared using the `const` keyword.

In the future, the scope of the methods might be expanded to also covered constants declared using `define()`, but that's for later.

Initially, the class comes with the following method:
* `getProperties(File $phpcsFile, $stackPtr): array` to retrieve an array of information about a constant declaration, like the visibility, whether visibility was explicitly declared, whether the constant was declared as final, what the type is for the constant etc.

Includes extensive unit tests.