### PR TITLE
:sparkles: Introduce 7 new exceptions

### DIFF
--- a/PHPCSUtils/Exceptions/InvalidTokenArray.php
+++ b/PHPCSUtils/Exceptions/InvalidTokenArray.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSUtils\Exceptions;
 
-use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHPCSUtils\Exceptions\RuntimeException;
 
 /**
  * Exception thrown when an non-existent token array is requested.

--- a/PHPCSUtils/Exceptions/LogicException.php
+++ b/PHPCSUtils/Exceptions/LogicException.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Exceptions;
+
+use PHPCSUtils\Exceptions\RuntimeException;
+
+/**
+ * Exception for reporting a logic error.
+ *
+ * {@internal This exception should probably extend the PHP native `LogicException`, but
+ * that would inhibit the use of this exception, as replacing existing exceptions with this
+ * (better) one would then be a breaking change.}
+ *
+ * @since 1.1.0
+ */
+final class LogicException extends RuntimeException
+{
+
+    /**
+     * Create a new LogicException with a standardized start of the text.
+     *
+     * @param string $message Arbitrary message text.
+     *
+     * @return \PHPCSUtils\Exceptions\LogicException
+     */
+    public static function create($message)
+    {
+        $stack = \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+
+        return new self(
+            \sprintf(
+                '%s::%s(): %s',
+                $stack[1]['class'],
+                $stack[1]['function'],
+                $message
+            )
+        );
+    }
+}

--- a/PHPCSUtils/Exceptions/MissingArgumentError.php
+++ b/PHPCSUtils/Exceptions/MissingArgumentError.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Exceptions;
+
+use PHPCSUtils\Exceptions\RuntimeException;
+
+/**
+ * Exception for when a (conditionally) required parameter is not passed.
+ *
+ * {@internal This exception should probably extend the PHP native `ArgumentCountError`, but
+ * that would inhibit the use of this exception, as replacing existing exceptions with this
+ * (better) one would then be a breaking change.}
+ *
+ * @since 1.1.0
+ */
+final class MissingArgumentError extends RuntimeException
+{
+
+    /**
+     * Create a new MissingArgumentError exception with a standardized start of the text.
+     *
+     * @param int    $position The argument position in the function signature. 1-based.
+     * @param string $name     The argument name in the function signature.
+     * @param string $message  Arbitrary message text, which should indicate under what
+     *                         conditions the parameter is required.
+     *
+     * @return \PHPCSUtils\Exceptions\MissingArgumentError
+     */
+    public static function create($position, $name, $message)
+    {
+        $stack = \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+
+        return new self(
+            \sprintf(
+                '%s::%s(): Argument #%d (%s) is required %s.',
+                $stack[1]['class'],
+                $stack[1]['function'],
+                $position,
+                $name,
+                $message
+            )
+        );
+    }
+}

--- a/PHPCSUtils/Exceptions/OutOfBoundsStackPtr.php
+++ b/PHPCSUtils/Exceptions/OutOfBoundsStackPtr.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Exceptions;
+
+use PHPCSUtils\Exceptions\RuntimeException;
+
+/**
+ * Exception for when a stack pointer which doesn't exist in the current file is passed.
+ *
+ * {@internal This exception should probably extend the PHP native `OutOfBoundsException`, but
+ * that would inhibit the use of this exception, as replacing existing exceptions with this
+ * (better) one would then be a breaking change.}
+ *
+ * @since 1.1.0
+ */
+final class OutOfBoundsStackPtr extends RuntimeException
+{
+
+    /**
+     * Create a new OutOfBoundsStackPtr exception with a standardized text.
+     *
+     * @param int    $position The argument position in the function signature. 1-based.
+     * @param string $name     The argument name in the function signature.
+     * @param mixed  $received The received stack pointer position.
+     *
+     * @return \PHPCSUtils\Exceptions\OutOfBoundsStackPtr
+     */
+    public static function create($position, $name, $received)
+    {
+        $stack = \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+
+        return new self(
+            \sprintf(
+                '%s::%s(): Argument #%d (%s) must be a stack pointer which exists in the $phpcsFile object, %s given.',
+                $stack[1]['class'],
+                $stack[1]['function'],
+                $position,
+                $name,
+                \is_scalar($received) ? \var_export($received, true) : \gettype($received)
+            )
+        );
+    }
+}

--- a/PHPCSUtils/Exceptions/RuntimeException.php
+++ b/PHPCSUtils/Exceptions/RuntimeException.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Exceptions;
+
+use PHP_CodeSniffer\Exceptions\RuntimeException as PHPCSRuntimeException;
+
+/**
+ * Exception for reporting a runtime error.
+ *
+ * @phpcs:disable Universal.Classes.RequireFinalClass -- Deliberately not final.
+ *
+ * @since 1.1.0
+ */
+class RuntimeException extends PHPCSRuntimeException
+{
+}

--- a/PHPCSUtils/Exceptions/TypeError.php
+++ b/PHPCSUtils/Exceptions/TypeError.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Exceptions;
+
+use PHPCSUtils\Exceptions\RuntimeException;
+
+/**
+ * Exception for an invalid argument type passed.
+ *
+ * {@internal This exception should probably extend the PHP native `InvalidArgumentException`, or
+ * the PHP 7.0+ `TypeError`, but that would inhibit the use of this exception, as replacing existing
+ * exceptions with this (better) one would then be a breaking change.}
+ *
+ * @since 1.1.0
+ */
+final class TypeError extends RuntimeException
+{
+
+    /**
+     * Create a new TypeError exception with a standardized text.
+     *
+     * @param int    $position The argument position in the function signature. 1-based.
+     * @param string $name     The argument name in the function signature.
+     * @param string $expected The argument type expected as a string.
+     * @param mixed  $received The actual argument received.
+     *
+     * @return \PHPCSUtils\Exceptions\TypeError
+     */
+    public static function create($position, $name, $expected, $received)
+    {
+        $stack = \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+
+        return new self(
+            \sprintf(
+                '%s::%s(): Argument #%d (%s) must be of type %s, %s given.',
+                $stack[1]['class'],
+                $stack[1]['function'],
+                $position,
+                $name,
+                $expected,
+                \gettype($received)
+            )
+        );
+    }
+}

--- a/PHPCSUtils/Exceptions/UnexpectedTokenType.php
+++ b/PHPCSUtils/Exceptions/UnexpectedTokenType.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Exceptions;
+
+use PHPCSUtils\Exceptions\RuntimeException;
+
+/**
+ * Exception for when a stack pointer is passed which is not of the expected token type.
+ *
+ * {@internal This exception should probably extend the PHP native `InvalidArgumentException`, but
+ * that would inhibit the use of this exception, as replacing existing exceptions with this
+ * (better) one would then be a breaking change.}
+ *
+ * @since 1.1.0
+ */
+final class UnexpectedTokenType extends RuntimeException
+{
+
+    /**
+     * Create a new UnexpectedTokenType exception with a standardized text.
+     *
+     * @param int    $position      The argument position in the function signature. 1-based.
+     * @param string $name          The argument name in the function signature.
+     * @param string $acceptedTypes Phrase listing the accepted token type(s).
+     * @param string $receivedType  The received token type.
+     *
+     * @return \PHPCSUtils\Exceptions\UnexpectedTokenType
+     */
+    public static function create($position, $name, $acceptedTypes, $receivedType)
+    {
+        $stack = \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+
+        return new self(
+            \sprintf(
+                '%s::%s(): Argument #%d (%s) must be of type %s; %s given.',
+                $stack[1]['class'],
+                $stack[1]['function'],
+                $position,
+                $name,
+                $acceptedTypes,
+                $receivedType
+            )
+        );
+    }
+}

--- a/PHPCSUtils/Exceptions/ValueError.php
+++ b/PHPCSUtils/Exceptions/ValueError.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Exceptions;
+
+use PHPCSUtils\Exceptions\RuntimeException;
+
+/**
+ * Exception for an invalid argument value passed.
+ *
+ * This exception should be used when the argument uses the correct type, but doesn't comply with
+ * predefined restrictions, like an empty string being passed, when only a non-empty string is accepted
+ * or a negative integer being passed when a positive integer is expected.
+ *
+ * {@internal This exception should probably extend the PHP native `InvalidArgumentException`, or the
+ * PHP 8.0+ `ValueError`, but that would inhibit the use of this exception, as replacing existing
+ * exceptions with this (better) one would then be a breaking change.}
+ *
+ * @since 1.1.0
+ */
+final class ValueError extends RuntimeException
+{
+
+    /**
+     * Create a new ValueError exception with a standardized start of the text.
+     *
+     * @param int    $position The argument position in the function signature. 1-based.
+     * @param string $name     The argument name in the function signature.
+     * @param string $message  Arbitrary message text.
+     *
+     * @return \PHPCSUtils\Exceptions\ValueError
+     */
+    public static function create($position, $name, $message)
+    {
+        $stack = \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+
+        return new self(
+            \sprintf(
+                '%s::%s(): The value of argument #%d (%s) %s.',
+                $stack[1]['class'],
+                $stack[1]['function'],
+                $position,
+                $name,
+                $message
+            )
+        );
+    }
+}

--- a/Tests/Exceptions/LogicException/LogicExceptionTest.php
+++ b/Tests/Exceptions/LogicException/LogicExceptionTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Exceptions\LogicException;
+
+use PHPCSUtils\Exceptions\LogicException;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Exceptions\LogicException
+ *
+ * @since 1.1.0
+ */
+final class LogicExceptionTest extends TestCase
+{
+
+    /**
+     * Test that the text of the exception is as expected.
+     *
+     * @return void
+     */
+    public function testCreate()
+    {
+        $message = \sprintf(
+            '%s(): your message',
+            __METHOD__
+        );
+
+        $this->expectException('PHPCSUtils\Exceptions\LogicException');
+        $this->expectExceptionMessage($message);
+
+        throw LogicException::create('your message');
+    }
+}

--- a/Tests/Exceptions/MissingArgumentError/MissingArgumentErrorTest.php
+++ b/Tests/Exceptions/MissingArgumentError/MissingArgumentErrorTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Exceptions\MissingArgumentError;
+
+use PHPCSUtils\Exceptions\MissingArgumentError;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Exceptions\MissingArgumentError
+ *
+ * @since 1.1.0
+ */
+final class MissingArgumentErrorTest extends TestCase
+{
+
+    /**
+     * Test that the text of the exception is as expected.
+     *
+     * @return void
+     */
+    public function testCreate()
+    {
+        $message = \sprintf(
+            '%s(): Argument #2 ($config) is required for PHPCS 4.x',
+            __METHOD__
+        );
+
+        $this->expectException('PHPCSUtils\Exceptions\MissingArgumentError');
+        $this->expectExceptionMessage($message);
+
+        throw MissingArgumentError::create(2, '$config', 'for PHPCS 4.x');
+    }
+}

--- a/Tests/Exceptions/OutOfBoundsStackPtr/OutOfBoundsStackPtrTest.php
+++ b/Tests/Exceptions/OutOfBoundsStackPtr/OutOfBoundsStackPtrTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Exceptions\OutOfBoundsStackPtr;
+
+use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Exceptions\OutOfBoundsStackPtr
+ *
+ * @since 1.1.0
+ */
+final class OutOfBoundsStackPtrTest extends TestCase
+{
+
+    /**
+     * Test that the text of the exception is as expected.
+     *
+     * @return void
+     */
+    public function testCreateForScalar()
+    {
+        $message = \sprintf(
+            '%s(): Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object, 100000 given',
+            __METHOD__
+        );
+
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage($message);
+
+        throw OutOfBoundsStackPtr::create(2, '$stackPtr', 100000);
+    }
+
+    /**
+     * Test that the text of the exception is as expected.
+     *
+     * @return void
+     */
+    public function testCreateForNonScalar()
+    {
+        $message = \sprintf(
+            '%s(): Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object, array given',
+            __METHOD__
+        );
+
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage($message);
+
+        throw OutOfBoundsStackPtr::create(2, '$stackPtr', []);
+    }
+}

--- a/Tests/Exceptions/TypeError/TypeErrorTest.php
+++ b/Tests/Exceptions/TypeError/TypeErrorTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Exceptions\TypeError;
+
+use PHPCSUtils\Exceptions\TypeError;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Exceptions\TypeError
+ *
+ * @since 1.1.0
+ */
+final class TypeErrorTest extends TestCase
+{
+
+    /**
+     * Test that the text of the exception is as expected.
+     *
+     * @return void
+     */
+    public function testCreate()
+    {
+        $message = \sprintf(
+            '%s(): Argument #1 ($typeString) must be of type string, integer given',
+            __METHOD__
+        );
+
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage($message);
+
+        throw TypeError::create(1, '$typeString', 'string', 1);
+    }
+}

--- a/Tests/Exceptions/UnexpectedTokenType/UnexpectedTokenTypeTest.php
+++ b/Tests/Exceptions/UnexpectedTokenType/UnexpectedTokenTypeTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Exceptions\UnexpectedTokenType;
+
+use PHPCSUtils\Exceptions\UnexpectedTokenType;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Exceptions\UnexpectedTokenType
+ *
+ * @since 1.1.0
+ */
+final class UnexpectedTokenTypeTest extends TestCase
+{
+
+    /**
+     * Test that the text of the exception is as expected.
+     *
+     * @return void
+     */
+    public function testCreate()
+    {
+        $message = \sprintf(
+            '%s(): Argument #2 ($stackPtr) must be of type T_NAMESPACE; T_WHITESPACE given',
+            __METHOD__
+        );
+
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage($message);
+
+        throw UnexpectedTokenType::create(2, '$stackPtr', 'T_NAMESPACE', 'T_WHITESPACE');
+    }
+}

--- a/Tests/Exceptions/ValueError/ValueErrorTest.php
+++ b/Tests/Exceptions/ValueError/ValueErrorTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Exceptions\ValueError;
+
+use PHPCSUtils\Exceptions\ValueError;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\Exceptions\ValueError
+ *
+ * @since 1.1.0
+ */
+final class ValueErrorTest extends TestCase
+{
+
+    /**
+     * Test that the text of the exception is as expected.
+     *
+     * @return void
+     */
+    public function testCreate()
+    {
+        $message = \sprintf(
+            '%s(): The value of argument #1 ($end) must be before $start',
+            __METHOD__
+        );
+
+        $this->expectException('PHPCSUtils\Exceptions\ValueError');
+        $this->expectExceptionMessage($message);
+
+        throw ValueError::create(1, '$end', 'must be before $start');
+    }
+}


### PR DESCRIPTION
These exceptions are primarily for use by PHPCSUtils itself, though could be used for utilities in external standards as well.

All exceptions extend the PHPCS native `RuntimeException`, which means replacing existing exceptions being thrown with the new exceptions will not cause a breaking change as `catch( PHP_CodeSniffer\Exceptions\RuntimeException $e )` will still catch the new exceptions.

Having said that, once the new exceptions are in use, it also allows for making the `catch` more specific, which should allow for surfacing errors in sniffs which were accidentally caught.


### ✨ New PHPCSUtils native RuntimeException class

This exception extends the PHPCS native `RuntimeException` to allow pre-existing PHPCSUtils code to switch to this exception without causing a breaking change.

This exception is also not `final` to allow more specific exceptions to extend from it. This is, again, deliberate, to allow pre-existing PHPCSUtils code to switch to more specific child-exceptions without causing a breaking change.

Includes changing the `InvalidTokenArray` exception to extend this new exception.

### ✨ New PHPCSUtils\Exceptions\TypeError exception class

New exception to flag an invalid argument type passed to a method using a standardized message.

This exception extends the PHPCSUtils native `RuntimeException` to allow pre-existing PHPCSUtils code to switch to this exception without causing a breaking change.

If, by the time a 2.0 release happens, usage of this exception has not been replaced with PHP native type declarations yet, it should be considered to switch the parent class for the exception to the PHP native `TypeError` class (PHP 7.0+), which this exception largely emulates.

Includes perfunctory test for the exception.

### ✨ New PHPCSUtils\Exceptions\ValueError exception class

New exception to flag arguments using the correct type, but where the value doesn't comply with predefined restrictions, like an empty string being passed, when only a non-empty string is accepted or a negative integer being passed when a positive integer is expected.

The exception ensures these issues are flagged with a more consistent message format using a standardized message prefix.

This exception extends the PHPCSUtils native `RuntimeException` to allow pre-existing PHPCSUtils code to switch to this exception without causing a breaking change.

By rights, this exception should extend the PHP native `ValueError` class, but unfortunately, that class is not available until PHP 8.0 (and not extending the `RuntimeException` would be a breaking change).

By the time a 2.0 release happens, it should be considered to switch the parent class for the exception to the PHP native `ValueError` (PHP 8.0+) if the minimum supported PHP version allows for it.

Includes perfunctory test for the exception.

### ✨ New PHPCSUtils\Exceptions\OutOfBoundsStackPtr exception class

New exception to flag a passed stack pointer which doesn't exist in the $phpcsFile.

This exception extends the PHPCSUtils native `RuntimeException` to allow pre-existing PHPCSUtils code to switch to this exception without causing a breaking change, though extending the PHPCSUtils `ValueError` class would also have been an option.

By rights, this exception should probably extend the PHP native `OutOfBoundsException` class, but not extending the `RuntimeException` would be a breaking change.

By the time a 2.0 release happens, it should be considered to switch the parent class for the exception to the PHP native `OutOfBoundsException`.

Includes perfunctory test for the exception.

### ✨ New PHPCSUtils\Exceptions\UnexpectedTokenType exception class

New exception to flag a passed stack pointer argument, which does not comply with the token type requirements of the receiving method.

This exception extends the PHPCSUtils native `RuntimeException` to allow pre-existing PHPCSUtils code to switch to this exception without causing a breaking change, though extending the PHPCSUtils `ValueError` class would also have been an option.

By rights, this exception should probably extend the PHP native `InvalidArgumentException` class, but not extending the `RuntimeException` would be a breaking change.

By the time a 2.0 release happens, it should be considered to switch the parent class for the exception to the PHP native `InvalidArgumentException`.

Includes perfunctory test for the exception.

### ✨ New PHPCSUtils\Exceptions\LogicException class

New exception to flag an error in the program logic.

The exception ensures these issues are flagged with a more consistent message format using a standardized message prefix.

This exception extends the PHPCS native `RuntimeException` to allow pre-existing PHPCSUtils code to switch to this exception without causing a breaking change.

By rights, this exception should extend the PHP native `LogicException` class, but not extending the `RuntimeException` would be a breaking change.

By the time a 2.0 release happens, it should be considered to switch the parent class for the exception to the PHP native `LogicException`.

Includes perfunctory test for the exception.

### ✨ New PHPCSUtils\Exceptions\MissingArgumentError exception class

New exception to flag missing, conditionally required, parameters.

The exception ensures these issues are flagged with a more consistent message format using a standardized message prefix.

This exception extends the PHPCS native `RuntimeException` to allow pre-existing PHPCSUtils code to switch to this exception without causing a breaking change.

By rights, this exception should extend the PHP native `ArgumentCountError` class, but not extending the `RuntimeException` would be a breaking change.

By the time a 2.0 release happens, it should be considered to switch the parent class for the exception to the PHP native `ArgumentCountError`.

Includes perfunctory test for the exception.