### PR TITLE
:sparkles: New ObjectDeclarations::getDeclared*() utility methods

### DIFF
--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -15,7 +15,9 @@ use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
 use PHPCSUtils\Exceptions\TypeError;
 use PHPCSUtils\Exceptions\UnexpectedTokenType;
+use PHPCSUtils\Internal\Cache;
 use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\FunctionDeclarations;
 use PHPCSUtils\Utils\GetTokensAsString;
 
 /**
@@ -369,5 +371,261 @@ final class ObjectDeclarations
         }
 
         return $names;
+    }
+
+    /**
+     * Retrieve all constants declared in an OO structure.
+     *
+     * @since 1.1.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The stack position of the OO keyword.
+     *
+     * @return array<string, int> Array with names of the found constants as keys and the stack pointers
+     *                            to the T_CONST token for each constant as values.
+     *                            If no constants are found or a parse error is encountered,
+     *                            an empty array is returned.
+     *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not an OO keyword token.
+     */
+    public static function getDeclaredConstants(File $phpcsFile, $stackPtr)
+    {
+        return self::analyzeOOStructure($phpcsFile, $stackPtr)['constants'];
+    }
+
+    /**
+     * Retrieve all cases declared in an enum.
+     *
+     * @since 1.1.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The stack position of the OO keyword.
+     *
+     * @return array<string, int> Array with names of the found cases as keys and the stack pointers
+     *                            to the T_ENUM_CASE token for each case as values.
+     *                            If no cases are found or a parse error is encountered,
+     *                            an empty array is returned.
+     *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a T_ENUM token.
+     */
+    public static function getDeclaredEnumCases(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        if (\is_int($stackPtr) === false) {
+            throw TypeError::create(2, '$stackPtr', 'integer', $stackPtr);
+        }
+
+        if (isset($tokens[$stackPtr]) === false) {
+            throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);
+        }
+
+        if ($tokens[$stackPtr]['code'] !== \T_ENUM) {
+            throw UnexpectedTokenType::create(2, '$stackPtr', 'T_ENUM', $tokens[$stackPtr]['type']);
+        }
+
+        return self::analyzeOOStructure($phpcsFile, $stackPtr)['cases'];
+    }
+
+    /**
+     * Retrieve all properties declared in an OO structure.
+     *
+     * Note: interfaces and enums cannot contain properties. This method does not take this into
+     * account to allow sniffs to flag this kind of incorrect PHP code.
+     *
+     * @since 1.1.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The stack position of the OO keyword.
+     *
+     * @return array<string, int> Array with names of the found properties as keys and the stack pointers
+     *                            to the T_VARIABLE token for each property as values.
+     *                            If no properties are found or a parse error is encountered,
+     *                            an empty array is returned.
+     *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not an OO keyword token.
+     */
+    public static function getDeclaredProperties(File $phpcsFile, $stackPtr)
+    {
+        return self::analyzeOOStructure($phpcsFile, $stackPtr)['properties'];
+    }
+
+    /**
+     * Retrieve all methods declared in an OO structure.
+     *
+     * @since 1.1.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The stack pointer to the OO keyword.
+     *
+     * @return array<string, int> Array with names of the found methods as keys and the stack pointers
+     *                            to the T_FUNCTION keyword for each method as values.
+     *                            If no methods are found or a parse error is encountered,
+     *                            an empty array is returned.
+     *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not an OO keyword token.
+     */
+    public static function getDeclaredMethods(File $phpcsFile, $stackPtr)
+    {
+        return self::analyzeOOStructure($phpcsFile, $stackPtr)['methods'];
+    }
+
+    /**
+     * Retrieve all constants, cases, properties and methods in an OO structure.
+     *
+     * @since 1.1.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The stack position of the OO keyword.
+     *
+     * @return array<string, array<string, int>> Multi-dimensional array with four keys:
+     *                                           - "constants"
+     *                                           - "cases"
+     *                                           - "properties"
+     *                                           - "methods"
+     *                                           Each index holds an associative array with the name of the "thing"
+     *                                           as the key and the stack pointer to the related token as the value.
+     *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not an OO keyword token.
+     */
+    private static function analyzeOOStructure(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (\is_int($stackPtr) === false) {
+            throw TypeError::create(2, '$stackPtr', 'integer', $stackPtr);
+        }
+
+        if (isset($tokens[$stackPtr]) === false) {
+            throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);
+        }
+
+        if (isset(Tokens::$ooScopeTokens[$tokens[$stackPtr]['code']]) === false) {
+            $acceptedTokens = 'T_CLASS, T_ANON_CLASS, T_INTERFACE, T_TRAIT or T_ENUM';
+            throw UnexpectedTokenType::create(2, '$stackPtr', $acceptedTokens, $tokens[$stackPtr]['type']);
+        }
+
+        // Set defaults.
+        $found = [
+            'constants'  => [],
+            'cases'      => [],
+            'properties' => [],
+            'methods'    => [],
+        ];
+
+        if (isset($tokens[$stackPtr]['scope_opener'], $tokens[$stackPtr]['scope_closer']) === false) {
+            return $found;
+        }
+
+        if (Cache::isCached($phpcsFile, __METHOD__, $stackPtr) === true) {
+            return Cache::get($phpcsFile, __METHOD__, $stackPtr);
+        }
+
+        for ($i = ($tokens[$stackPtr]['scope_opener'] + 1); $i < $tokens[$stackPtr]['scope_closer']; $i++) {
+            // Skip over potentially large docblocks.
+            if (isset($tokens[$i]['comment_closer']) === true) {
+                $i = $tokens[$i]['comment_closer'];
+                continue;
+            }
+
+            // Skip over attributes.
+            if (isset($tokens[$i]['attribute_closer']) === true) {
+                $i = $tokens[$i]['attribute_closer'];
+                continue;
+            }
+
+            // Skip over trait imports with conflict resolution.
+            if ($tokens[$i]['code'] === \T_USE
+                && isset($tokens[$i]['scope_closer']) === true
+            ) {
+                $i = $tokens[$i]['scope_closer'];
+                continue;
+            }
+
+            // Defensive coding against parse errors.
+            if ($tokens[$i]['code'] === \T_CLOSURE
+                && isset($tokens[$i]['scope_closer']) === true
+            ) {
+                $i = $tokens[$i]['scope_closer'];
+                continue;
+            }
+
+            switch ($tokens[$i]['code']) {
+                case \T_CONST:
+                    $assignmentPtr = $phpcsFile->findNext([\T_EQUAL, \T_SEMICOLON, \T_CLOSE_CURLY_BRACKET], ($i + 1));
+                    if ($assignmentPtr === false || $tokens[$assignmentPtr]['code'] !== \T_EQUAL) {
+                        // Probably a parse error. Ignore.
+                        continue 2;
+                    }
+
+                    $namePtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($assignmentPtr - 1), ($i + 1), true);
+                    if ($namePtr === false || $tokens[$namePtr]['code'] !== \T_STRING) {
+                        // Probably a parse error. Ignore.
+                        continue 2;
+                    }
+
+                    $found['constants'][$tokens[$namePtr]['content']] = $i;
+
+                    // Skip to the assignment pointer, no need to double walk.
+                    $i = $assignmentPtr;
+                    break;
+
+                case \T_ENUM_CASE:
+                    $namePtr = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
+                    if ($namePtr === false || $tokens[$namePtr]['code'] !== \T_STRING) {
+                        // Probably a parse error. Ignore.
+                        continue 2;
+                    }
+
+                    $name                  = $tokens[$namePtr]['content'];
+                    $found['cases'][$name] = $i;
+
+                    // Skip to the name pointer, no need to double walk.
+                    $i = $namePtr;
+                    break;
+
+                case \T_VARIABLE:
+                    $name                       = $tokens[$i]['content'];
+                    $found['properties'][$name] = $i;
+                    break;
+
+                case \T_FUNCTION:
+                    $name = self::getName($phpcsFile, $i);
+                    if (\is_string($name) && $name !== '') {
+                        $found['methods'][$name] = $i;
+
+                        if (\strtolower($name) === '__construct') {
+                            // Check for constructor property promotion.
+                            $parameters = FunctionDeclarations::getParameters($phpcsFile, $i);
+                            foreach ($parameters as $param) {
+                                if (isset($param['property_visibility'])) {
+                                    $found['properties'][$param['name']] = $param['token'];
+                                }
+                            }
+                        }
+                    }
+
+                    if (isset($tokens[$i]['scope_closer']) === true) {
+                        // Skip over the contents of the method, including the parameters.
+                        $i = $tokens[$i]['scope_closer'];
+                    } elseif (isset($tokens[$i]['parenthesis_closer']) === true) {
+                        // Skip over the contents of an abstract/interface method, including the parameters.
+                        $i = $tokens[$i]['parenthesis_closer'];
+                    }
+                    break;
+            }
+        }
+
+        Cache::set($phpcsFile, __METHOD__, $stackPtr, $found);
+        return $found;
     }
 }

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/AnalyzeOOStructureTest.inc
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/AnalyzeOOStructureTest.inc
@@ -1,0 +1,347 @@
+<?php
+
+/* testUnacceptableToken */
+function globalFunction() {}
+
+/* testEmptyClass */
+class EmptyClass extends TestCase {}
+
+/* testEmptyInterface */
+interface EmptyInterface extends AnotherInterface {}
+
+/* testEmptyTrait */
+trait EmptyTrait {}
+
+/* testEmptyEnum */
+enum EmptyEnum {}
+
+/* testEmptyAnonClass */
+$anon = new class implements SomeInterface {};
+
+/* testClass */
+abstract class testClass {
+
+    use someTrait;
+    // Test skipping over contents between {}.
+    use A, B {
+        B::smallTalk insteadof A;
+        A::function insteadof B;
+        B::bigTalk as function;
+    }
+
+    // Ensuring the utility method does not get confused over keywords being used as a constant name.
+
+    /* markerClassConst1 */
+    public const CONST = 'name';
+
+    /* markerClassConst2 */
+    const CASE = 'name';
+
+    /* markerClassConst3 */
+    final protected const FINAL = 'name';
+
+    /* markerClassConst4 */
+    const FUNCTION = 'name';
+
+    /* markerClassConst5 */
+    final protected const int|string UNION_TYPED = 'name';
+
+    /* markerClassConst6 */
+    private const (A&B)|null DNF_TYPED = null;
+
+
+    /* markerClassProperty1 */
+    public readonly string $prop = self::FUNCTION;
+
+    /**
+     * Docblock.
+     */
+    /* markerClassMethod1 */
+    public function testDocblockSkipping() {
+        // Do something.
+    }
+
+    #[TestAttributeUsingFunctionKeyword(self::FUNCTION)]
+    #[
+        MultilineAttribute,
+        SecondAttribute
+    ]
+    #[ReturnTypeWillChange]
+    /* markerClassMethod2 */
+    public function testAttributesSkipping() {
+        // Do something.
+    }
+
+    #[MyAttribute(self::FUNCTION)]
+    #[
+        MultilineAttribute,
+        SecondAttribute
+    ]
+    /**
+     * Docblock.
+     */
+    #[ReturnTypeWillChange]
+    /* markerClassMethod3 */
+    public function testDocblockAndAttributeSkipping() {
+        // Do something.
+    }
+
+    /* markerClassMethod4 */
+    private function testFunctionKeywordUsedInParams($a = self::FUNCTION) {}
+
+    // Silly, but "legal" as of PHP 7.0.
+    /* markerClassMethod5A */
+    protected function function() {}
+
+    /* markerClassMethod5B */
+    protected function const() {}
+
+    /* markerClassMethod5C */
+    protected function case() {}
+
+    /* markerClassMethod6 */
+    protected static function skipOverContentsOfFunctionA () {
+        if (function_exists('shouldNotBeListed') === false) {
+            function shouldNotBeListed() {
+                // Do something.
+                function shouldAlsoNotBeListed($forReal) {}
+            }
+        }
+    }
+
+    /* markerClassMethod7 */
+    protected static function skipOverContentsOfFunctionB () {
+        // These functions should be listed for the anon class, but not for the wrapping class.
+        /* testAnonClass */
+        return new class() {
+            /**
+             * Kitchen sink to collect dynamic properties.
+             *
+             * @var array
+             */
+            /* markerAnonNestedProperty1 */
+            private $sink = [];
+
+            #[ReturnTypeWillChange]
+            #[Multi, Attribute, AndMore([1,2,3])]
+            /* markerAnonNestedMethod1 */
+            public function __isset($name) {}
+            /* markerAnonNestedMethod2 */
+            public function __get($name) {}
+            /* markerAnonNestedMethod3 */
+            public function __set($name, $value) {}
+            /* markerAnonNestedMethod4 */
+            public function __unset($name) {}
+
+            /**
+             * Docblock.
+             */
+            /* markerAnonNestedMethod5 */
+            private function doSomething() {}
+        };
+    }
+
+    /* markerClassMethod8 */
+    protected static function skipOverContentsOfFunctionC () {
+        $closure = function ($ignoreThis) {};
+    }
+
+    /* markerClassMethod9 */
+    protected function __construct( /* markerClassProperty2 */ public $property, /* markerClassProperty3 */ private $promotion) {}
+
+    /* markerClassMethod10 */
+    private function PrivateFunction() {}
+
+    /* markerClassMethod11 */
+    final public function FinalPublic() {
+        // Intentional parse error. Illegal const declaration using const keyword without function.
+        const Foo = 10;
+    }
+
+    /* markerClassMethod12 */
+    abstract function implementMe();
+}
+
+/* testInterface */
+interface testInterface {
+    /* markerInterfaceConst1 */
+    const IM = 'I am';
+    /* markerInterfaceConst2 */
+    final public const ?string WALKING = 'walking';
+    /* markerInterfaceConst3 */
+    public const int|false ON = false;
+    /* markerInterfaceConst4 */
+    public const (D&\N)|namespace\F SUNSHINE = Sunshine;
+
+    /* markerInterfaceIllegalProperty */
+    // Intentional parse error. Properties are not allowed in interfaces (until PHP 8.4), but that's not the concern of this method.
+    public $invalid;
+
+    public /* markerInterfaceMethod1 */ function oh_oh();
+    public /* markerInterfaceMethod2 */ function im();
+    public /* markerInterfaceMethod3 */ FUNCTION walking();
+    public /* markerInterfaceMethod4 */ Function on();
+    public /* markerInterfaceMethod5 */ function sunshine();
+}
+
+/* testTrait */
+trait testTrait {
+    /* markerTraitConst1 */
+    const DO = 10;
+    /* markerTraitConst2 */
+    public const /*comment*/ ?array RE = [];
+    /* markerTraitConst3 */
+    final const
+            mi = 'soup';
+
+    /* markerTraitProperty1 */
+    public $fa;
+    /* markerTraitProperty2 */
+    readonly
+    string
+    $sol;
+    /* markerTraitProperty3 */
+    var
+    // phpcs:ignore Stnd.Cat.Something
+    $LA = 'string';
+
+    /* markerTraitMethod1 */
+    public function ti() {}
+    /* markerTraitMethod2 */
+    protected static function DO() {}
+    /* markerTraitMethod3 */
+    abstract public function doReMiFa();
+    /* markerTraitMethod4 */
+    function solLaTiDo() {}
+}
+
+/* testAnonClassUnconventionalOrder */
+$anon = new class() {
+    /* markerAnonOrderMethod1 */
+    function hereIGoAgain( $param ) {
+        return 'on my own';
+    }
+
+    /* markerAnonOrderProperty1 */
+    public ?string $goingDownTheOnlyRoad = "I've ever known";
+
+    /* markerAnonOrderMethod2 */
+    private static function LikeADrifter(int $I, string $Was, (\born&To)|namespace\Walk $alone) {}
+
+    /* markerAnonOrderConst1 */
+    protected const iterable AndIveMadeUp = ['MyMind'];
+
+    /* markerAnonOrderMethod3 */
+    final protected function Iaint($wasting) : NoMore {
+        return new Time;
+    }
+
+    /* markerAnonOrderProperty2 */
+    readonly (\Im&Just)|namespace\Another\Heart $inNeedOfRescue;
+
+    /* markerAnonOrderConst2 */
+    final const WAITING_ON_LOVES = 'sweet charity';
+
+    /* markerAnonOrderMethod4 */
+    public function /*comment*/ AndImGonnaHoldOn( $for, $the, Rest $ofMyDays) {}
+};
+
+/* testEnum */
+enum testEnum: string implements ArrayAccess {
+    /* markerEnumConst1 */
+    final const SUIT = 'Something';
+
+    /* markerEnumConst2 */
+    public const ANOTHER = 10;
+
+    /* markerEnumCase1 */
+    case Hearts = 'H';
+    /* markerEnumCase2 */
+    case
+          Diamonds = 'D';
+    /* markerEnumCase3 */
+    case /*comment*/ Clubs = 'C';
+    /* markerEnumCase4 */
+    case Spades = 'S';
+
+    /* markerEnumIllegalProperty */
+    // Intentional parse error. Properties are not allowed in enums, but that's not the concern of this method.
+    public $invalid;
+
+    /* markerEnumMethod1 */
+    public function color(): string
+    {
+        return match($this) {
+            Suit::Hearts, Suit::Diamonds => 'Red',
+            Suit::Clubs, Suit::Spades => 'Black',
+        };
+    }
+
+    /* markerEnumMethod2 */
+    public function offsetGet($val) : mixed {
+        // Do something.
+    }
+
+    /* markerEnumMethod3 */
+    public function offsetExists($val): bool {
+        // Do something.
+    }
+
+    /* markerEnumMethod4 */
+    public function offsetSet($offset, $val): void {
+        throw new Exception();
+    }
+
+    /* markerEnumMethod5 */
+    public function offsetUnset($val): void {
+        throw new Exception();
+    }
+}
+
+/* testClassConstructorNoParams */
+class ConstructorNoParams {
+    /* markerCPP1_Constructor */
+    public function __construct() {}
+}
+
+/* testInterfaceConstructorWithParamsNotProperties */
+interface ConstructorWithParamsNotProperties {
+    /* markerCPP2_Constructor */
+    public function __Construct(int $paramA, Union|null $paramB, false|(D&N&F) $paramC = false);
+}
+
+/* testClassConstructorWithProperties */
+class ConstructorWithProperties {
+    /* markerCPP3_Constructor */
+    public function __CONSTRUCT(
+        /* markerCPP3_Property1 */
+        private int $propA,
+        /* markerCPP3_Property2 */
+        protected readonly string $propB,
+        /* markerCPP3_Property3 */
+        readonly Onion|Union $propC,
+        /* markerCPP3_Property4 */
+        public (D&N)|F $propD,
+    ) {}
+}
+
+/* testTraitConstructorWithParamsAndProperties */
+trait ConstructorWithParamsAndProperties {
+    /* markerCPP4_Property1 */
+    public int $declared;
+
+    /* markerCPP4_Property2 */
+    private self $instance;
+
+    /* markerCPP4_Constructor */
+    public function __construct(
+        /* markerCPP4_Property3 */
+        public ?string $propA,
+        /* markerCPP4_Property4 */
+        protected \MyClass $propB,
+        /* markerCPP4_Property5 */
+        private namespace\Relative|Partially\Qualified $propC,
+        ?int $paramA,
+        string $paramB,
+    ) {}
+}

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/GetDeclaredConstantsTest.php
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/GetDeclaredConstantsTest.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations\AnalyzeOOStructure;
+
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Internal\Cache;
+use PHPCSUtils\Tests\PolyfilledTestCase;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredConstants() method.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredConstants
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure
+ *
+ * @since 1.1.0
+ */
+final class GetDeclaredConstantsTest extends PolyfilledTestCase
+{
+
+    /**
+     * Full path to the test case file associated with this test class.
+     *
+     * @var string
+     */
+    protected static $caseFile = '';
+
+    /**
+     * Initialize PHPCS & tokenize the test case file.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        self::$caseFile = __DIR__ . '/AnalyzeOOStructureTest.inc';
+        parent::setUpTestFile();
+    }
+
+    /**
+     * Test receiving an expected exception when a non-integer token is passed.
+     *
+     * @return void
+     */
+    public function testNonIntegerToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, boolean given');
+
+        ObjectDeclarations::getDeclaredConstants(self::$phpcsFile, false);
+    }
+
+    /**
+     * Test receiving an expected exception when a non-existent token is passed.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object, 100000 given'
+        );
+
+        ObjectDeclarations::getDeclaredConstants(self::$phpcsFile, 100000);
+    }
+
+    /**
+     * Test receiving an expected exception when a non-OO token is passed.
+     *
+     * @return void
+     */
+    public function testNotTargetToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be of type T_CLASS, T_ANON_CLASS, T_INTERFACE, T_TRAIT or T_ENUM;'
+        );
+
+        $stackPtr = $this->getTargetToken('/* testUnacceptableToken */', \T_FUNCTION);
+        ObjectDeclarations::getDeclaredConstants(self::$phpcsFile, $stackPtr);
+    }
+
+    /**
+     * Test retrieving the constants declared in an OO structure.
+     *
+     * @dataProvider dataGetDeclaredConstants
+     *
+     * @param string                $testMarker The comment which prefaces the target token in the test file.
+     * @param array<string, string> $expected   Expected function return value.
+     *
+     * @return void
+     */
+    public function testGetDeclaredConstants($testMarker, $expected)
+    {
+        // Translate the constant markers to token pointers.
+        foreach ($expected as $name => $marker) {
+            $expected[$name] = $this->getTargetToken($marker, [\T_CONST]);
+        }
+
+        $stackPtr = $this->getTargetToken($testMarker, Tokens::$ooScopeTokens);
+        $result   = ObjectDeclarations::getDeclaredConstants(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetDeclaredConstants() For the array format.
+     *
+     * @return array<string, array<string, string|array<string, string>>>
+     */
+    public static function dataGetDeclaredConstants()
+    {
+        return [
+            'empty class' => [
+                'testMarker' => '/* testEmptyClass */',
+                'expected'   => [],
+            ],
+            'empty interface' => [
+                'testMarker' => '/* testEmptyInterface */',
+                'expected'   => [],
+            ],
+            'empty trait' => [
+                'testMarker' => '/* testEmptyTrait */',
+                'expected'   => [],
+            ],
+            'empty enum' => [
+                'testMarker' => '/* testEmptyEnum */',
+                'expected'   => [],
+            ],
+            'empty anonymous class' => [
+                'testMarker' => '/* testEmptyAnonClass */',
+                'expected'   => [],
+            ],
+            'class with constants, properties, methods and everything else' => [
+                'testMarker' => '/* testClass */',
+                'expected'   => [
+                    'CONST'       => '/* markerClassConst1 */',
+                    'CASE'        => '/* markerClassConst2 */',
+                    'FINAL'       => '/* markerClassConst3 */',
+                    'FUNCTION'    => '/* markerClassConst4 */',
+                    'UNION_TYPED' => '/* markerClassConst5 */',
+                    'DNF_TYPED'   => '/* markerClassConst6 */',
+                ],
+            ],
+            'anonymous class with constants' => [
+                'testMarker' => '/* testAnonClass */',
+                'expected'   => [],
+            ],
+            'interface with constants and methods' => [
+                'testMarker' => '/* testInterface */',
+                'expected'   => [
+                    'IM'       => '/* markerInterfaceConst1 */',
+                    'WALKING'  => '/* markerInterfaceConst2 */',
+                    'ON'       => '/* markerInterfaceConst3 */',
+                    'SUNSHINE' => '/* markerInterfaceConst4 */',
+                ],
+            ],
+            'trait with constants, properties and methods' => [
+                'testMarker' => '/* testTrait */',
+                'expected'   => [
+                    'DO' => '/* markerTraitConst1 */',
+                    'RE' => '/* markerTraitConst2 */',
+                    'mi' => '/* markerTraitConst3 */',
+                ],
+            ],
+            'anon class with constants, properties and methods in unconventional order' => [
+                'testMarker' => '/* testAnonClassUnconventionalOrder */',
+                'expected'   => [
+                    'AndIveMadeUp'     => '/* markerAnonOrderConst1 */',
+                    'WAITING_ON_LOVES' => '/* markerAnonOrderConst2 */',
+                ],
+            ],
+            'enum with constants, cases and methods' => [
+                'testMarker' => '/* testEnum */',
+                'expected'   => [
+                    'SUIT'    => '/* markerEnumConst1 */',
+                    'ANOTHER' => '/* markerEnumConst2 */',
+                ],
+            ],
+            'class with constructor, no properties, no params' => [
+                'testMarker' => '/* testClassConstructorNoParams */',
+                'expected'   => [],
+            ],
+            'interface with constructor, no properties, has params' => [
+                'testMarker' => '/* testInterfaceConstructorWithParamsNotProperties */',
+                'expected'   => [],
+            ],
+            'class with constructor, with properties, no params' => [
+                'testMarker' => '/* testClassConstructorWithProperties */',
+                'expected'   => [],
+            ],
+            'trait with constructor, with properties, with params' => [
+                'testMarker' => '/* testTraitConstructorWithParamsAndProperties */',
+                'expected'   => [],
+            ],
+        ];
+    }
+
+    /**
+     * Verify that the build-in caching is used when caching is enabled.
+     *
+     * @return void
+     */
+    public function testGetDeclaredConstantsResultIsCached()
+    {
+        $methodName = 'PHPCSUtils\\Utils\\ObjectDeclarations::analyzeOOStructure';
+        $cases      = $this->dataGetDeclaredConstants();
+        $testMarker = $cases['class with constants, properties, methods and everything else']['testMarker'];
+        $expected   = $cases['class with constants, properties, methods and everything else']['expected'];
+
+        // Translate the constant markers to token pointers.
+        foreach ($expected as $name => $marker) {
+            $expected[$name] = $this->getTargetToken($marker, [\T_CONST]);
+        }
+
+        $stackPtr = $this->getTargetToken($testMarker, Tokens::$ooScopeTokens);
+
+        // Verify the caching works.
+        $origStatus     = Cache::$enabled;
+        Cache::$enabled = true;
+
+        $resultFirstRun  = ObjectDeclarations::getDeclaredConstants(self::$phpcsFile, $stackPtr);
+        $isCached        = Cache::isCached(self::$phpcsFile, $methodName, $stackPtr);
+        $resultSecondRun = ObjectDeclarations::getDeclaredConstants(self::$phpcsFile, $stackPtr);
+
+        if ($origStatus === false) {
+            Cache::clear();
+        }
+        Cache::$enabled = $origStatus;
+
+        $this->assertSame($expected, $resultFirstRun, 'First result did not match expectation');
+        $this->assertTrue($isCached, 'Cache::isCached() could not find the cached value');
+        $this->assertSame($resultFirstRun, $resultSecondRun, 'Second result did not match first');
+    }
+}

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/GetDeclaredEnumCasesTest.php
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/GetDeclaredEnumCasesTest.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations\AnalyzeOOStructure;
+
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Internal\Cache;
+use PHPCSUtils\Tests\PolyfilledTestCase;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredEnumCases() method.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredEnumCases
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure
+ *
+ * @since 1.1.0
+ */
+final class GetDeclaredEnumCasesTest extends PolyfilledTestCase
+{
+
+    /**
+     * Full path to the test case file associated with this test class.
+     *
+     * @var string
+     */
+    protected static $caseFile = '';
+
+    /**
+     * Initialize PHPCS & tokenize the test case file.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        self::$caseFile = __DIR__ . '/AnalyzeOOStructureTest.inc';
+        parent::setUpTestFile();
+    }
+
+    /**
+     * Test receiving an expected exception when a non-integer token is passed.
+     *
+     * @return void
+     */
+    public function testNonIntegerToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, boolean given');
+
+        ObjectDeclarations::getDeclaredEnumCases(self::$phpcsFile, false);
+    }
+
+    /**
+     * Test receiving an expected exception when a non-existent token is passed.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object, 100000 given'
+        );
+
+        ObjectDeclarations::getDeclaredEnumCases(self::$phpcsFile, 100000);
+    }
+
+    /**
+     * Test receiving an expected exception when a non-OO token is passed.
+     *
+     * @return void
+     */
+    public function testNotTargetToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type T_ENUM;');
+
+        $stackPtr = $this->getTargetToken('/* testUnacceptableToken */', \T_FUNCTION);
+        ObjectDeclarations::getDeclaredEnumCases(self::$phpcsFile, $stackPtr);
+    }
+
+    /**
+     * Test retrieving the cases declared in an enum.
+     *
+     * @dataProvider dataGetDeclaredEnumCases
+     *
+     * @param string                $testMarker The comment which prefaces the target token in the test file.
+     * @param array<string, string> $expected   Expected function return value.
+     *
+     * @return void
+     */
+    public function testGetDeclaredEnumCases($testMarker, $expected)
+    {
+        // Translate the case markers to token pointers.
+        foreach ($expected as $name => $marker) {
+            $expected[$name] = $this->getTargetToken($marker, [\T_ENUM_CASE]);
+        }
+
+        $stackPtr = $this->getTargetToken($testMarker, Tokens::$ooScopeTokens);
+        $result   = ObjectDeclarations::getDeclaredEnumCases(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetDeclaredEnumCases() For the array format.
+     *
+     * @return array<string, array<string, string|array<string, string>>>
+     */
+    public static function dataGetDeclaredEnumCases()
+    {
+        return [
+            'empty enum' => [
+                'testMarker' => '/* testEmptyEnum */',
+                'expected'   => [],
+            ],
+            'enum with constants, cases and methods' => [
+                'testMarker' => '/* testEnum */',
+                'expected'   => [
+                    'Hearts'   => '/* markerEnumCase1 */',
+                    'Diamonds' => '/* markerEnumCase2 */',
+                    'Clubs'    => '/* markerEnumCase3 */',
+                    'Spades'   => '/* markerEnumCase4 */',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Verify that the build-in caching is used when caching is enabled.
+     *
+     * @return void
+     */
+    public function testGetDeclaredEnumCasesResultIsCached()
+    {
+        $methodName = 'PHPCSUtils\\Utils\\ObjectDeclarations::analyzeOOStructure';
+        $cases      = $this->dataGetDeclaredEnumCases();
+        $testMarker = $cases['enum with constants, cases and methods']['testMarker'];
+        $expected   = $cases['enum with constants, cases and methods']['expected'];
+
+        // Translate the case markers to token pointers.
+        foreach ($expected as $name => $marker) {
+            $expected[$name] = $this->getTargetToken($marker, [\T_ENUM_CASE]);
+        }
+
+        $stackPtr = $this->getTargetToken($testMarker, Tokens::$ooScopeTokens);
+
+        // Verify the caching works.
+        $origStatus     = Cache::$enabled;
+        Cache::$enabled = true;
+
+        $resultFirstRun  = ObjectDeclarations::getDeclaredEnumCases(self::$phpcsFile, $stackPtr);
+        $isCached        = Cache::isCached(self::$phpcsFile, $methodName, $stackPtr);
+        $resultSecondRun = ObjectDeclarations::getDeclaredEnumCases(self::$phpcsFile, $stackPtr);
+
+        if ($origStatus === false) {
+            Cache::clear();
+        }
+        Cache::$enabled = $origStatus;
+
+        $this->assertSame($expected, $resultFirstRun, 'First result did not match expectation');
+        $this->assertTrue($isCached, 'Cache::isCached() could not find the cached value');
+        $this->assertSame($resultFirstRun, $resultSecondRun, 'Second result did not match first');
+    }
+}

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/GetDeclaredMethodsTest.php
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/GetDeclaredMethodsTest.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations\AnalyzeOOStructure;
+
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Internal\Cache;
+use PHPCSUtils\Tests\PolyfilledTestCase;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredMethods() method.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredMethods
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure
+ *
+ * @since 1.1.0
+ */
+final class GetDeclaredMethodsTest extends PolyfilledTestCase
+{
+
+    /**
+     * Full path to the test case file associated with this test class.
+     *
+     * @var string
+     */
+    protected static $caseFile = '';
+
+    /**
+     * Initialize PHPCS & tokenize the test case file.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        self::$caseFile = __DIR__ . '/AnalyzeOOStructureTest.inc';
+        parent::setUpTestFile();
+    }
+
+    /**
+     * Test receiving an expected exception when a non-integer token is passed.
+     *
+     * @return void
+     */
+    public function testNonIntegerToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, boolean given');
+
+        ObjectDeclarations::getDeclaredMethods(self::$phpcsFile, false);
+    }
+
+    /**
+     * Test receiving an expected exception when a non-existent token is passed.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object, 100000 given'
+        );
+
+        ObjectDeclarations::getDeclaredMethods(self::$phpcsFile, 100000);
+    }
+
+    /**
+     * Test receiving an expected exception when a non-OO token is passed.
+     *
+     * @return void
+     */
+    public function testNotTargetToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be of type T_CLASS, T_ANON_CLASS, T_INTERFACE, T_TRAIT or T_ENUM;'
+        );
+
+        $stackPtr = $this->getTargetToken('/* testUnacceptableToken */', \T_FUNCTION);
+        ObjectDeclarations::getDeclaredMethods(self::$phpcsFile, $stackPtr);
+    }
+
+    /**
+     * Test retrieving the methods declared in an OO structure.
+     *
+     * @dataProvider dataGetDeclaredMethods
+     *
+     * @param string                $testMarker The comment which prefaces the target token in the test file.
+     * @param array<string, string> $expected   Expected function return value.
+     *
+     * @return void
+     */
+    public function testGetDeclaredMethods($testMarker, $expected)
+    {
+        // Translate the method markers to token pointers.
+        foreach ($expected as $name => $marker) {
+            $expected[$name] = $this->getTargetToken($marker, [\T_FUNCTION]);
+        }
+
+        $stackPtr = $this->getTargetToken($testMarker, Tokens::$ooScopeTokens);
+        $result   = ObjectDeclarations::getDeclaredMethods(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetDeclaredMethods() For the array format.
+     *
+     * @return array<string, array<string, string|array<string, string>>>
+     */
+    public static function dataGetDeclaredMethods()
+    {
+        return [
+            'empty class' => [
+                'testMarker' => '/* testEmptyClass */',
+                'expected'   => [],
+            ],
+            'empty interface' => [
+                'testMarker' => '/* testEmptyInterface */',
+                'expected'   => [],
+            ],
+            'empty trait' => [
+                'testMarker' => '/* testEmptyTrait */',
+                'expected'   => [],
+            ],
+            'empty enum' => [
+                'testMarker' => '/* testEmptyEnum */',
+                'expected'   => [],
+            ],
+            'empty anonymous class' => [
+                'testMarker' => '/* testEmptyAnonClass */',
+                'expected'   => [],
+            ],
+            'class with constants, properties, methods and everything else' => [
+                'testMarker' => '/* testClass */',
+                'expected'   => [
+                    'testDocblockSkipping'             => '/* markerClassMethod1 */',
+                    'testAttributesSkipping'           => '/* markerClassMethod2 */',
+                    'testDocblockAndAttributeSkipping' => '/* markerClassMethod3 */',
+                    'testFunctionKeywordUsedInParams'  => '/* markerClassMethod4 */',
+                    'function'                         => '/* markerClassMethod5A */',
+                    'const'                            => '/* markerClassMethod5B */',
+                    'case'                             => '/* markerClassMethod5C */',
+                    'skipOverContentsOfFunctionA'      => '/* markerClassMethod6 */',
+                    'skipOverContentsOfFunctionB'      => '/* markerClassMethod7 */',
+                    'skipOverContentsOfFunctionC'      => '/* markerClassMethod8 */',
+                    '__construct'                      => '/* markerClassMethod9 */',
+                    'PrivateFunction'                  => '/* markerClassMethod10 */',
+                    'FinalPublic'                      => '/* markerClassMethod11 */',
+                    'implementMe'                      => '/* markerClassMethod12 */',
+                ],
+            ],
+            'anon class with methods, nested within a method of another class' => [
+                'testMarker' => '/* testAnonClass */',
+                'expected'   => [
+                    '__isset'     => '/* markerAnonNestedMethod1 */',
+                    '__get'       => '/* markerAnonNestedMethod2 */',
+                    '__set'       => '/* markerAnonNestedMethod3 */',
+                    '__unset'     => '/* markerAnonNestedMethod4 */',
+                    'doSomething' => '/* markerAnonNestedMethod5 */',
+                ],
+            ],
+            'interface with constants and methods' => [
+                'testMarker' => '/* testInterface */',
+                'expected'   => [
+                    'oh_oh'    => '/* markerInterfaceMethod1 */',
+                    'im'       => '/* markerInterfaceMethod2 */',
+                    'walking'  => '/* markerInterfaceMethod3 */',
+                    'on'       => '/* markerInterfaceMethod4 */',
+                    'sunshine' => '/* markerInterfaceMethod5 */',
+                ],
+            ],
+            'trait with constants, properties and methods' => [
+                'testMarker' => '/* testTrait */',
+                'expected'   => [
+                    'ti'        => '/* markerTraitMethod1 */',
+                    'DO'        => '/* markerTraitMethod2 */',
+                    'doReMiFa'  => '/* markerTraitMethod3 */',
+                    'solLaTiDo' => '/* markerTraitMethod4 */',
+                ],
+            ],
+            'anon class with constants, properties and methods in unconventional order' => [
+                'testMarker' => '/* testAnonClassUnconventionalOrder */',
+                'expected'   => [
+                    'hereIGoAgain'     => '/* markerAnonOrderMethod1 */',
+                    'LikeADrifter'     => '/* markerAnonOrderMethod2 */',
+                    'Iaint'            => '/* markerAnonOrderMethod3 */',
+                    'AndImGonnaHoldOn' => '/* markerAnonOrderMethod4 */',
+                ],
+            ],
+            'enum with constants, cases and methods' => [
+                'testMarker' => '/* testEnum */',
+                'expected'   => [
+                    'color'        => '/* markerEnumMethod1 */',
+                    'offsetGet'    => '/* markerEnumMethod2 */',
+                    'offsetExists' => '/* markerEnumMethod3 */',
+                    'offsetSet'    => '/* markerEnumMethod4 */',
+                    'offsetUnset'  => '/* markerEnumMethod5 */',
+                ],
+            ],
+            'class with constructor, no properties, no params' => [
+                'testMarker' => '/* testClassConstructorNoParams */',
+                'expected'   => [
+                    '__construct' => '/* markerCPP1_Constructor */',
+                ],
+            ],
+            'interface with constructor, no properties, has params' => [
+                'testMarker' => '/* testInterfaceConstructorWithParamsNotProperties */',
+                'expected'   => [
+                    '__Construct' => '/* markerCPP2_Constructor */',
+                ],
+            ],
+            'class with constructor, with properties, no params' => [
+                'testMarker' => '/* testClassConstructorWithProperties */',
+                'expected'   => [
+                    '__CONSTRUCT' => '/* markerCPP3_Constructor */',
+                ],
+            ],
+            'trait with constructor, with properties, with params' => [
+                'testMarker' => '/* testTraitConstructorWithParamsAndProperties */',
+                'expected'   => [
+                    '__construct' => '/* markerCPP4_Constructor */',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Verify that the build-in caching is used when caching is enabled.
+     *
+     * @return void
+     */
+    public function testGetDeclaredMethodsResultIsCached()
+    {
+        $methodName = 'PHPCSUtils\\Utils\\ObjectDeclarations::analyzeOOStructure';
+        $cases      = $this->dataGetDeclaredMethods();
+        $testMarker = $cases['class with constants, properties, methods and everything else']['testMarker'];
+        $expected   = $cases['class with constants, properties, methods and everything else']['expected'];
+
+        // Translate the method markers to token pointers.
+        foreach ($expected as $name => $marker) {
+            $expected[$name] = $this->getTargetToken($marker, [\T_FUNCTION]);
+        }
+
+        $stackPtr = $this->getTargetToken($testMarker, Tokens::$ooScopeTokens);
+
+        // Verify the caching works.
+        $origStatus     = Cache::$enabled;
+        Cache::$enabled = true;
+
+        $resultFirstRun  = ObjectDeclarations::getDeclaredMethods(self::$phpcsFile, $stackPtr);
+        $isCached        = Cache::isCached(self::$phpcsFile, $methodName, $stackPtr);
+        $resultSecondRun = ObjectDeclarations::getDeclaredMethods(self::$phpcsFile, $stackPtr);
+
+        if ($origStatus === false) {
+            Cache::clear();
+        }
+        Cache::$enabled = $origStatus;
+
+        $this->assertSame($expected, $resultFirstRun, 'First result did not match expectation');
+        $this->assertTrue($isCached, 'Cache::isCached() could not find the cached value');
+        $this->assertSame($resultFirstRun, $resultSecondRun, 'Second result did not match first');
+    }
+}

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/GetDeclaredPropertiesTest.php
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/GetDeclaredPropertiesTest.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations\AnalyzeOOStructure;
+
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Internal\Cache;
+use PHPCSUtils\Tests\PolyfilledTestCase;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredProperties() method.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredProperties
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure
+ *
+ * @since 1.1.0
+ */
+final class GetDeclaredPropertiesTest extends PolyfilledTestCase
+{
+
+    /**
+     * Full path to the test case file associated with this test class.
+     *
+     * @var string
+     */
+    protected static $caseFile = '';
+
+    /**
+     * Initialize PHPCS & tokenize the test case file.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        self::$caseFile = __DIR__ . '/AnalyzeOOStructureTest.inc';
+        parent::setUpTestFile();
+    }
+
+    /**
+     * Test receiving an expected exception when a non-integer token is passed.
+     *
+     * @return void
+     */
+    public function testNonIntegerToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, boolean given');
+
+        ObjectDeclarations::getDeclaredProperties(self::$phpcsFile, false);
+    }
+
+    /**
+     * Test receiving an expected exception when a non-existent token is passed.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object, 100000 given'
+        );
+
+        ObjectDeclarations::getDeclaredProperties(self::$phpcsFile, 100000);
+    }
+
+    /**
+     * Test receiving an expected exception when a non-OO token is passed.
+     *
+     * @return void
+     */
+    public function testNotTargetToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be of type T_CLASS, T_ANON_CLASS, T_INTERFACE, T_TRAIT or T_ENUM;'
+        );
+
+        $stackPtr = $this->getTargetToken('/* testUnacceptableToken */', \T_FUNCTION);
+        ObjectDeclarations::getDeclaredProperties(self::$phpcsFile, $stackPtr);
+    }
+
+    /**
+     * Test retrieving the properties declared in an OO structure.
+     *
+     * @dataProvider dataGetDeclaredProperties
+     *
+     * @param string                $testMarker The comment which prefaces the target token in the test file.
+     * @param array<string, string> $expected   Expected function return value.
+     *
+     * @return void
+     */
+    public function testGetDeclaredProperties($testMarker, $expected)
+    {
+        // Translate the method marker to token pointers.
+        foreach ($expected as $name => $marker) {
+            $expected[$name] = $this->getTargetToken($marker, [\T_VARIABLE]);
+        }
+
+        $stackPtr = $this->getTargetToken($testMarker, Tokens::$ooScopeTokens);
+        $result   = ObjectDeclarations::getDeclaredProperties(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetDeclaredProperties() For the array format.
+     *
+     * @return array<string, array<string, string|array<string, string>>>
+     */
+    public static function dataGetDeclaredProperties()
+    {
+        return [
+            'empty class' => [
+                'testMarker' => '/* testEmptyClass */',
+                'expected'   => [],
+            ],
+            'empty interface' => [
+                'testMarker' => '/* testEmptyInterface */',
+                'expected'   => [],
+            ],
+            'empty trait' => [
+                'testMarker' => '/* testEmptyTrait */',
+                'expected'   => [],
+            ],
+            'empty enum' => [
+                'testMarker' => '/* testEmptyEnum */',
+                'expected'   => [],
+            ],
+            'empty anonymous class' => [
+                'testMarker' => '/* testEmptyAnonClass */',
+                'expected'   => [],
+            ],
+            'class with constants, properties, methods and everything else' => [
+                'testMarker' => '/* testClass */',
+                'expected'   => [
+                    '$prop'      => '/* markerClassProperty1 */',
+                    '$property'  => '/* markerClassProperty2 */',
+                    '$promotion' => '/* markerClassProperty3 */',
+                ],
+            ],
+            'anonymous class with properties' => [
+                'testMarker' => '/* testAnonClass */',
+                'expected'   => [
+                    '$sink' => '/* markerAnonNestedProperty1 */',
+                ],
+            ],
+            'interface with constants and methods' => [
+                'testMarker' => '/* testInterface */',
+                'expected'   => [
+                    '$invalid' => '/* markerInterfaceIllegalProperty */',
+                ],
+            ],
+            'trait with constants, properties and methods' => [
+                'testMarker' => '/* testTrait */',
+                'expected'   => [
+                    '$fa'  => '/* markerTraitProperty1 */',
+                    '$sol' => '/* markerTraitProperty2 */',
+                    '$LA'  => '/* markerTraitProperty3 */',
+                ],
+            ],
+            'anon class with constants, properties and methods in unconventional order' => [
+                'testMarker' => '/* testAnonClassUnconventionalOrder */',
+                'expected'   => [
+                    '$goingDownTheOnlyRoad' => '/* markerAnonOrderProperty1 */',
+                    '$inNeedOfRescue'       => '/* markerAnonOrderProperty2 */',
+                ],
+            ],
+            'enum with constants, cases and methods' => [
+                'testMarker' => '/* testEnum */',
+                'expected'   => [
+                    '$invalid' => '/* markerEnumIllegalProperty */',
+                ],
+            ],
+            'class with constructor, no properties, no params' => [
+                'testMarker' => '/* testClassConstructorNoParams */',
+                'expected'   => [],
+            ],
+            'interface with constructor, no properties, has params' => [
+                'testMarker' => '/* testInterfaceConstructorWithParamsNotProperties */',
+                'expected'   => [],
+            ],
+            'class with constructor, with properties, no params' => [
+                'testMarker' => '/* testClassConstructorWithProperties */',
+                'expected'   => [
+                    '$propA' => '/* markerCPP3_Property1 */',
+                    '$propB' => '/* markerCPP3_Property2 */',
+                    '$propC' => '/* markerCPP3_Property3 */',
+                    '$propD' => '/* markerCPP3_Property4 */',
+                ],
+            ],
+            'trait with constructor, with properties, with params' => [
+                'testMarker' => '/* testTraitConstructorWithParamsAndProperties */',
+                'expected'   => [
+                    '$declared' => '/* markerCPP4_Property1 */',
+                    '$instance' => '/* markerCPP4_Property2 */',
+                    '$propA'    => '/* markerCPP4_Property3 */',
+                    '$propB'    => '/* markerCPP4_Property4 */',
+                    '$propC'    => '/* markerCPP4_Property5 */',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Verify that the build-in caching is used when caching is enabled.
+     *
+     * @return void
+     */
+    public function testGetDeclaredPropertiesResultIsCached()
+    {
+        // The test case used is specifically selected as the raw and the clean param values will be the same.
+        $methodName = 'PHPCSUtils\\Utils\\ObjectDeclarations::analyzeOOStructure';
+        $cases      = $this->dataGetDeclaredProperties();
+        $testMarker = $cases['class with constants, properties, methods and everything else']['testMarker'];
+        $expected   = $cases['class with constants, properties, methods and everything else']['expected'];
+
+        // Translate the property markers to token pointers.
+        foreach ($expected as $name => $marker) {
+            $expected[$name] = $this->getTargetToken($marker, [\T_VARIABLE]);
+        }
+
+        $stackPtr = $this->getTargetToken($testMarker, Tokens::$ooScopeTokens);
+
+        // Verify the caching works.
+        $origStatus     = Cache::$enabled;
+        Cache::$enabled = true;
+
+        $resultFirstRun  = ObjectDeclarations::getDeclaredProperties(self::$phpcsFile, $stackPtr);
+        $isCached        = Cache::isCached(self::$phpcsFile, $methodName, $stackPtr);
+        $resultSecondRun = ObjectDeclarations::getDeclaredProperties(self::$phpcsFile, $stackPtr);
+
+        if ($origStatus === false) {
+            Cache::clear();
+        }
+        Cache::$enabled = $origStatus;
+
+        $this->assertSame($expected, $resultFirstRun, 'First result did not match expectation');
+        $this->assertTrue($isCached, 'Cache::isCached() could not find the cached value');
+        $this->assertSame($resultFirstRun, $resultSecondRun, 'Second result did not match first');
+    }
+}

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError1Test.inc
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError1Test.inc
@@ -1,0 +1,7 @@
+<?php
+
+// Intentional parse error. Has to be the only test in the file.
+// Missing OO opening curly.
+
+/* testParseError */
+enum testParseError: int implements Countable

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError1Test.php
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError1Test.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations\AnalyzeOOStructure;
+
+use PHPCSUtils\Tests\Utils\ObjectDeclarations\AnalyzeOOStructure\ParseErrorTestCase;
+
+/**
+ * Test for the \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure method.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredEnumCases
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredConstants
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredProperties
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredMethods
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure
+ *
+ * @since 1.1.0
+ */
+final class ParseError1Test extends ParseErrorTestCase
+{
+}

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError2Test.inc
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError2Test.inc
@@ -1,0 +1,9 @@
+<?php
+
+// Intentional parse error. Has to be the only test in the file.
+// Missing OO close curly.
+
+/* testParseError */
+enum testParseError {
+
+    public function foo($param);

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError2Test.php
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError2Test.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations\AnalyzeOOStructure;
+
+use PHPCSUtils\Tests\Utils\ObjectDeclarations\AnalyzeOOStructure\ParseErrorTestCase;
+
+/**
+ * Test for the \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure method.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredEnumCases
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredConstants
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredProperties
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredMethods
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure
+ *
+ * @since 1.1.0
+ */
+final class ParseError2Test extends ParseErrorTestCase
+{
+}

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError3Test.inc
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError3Test.inc
@@ -1,0 +1,9 @@
+<?php
+
+// Intentional parse error. Has to be the only test in the file.
+// Missing constant name.
+
+/* testParseError */
+enum ParseError {
+    public const = 'name';
+}

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError3Test.php
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError3Test.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations\AnalyzeOOStructure;
+
+use PHPCSUtils\Tests\Utils\ObjectDeclarations\AnalyzeOOStructure\ParseErrorTestCase;
+
+/**
+ * Test for the \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure method.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredEnumCases
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredConstants
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredProperties
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredMethods
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure
+ *
+ * @since 1.1.0
+ */
+final class ParseError3Test extends ParseErrorTestCase
+{
+}

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError4Test.inc
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError4Test.inc
@@ -1,0 +1,9 @@
+<?php
+
+// Intentional parse error. Has to be the only test in the file.
+// Missing constant value assignment.
+
+/* testParseError */
+enum ParseError {
+    public const name;
+}

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError4Test.php
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError4Test.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations\AnalyzeOOStructure;
+
+use PHPCSUtils\Tests\Utils\ObjectDeclarations\AnalyzeOOStructure\ParseErrorTestCase;
+
+/**
+ * Test for the \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure method.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredEnumCases
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredConstants
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredProperties
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredMethods
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure
+ *
+ * @since 1.1.0
+ */
+final class ParseError4Test extends ParseErrorTestCase
+{
+}

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError5Test.inc
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError5Test.inc
@@ -1,0 +1,9 @@
+<?php
+
+// Intentional parse error. Has to be the only test in the file.
+// Missing enum case name.
+
+/* testParseError */
+enum ParseError: string {
+    case  = 'name';
+}

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError5Test.php
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError5Test.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations\AnalyzeOOStructure;
+
+use PHPCSUtils\Tests\Utils\ObjectDeclarations\AnalyzeOOStructure\ParseErrorTestCase;
+
+/**
+ * Test for the \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure method.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredEnumCases
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredConstants
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredProperties
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredMethods
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure
+ *
+ * @since 1.1.0
+ */
+final class ParseError5Test extends ParseErrorTestCase
+{
+}

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError6Test.inc
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError6Test.inc
@@ -1,0 +1,9 @@
+<?php
+
+// Intentional parse error. Has to be the only test in the file.
+// Missing function name.
+
+/* testParseError */
+enum ParseError {
+    public function ($param) {}
+}

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError6Test.php
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError6Test.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations\AnalyzeOOStructure;
+
+use PHPCSUtils\Tests\Utils\ObjectDeclarations\AnalyzeOOStructure\ParseErrorTestCase;
+
+/**
+ * Test for the \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure method.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredEnumCases
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredConstants
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredProperties
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredMethods
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure
+ *
+ * @since 1.1.0
+ */
+final class ParseError6Test extends ParseErrorTestCase
+{
+}

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError7Test.inc
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError7Test.inc
@@ -1,0 +1,13 @@
+<?php
+
+// Intentional parse error. Has to be the only test in the file.
+// Missing function parentheses in abstract function.
+
+/* testParseError */
+abstract class ParseError {
+    /* markerFunction1 */
+    abstract public function name ;
+
+    /* markerFunction2 */
+    public function another() {}
+}

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError7Test.php
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseError7Test.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations\AnalyzeOOStructure;
+
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tests\Utils\ObjectDeclarations\AnalyzeOOStructure\ParseErrorTestCase;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * Test for the \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure method.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredEnumCases
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredConstants
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredProperties
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredMethods
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure
+ *
+ * @since 1.1.0
+ */
+final class ParseError7Test extends ParseErrorTestCase
+{
+
+    /**
+     * Test retrieving the cases declared in an enum.
+     *
+     * @return void
+     */
+    public function testGetDeclaredEnumCases()
+    {
+        $this->markTestSkipped('Parse error which doesn\'t involve an enum');
+    }
+
+    /**
+     * Test retrieving the methods declared in an OO structure.
+     *
+     * @return void
+     */
+    public function testGetDeclaredMethods()
+    {
+        $expected = [
+            'name'    => '/* markerFunction1 */',
+            'another' => '/* markerFunction2 */',
+        ];
+
+        // Translate the method markers to token pointers.
+        foreach ($expected as $name => $marker) {
+            $expected[$name] = $this->getTargetToken($marker, [\T_FUNCTION]);
+        }
+
+        $stackPtr = $this->getTargetToken('/* testParseError */', Tokens::$ooScopeTokens);
+        $result   = ObjectDeclarations::getDeclaredMethods(self::$phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+}

--- a/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseErrorTestCase.php
+++ b/Tests/Utils/ObjectDeclarations/AnalyzeOOStructure/ParseErrorTestCase.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\ObjectDeclarations\AnalyzeOOStructure;
+
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * Testcase for the \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure method
+ * and its associated get*() methods.
+ *
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredEnumCases
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredConstants
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredProperties
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::getDeclaredMethods
+ * @covers \PHPCSUtils\Utils\ObjectDeclarations::analyzeOOStructure
+ *
+ * @since 1.1.0
+ */
+abstract class ParseErrorTestCase extends UtilityMethodTestCase
+{
+
+    /**
+     * Test retrieving the constants declared in an OO structure.
+     *
+     * @return void
+     */
+    public function testGetDeclaredConstants()
+    {
+        $stackPtr = $this->getTargetToken('/* testParseError */', Tokens::$ooScopeTokens);
+        $this->assertSame([], ObjectDeclarations::getDeclaredConstants(self::$phpcsFile, $stackPtr));
+    }
+
+    /**
+     * Test retrieving the cases declared in an enum.
+     *
+     * @return void
+     */
+    public function testGetDeclaredEnumCases()
+    {
+        $stackPtr = $this->getTargetToken('/* testParseError */', Tokens::$ooScopeTokens);
+        $this->assertSame([], ObjectDeclarations::getDeclaredEnumCases(self::$phpcsFile, $stackPtr));
+    }
+
+    /**
+     * Test retrieving the properties declared in an OO structure.
+     *
+     * @return void
+     */
+    public function testGetDeclaredProperties()
+    {
+        $stackPtr = $this->getTargetToken('/* testParseError */', Tokens::$ooScopeTokens);
+        $this->assertSame([], ObjectDeclarations::getDeclaredProperties(self::$phpcsFile, $stackPtr));
+    }
+
+    /**
+     * Test retrieving the methods declared in an OO structure.
+     *
+     * @return void
+     */
+    public function testGetDeclaredMethods()
+    {
+        $stackPtr = $this->getTargetToken('/* testParseError */', Tokens::$ooScopeTokens);
+        $this->assertSame([], ObjectDeclarations::getDeclaredMethods(self::$phpcsFile, $stackPtr));
+    }
+}


### PR DESCRIPTION
This commit adds a new set of utility methods to the `ObjectDeclarations` class:
* `getDeclaredConstants(File $phpcsFile, int $stackPtr): array`
* `getDeclaredEnumCases(File $phpcsFile, int $stackPtr): array`
* `getDeclaredProperties(File $phpcsFile, int $stackPtr): array`
* `getDeclaredMethods(File $phpcsFile, int $stackPtr): array`
* (`private`) `analyzeOOStructure(File $phpcsFile, int $stackPtr): array`

These methods allow for retrieving an array with the names of all constants, enum cases, properties and methods as the keys and the stack pointer to the relevant `T_CONST`, `T_ENUM_CASE`, `T_VARIABLE` or `T_FUNCTION` token as the value.

As these methods all used the same `analyzeOOStructure()` method under the hood and the results of that method are cached, the method are highly optimized for performance.

If a sniff needs to search for a named constant/enum case/property/method in an OO structure, in most cases, these methods should be the recommended way for finding the declaration, instead of the sniff attempting to do this itself.

Includes extensive unit tests.

Closes #124 