### PR TITLE
ControlStructures::getCaughtExceptions(): don't throw an exception for a parse error

### DIFF
--- a/PHPCSUtils/Utils/ControlStructures.php
+++ b/PHPCSUtils/Utils/ControlStructures.php
@@ -214,8 +214,6 @@ final class ControlStructures
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified `$stackPtr` is not of
      *                                                      type `T_CATCH` or doesn't exist.
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If no parenthesis opener or closer can be
-     *                                                      determined (parse error).
      */
     public static function getCaughtExceptions(File $phpcsFile, $stackPtr)
     {
@@ -228,7 +226,7 @@ final class ControlStructures
         }
 
         if (isset($tokens[$stackPtr]['parenthesis_opener'], $tokens[$stackPtr]['parenthesis_closer']) === false) {
-            throw new RuntimeException('Parentheses opener/closer of the T_CATCH could not be determined');
+            return [];
         }
 
         $opener     = $tokens[$stackPtr]['parenthesis_opener'];

--- a/Tests/Utils/ControlStructures/GetCaughtExceptionsTest.php
+++ b/Tests/Utils/ControlStructures/GetCaughtExceptionsTest.php
@@ -48,19 +48,6 @@ final class GetCaughtExceptionsTest extends UtilityMethodTestCase
     }
 
     /**
-     * Test receiving an expected exception when a parse error is encountered.
-     *
-     * @return void
-     */
-    public function testParseError()
-    {
-        $this->expectPhpcsException('Parentheses opener/closer of the T_CATCH could not be determined');
-
-        $target = $this->getTargetToken('/* testLiveCoding */', \T_CATCH);
-        ControlStructures::getCaughtExceptions(self::$phpcsFile, $target);
-    }
-
-    /**
      * Test retrieving the exceptions caught in a `catch` condition.
      *
      * @dataProvider dataGetCaughtExceptions
@@ -218,6 +205,10 @@ final class GetCaughtExceptionsTest extends UtilityMethodTestCase
             ],
             'multi-catch-without-named-exceptions' => [
                 'testMarker'    => '/* testMultiMissingExceptionNames */',
+                'expected'      => [],
+            ],
+            'live coding / parse error' => [
+                'testMarker'    => '/* testLiveCoding */',
                 'expected'      => [],
             ],
         ];


### PR DESCRIPTION
Sniffs should silently ignore parse errors in the file under scan.

This commit removes a parse error related exception.

Includes updated unit test.

Also see squizlabs/PHP_CodeSniffer#2455