### PR TITLE
UseStatements::splitImportUseStatement(): improve handling of leading backslash

### DIFF
--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -301,9 +301,9 @@ final class UseStatements
                 case \T_COMMA:
                     if ($name !== '') {
                         if ($useGroup === true) {
-                            $statements[$type][$alias] = $baseName . $name;
+                            $statements[$type][$alias] = \ltrim($baseName, '\\') . $name;
                         } else {
-                            $statements[$type][$alias] = $name;
+                            $statements[$type][$alias] = \ltrim($name, '\\');
                         }
                     }
 

--- a/Tests/Utils/UseStatements/SplitImportUseStatementTest.inc
+++ b/Tests/Utils/UseStatements/SplitImportUseStatementTest.inc
@@ -14,6 +14,9 @@ use MyNamespace\MyClass;
 /* testUsePlainAliased */
 use MyNamespace \ YourClass as ClassAlias;
 
+/* testUsePlainLeadingBackslash */
+use \MyNamespace\TheirClass;
+
 /* testUseMultipleWithComments */
 use Vendor\Foo\ClassA as ClassABC,
    Vendor \ /*comment*/ Bar \ /*another comment */ InterfaceB,
@@ -38,13 +41,19 @@ use CONST MyNamespace\MY_CONST;
 use const MyNamespace\YOUR_CONST as CONST_ALIAS;
 
 /* testUseConstMultiple */
-use const foo\math\PI, foo\math\GOLDEN_RATIO as MATH_GOLDEN;
+use const foo\math\PI, \foo\math\GOLDEN_RATIO as MATH_GOLDEN;
 
 /* testGroupUse */
 use some\namespacing\{
     SomeClassA,
     deeper\level\SomeClassB,
     another\level\SomeClassC as C
+};
+
+/* testGroupUseLeadingBackslash */
+use \world\namespacing\{
+    SomeClassA,
+    deeper\level\SomeClassB
 };
 
 /* testGroupUseFunctionTrailingComma */
@@ -70,15 +79,15 @@ use Some\NS\ {
 };
 
 /* testUsePlainReservedKeyword */
-// Intentional parse error - use of reserved keyword in namespace.
+// Intentional parse error for PHP < 8.0 - use of reserved keyword in namespace.
 use Vendor\break\ClassName;
 
 /* testUseFunctionPlainReservedKeyword */
-// Intentional parse error - use of reserved keyword in namespace.
+// Intentional parse error for PHP < 8.0  - use of reserved keyword in namespace.
 use function Vendor\YourNamespace\switch\yourFunction;
 
 /* testUseConstPlainReservedKeyword */
-// Intentional parse error - use of reserved keyword in namespace.
+// Intentional parse error for PHP < 8.0  - use of reserved keyword in namespace.
 use const Vendor\YourNamespace\function\yourConst;
 
 /* testUsePlainAliasReservedKeyword */
@@ -88,7 +97,7 @@ use Vendor\YourNamespace\ClassName as class;
 /* testUsePlainAliasReservedKeywordFunction */
 // Intentional parse error - use of reserved keyword as alias.
 use Vendor\{
-	YourNamespace\ClassName as function
+    YourNamespace\ClassName as function
 };
 
 /* testUsePlainAliasReservedKeywordConst */

--- a/Tests/Utils/UseStatements/SplitImportUseStatementTest.php
+++ b/Tests/Utils/UseStatements/SplitImportUseStatementTest.php
@@ -124,6 +124,15 @@ final class SplitImportUseStatementTest extends UtilityMethodTestCase
                     'const'    => [],
                 ],
             ],
+            'plain-with-leading-backslash' => [
+                'testMarker' => '/* testUsePlainLeadingBackslash */',
+                'expected'   => [
+                    'name'     => ['TheirClass' => 'MyNamespace\TheirClass'],
+                    'function' => [],
+                    'const'    => [],
+                ],
+            ],
+
             'multiple-with-comments' => [
                 'testMarker' => '/* testUseMultipleWithComments */',
                 'expected'   => [
@@ -198,6 +207,17 @@ final class SplitImportUseStatementTest extends UtilityMethodTestCase
                         'SomeClassA' => 'some\namespacing\SomeClassA',
                         'SomeClassB' => 'some\namespacing\deeper\level\SomeClassB',
                         'C'          => 'some\namespacing\another\level\SomeClassC',
+                    ],
+                    'function' => [],
+                    'const'    => [],
+                ],
+            ],
+            'group-with-leading-backslash' => [
+                'testMarker' => '/* testGroupUseLeadingBackslash */',
+                'expected'   => [
+                    'name'     => [
+                        'SomeClassA' => 'world\namespacing\SomeClassA',
+                        'SomeClassB' => 'world\namespacing\deeper\level\SomeClassB',
                     ],
                     'function' => [],
                     'const'    => [],


### PR DESCRIPTION
Import use statements should not be declared with a leading backslash and doing so is discouraged by PHP itself:

> Note that for namespaced names (fully qualified namespace names containing namespace separator, such as `Foo\Bar` as opposed to global names that do not, such as `FooBar`), the leading backslash is unnecessary and not recommended, as import names must be fully qualified, and are not processed relative to the current namespace.

Ref: https://www.php.net/manual/en/language.namespaces.importing.php

However, it is not a parse error to declare an import with a leading backslash. Until now, the behaviour of this method in such a case was undefined, which, in practice, meant that the leading backslash would be included in the full name.

For consistency, however, this is undesirable and makes the names found in the return value more awkward to handle by sniffs using the method.

This commit now explicitly defines the behaviour around leading backslashes in import use statements and prevents these from being included in the names in the return value.

Includes unit tests.