### PR TITLE
UseStatements::splitImportUseStatement(): minor simplification

### DIFF
--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -192,10 +192,6 @@ final class UseStatements
     {
         $tokens = $phpcsFile->getTokens();
 
-        if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== \T_USE) {
-            throw new RuntimeException('$stackPtr must be of type T_USE');
-        }
-
         if (self::isImportUse($phpcsFile, $stackPtr) === false) {
             throw new RuntimeException('$stackPtr must be an import use statement');
         }


### PR DESCRIPTION
These same validations are also being done in the `isImportUse()` method, so let's not duplicate them, but let the potential exceptions fall through from the `isImportUse()` method.