### PR TITLE
Composer: avoid writing a lock file

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -64,6 +64,10 @@ jobs:
         if: ${{ matrix.phpcs_version != 'lowest' }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
+      - name: "Composer: use lock file when necessary"
+        if: ${{ matrix.phpcs_version == 'lowest' }}
+        run: composer config --unset lock
+
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,13 +176,13 @@ jobs:
         if: ${{ matrix.phpcs_version != 'lowest' }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
-      - name: "Composer: use lock file when necessary"
-        if: ${{ matrix.phpcs_version == 'lowest' }}
-        run: composer config --unset lock
-
       # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
       - name: 'Composer: remove PHPCSDevCS'
         run: composer remove --dev --no-update phpcsstandards/phpcsdevcs
+
+      - name: "Composer: use lock file when necessary"
+        if: ${{ matrix.phpcs_version == 'lowest' }}
+        run: composer config --unset lock
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,6 +176,10 @@ jobs:
         if: ${{ matrix.phpcs_version != 'lowest' }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
+      - name: "Composer: use lock file when necessary"
+        if: ${{ matrix.phpcs_version == 'lowest' }}
+        run: composer config --unset lock
+
       # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
       - name: 'Composer: remove PHPCSDevCS'
         run: composer remove --dev --no-update phpcsstandards/phpcsdevcs
@@ -307,6 +311,10 @@ jobs:
       - name: "Composer: set PHPCS version for tests (master)"
         if: ${{ matrix.phpcs_version != 'lowest' }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
+
+      - name: "Composer: use lock file when necessary"
+        if: ${{ matrix.phpcs_version == 'lowest' }}
+        run: composer config --unset lock
 
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v3"

--- a/composer.json
+++ b/composer.json
@@ -86,6 +86,7 @@
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
-        }
+        },
+        "lock": false
     }
 }


### PR DESCRIPTION
When working with this repository as a developer, we should be using the latest compatible packages. By writing a lock file for Composer, we may get into a state where we are "stuck" on an older version of a dependency. This change avoids such a situation by telling Composer to not write out a lock file in the project.