### PR TITLE
Start using the new exceptions

### DIFF
--- a/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
+++ b/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
@@ -10,10 +10,11 @@
 
 namespace PHPCSUtils\AbstractSniffs;
 
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Exceptions\LogicException;
+use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\Numbers;
@@ -178,7 +179,7 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
     {
         try {
             $this->arrayItems = PassedParameters::getParameters($phpcsFile, $stackPtr);
-        } catch (RuntimeException $e) {
+        } catch (UnexpectedTokenType $e) {
             // Parse error, short list, real square open bracket or incorrectly tokenized short array token.
             return;
         }
@@ -245,7 +246,7 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
         foreach ($this->arrayItems as $itemNr => $arrayItem) {
             try {
                 $arrowPtr = Arrays::getDoubleArrowPtr($phpcsFile, $arrayItem['start'], $arrayItem['end']);
-            } catch (RuntimeException $e) {
+            } catch (LogicException $e) {
                 // Parse error: empty array item. Ignore.
                 continue;
             }

--- a/PHPCSUtils/BackCompat/Helper.php
+++ b/PHPCSUtils/BackCompat/Helper.php
@@ -11,8 +11,8 @@
 namespace PHPCSUtils\BackCompat;
 
 use PHP_CodeSniffer\Config;
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Exceptions\MissingArgumentError;
 
 /**
  * Utility methods to retrieve (configuration) information from PHP_CodeSniffer.
@@ -63,6 +63,8 @@ final class Helper
      *                                        in PHPCS 3.x and higher.
      *
      * @return bool Whether the setting of the data was successfull.
+     *
+     * @throws \PHPCSUtils\Exceptions\MissingArgumentError When using PHPCS 4.x and not passing the $config parameter.
      */
     public static function setConfigData($key, $value, $temp = false, $config = null)
     {
@@ -72,7 +74,7 @@ final class Helper
         }
 
         if (\version_compare(self::getVersion(), '3.99.99', '>') === true) {
-            throw new RuntimeException('Passing the $config parameter is required in PHPCS 4.x');
+            throw MissingArgumentError::create(4, '$config', 'when running on PHPCS 4.x');
         }
 
         // PHPCS 3.x.

--- a/PHPCSUtils/Fixers/SpacesFixer.php
+++ b/PHPCSUtils/Fixers/SpacesFixer.php
@@ -10,9 +10,12 @@
 
 namespace PHPCSUtils\Fixers;
 
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Exceptions\LogicException;
+use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\UnexpectedTokenType;
+use PHPCSUtils\Exceptions\ValueError;
 use PHPCSUtils\Utils\Numbers;
 
 /**
@@ -80,11 +83,11 @@ final class SpacesFixer
      *
      * @return void
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the tokens passed do not exist or are whitespace
-     *                                                      tokens.
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If `$expectedSpaces` is not a valid value.
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the tokens passed are separated by more than just
-     *                                                      empty (whitespace + comments/annotations) tokens.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the tokens passed do not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the tokens passed are whitespace tokens.
+     * @throws \PHPCSUtils\Exceptions\ValueError          If `$expectedSpaces` parameter is not a valid value.
+     * @throws \PHPCSUtils\Exceptions\LogicException      If the tokens passed are separated by more than just
+     *                                                    empty (whitespace + comments/annotations) tokens.
      */
     public static function checkAndFix(
         File $phpcsFile,
@@ -103,11 +106,20 @@ final class SpacesFixer
          * Validate the received function input.
          */
 
-        if (isset($tokens[$stackPtr], $tokens[$secondPtr]) === false
-            || $tokens[$stackPtr]['code'] === \T_WHITESPACE
-            || $tokens[$secondPtr]['code'] === \T_WHITESPACE
-        ) {
-            throw new RuntimeException('The $stackPtr and the $secondPtr token must exist and not be whitespace');
+        if (isset($tokens[$stackPtr]) === false) {
+            throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);
+        }
+
+        if (isset($tokens[$secondPtr]) === false) {
+            throw OutOfBoundsStackPtr::create(3, '$secondPtr', $secondPtr);
+        }
+
+        if ($tokens[$stackPtr]['code'] === \T_WHITESPACE) {
+            throw UnexpectedTokenType::create(2, '$stackPtr', 'any, except whitespace', 'T_WHITESPACE');
+        }
+
+        if ($tokens[$secondPtr]['code'] === \T_WHITESPACE) {
+            throw UnexpectedTokenType::create(3, '$secondPtr', 'any, except whitespace', 'T_WHITESPACE');
         }
 
         $expected = false;
@@ -120,9 +132,8 @@ final class SpacesFixer
         }
 
         if ($expected === false) {
-            throw new RuntimeException(
-                'The $expectedSpaces setting should be either "newline", 0 or a positive integer'
-            );
+            $message = \sprintf('should be either "newline", 0 or a positive integer; %s given', $expectedSpaces);
+            throw ValueError::create(4, '$expectedSpaces', $message);
         }
 
         $ptrA = $stackPtr;
@@ -134,7 +145,7 @@ final class SpacesFixer
 
         $nextNonEmpty = $phpcsFile->findNext(Tokens::$emptyTokens, ($ptrA + 1), null, true);
         if ($nextNonEmpty !== false && $nextNonEmpty < $ptrB) {
-            throw new RuntimeException(
+            throw LogicException::create(
                 'The $stackPtr and the $secondPtr token must be adjacent tokens separated only'
                     . ' by whitespace and/or comments'
             );

--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -10,8 +10,9 @@
 
 namespace PHPCSUtils\Utils;
 
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Exceptions\LogicException;
+use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
 use PHPCSUtils\Internal\Cache;
 use PHPCSUtils\Internal\IsShortArrayOrListWithCache;
 use PHPCSUtils\Tokens\Collections;
@@ -151,16 +152,24 @@ final class Arrays
      *
      * @return int|false Stack pointer to the double arrow if this array item has a key; or `FALSE` otherwise.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the start or end positions are invalid.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the tokens passed do not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\LogicException      If $end pointer is before the $start pointer.
      */
     public static function getDoubleArrowPtr(File $phpcsFile, $start, $end)
     {
         $tokens = $phpcsFile->getTokens();
 
-        if (isset($tokens[$start], $tokens[$end]) === false || $start > $end) {
-            throw new RuntimeException(
-                'Invalid start and/or end position passed to getDoubleArrowPtr().'
-                . ' Received: $start ' . $start . ', $end ' . $end
+        if (isset($tokens[$start]) === false) {
+            throw OutOfBoundsStackPtr::create(2, '$start', $start);
+        }
+
+        if (isset($tokens[$end]) === false) {
+            throw OutOfBoundsStackPtr::create(3, '$end', $end);
+        }
+
+        if ($start > $end) {
+            throw LogicException::create(
+                \sprintf('The $start token must be before the $end token. Received: $start %d, $end %d', $start, $end)
             );
         }
 

--- a/PHPCSUtils/Utils/ControlStructures.php
+++ b/PHPCSUtils/Utils/ControlStructures.php
@@ -10,9 +10,10 @@
 
 namespace PHPCSUtils\Utils;
 
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Tokens\Collections;
 
 /**
@@ -212,17 +213,19 @@ final class ControlStructures
      *               ```
      *               In case of an invalid catch structure, the array may be empty.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified `$stackPtr` is not of
-     *                                                      type `T_CATCH` or doesn't exist.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_CATCH` token.
      */
     public static function getCaughtExceptions(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
-        if (isset($tokens[$stackPtr]) === false
-            || $tokens[$stackPtr]['code'] !== \T_CATCH
-        ) {
-            throw new RuntimeException('$stackPtr must be of type T_CATCH');
+        if (isset($tokens[$stackPtr]) === false) {
+            throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);
+        }
+
+        if ($tokens[$stackPtr]['code'] !== \T_CATCH) {
+            throw UnexpectedTokenType::create(2, '$stackPtr', 'T_CATCH', $tokens[$stackPtr]['type']);
         }
 
         if (isset($tokens[$stackPtr]['parenthesis_opener'], $tokens[$stackPtr]['parenthesis_closer']) === false) {

--- a/PHPCSUtils/Utils/GetTokensAsString.php
+++ b/PHPCSUtils/Utils/GetTokensAsString.php
@@ -10,9 +10,9 @@
 
 namespace PHPCSUtils\Utils;
 
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
 
 /**
  * Utility functions to retrieve the content of a set of tokens as a string.
@@ -43,7 +43,7 @@ final class GetTokensAsString
      *
      * @return string The token contents.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified start position does not exist.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the $start token does not exist in the $phpcsFile.
      */
     public static function normal(File $phpcsFile, $start, $end)
     {
@@ -72,7 +72,7 @@ final class GetTokensAsString
      *
      * @return string The token contents.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified start position does not exist.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the $start token does not exist in the $phpcsFile.
      */
     public static function tabReplaced(File $phpcsFile, $start, $end)
     {
@@ -103,7 +103,7 @@ final class GetTokensAsString
      *
      * @return string The token contents.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified start position does not exist.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the $start token does not exist in the $phpcsFile.
      */
     public static function origContent(File $phpcsFile, $start, $end)
     {
@@ -124,7 +124,7 @@ final class GetTokensAsString
      *
      * @return string The token contents stripped off comments.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified start position does not exist.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the $start token does not exist in the $phpcsFile.
      */
     public static function noComments(File $phpcsFile, $start, $end)
     {
@@ -148,7 +148,7 @@ final class GetTokensAsString
      *
      * @return string The token contents stripped off comments and whitespace.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified start position does not exist.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the $start token does not exist in the $phpcsFile.
      */
     public static function noEmpties(File $phpcsFile, $start, $end)
     {
@@ -172,7 +172,7 @@ final class GetTokensAsString
      *
      * @return string The token contents with compacted whitespace and optionally stripped off comments.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified start position does not exist.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the $start token does not exist in the $phpcsFile.
      */
     public static function compact(File $phpcsFile, $start, $end, $stripComments = false)
     {
@@ -200,7 +200,7 @@ final class GetTokensAsString
      *
      * @return string The token contents.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified start position does not exist.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the $start token does not exist in the $phpcsFile.
      */
     protected static function getString(
         File $phpcsFile,
@@ -214,9 +214,7 @@ final class GetTokensAsString
         $tokens = $phpcsFile->getTokens();
 
         if (\is_int($start) === false || isset($tokens[$start]) === false) {
-            throw new RuntimeException(
-                'The $start position for GetTokensAsString methods must exist in the token stack'
-            );
+            throw OutOfBoundsStackPtr::create(2, '$start', $start);
         }
 
         if (\is_int($end) === false || $end < $start) {

--- a/PHPCSUtils/Utils/Namespaces.php
+++ b/PHPCSUtils/Utils/Namespaces.php
@@ -14,6 +14,8 @@ use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Internal\Cache;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Conditions;
@@ -44,8 +46,8 @@ final class Namespaces
      *                reliably determined what the `T_NAMESPACE` token is used for,
      *                which, in most cases, will mean the code contains a parse/fatal error.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is
-     *                                                      not a `T_NAMESPACE` token.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_NAMESPACE` token.
      */
     public static function getType(File $phpcsFile, $stackPtr)
     {
@@ -70,8 +72,12 @@ final class Namespaces
 
         $tokens = $phpcsFile->getTokens();
 
-        if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== \T_NAMESPACE) {
-            throw new RuntimeException('$stackPtr must be of type T_NAMESPACE');
+        if (isset($tokens[$stackPtr]) === false) {
+            throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);
+        }
+
+        if ($tokens[$stackPtr]['code'] !== \T_NAMESPACE) {
+            throw UnexpectedTokenType::create(2, '$stackPtr', 'T_NAMESPACE', $tokens[$stackPtr]['type']);
         }
 
         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
@@ -125,8 +131,8 @@ final class Namespaces
      * @return bool `TRUE` if the token passed is the keyword for a namespace declaration.
      *              `FALSE` if not.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is
-     *                                                      not a `T_NAMESPACE` token.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_NAMESPACE` token.
      */
     public static function isDeclaration(File $phpcsFile, $stackPtr)
     {
@@ -146,8 +152,8 @@ final class Namespaces
      *
      * @return bool `TRUE` if the namespace token passed is used as an operator. `FALSE` if not.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is
-     *                                                      not a `T_NAMESPACE` token.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_NAMESPACE` token.
      */
     public static function isOperator(File $phpcsFile, $stackPtr)
     {

--- a/PHPCSUtils/Utils/Namespaces.php
+++ b/PHPCSUtils/Utils/Namespaces.php
@@ -10,11 +10,11 @@
 
 namespace PHPCSUtils\Utils;
 
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\RuntimeException;
 use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Internal\Cache;
 use PHPCSUtils\Tokens\Collections;

--- a/PHPCSUtils/Utils/Numbers.php
+++ b/PHPCSUtils/Utils/Numbers.php
@@ -10,8 +10,9 @@
 
 namespace PHPCSUtils\Utils;
 
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\UnexpectedTokenType;
 
 /**
  * Utility functions for working with integer/float tokens.
@@ -125,19 +126,19 @@ final class Numbers
      *               )
      *               ```
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified token is not of type
-     *                                                      `T_LNUMBER` or `T_DNUMBER`.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_LNUMBER` or `T_DNUMBER` token.
      */
     public static function getCompleteNumber(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
-        if (isset($tokens[$stackPtr]) === false
-            || ($tokens[$stackPtr]['code'] !== \T_LNUMBER && $tokens[$stackPtr]['code'] !== \T_DNUMBER)
-        ) {
-            throw new RuntimeException(
-                'Token type "' . $tokens[$stackPtr]['type'] . '" is not T_LNUMBER or T_DNUMBER'
-            );
+        if (isset($tokens[$stackPtr]) === false) {
+            throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);
+        }
+
+        if ($tokens[$stackPtr]['code'] !== \T_LNUMBER && $tokens[$stackPtr]['code'] !== \T_DNUMBER) {
+            throw UnexpectedTokenType::create(2, '$stackPtr', 'T_LNUMBER or T_DNUMBER', $tokens[$stackPtr]['type']);
         }
 
         $content = $tokens[$stackPtr]['content'];

--- a/PHPCSUtils/Utils/TextStrings.php
+++ b/PHPCSUtils/Utils/TextStrings.php
@@ -10,9 +10,11 @@
 
 namespace PHPCSUtils\Utils;
 
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\UnexpectedTokenType;
+use PHPCSUtils\Exceptions\ValueError;
 use PHPCSUtils\Internal\Cache;
 use PHPCSUtils\Internal\NoFileCache;
 use PHPCSUtils\Tokens\Collections;
@@ -72,10 +74,10 @@ final class TextStrings
      *
      * @return string The contents of the complete text string.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      valid text string token.
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified token is not the _first_
-     *                                                      token in a text string.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a valid text string token.
+     * @throws \PHPCSUtils\Exceptions\ValueError          If the specified token is not the _first_ token in
+     *                                                    a text string.
      */
     public static function getCompleteTextString(File $phpcsFile, $stackPtr, $stripQuotes = true)
     {
@@ -118,27 +120,29 @@ final class TextStrings
      *
      * @return int Stack pointer to the last token in the text string.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      valid text string token.
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified token is not the _first_
-     *                                                      token in a text string.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a valid text string token.
+     * @throws \PHPCSUtils\Exceptions\ValueError          If the specified token is not the _first_ token in
+     *                                                    a text string.
      */
     public static function getEndOfCompleteTextString(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
-        // Must be the start of a text string token.
-        if (isset($tokens[$stackPtr], Collections::textStringStartTokens()[$tokens[$stackPtr]['code']]) === false) {
-            throw new RuntimeException(
-                '$stackPtr must be of type T_START_HEREDOC, T_START_NOWDOC, T_CONSTANT_ENCAPSED_STRING'
-                . ' or T_DOUBLE_QUOTED_STRING'
-            );
+        if (isset($tokens[$stackPtr]) === false) {
+            throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);
         }
 
+        if (isset(Collections::textStringStartTokens()[$tokens[$stackPtr]['code']]) === false) {
+            $acceptedTokens = 'T_START_HEREDOC, T_START_NOWDOC, T_CONSTANT_ENCAPSED_STRING or T_DOUBLE_QUOTED_STRING';
+            throw UnexpectedTokenType::create(2, '$stackPtr', $acceptedTokens, $tokens[$stackPtr]['type']);
+        }
+
+        // Must be the start of a text string token.
         if (isset(Tokens::$stringTokens[$tokens[$stackPtr]['code']]) === true) {
             $prev = $phpcsFile->findPrevious(\T_WHITESPACE, ($stackPtr - 1), null, true);
             if ($tokens[$stackPtr]['code'] === $tokens[$prev]['code']) {
-                throw new RuntimeException('$stackPtr must be the start of the text string');
+                throw ValueError::create(2, '$stackPtr', 'must be the start of the text string');
             }
         }
 

--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -10,7 +10,6 @@
 
 namespace PHPCSUtils\Utils;
 
-use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
@@ -379,7 +378,7 @@ final class UseStatements
         try {
             $useStatements         = self::splitImportUseStatement($phpcsFile, $stackPtr);
             $previousUseStatements = self::mergeImportUseStatements($previousUseStatements, $useStatements);
-        } catch (RuntimeException $e) {
+        } catch (ValueError $e) {
             // Not an import use statement.
         }
 

--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -13,6 +13,9 @@ namespace PHPCSUtils\Utils;
 use PHP_CodeSniffer\Exceptions\RuntimeException;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\UnexpectedTokenType;
+use PHPCSUtils\Exceptions\ValueError;
 use PHPCSUtils\Internal\Cache;
 use PHPCSUtils\Utils\Conditions;
 use PHPCSUtils\Utils\Parentheses;
@@ -39,17 +42,19 @@ final class UseStatements
      *                the `T_USE` token is used for. An empty string being returned will
      *                normally mean the code being examined contains a parse error.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      `T_USE` token.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_USE` token.
      */
     public static function getType(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
-        if (isset($tokens[$stackPtr]) === false
-            || $tokens[$stackPtr]['code'] !== \T_USE
-        ) {
-            throw new RuntimeException('$stackPtr must be of type T_USE');
+        if (isset($tokens[$stackPtr]) === false) {
+            throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);
+        }
+
+        if ($tokens[$stackPtr]['code'] !== \T_USE) {
+            throw UnexpectedTokenType::create(2, '$stackPtr', 'T_USE', $tokens[$stackPtr]['type']);
         }
 
         $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
@@ -100,8 +105,8 @@ final class UseStatements
      * @return bool `TRUE` if the token passed is a closure use statement.
      *              `FALSE` if it's not.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      `T_USE` token.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_USE` token.
      */
     public static function isClosureUse(File $phpcsFile, $stackPtr)
     {
@@ -119,8 +124,8 @@ final class UseStatements
      * @return bool `TRUE` if the token passed is an import use statement.
      *              `FALSE` if it's not.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      `T_USE` token.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_USE` token.
      */
     public static function isImportUse(File $phpcsFile, $stackPtr)
     {
@@ -138,8 +143,8 @@ final class UseStatements
      * @return bool `TRUE` if the token passed is a trait use statement.
      *              `FALSE` if it's not.
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      `T_USE` token.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_USE` token.
      */
     public static function isTraitUse(File $phpcsFile, $stackPtr)
     {
@@ -183,17 +188,16 @@ final class UseStatements
      *               )
      *               ```
      *
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified position is not a
-     *                                                      `T_USE` token.
-     * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the `T_USE` token is not for an import
-     *                                                      use statement.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_USE` token.
+     * @throws \PHPCSUtils\Exceptions\ValueError          If the `T_USE` token is not for an import use statement.
      */
     public static function splitImportUseStatement(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
         if (self::isImportUse($phpcsFile, $stackPtr) === false) {
-            throw new RuntimeException('$stackPtr must be an import use statement');
+            throw ValueError::create(2, '$stackPtr', 'must be the pointer to an import use statement');
         }
 
         if (Cache::isCached($phpcsFile, __METHOD__, $stackPtr) === true) {

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
@@ -41,6 +41,41 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
     ];
 
     /**
+     * Test receiving an expected exception when an invalid token pointer is passed.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object, 100000 given'
+        );
+
+        $mockObj = $this->getMockedClassUnderTest();
+
+        $mockObj->expects($this->never())
+            ->method('processOpenClose');
+
+        $mockObj->expects($this->never())
+            ->method('processKey');
+
+        $mockObj->expects($this->never())
+            ->method('processNoKey');
+
+        $mockObj->expects($this->never())
+            ->method('processArrow');
+
+        $mockObj->expects($this->never())
+            ->method('processValue');
+
+        $mockObj->expects($this->never())
+            ->method('processComma');
+
+        $mockObj->process(self::$phpcsFile, 100000);
+    }
+
+    /**
      * Test that the abstract sniff correctly bows out when presented with a token which is not an array.
      *
      * @return void

--- a/Tests/BackCompat/BCFile/GetClassPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetClassPropertiesTest.php
@@ -11,7 +11,7 @@
 namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
 use PHPCSUtils\BackCompat\BCFile;
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 
 /**
  * Tests for the \PHPCSUtils\BackCompat\BCFile::getClassProperties() method.
@@ -22,7 +22,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class GetClassPropertiesTest extends UtilityMethodTestCase
+class GetClassPropertiesTest extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/BackCompat/BCFile/GetDeclarationNameJSTest.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameJSTest.php
@@ -11,7 +11,7 @@
 namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
 use PHPCSUtils\BackCompat\BCFile;
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 
 /**
  * Tests for the \PHPCSUtils\BackCompat\BCFile::getDeclarationName() method.
@@ -22,7 +22,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class GetDeclarationNameJSTest extends UtilityMethodTestCase
+class GetDeclarationNameJSTest extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
@@ -11,7 +11,7 @@
 namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
 use PHPCSUtils\BackCompat\BCFile;
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 
 /**
  * Tests for the \PHPCSUtils\BackCompat\BCFile::getDeclarationName() method.
@@ -22,7 +22,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class GetDeclarationNameTest extends UtilityMethodTestCase
+class GetDeclarationNameTest extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -22,7 +22,7 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 
 /**
  * Tests for the \PHPCSUtils\BackCompat\BCFile::getMemberProperties method.
@@ -33,7 +33,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class GetMemberPropertiesTest extends UtilityMethodTestCase
+class GetMemberPropertiesTest extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -24,7 +24,7 @@
 namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
 use PHPCSUtils\BackCompat\BCFile;
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 
 /**
  * Tests for the \PHPCSUtils\BackCompat\BCFile::getMethodParameters method.
@@ -35,7 +35,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class GetMethodParametersTest extends UtilityMethodTestCase
+class GetMethodParametersTest extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -21,7 +21,7 @@
 namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
 use PHPCSUtils\BackCompat\BCFile;
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 
 /**
  * Tests for the \PHPCSUtils\BackCompat\BCFile::getMethodProperties method.
@@ -32,7 +32,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-class GetMethodPropertiesTest extends UtilityMethodTestCase
+class GetMethodPropertiesTest extends PolyfilledTestCase
 {
 
     /**

--- a/Tests/BackCompat/Helper/ConfigDataTest.php
+++ b/Tests/BackCompat/Helper/ConfigDataTest.php
@@ -81,8 +81,8 @@ final class ConfigDataTest extends TestCase
             $this->markTestSkipped('Test only applicable to PHPCS 4.x');
         }
 
-        $this->expectException('PHP_CodeSniffer\Exceptions\RuntimeException');
-        $this->expectExceptionMessage('Passing the $config parameter is required in PHPCS 4.x');
+        $this->expectException('PHPCSUtils\Exceptions\MissingArgumentError');
+        $this->expectExceptionMessage('Argument #4 ($config) is required when running on PHPCS 4.x.');
 
         Helper::setConfigData('arbitrary_name', 'test', true);
     }

--- a/Tests/Fixers/SpacesFixer/SpacesFixerExceptionsTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerExceptionsTest.php
@@ -11,7 +11,7 @@
 namespace PHPCSUtils\Tests\Fixers\SpacesFixer;
 
 use PHPCSUtils\Fixers\SpacesFixer;
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 
 /**
  * Tests for the exceptions thrown in the \PHPCSUtils\Fixers\SpacesFixer::checkAndFix() method.
@@ -20,7 +20,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-final class SpacesFixerExceptionsTest extends UtilityMethodTestCase
+final class SpacesFixerExceptionsTest extends PolyfilledTestCase
 {
 
     /**
@@ -30,7 +30,10 @@ final class SpacesFixerExceptionsTest extends UtilityMethodTestCase
      */
     public function testNonExistentFirstToken()
     {
-        $this->expectPhpcsException('The $stackPtr and the $secondPtr token must exist and not be whitespace');
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object, 10000 given'
+        );
 
         SpacesFixer::checkAndFix(self::$phpcsFile, 10000, 10, 0, 'Dummy');
     }
@@ -42,7 +45,10 @@ final class SpacesFixerExceptionsTest extends UtilityMethodTestCase
      */
     public function testNonExistentSecondToken()
     {
-        $this->expectPhpcsException('The $stackPtr and the $secondPtr token must exist and not be whitespace');
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #3 ($secondPtr) must be a stack pointer which exists in the $phpcsFile object, 10000 given'
+        );
 
         SpacesFixer::checkAndFix(self::$phpcsFile, 10, 10000, 0, 'Dummy');
     }
@@ -54,7 +60,8 @@ final class SpacesFixerExceptionsTest extends UtilityMethodTestCase
      */
     public function testFirstTokenWhitespace()
     {
-        $this->expectPhpcsException('The $stackPtr and the $secondPtr token must exist and not be whitespace');
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type any, except whitespace;');
 
         $stackPtr = $this->getTargetToken('/* testPassingWhitespace1 */', \T_WHITESPACE);
         SpacesFixer::checkAndFix(self::$phpcsFile, $stackPtr, 10, 0, 'Dummy');
@@ -67,7 +74,8 @@ final class SpacesFixerExceptionsTest extends UtilityMethodTestCase
      */
     public function testSecondTokenWhitespace()
     {
-        $this->expectPhpcsException('The $stackPtr and the $secondPtr token must exist and not be whitespace');
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage('Argument #3 ($secondPtr) must be of type any, except whitespace;');
 
         $secondPtr = $this->getTargetToken('/* testPassingWhitespace2 */', \T_WHITESPACE);
         SpacesFixer::checkAndFix(self::$phpcsFile, 10, $secondPtr, 0, 'Dummy');
@@ -80,7 +88,8 @@ final class SpacesFixerExceptionsTest extends UtilityMethodTestCase
      */
     public function testNonAdjacentTokens()
     {
-        $this->expectPhpcsException(
+        $this->expectException('PHPCSUtils\Exceptions\LogicException');
+        $this->expectExceptionMessage(
             'The $stackPtr and the $secondPtr token must be adjacent tokens separated only'
                 . ' by whitespace and/or comments'
         );
@@ -97,7 +106,8 @@ final class SpacesFixerExceptionsTest extends UtilityMethodTestCase
      */
     public function testNonAdjacentTokensReverseOrder()
     {
-        $this->expectPhpcsException(
+        $this->expectException('PHPCSUtils\Exceptions\LogicException');
+        $this->expectExceptionMessage(
             'The $stackPtr and the $secondPtr token must be adjacent tokens separated only'
                 . ' by whitespace and/or comments'
         );
@@ -114,7 +124,10 @@ final class SpacesFixerExceptionsTest extends UtilityMethodTestCase
      */
     public function testInvalidExpectedSpacesNegativeValue()
     {
-        $this->expectPhpcsException('The $expectedSpaces setting should be either "newline", 0 or a positive integer');
+        $this->expectException('PHPCSUtils\Exceptions\ValueError');
+        $this->expectExceptionMessage(
+            'The value of argument #4 ($expectedSpaces) should be either "newline", 0 or a positive integer'
+        );
 
         $stackPtr  = $this->getTargetToken('/* testPassingWhitespace1 */', \T_ECHO);
         $secondPtr = $this->getTargetToken('/* testPassingWhitespace1 */', \T_CONSTANT_ENCAPSED_STRING);
@@ -128,7 +141,10 @@ final class SpacesFixerExceptionsTest extends UtilityMethodTestCase
      */
     public function testInvalidExpectedSpacesUnexpectedType()
     {
-        $this->expectPhpcsException('The $expectedSpaces setting should be either "newline", 0 or a positive integer');
+        $this->expectException('PHPCSUtils\Exceptions\ValueError');
+        $this->expectExceptionMessage(
+            'The value of argument #4 ($expectedSpaces) should be either "newline", 0 or a positive integer'
+        );
 
         $stackPtr  = $this->getTargetToken('/* testPassingWhitespace1 */', \T_ECHO);
         $secondPtr = $this->getTargetToken('/* testPassingWhitespace1 */', \T_CONSTANT_ENCAPSED_STRING);
@@ -142,7 +158,10 @@ final class SpacesFixerExceptionsTest extends UtilityMethodTestCase
      */
     public function testInvalidExpectedSpacesNonDecimalString()
     {
-        $this->expectPhpcsException('The $expectedSpaces setting should be either "newline", 0 or a positive integer');
+        $this->expectException('PHPCSUtils\Exceptions\ValueError');
+        $this->expectExceptionMessage(
+            'The value of argument #4 ($expectedSpaces) should be either "newline", 0 or a positive integer'
+        );
 
         $stackPtr  = $this->getTargetToken('/* testPassingWhitespace1 */', \T_ECHO);
         $secondPtr = $this->getTargetToken('/* testPassingWhitespace1 */', \T_CONSTANT_ENCAPSED_STRING);

--- a/Tests/Internal/IsShortArrayOrList/ConstructorTest.php
+++ b/Tests/Internal/IsShortArrayOrList/ConstructorTest.php
@@ -11,7 +11,7 @@
 namespace PHPCSUtils\Tests\Internal\IsShortArrayOrList;
 
 use PHPCSUtils\Internal\IsShortArrayOrList;
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 
 /**
  * Tests for the \PHPCSUtils\Utils\IsShortArrayOrList class.
@@ -20,7 +20,7 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  *
  * @since 1.0.0
  */
-final class ConstructorTest extends UtilityMethodTestCase
+final class ConstructorTest extends PolyfilledTestCase
 {
 
     /**
@@ -30,8 +30,9 @@ final class ConstructorTest extends UtilityMethodTestCase
      */
     public function testNonExistentToken()
     {
-        $this->expectPhpcsException(
-            'The IsShortArrayOrList class expects to be passed a T_OPEN_SHORT_ARRAY or T_OPEN_SQUARE_BRACKET token.'
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object, 100000 given'
         );
 
         new IsShortArrayOrList(self::$phpcsFile, 100000);
@@ -49,8 +50,9 @@ final class ConstructorTest extends UtilityMethodTestCase
      */
     public function testNotOpenBracket($testMarker, $targetType)
     {
-        $this->expectPhpcsException(
-            'The IsShortArrayOrList class expects to be passed a T_OPEN_SHORT_ARRAY or T_OPEN_SQUARE_BRACKET token.'
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be of type T_OPEN_SHORT_ARRAY or T_OPEN_SQUARE_BRACKET;'
         );
 
         $target = $this->getTargetToken($testMarker, $targetType);

--- a/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
+++ b/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
@@ -11,7 +11,7 @@
 namespace PHPCSUtils\Tests\Utils\Arrays;
 
 use PHPCSUtils\Internal\Cache;
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 1.0.0
  */
-final class GetDoubleArrowPtrTest extends UtilityMethodTestCase
+final class GetDoubleArrowPtrTest extends PolyfilledTestCase
 {
 
     /**
@@ -64,8 +64,9 @@ final class GetDoubleArrowPtrTest extends UtilityMethodTestCase
      */
     public function testInvalidStartPositionException()
     {
-        $this->expectPhpcsException(
-            'Invalid start and/or end position passed to getDoubleArrowPtr(). Received: $start -10, $end 10'
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($start) must be a stack pointer which exists in the $phpcsFile object'
         );
 
         Arrays::getDoubleArrowPtr(self::$phpcsFile, -10, 10);
@@ -78,8 +79,9 @@ final class GetDoubleArrowPtrTest extends UtilityMethodTestCase
      */
     public function testInvalidEndPositionException()
     {
-        $this->expectPhpcsException(
-            'Invalid start and/or end position passed to getDoubleArrowPtr(). Received: $start 0, $end 100000'
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #3 ($end) must be a stack pointer which exists in the $phpcsFile object'
         );
 
         Arrays::getDoubleArrowPtr(self::$phpcsFile, 0, 100000);
@@ -92,8 +94,9 @@ final class GetDoubleArrowPtrTest extends UtilityMethodTestCase
      */
     public function testInvalidStartEndPositionException()
     {
-        $this->expectPhpcsException(
-            'Invalid start and/or end position passed to getDoubleArrowPtr(). Received: $start 10, $end 5'
+        $this->expectException('PHPCSUtils\Exceptions\LogicException');
+        $this->expectExceptionMessage(
+            'The $start token must be before the $end token. Received: $start 10, $end 5'
         );
 
         Arrays::getDoubleArrowPtr(self::$phpcsFile, 10, 5);

--- a/Tests/Utils/ControlStructures/GetCaughtExceptionsTest.php
+++ b/Tests/Utils/ControlStructures/GetCaughtExceptionsTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSUtils\Tests\Utils\ControlStructures;
 
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 use PHPCSUtils\Utils\ControlStructures;
 
 /**
@@ -20,7 +20,7 @@ use PHPCSUtils\Utils\ControlStructures;
  *
  * @since 1.0.0
  */
-final class GetCaughtExceptionsTest extends UtilityMethodTestCase
+final class GetCaughtExceptionsTest extends PolyfilledTestCase
 {
 
     /**
@@ -30,7 +30,10 @@ final class GetCaughtExceptionsTest extends UtilityMethodTestCase
      */
     public function testNonExistentToken()
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_CATCH');
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object'
+        );
         ControlStructures::getCaughtExceptions(self::$phpcsFile, 10000);
     }
 
@@ -41,7 +44,8 @@ final class GetCaughtExceptionsTest extends UtilityMethodTestCase
      */
     public function testNotCatch()
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_CATCH');
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type T_CATCH; T_TRY given');
 
         $target = $this->getTargetToken('/* testNotCatch */', \T_TRY);
         ControlStructures::getCaughtExceptions(self::$phpcsFile, $target);

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSUtils\Tests\Utils\FunctionDeclarations;
 
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 use PHPCSUtils\Utils\FunctionDeclarations;
 
 /**
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  *
  * @since 1.0.0
  */
-final class GetParametersDiffTest extends UtilityMethodTestCase
+final class GetParametersDiffTest extends PolyfilledTestCase
 {
 
     /**
@@ -48,7 +48,10 @@ final class GetParametersDiffTest extends UtilityMethodTestCase
      */
     public function testNonExistentToken()
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION, T_CLOSURE or T_USE or an arrow function');
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object'
+        );
 
         FunctionDeclarations::getParameters(self::$phpcsFile, 10000);
     }

--- a/Tests/Utils/FunctionDeclarations/GetParametersTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersTest.php
@@ -61,7 +61,8 @@ final class GetParametersTest extends BCFile_GetMethodParametersTest
      */
     public function testUnexpectedTokenException($commentString, $targetTokenType)
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION, T_CLOSURE or T_USE or an arrow function');
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type T_FUNCTION, T_CLOSURE, T_FN or T_USE');
 
         $next = $this->getTargetToken($commentString, $targetTokenType);
         FunctionDeclarations::getParameters(self::$phpcsFile, $next);
@@ -78,7 +79,8 @@ final class GetParametersTest extends BCFile_GetMethodParametersTest
      */
     public function testInvalidUse($identifier)
     {
-        $this->expectPhpcsException('$stackPtr was not a valid closure T_USE');
+        $this->expectException('PHPCSUtils\Exceptions\ValueError');
+        $this->expectExceptionMessage('The value of argument #2 ($stackPtr) must be the pointer to a closure use statement');
 
         $use = $this->getTargetToken($identifier, [\T_USE]);
         FunctionDeclarations::getParameters(self::$phpcsFile, $use);

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
@@ -11,7 +11,7 @@
 namespace PHPCSUtils\Tests\Utils\FunctionDeclarations;
 
 use PHPCSUtils\Internal\Cache;
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\FunctionDeclarations;
 
@@ -27,7 +27,7 @@ use PHPCSUtils\Utils\FunctionDeclarations;
  *
  * @since 1.0.0
  */
-final class GetPropertiesDiffTest extends UtilityMethodTestCase
+final class GetPropertiesDiffTest extends PolyfilledTestCase
 {
 
     /**
@@ -37,7 +37,10 @@ final class GetPropertiesDiffTest extends UtilityMethodTestCase
      */
     public function testNonExistentToken()
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or an arrow function');
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object'
+        );
 
         FunctionDeclarations::getProperties(self::$phpcsFile, 10000);
     }

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesTest.php
@@ -59,7 +59,8 @@ final class GetPropertiesTest extends BCFile_GetMethodPropertiesTest
      */
     public function testNotAFunctionException($commentString, $targetTokenType)
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or an arrow function');
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type T_FUNCTION, T_CLOSURE or T_FN');
 
         $next = $this->getTargetToken($commentString, $targetTokenType);
         FunctionDeclarations::getProperties(self::$phpcsFile, $next);

--- a/Tests/Utils/GetTokensAsString/GetTokensAsStringTest.php
+++ b/Tests/Utils/GetTokensAsString/GetTokensAsStringTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSUtils\Tests\Utils\GetTokensAsString;
 
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 use PHPCSUtils\Utils\GetTokensAsString;
 
 /**
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\GetTokensAsString;
  *
  * @since 1.0.0
  */
-final class GetTokensAsStringTest extends UtilityMethodTestCase
+final class GetTokensAsStringTest extends PolyfilledTestCase
 {
 
     /**
@@ -54,7 +54,10 @@ final class GetTokensAsStringTest extends UtilityMethodTestCase
      */
     public function testNonExistentStart()
     {
-        $this->expectPhpcsException('The $start position for GetTokensAsString methods must exist in the token stack');
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($start) must be a stack pointer which exists in the $phpcsFile object, 100000 given'
+        );
 
         GetTokensAsString::normal(self::$phpcsFile, 100000, 100010);
     }
@@ -66,7 +69,10 @@ final class GetTokensAsStringTest extends UtilityMethodTestCase
      */
     public function testNonIntegerStart()
     {
-        $this->expectPhpcsException('The $start position for GetTokensAsString methods must exist in the token stack');
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($start) must be a stack pointer which exists in the $phpcsFile object, false given'
+        );
 
         GetTokensAsString::noEmpties(self::$phpcsFile, false, 10);
     }

--- a/Tests/Utils/Lists/GetAssignmentsTest.php
+++ b/Tests/Utils/Lists/GetAssignmentsTest.php
@@ -11,7 +11,7 @@
 namespace PHPCSUtils\Tests\Utils\Lists;
 
 use PHPCSUtils\Internal\Cache;
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\Lists;
 
@@ -22,7 +22,7 @@ use PHPCSUtils\Utils\Lists;
  *
  * @since 1.0.0
  */
-final class GetAssignmentsTest extends UtilityMethodTestCase
+final class GetAssignmentsTest extends PolyfilledTestCase
 {
 
     /**
@@ -32,7 +32,8 @@ final class GetAssignmentsTest extends UtilityMethodTestCase
      */
     public function testNonExistentToken()
     {
-        $this->expectPhpcsException('The Lists::getAssignments() method expects a long/short list token.');
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type long/short list; 100000');
 
         Lists::getAssignments(self::$phpcsFile, 100000);
     }
@@ -49,7 +50,8 @@ final class GetAssignmentsTest extends UtilityMethodTestCase
      */
     public function testNotListToken($testMarker, $targetToken)
     {
-        $this->expectPhpcsException('The Lists::getAssignments() method expects a long/short list token.');
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type long/short list; T_');
 
         $target = $this->getTargetToken($testMarker, $targetToken);
         Lists::getAssignments(self::$phpcsFile, $target);

--- a/Tests/Utils/Namespaces/NamespaceTypeTest.php
+++ b/Tests/Utils/Namespaces/NamespaceTypeTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSUtils\Tests\Utils\Namespaces;
 
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 use PHPCSUtils\Utils\Namespaces;
 
 /**
@@ -24,7 +24,7 @@ use PHPCSUtils\Utils\Namespaces;
  *
  * @since 1.0.0
  */
-final class NamespaceTypeTest extends UtilityMethodTestCase
+final class NamespaceTypeTest extends PolyfilledTestCase
 {
 
     /**
@@ -34,7 +34,10 @@ final class NamespaceTypeTest extends UtilityMethodTestCase
      */
     public function testNonExistentToken()
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_NAMESPACE');
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object, 100000 given'
+        );
 
         Namespaces::getType(self::$phpcsFile, 100000);
     }
@@ -46,7 +49,10 @@ final class NamespaceTypeTest extends UtilityMethodTestCase
      */
     public function testNonNamespaceToken()
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_NAMESPACE');
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be of type T_NAMESPACE;'
+        );
 
         Namespaces::getType(self::$phpcsFile, 0);
     }

--- a/Tests/Utils/Numbers/GetCompleteNumberTest.php
+++ b/Tests/Utils/Numbers/GetCompleteNumberTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSUtils\Tests\Utils\Numbers;
 
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 use PHPCSUtils\Utils\Numbers;
 
 /**
@@ -20,8 +20,23 @@ use PHPCSUtils\Utils\Numbers;
  *
  * @since 1.0.0
  */
-final class GetCompleteNumberTest extends UtilityMethodTestCase
+final class GetCompleteNumberTest extends PolyfilledTestCase
 {
+
+    /**
+     * Test receiving an exception when a non-existent token is passed to the method.
+     *
+     * @return void
+     */
+    public function testNonExistentTokenException()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object, 100000 given'
+        );
+
+        Numbers::getCompleteNumber(self::$phpcsFile, 100000);
+    }
 
     /**
      * Test receiving an exception when a non-numeric token is passed to the method.
@@ -30,7 +45,8 @@ final class GetCompleteNumberTest extends UtilityMethodTestCase
      */
     public function testNotANumberException()
     {
-        $this->expectPhpcsException('Token type "T_STRING" is not T_LNUMBER or T_DNUMBER');
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type T_LNUMBER or T_DNUMBER;');
 
         $stackPtr = $this->getTargetToken('/* testNotAnLNumber */', \T_STRING);
         Numbers::getCompleteNumber(self::$phpcsFile, $stackPtr);

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSUtils\Tests\Utils\ObjectDeclarations;
 
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 use PHPCSUtils\Utils\ObjectDeclarations;
 
 /**
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  *
  * @since 1.0.0
  */
-final class GetClassPropertiesDiffTest extends UtilityMethodTestCase
+final class GetClassPropertiesDiffTest extends PolyfilledTestCase
 {
 
     /**
@@ -35,7 +35,10 @@ final class GetClassPropertiesDiffTest extends UtilityMethodTestCase
      */
     public function testNonExistentToken()
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_CLASS');
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object'
+        );
 
         ObjectDeclarations::getClassProperties(self::$phpcsFile, 10000);
     }

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesTest.php
@@ -58,6 +58,25 @@ final class GetClassPropertiesTest extends BCFile_GetClassPropertiesTest
     }
 
     /**
+     * Test receiving an expected exception when a non class token is passed.
+     *
+     * @dataProvider dataNotAClassException
+     *
+     * @param string     $testMarker The comment which prefaces the target token in the test file.
+     * @param int|string $tokenType  The type of token to look for after the marker.
+     *
+     * @return void
+     */
+    public function testNotAClassException($testMarker, $tokenType)
+    {
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type T_CLASS');
+
+        $target = $this->getTargetToken($testMarker, $tokenType);
+        ObjectDeclarations::getClassProperties(self::$phpcsFile, $target);
+    }
+
+    /**
      * Test retrieving the properties for a class declaration.
      *
      * @dataProvider dataGetClassProperties

--- a/Tests/Utils/ObjectDeclarations/GetNameJSTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameJSTest.php
@@ -54,7 +54,10 @@ final class GetNameJSTest extends BCFile_GetDeclarationNameJSTest
      */
     public function testInvalidTokenPassed()
     {
-        $this->expectPhpcsException('Token type "T_STRING" is not T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT or T_ENUM');
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be of type T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT or T_ENUM'
+        );
 
         $target = $this->getTargetToken('/* testInvalidTokenPassed */', \T_STRING);
         ObjectDeclarations::getName(self::$phpcsFile, $target);

--- a/Tests/Utils/ObjectDeclarations/GetNameTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameTest.php
@@ -54,7 +54,10 @@ final class GetNameTest extends BCFile_GetDeclarationNameTest
      */
     public function testInvalidTokenPassed()
     {
-        $this->expectPhpcsException('Token type "T_STRING" is not T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT or T_ENUM');
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be of type T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT or T_ENUM'
+        );
 
         $target = $this->getTargetToken('/* testInvalidTokenPassed */', \T_STRING);
         ObjectDeclarations::getName(self::$phpcsFile, $target);

--- a/Tests/Utils/PassedParameters/GetParameterFromStackTest.php
+++ b/Tests/Utils/PassedParameters/GetParameterFromStackTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSUtils\Tests\Utils\PassedParameters;
 
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 use PHPCSUtils\Utils\PassedParameters;
 
 /**
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 1.0.0
  */
-final class GetParameterFromStackTest extends UtilityMethodTestCase
+final class GetParameterFromStackTest extends PolyfilledTestCase
 {
 
     /**
@@ -113,8 +113,9 @@ final class GetParameterFromStackTest extends UtilityMethodTestCase
      */
     public function testGetParameterFunctionCallMissingParamName()
     {
-        $this->expectPhpcsException(
-            'To allow for support for PHP 8 named parameters, the $paramNames parameter must be passed.'
+        $this->expectException('PHPCSUtils\Exceptions\MissingArgumentError');
+        $this->expectExceptionMessage(
+            'Argument #3 ($paramNames) is required to allow for support for PHP 8 named parameters.'
         );
 
         $stackPtr = $this->getTargetToken('/* testAllParamsNamedStandardOrder */', \T_STRING);
@@ -131,8 +132,9 @@ final class GetParameterFromStackTest extends UtilityMethodTestCase
      */
     public function testGetParameterFunctionCallPositionalMissingParamNameNonExistentParam()
     {
-        $this->expectPhpcsException(
-            'To allow for support for PHP 8 named parameters, the $paramNames parameter must be passed.'
+        $this->expectException('PHPCSUtils\Exceptions\MissingArgumentError');
+        $this->expectExceptionMessage(
+            'Argument #3 ($paramNames) is required to allow for support for PHP 8 named parameters.'
         );
 
         $stackPtr = $this->getTargetToken('/* testAllParamsPositional */', \T_STRING);

--- a/Tests/Utils/PassedParameters/GetParametersSkipShortArrayCheckTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersSkipShortArrayCheckTest.php
@@ -43,8 +43,9 @@ final class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase
     public function testHasParametersDontSkipShortArrayCheck($testMarker, $targetType, $expectException)
     {
         if ($expectException === true) {
-            $this->expectPhpcsException(
-                'The hasParameters() method expects a function call, array, isset or unset token to be passed.'
+            $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+            $this->expectExceptionMessage(
+                'Argument #2 ($stackPtr) must be of type function call, array, isset or unset;'
             );
         }
 
@@ -93,8 +94,9 @@ final class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase
          * will be received before the code reaches that point.
          */
         if ($targetType === \T_OPEN_SQUARE_BRACKET) {
-            $this->expectPhpcsException(
-                'The hasParameters() method expects a function call, array, isset or unset token to be passed.'
+            $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+            $this->expectExceptionMessage(
+                'Argument #2 ($stackPtr) must be of type function call, array, isset or unset;'
             );
         }
 

--- a/Tests/Utils/PassedParameters/HasParametersTest.php
+++ b/Tests/Utils/PassedParameters/HasParametersTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSUtils\Tests\Utils\PassedParameters;
 
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\PassedParameters;
 
@@ -21,7 +21,7 @@ use PHPCSUtils\Utils\PassedParameters;
  *
  * @since 1.0.0
  */
-final class HasParametersTest extends UtilityMethodTestCase
+final class HasParametersTest extends PolyfilledTestCase
 {
 
     /**
@@ -31,8 +31,9 @@ final class HasParametersTest extends UtilityMethodTestCase
      */
     public function testNonExistentToken()
     {
-        $this->expectPhpcsException(
-            'The hasParameters() method expects a function call, array, isset or unset token to be passed'
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object, 100000 given'
         );
 
         PassedParameters::hasParameters(self::$phpcsFile, 100000);
@@ -46,8 +47,9 @@ final class HasParametersTest extends UtilityMethodTestCase
      */
     public function testNotAnAcceptedTokenException()
     {
-        $this->expectPhpcsException(
-            'The hasParameters() method expects a function call, array, isset or unset token to be passed.'
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be of type function call, array, isset or unset;'
         );
 
         $interface = $this->getTargetToken('/* testNotAnAcceptedToken */', \T_INTERFACE);
@@ -66,8 +68,9 @@ final class HasParametersTest extends UtilityMethodTestCase
      */
     public function testNotACallToConstructor($testMarker, $targetType)
     {
-        $this->expectPhpcsException(
-            'The hasParameters() method expects a function call, array, isset or unset token to be passed.'
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be of type function call, array, isset or unset;'
         );
 
         $self = $this->getTargetToken($testMarker, $targetType);
@@ -106,8 +109,9 @@ final class HasParametersTest extends UtilityMethodTestCase
      */
     public function testNotAShortArray()
     {
-        $this->expectPhpcsException(
-            'The hasParameters() method expects a function call, array, isset or unset token to be passed.'
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be of type function call, array, isset or unset;'
         );
 
         $self = $this->getTargetToken(

--- a/Tests/Utils/TextStrings/GetCompleteTextStringTest.php
+++ b/Tests/Utils/TextStrings/GetCompleteTextStringTest.php
@@ -11,7 +11,7 @@
 namespace PHPCSUtils\Tests\Utils\TextStrings;
 
 use PHPCSUtils\Internal\Cache;
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 use PHPCSUtils\Utils\TextStrings;
 
 /**
@@ -23,7 +23,7 @@ use PHPCSUtils\Utils\TextStrings;
  *
  * @since 1.0.0
  */
-final class GetCompleteTextStringTest extends UtilityMethodTestCase
+final class GetCompleteTextStringTest extends PolyfilledTestCase
 {
 
     /**
@@ -49,9 +49,9 @@ final class GetCompleteTextStringTest extends UtilityMethodTestCase
      */
     public function testNonExistentToken($method)
     {
-        $this->expectPhpcsException(
-            '$stackPtr must be of type T_START_HEREDOC, T_START_NOWDOC, T_CONSTANT_ENCAPSED_STRING'
-            . ' or T_DOUBLE_QUOTED_STRING'
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object, 100000 given'
         );
 
         TextStrings::$method(self::$phpcsFile, 100000);
@@ -68,9 +68,10 @@ final class GetCompleteTextStringTest extends UtilityMethodTestCase
      */
     public function testNotATextStringException($method)
     {
-        $this->expectPhpcsException(
-            '$stackPtr must be of type T_START_HEREDOC, T_START_NOWDOC, T_CONSTANT_ENCAPSED_STRING'
-            . ' or T_DOUBLE_QUOTED_STRING'
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be of type T_START_HEREDOC, T_START_NOWDOC, T_CONSTANT_ENCAPSED_STRING'
+            . ' or T_DOUBLE_QUOTED_STRING;'
         );
 
         $next = $this->getTargetToken('/* testNotATextString */', \T_RETURN);
@@ -89,7 +90,8 @@ final class GetCompleteTextStringTest extends UtilityMethodTestCase
      */
     public function testNotFirstTextStringException($method)
     {
-        $this->expectPhpcsException('$stackPtr must be the start of the text string');
+        $this->expectException('PHPCSUtils\Exceptions\ValueError');
+        $this->expectExceptionMessage('The value of argument #2 ($stackPtr) must be the start of the text string');
 
         $next = $this->getTargetToken(
             '/* testNotFirstTextStringToken */',

--- a/Tests/Utils/UseStatements/SplitAndMergeImportUseStatementTest.inc
+++ b/Tests/Utils/UseStatements/SplitAndMergeImportUseStatementTest.inc
@@ -1,5 +1,8 @@
 <?php
 
+/* testClosureUse */
+$closure = function() use($bar) {};
+
 /* testUseNamePlainAliased */
 use MyNamespace \ YourClass as ClassAlias;
 

--- a/Tests/Utils/UseStatements/SplitAndMergeImportUseStatementTest.php
+++ b/Tests/Utils/UseStatements/SplitAndMergeImportUseStatementTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSUtils\Tests\Utils\UseStatements;
 
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 use PHPCSUtils\Utils\UseStatements;
 
 /**
@@ -22,8 +22,37 @@ use PHPCSUtils\Utils\UseStatements;
  *
  * @since 1.0.0
  */
-final class SplitAndMergeImportUseStatementTest extends UtilityMethodTestCase
+final class SplitAndMergeImportUseStatementTest extends PolyfilledTestCase
 {
+
+    /**
+     * Test passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object, 100000 given'
+        );
+
+        UseStatements::splitAndMergeImportUseStatement(self::$phpcsFile, 100000, []);
+    }
+
+    /**
+     * Test receiving an expected exception when a non-supported token is passed.
+     *
+     * @return void
+     */
+    public function testInvalidTokenPassed()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type T_USE;');
+
+        // 0 = PHP open tag.
+        UseStatements::splitAndMergeImportUseStatement(self::$phpcsFile, 0, []);
+    }
 
     /**
      * Test correctly splitting and merging a import `use` statements.
@@ -53,6 +82,15 @@ final class SplitAndMergeImportUseStatementTest extends UtilityMethodTestCase
     public static function dataSplitAndMergeImportUseStatement()
     {
         $data = [
+            'closure-use' => [
+                'testMarker' => '/* testClosureUse */',
+                // Same as previous, which, as this is the first test case, is an empty statements array.
+                'expected'   => [
+                    'name'     => [],
+                    'function' => [],
+                    'const'    => [],
+                ],
+            ],
             'name-plain' => [
                 'testMarker' => '/* testUseNamePlainAliased */',
                 'expected'   => [
@@ -118,7 +156,11 @@ final class SplitAndMergeImportUseStatementTest extends UtilityMethodTestCase
             ],
         ];
 
-        $previousUse = [];
+        $previousUse = [
+            'name'     => [],
+            'function' => [],
+            'const'    => [],
+        ];
         foreach ($data as $key => $value) {
             $data[$key]['previousUse'] = $previousUse;
             $previousUse               = $value['expected'];

--- a/Tests/Utils/UseStatements/SplitImportUseStatementTest.php
+++ b/Tests/Utils/UseStatements/SplitImportUseStatementTest.php
@@ -11,7 +11,7 @@
 namespace PHPCSUtils\Tests\Utils\UseStatements;
 
 use PHPCSUtils\Internal\Cache;
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 use PHPCSUtils\Utils\UseStatements;
 
 /**
@@ -21,7 +21,7 @@ use PHPCSUtils\Utils\UseStatements;
  *
  * @since 1.0.0
  */
-final class SplitImportUseStatementTest extends UtilityMethodTestCase
+final class SplitImportUseStatementTest extends PolyfilledTestCase
 {
 
     /**
@@ -31,7 +31,10 @@ final class SplitImportUseStatementTest extends UtilityMethodTestCase
      */
     public function testNonExistentToken()
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_USE');
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object, 10000 given'
+        );
 
         UseStatements::splitImportUseStatement(self::$phpcsFile, 10000);
     }
@@ -43,7 +46,8 @@ final class SplitImportUseStatementTest extends UtilityMethodTestCase
      */
     public function testInvalidTokenPassed()
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_USE');
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type T_USE;');
 
         // 0 = PHP open tag.
         UseStatements::splitImportUseStatement(self::$phpcsFile, 0);
@@ -60,7 +64,8 @@ final class SplitImportUseStatementTest extends UtilityMethodTestCase
      */
     public function testNonImportUseTokenPassed($testMarker)
     {
-        $this->expectPhpcsException('$stackPtr must be an import use statement');
+        $this->expectException('PHPCSUtils\Exceptions\ValueError');
+        $this->expectExceptionMessage('The value of argument #2 ($stackPtr) must be the pointer to an import use statement');
 
         $stackPtr = $this->getTargetToken($testMarker, \T_USE);
         UseStatements::splitImportUseStatement(self::$phpcsFile, $stackPtr);

--- a/Tests/Utils/UseStatements/UseTypeTest.php
+++ b/Tests/Utils/UseStatements/UseTypeTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSUtils\Tests\Utils\UseStatements;
 
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 use PHPCSUtils\Utils\UseStatements;
 
 /**
@@ -26,7 +26,7 @@ use PHPCSUtils\Utils\UseStatements;
  *
  * @since 1.0.0
  */
-final class UseTypeTest extends UtilityMethodTestCase
+final class UseTypeTest extends PolyfilledTestCase
 {
 
     /**
@@ -36,7 +36,10 @@ final class UseTypeTest extends UtilityMethodTestCase
      */
     public function testNonExistentToken()
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_USE');
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object, 100000 given'
+        );
 
         UseStatements::getType(self::$phpcsFile, 100000);
     }
@@ -48,7 +51,8 @@ final class UseTypeTest extends UtilityMethodTestCase
      */
     public function testNonUseToken()
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_USE');
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type T_USE;');
 
         UseStatements::getType(self::$phpcsFile, 0);
     }

--- a/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSUtils\Tests\Utils\Variables;
 
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 use PHPCSUtils\Utils\Variables;
 
 /**
@@ -25,7 +25,7 @@ use PHPCSUtils\Utils\Variables;
  *
  * @since 1.0.0
  */
-final class GetMemberPropertiesDiffTest extends UtilityMethodTestCase
+final class GetMemberPropertiesDiffTest extends PolyfilledTestCase
 {
 
     /**
@@ -35,7 +35,10 @@ final class GetMemberPropertiesDiffTest extends UtilityMethodTestCase
      */
     public function testNonExistentToken()
     {
-        $this->expectPhpcsException('$stackPtr must be of type T_VARIABLE');
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object, 10000 given'
+        );
 
         Variables::getMemberProperties(self::$phpcsFile, 10000);
     }
@@ -51,7 +54,8 @@ final class GetMemberPropertiesDiffTest extends UtilityMethodTestCase
      */
     public function testNotClassPropertyException($testMarker)
     {
-        $this->expectPhpcsException('$stackPtr is not a class member var');
+        $this->expectException('PHPCSUtils\Exceptions\ValueError');
+        $this->expectExceptionMessage('The value of argument #2 ($stackPtr) must be the pointer to a class member var');
 
         $variable = $this->getTargetToken($testMarker, \T_VARIABLE);
         Variables::getMemberProperties(self::$phpcsFile, $variable);

--- a/Tests/Utils/Variables/GetMemberPropertiesTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesTest.php
@@ -59,6 +59,38 @@ final class GetMemberPropertiesTest extends BCFile_GetMemberPropertiesTest
     }
 
     /**
+     * Test receiving an expected exception when a non property is passed.
+     *
+     * @dataProvider dataNotClassProperty
+     *
+     * @param string $identifier Comment which precedes the test case.
+     *
+     * @return void
+     */
+    public function testNotClassPropertyException($identifier)
+    {
+        $this->expectException('PHPCSUtils\Exceptions\ValueError');
+        $this->expectExceptionMessage('The value of argument #2 ($stackPtr) must be the pointer to a class member var');
+
+        $variable = $this->getTargetToken($identifier, \T_VARIABLE);
+        Variables::getMemberProperties(self::$phpcsFile, $variable);
+    }
+
+    /**
+     * Test receiving an expected exception when a non variable is passed.
+     *
+     * @return void
+     */
+    public function testNotAVariableException()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type T_VARIABLE;');
+
+        $next = $this->getTargetToken('/* testNotAVariable */', \T_RETURN);
+        Variables::getMemberProperties(self::$phpcsFile, $next);
+    }
+
+    /**
      * Data provider.
      *
      * @see testGetMemberProperties()


### PR DESCRIPTION
### Start using the new exceptions throughout PHPCSUtils

This implements the use of the new exceptions introduced in #598 in all the right places in PHPCSUtils.

Notes:
* The `BCFile` class is explicitly exempt from this change as the methods in that class emulate the PHPCS native methods, which means they should also throw the PHPCS native exception.
* Includes switching a number of test classes from the `UtilityMethodTestCase` parent class to the `PolyfilledTestCase` parent class - which is basically the `UtilityMethodTestCase` + the PHPUnit Polyfills -. This allows for expecting the exceptions without having to jump through hoops for PHPUnit cross-version support.
* Includes adding select extra tests where needed.

### Only catch what should be caught

This changes the exceptions being caught in various `catch` statements to more specific ones.

This means that errors which should always have been thrown, will now throw and only the potentially expected (and acceptable) exceptions will now be caught.

Note:
* For the `Namespaces::getDeclaredName()` method, the `catch` has not been changed (other than switching from the PHPCS native `RuntimeException` to the PHPCSUtils one).
    The reason for this is that the method is explicitly documented as returning `false` for non-existent tokens.
    While this behaviour is not in line with other methods in PHPCSUtils, changing the behaviour could be seen as a breaking change, so should be done in a major release.

Includes test for where the behaviour of the functions is now different.