### PR TITLE
PHP 8.4 | BackCompat\Helper: fix implicitly nullable types deprecation notice

### DIFF
--- a/PHPCSUtils/BackCompat/Helper.php
+++ b/PHPCSUtils/BackCompat/Helper.php
@@ -143,13 +143,14 @@ final class Helper
      * command-line or the ruleset.
      *
      * @since 1.0.0
+     * @since 1.0.10 The `File` type declaration has been removed from the parameter declaration.
      *
      * @param \PHP_CodeSniffer\Files\File|null $phpcsFile Optional. The current file being processed.
      *
      * @return string Encoding. Defaults to the PHPCS native default, which is 'utf-8'
      *                for PHPCS 3.x.
      */
-    public static function getEncoding(File $phpcsFile = null)
+    public static function getEncoding($phpcsFile = null)
     {
         $default = 'utf-8';
 
@@ -176,14 +177,18 @@ final class Helper
      * Check whether the "--ignore-annotations" option is in effect.
      *
      * @since 1.0.0
+     * @since 1.0.10 The `File` type declaration has been removed from the parameter declaration.
      *
      * @param \PHP_CodeSniffer\Files\File|null $phpcsFile Optional. The current file being processed.
      *
      * @return bool `TRUE` if annotations should be ignored, `FALSE` otherwise.
      */
-    public static function ignoreAnnotations(File $phpcsFile = null)
+    public static function ignoreAnnotations($phpcsFile = null)
     {
-        if (isset($phpcsFile, $phpcsFile->config->annotations)) {
+        if (isset($phpcsFile)
+            && $phpcsFile instanceof File
+            && isset($phpcsFile->config->annotations)
+        ) {
             return ! $phpcsFile->config->annotations;
         }
 

--- a/Tests/BackCompat/Helper/GetCommandLineDataTest.php
+++ b/Tests/BackCompat/Helper/GetCommandLineDataTest.php
@@ -12,6 +12,7 @@ namespace PHPCSUtils\Tests\BackCompat\Helper;
 
 use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use stdClass;
 
 /**
  * Test class.
@@ -197,6 +198,30 @@ final class GetCommandLineDataTest extends UtilityMethodTestCase
 
         // Restore defaults before moving to the next test.
         self::$phpcsFile->config->restoreDefaults();
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test the ignoreAnnotations() method.
+     *
+     * @covers ::ignoreAnnotations
+     *
+     * @return void
+     */
+    public function testIgnoreAnnotationsUsesGetConfigDataWhenInvalidFileParamPassed()
+    {
+        $config = null;
+        if (isset(self::$phpcsFile->config) === true) {
+            $config = self::$phpcsFile->config;
+        }
+
+        Helper::setConfigData('annotations', false, true, $config);
+
+        $result = Helper::ignoreAnnotations(new stdClass());
+
+        // Restore defaults before moving to the next test.
+        Helper::setConfigData('annotations', true, true, $config);
 
         $this->assertTrue($result);
     }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -74,6 +74,7 @@ parameters:
         -
             message: '`^Parameter #[0-9]+ \$\S+ of static method PHPCSUtils\\(?!Tests)[A-Za-z]+\\[A-Za-z]+::[A-Za-z]+\(\) expects [^,]+, \S+ given\.$`'
             paths:
+                - Tests/BackCompat/Helper/GetCommandLineDataTest.php
                 - Tests/BackCompat/BCFile/GetTokensAsStringTest.php
                 - Tests/Exceptions/TestTargetNotFound/TestTargetNotFoundTest.php
                 - Tests/Fixers/SpacesFixer/SpacesFixerExceptionsTest.php


### PR DESCRIPTION
The `$phpcsFile` parameter is optional for the `getEncoding()` and the `ignoreAnnotations()` method, but the type declaration cannot be made nullable as the minimum supported PHP version of this package is PHP 5.4, while PHP 7.1 is needed for the nullable operator.

Removing the `File` type declaration effectively widens the type to `mixed`, which fixes the deprecation notice.

As the class is `final`, this change does not constitute a BC-break.

Ref: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types