### PR TITLE
Set `nullable_type` = `true` when type is nullable

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -242,6 +242,10 @@ final class BCFile
                 }
             }
 
+            if ($tokens[$i]['code'] === \T_NULL) {
+                $nullableType = true;
+            }
+
             switch ($tokens[$i]['code']) {
                 case T_ATTRIBUTE:
                     $hasAttributes = true;

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -452,6 +452,10 @@ final class FunctionDeclarations
                     $typeHintToken = $i;
                 }
 
+                if ($tokens[$i]['code'] === \T_NULL) {
+                    $nullableType = true;
+                }
+
                 $typeHint        .= $tokens[$i]['content'];
                 $typeHintEndToken = $i;
                 continue;
@@ -600,6 +604,12 @@ final class FunctionDeclarations
                     }
 
                     $i = ($j - 1);
+
+                    $defaultValue = GetTokensAsString::noEmpties($phpcsFile, $equalToken + 1, $i);
+                    if (strtolower($defaultValue) === 'null') {
+                        $nullableType = true;
+                    }
+
                     break;
             }
         }

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
@@ -319,6 +319,15 @@ function() use(
 /* testInvalidUse */
 function() use {}; // Intentional parse error.
 
+/* testUnionWithNull */
+function unionWithNull(
+    A|null $one,
+    B|C|null $two,
+    null|D $three,
+    E|null|F $four,
+    A|B $five = null
+) {}
+
 /* testArrowFunctionLiveCoding */
 // Intentional parse error. This has to be the last test in the file.
 $fn = fn

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -1413,7 +1413,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'type_hint'           => 'float|null',
             'type_hint_token'     => 4,
             'type_hint_end_token' => 6,
-            'nullable_type'       => false,
+            'nullable_type'       => true,
             'comma_token'         => 10,
         ];
         $expected[1] = [
@@ -1517,7 +1517,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'type_hint'           => 'array|bool|callable|int|float|null|object|string',
             'type_hint_token'     => 4,
             'type_hint_end_token' => 18,
-            'nullable_type'       => false,
+            'nullable_type'       => true,
             'comma_token'         => false,
         ];
 
@@ -1606,7 +1606,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'type_hint'           => 'null',
             'type_hint_token'     => 4,
             'type_hint_end_token' => 4,
-            'nullable_type'       => false,
+            'nullable_type'       => true,
             'comma_token'         => false,
         ];
 
@@ -1825,7 +1825,7 @@ class GetMethodParametersTest extends UtilityMethodTestCase
             'type_hint'           => '',
             'type_hint_token'     => false,
             'type_hint_end_token' => false,
-            'nullable_type'       => false,
+            'nullable_type'       => true,
             'property_visibility' => 'private',
             'visibility_token'    => 26,
             'property_readonly'   => false,

--- a/Tests/Utils/FunctionDeclarations/GetParametersTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersTest.php
@@ -104,6 +104,98 @@ final class GetParametersTest extends BCFile_GetMethodParametersTest
     }
 
     /**
+     * Verify union parameter types including null work as expected.
+     *
+     * @return void
+     */
+    public function testUnionWithNull()
+    {
+        // Offsets are relative to the T_FUNCTION token.
+        $expected = [
+            [
+                'token'               => 10,
+                'name'                => '$one',
+                'content'             => 'A|null $one',
+                'has_attributes'      => false,
+                'pass_by_reference'   => false,
+                'reference_token'     => false,
+                'variable_length'     => false,
+                'variadic_token'      => false,
+                'type_hint'           => 'A|null',
+                'type_hint_token'     => 6,
+                'type_hint_end_token' => 8,
+                'nullable_type'       => true,
+                'comma_token'         => 11,
+            ],
+            [
+                'token'               => 20,
+                'name'                => '$two',
+                'content'             => 'B|C|null $two',
+                'has_attributes'      => false,
+                'pass_by_reference'   => false,
+                'reference_token'     => false,
+                'variable_length'     => false,
+                'variadic_token'      => false,
+                'type_hint'           => 'B|C|null',
+                'type_hint_token'     => 14,
+                'type_hint_end_token' => 18,
+                'nullable_type'       => true,
+                'comma_token'         => 21,
+            ],
+            [
+                'token'               => 28,
+                'name'                => '$three',
+                'content'             => 'null|D $three',
+                'has_attributes'      => false,
+                'pass_by_reference'   => false,
+                'reference_token'     => false,
+                'variable_length'     => false,
+                'variadic_token'      => false,
+                'type_hint'           => 'null|D',
+                'type_hint_token'     => 24,
+                'type_hint_end_token' => 26,
+                'nullable_type'       => true,
+                'comma_token'         => 29,
+            ],
+            [
+                'token'               => 38,
+                'name'                => '$four',
+                'content'             => 'E|null|F $four',
+                'has_attributes'      => false,
+                'pass_by_reference'   => false,
+                'reference_token'     => false,
+                'variable_length'     => false,
+                'variadic_token'      => false,
+                'type_hint'           => 'E|null|F',
+                'type_hint_token'     => 32,
+                'type_hint_end_token' => 36,
+                'nullable_type'       => true,
+                'comma_token'         => 39,
+            ],
+            [
+                'token'               => 46,
+                'name'                => '$five',
+                'content'             => 'A|B $five = null',
+                'default'             => 'null',
+                'default_token'       => 50,
+                'default_equal_token' => 48,
+                'has_attributes'      => false,
+                'pass_by_reference'   => false,
+                'reference_token'     => false,
+                'variable_length'     => false,
+                'variadic_token'      => false,
+                'type_hint'           => 'A|B',
+                'type_hint_token'     => 42,
+                'type_hint_end_token' => 44,
+                'nullable_type'       => true,
+                'comma_token'         => false,
+            ],
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Test helper.
      *
      * @param string                                     $marker     The comment which preceeds the test.


### PR DESCRIPTION
I've been down a rabbit hole today. I started with https://github.com/PHPCompatibility/PHPCompatibility/pull/1689 and ended up here setting `nullable_type` to `true` when a type is allowed to be null.