### PR TITLE
UtilityMethodTestCase: new `parseFile()` method

### DIFF
--- a/Tests/TestUtils/UtilityMethodTestCase/FailedToTokenizeTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/FailedToTokenizeTest.php
@@ -16,6 +16,7 @@ use PHPCSUtils\Tests\PolyfilledTestCase;
  * Tests for the \PHPCSUtils\TestUtils\UtilityMethodTestCase class.
  *
  * @covers \PHPCSUtils\TestUtils\UtilityMethodTestCase::setUpTestFile
+ * @covers \PHPCSUtils\TestUtils\UtilityMethodTestCase::parseFile
  *
  * @since 1.0.0
  */

--- a/Tests/TestUtils/UtilityMethodTestCase/MissingCaseFileTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/MissingCaseFileTest.php
@@ -16,6 +16,7 @@ use PHPCSUtils\Tests\PolyfilledTestCase;
  * Tests for the \PHPCSUtils\TestUtils\UtilityMethodTestCase class.
  *
  * @covers \PHPCSUtils\TestUtils\UtilityMethodTestCase::setUpTestFile
+ * @covers \PHPCSUtils\TestUtils\UtilityMethodTestCase::parseFile
  *
  * @since 1.0.0
  */


### PR DESCRIPTION
This abstracts the parsing of a file out from the `setUpTestFile()` method, without changing the functionality.

Having the parsing of a file as a separate method allows for tests to parse a secondary test case file for use in a test.

As the new method doesn't create any functional changes, it is already covered by existing tests.