### PR TITLE
IsReferenceTest: fix invalid test case

### DIFF
--- a/Tests/BackCompat/BCFile/IsReferenceTest.inc
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.inc
@@ -169,7 +169,7 @@ functionCall( $something , &new Foobar() );
 $closure = function() use (&$var){};
 
 /* testUseByReferenceWithCommentFirstParam */
-$closure = function() use /*comment*/ (&$this->value){};
+$closure = function() use /*comment*/ (&$value){};
 
 /* testUseByReferenceWithCommentSecondParam */
 $closure = function() use /*comment*/ ($varA, &$varB){};


### PR DESCRIPTION
Sister-PR to PHPCSStandards/PHP_CodeSniffer#426

Closures use clauses only take plain variables, not complex variables, like properties or array keys.

In other words, this test case as-is, was a parse error.

For the purposes of this test, it makes no difference what type of variable is passed, so let's fix the test.