### PR TITLE
GH Actions: update markdown lint workflow

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -118,24 +118,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # This action also handles the caching of the dependencies.
-      # https://github.com/actions/setup-node
-      - name: Set up node and enable caching of dependencies
-        uses: actions/setup-node@v4
-        with:
-          node-version: '16'
-
-      # @link https://github.com/DavidAnson/markdownlint-cli2
-      # @link https://github.com/DavidAnson/markdownlint
-      - name: Install Markdownlint CLI2
-        run: npm install -g markdownlint-cli2
-
       # @link https://github.com/marketplace/actions/problem-matcher-for-markdownlint-cli
       - name: Enable showing issue in PRs
         uses: xt0rted/markdownlint-problem-matcher@v3
 
+      # @link https://github.com/marketplace/actions/markdownlint-cli2-action
       - name: Check markdown with CLI2
-        run: markdownlint-cli2
+        uses: DavidAnson/markdownlint-cli2-action@v15
 
   remark:
     name: 'QA Markdown'


### PR DESCRIPTION
The author of the `markdownlint-cli2` NPM package has published a GH Action runner for the package.

Advantages of switching to using that package:
* No need to monitor which Node version is supported by the NPM package, nor to manually update that. This is especially useful as the `markdownlint-cli2` doesn't use the GH release feature, which means that one can't subscribe to automatically get informed of releases (and the changelog of those).

Ref:
* https://github.com/marketplace/actions/markdownlint-cli2-action