### PR TITLE
Add more defensive coding / improve type checking

### DIFF
--- a/PHPCSUtils/Fixers/SpacesFixer.php
+++ b/PHPCSUtils/Fixers/SpacesFixer.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Exceptions\LogicException;
 use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\TypeError;
 use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Exceptions\ValueError;
 use PHPCSUtils\Utils\Numbers;
@@ -83,6 +84,7 @@ final class SpacesFixer
      *
      * @return void
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr or $secondPtr parameters are not integers.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the tokens passed do not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the tokens passed are whitespace tokens.
      * @throws \PHPCSUtils\Exceptions\ValueError          If `$expectedSpaces` parameter is not a valid value.
@@ -105,6 +107,14 @@ final class SpacesFixer
         /*
          * Validate the received function input.
          */
+
+        if (\is_int($stackPtr) === false) {
+            throw TypeError::create(2, '$stackPtr', 'integer', $stackPtr);
+        }
+
+        if (\is_int($secondPtr) === false) {
+            throw TypeError::create(3, '$secondPtr', 'integer', $secondPtr);
+        }
 
         if (isset($tokens[$stackPtr]) === false) {
             throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);

--- a/PHPCSUtils/Internal/IsShortArrayOrList.php
+++ b/PHPCSUtils/Internal/IsShortArrayOrList.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\TypeError;
 use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Internal\Cache;
 use PHPCSUtils\Internal\IsShortArrayOrListWithCache;
@@ -183,6 +184,7 @@ final class IsShortArrayOrList
      *
      * @return void
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not one of the accepted types.
      */
@@ -190,6 +192,10 @@ final class IsShortArrayOrList
     {
         $tokens       = $phpcsFile->getTokens();
         $openBrackets = StableCollections::$shortArrayListOpenTokensBC;
+
+        if (\is_int($stackPtr) === false) {
+            throw TypeError::create(2, '$stackPtr', 'integer', $stackPtr);
+        }
 
         if (isset($tokens[$stackPtr]) === false) {
             throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);

--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -13,6 +13,7 @@ namespace PHPCSUtils\Utils;
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Exceptions\LogicException;
 use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\TypeError;
 use PHPCSUtils\Internal\Cache;
 use PHPCSUtils\Internal\IsShortArrayOrListWithCache;
 use PHPCSUtils\Tokens\Collections;
@@ -152,12 +153,21 @@ final class Arrays
      *
      * @return int|false Stack pointer to the double arrow if this array item has a key; or `FALSE` otherwise.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $start or $end parameters are not integers.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the tokens passed do not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\LogicException      If $end pointer is before the $start pointer.
      */
     public static function getDoubleArrowPtr(File $phpcsFile, $start, $end)
     {
         $tokens = $phpcsFile->getTokens();
+
+        if (\is_int($start) === false) {
+            throw TypeError::create(2, '$start', 'integer', $start);
+        }
+
+        if (\is_int($end) === false) {
+            throw TypeError::create(3, '$end', 'integer', $end);
+        }
 
         if (isset($tokens[$start]) === false) {
             throw OutOfBoundsStackPtr::create(2, '$start', $start);

--- a/PHPCSUtils/Utils/ControlStructures.php
+++ b/PHPCSUtils/Utils/ControlStructures.php
@@ -13,6 +13,7 @@ namespace PHPCSUtils\Utils;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\TypeError;
 use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Tokens\Collections;
 
@@ -213,12 +214,17 @@ final class ControlStructures
      *               ```
      *               In case of an invalid catch structure, the array may be empty.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_CATCH` token.
      */
     public static function getCaughtExceptions(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
+
+        if (\is_int($stackPtr) === false) {
+            throw TypeError::create(2, '$stackPtr', 'integer', $stackPtr);
+        }
 
         if (isset($tokens[$stackPtr]) === false) {
             throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);

--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -13,6 +13,7 @@ namespace PHPCSUtils\Utils;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\TypeError;
 use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Exceptions\ValueError;
 use PHPCSUtils\Internal\Cache;
@@ -131,6 +132,7 @@ final class FunctionDeclarations
      * @return string|null The name of the function; or `NULL` if the passed token doesn't exist,
      *                     the function is anonymous or in case of a parse error/live coding.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_FUNCTION` token.
      */
     public static function getName(File $phpcsFile, $stackPtr)
@@ -180,6 +182,7 @@ final class FunctionDeclarations
      *               );
      *               ```
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a T_FUNCTION, T_CLOSURE
      *                                                    or T_FN token.
@@ -187,6 +190,10 @@ final class FunctionDeclarations
     public static function getProperties(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
+
+        if (\is_int($stackPtr) === false) {
+            throw TypeError::create(2, '$stackPtr', 'integer', $stackPtr);
+        }
 
         if (isset($tokens[$stackPtr]) === false) {
             throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);
@@ -396,6 +403,7 @@ final class FunctionDeclarations
      *
      * @return array<int, array<string, mixed>>
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a T_FUNCTION, T_CLOSURE,
      *                                                    T_FN or T_USE token.
@@ -404,6 +412,10 @@ final class FunctionDeclarations
     public static function getParameters(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
+
+        if (\is_int($stackPtr) === false) {
+            throw TypeError::create(2, '$stackPtr', 'integer', $stackPtr);
+        }
 
         if (isset($tokens[$stackPtr]) === false) {
             throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);

--- a/PHPCSUtils/Utils/GetTokensAsString.php
+++ b/PHPCSUtils/Utils/GetTokensAsString.php
@@ -13,6 +13,7 @@ namespace PHPCSUtils\Utils;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\TypeError;
 
 /**
  * Utility functions to retrieve the content of a set of tokens as a string.
@@ -43,6 +44,7 @@ final class GetTokensAsString
      *
      * @return string The token contents.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $start parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the $start token does not exist in the $phpcsFile.
      */
     public static function normal(File $phpcsFile, $start, $end)
@@ -72,6 +74,7 @@ final class GetTokensAsString
      *
      * @return string The token contents.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $start parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the $start token does not exist in the $phpcsFile.
      */
     public static function tabReplaced(File $phpcsFile, $start, $end)
@@ -103,6 +106,7 @@ final class GetTokensAsString
      *
      * @return string The token contents.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $start parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the $start token does not exist in the $phpcsFile.
      */
     public static function origContent(File $phpcsFile, $start, $end)
@@ -124,6 +128,7 @@ final class GetTokensAsString
      *
      * @return string The token contents stripped off comments.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $start parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the $start token does not exist in the $phpcsFile.
      */
     public static function noComments(File $phpcsFile, $start, $end)
@@ -148,6 +153,7 @@ final class GetTokensAsString
      *
      * @return string The token contents stripped off comments and whitespace.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $start parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the $start token does not exist in the $phpcsFile.
      */
     public static function noEmpties(File $phpcsFile, $start, $end)
@@ -172,6 +178,7 @@ final class GetTokensAsString
      *
      * @return string The token contents with compacted whitespace and optionally stripped off comments.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $start parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the $start token does not exist in the $phpcsFile.
      */
     public static function compact(File $phpcsFile, $start, $end, $stripComments = false)
@@ -200,6 +207,7 @@ final class GetTokensAsString
      *
      * @return string The token contents.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $start parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the $start token does not exist in the $phpcsFile.
      */
     protected static function getString(
@@ -213,7 +221,11 @@ final class GetTokensAsString
     ) {
         $tokens = $phpcsFile->getTokens();
 
-        if (\is_int($start) === false || isset($tokens[$start]) === false) {
+        if (\is_int($start) === false) {
+            throw TypeError::create(2, '$start', 'integer', $start);
+        }
+
+        if (isset($tokens[$start]) === false) {
             throw OutOfBoundsStackPtr::create(2, '$start', $start);
         }
 

--- a/PHPCSUtils/Utils/Namespaces.php
+++ b/PHPCSUtils/Utils/Namespaces.php
@@ -15,6 +15,7 @@ use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
 use PHPCSUtils\Exceptions\RuntimeException;
+use PHPCSUtils\Exceptions\TypeError;
 use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Internal\Cache;
 use PHPCSUtils\Tokens\Collections;
@@ -46,6 +47,7 @@ final class Namespaces
      *                reliably determined what the `T_NAMESPACE` token is used for,
      *                which, in most cases, will mean the code contains a parse/fatal error.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_NAMESPACE` token.
      */
@@ -71,6 +73,10 @@ final class Namespaces
         }
 
         $tokens = $phpcsFile->getTokens();
+
+        if (\is_int($stackPtr) === false) {
+            throw TypeError::create(2, '$stackPtr', 'integer', $stackPtr);
+        }
 
         if (isset($tokens[$stackPtr]) === false) {
             throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);
@@ -131,6 +137,7 @@ final class Namespaces
      * @return bool `TRUE` if the token passed is the keyword for a namespace declaration.
      *              `FALSE` if not.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_NAMESPACE` token.
      */
@@ -152,6 +159,7 @@ final class Namespaces
      *
      * @return bool `TRUE` if the namespace token passed is used as an operator. `FALSE` if not.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_NAMESPACE` token.
      */

--- a/PHPCSUtils/Utils/Numbers.php
+++ b/PHPCSUtils/Utils/Numbers.php
@@ -12,6 +12,7 @@ namespace PHPCSUtils\Utils;
 
 use PHP_CodeSniffer\Files\File;
 use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\TypeError;
 use PHPCSUtils\Exceptions\UnexpectedTokenType;
 
 /**
@@ -126,12 +127,17 @@ final class Numbers
      *               )
      *               ```
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_LNUMBER` or `T_DNUMBER` token.
      */
     public static function getCompleteNumber(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
+
+        if (\is_int($stackPtr) === false) {
+            throw TypeError::create(2, '$stackPtr', 'integer', $stackPtr);
+        }
 
         if (isset($tokens[$stackPtr]) === false) {
             throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -13,6 +13,7 @@ namespace PHPCSUtils\Utils;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\TypeError;
 use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Tokens\Collections;
 use PHPCSUtils\Utils\GetTokensAsString;
@@ -58,6 +59,7 @@ final class ObjectDeclarations
      *                     or `NULL` if the passed token doesn't exist, the function or
      *                     class is anonymous or in case of a parse error/live coding.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_FUNCTION`, `T_CLASS`,
      *                                                    `T_ANON_CLASS`, `T_CLOSURE`, `T_TRAIT`, `T_ENUM`
      *                                                    or `T_INTERFACE` token.
@@ -65,6 +67,10 @@ final class ObjectDeclarations
     public static function getName(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
+
+        if (\is_int($stackPtr) === false) {
+            throw TypeError::create(2, '$stackPtr', 'integer', $stackPtr);
+        }
 
         if (isset($tokens[$stackPtr]) === false
             || ($tokens[$stackPtr]['code'] === \T_ANON_CLASS || $tokens[$stackPtr]['code'] === \T_CLOSURE)
@@ -162,12 +168,17 @@ final class ObjectDeclarations
      *               );
      *               ```
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a T_CLASS token.
      */
     public static function getClassProperties(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
+
+        if (\is_int($stackPtr) === false) {
+            throw TypeError::create(2, '$stackPtr', 'integer', $stackPtr);
+        }
 
         if (isset($tokens[$stackPtr]) === false) {
             throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);

--- a/PHPCSUtils/Utils/PassedParameters.php
+++ b/PHPCSUtils/Utils/PassedParameters.php
@@ -14,6 +14,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Exceptions\MissingArgumentError;
 use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\TypeError;
 use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Internal\Cache;
 use PHPCSUtils\Tokens\Collections;
@@ -77,12 +78,17 @@ final class PassedParameters
      *
      * @return bool
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not one of the accepted types.
      */
     public static function hasParameters(File $phpcsFile, $stackPtr, $isShortArray = null)
     {
         $tokens = $phpcsFile->getTokens();
+
+        if (\is_int($stackPtr) === false) {
+            throw TypeError::create(2, '$stackPtr', 'integer', $stackPtr);
+        }
 
         if (isset($tokens[$stackPtr]) === false) {
             throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);

--- a/PHPCSUtils/Utils/TextStrings.php
+++ b/PHPCSUtils/Utils/TextStrings.php
@@ -13,6 +13,7 @@ namespace PHPCSUtils\Utils;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\TypeError;
 use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Exceptions\ValueError;
 use PHPCSUtils\Internal\Cache;
@@ -74,6 +75,7 @@ final class TextStrings
      *
      * @return string The contents of the complete text string.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a valid text string token.
      * @throws \PHPCSUtils\Exceptions\ValueError          If the specified token is not the _first_ token in
@@ -120,6 +122,7 @@ final class TextStrings
      *
      * @return int Stack pointer to the last token in the text string.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a valid text string token.
      * @throws \PHPCSUtils\Exceptions\ValueError          If the specified token is not the _first_ token in
@@ -128,6 +131,10 @@ final class TextStrings
     public static function getEndOfCompleteTextString(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
+
+        if (\is_int($stackPtr) === false) {
+            throw TypeError::create(2, '$stackPtr', 'integer', $stackPtr);
+        }
 
         if (isset($tokens[$stackPtr]) === false) {
             throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);

--- a/PHPCSUtils/Utils/UseStatements.php
+++ b/PHPCSUtils/Utils/UseStatements.php
@@ -13,6 +13,7 @@ namespace PHPCSUtils\Utils;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\TypeError;
 use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Exceptions\ValueError;
 use PHPCSUtils\Internal\Cache;
@@ -41,12 +42,17 @@ final class UseStatements
      *                the `T_USE` token is used for. An empty string being returned will
      *                normally mean the code being examined contains a parse error.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_USE` token.
      */
     public static function getType(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
+
+        if (\is_int($stackPtr) === false) {
+            throw TypeError::create(2, '$stackPtr', 'integer', $stackPtr);
+        }
 
         if (isset($tokens[$stackPtr]) === false) {
             throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);
@@ -104,6 +110,7 @@ final class UseStatements
      * @return bool `TRUE` if the token passed is a closure use statement.
      *              `FALSE` if it's not.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_USE` token.
      */
@@ -123,6 +130,7 @@ final class UseStatements
      * @return bool `TRUE` if the token passed is an import use statement.
      *              `FALSE` if it's not.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_USE` token.
      */
@@ -142,6 +150,7 @@ final class UseStatements
      * @return bool `TRUE` if the token passed is a trait use statement.
      *              `FALSE` if it's not.
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_USE` token.
      */
@@ -187,6 +196,7 @@ final class UseStatements
      *               )
      *               ```
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_USE` token.
      * @throws \PHPCSUtils\Exceptions\ValueError          If the `T_USE` token is not for an import use statement.

--- a/PHPCSUtils/Utils/Variables.php
+++ b/PHPCSUtils/Utils/Variables.php
@@ -13,6 +13,7 @@ namespace PHPCSUtils\Utils;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\Exceptions\OutOfBoundsStackPtr;
+use PHPCSUtils\Exceptions\TypeError;
 use PHPCSUtils\Exceptions\UnexpectedTokenType;
 use PHPCSUtils\Exceptions\ValueError;
 use PHPCSUtils\Internal\Cache;
@@ -113,6 +114,7 @@ final class Variables
      *               );
      *               ```
      *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
      * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
      * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not a `T_VARIABLE` token.
      * @throws \PHPCSUtils\Exceptions\ValueError          If the specified position is not a class member variable.
@@ -120,6 +122,10 @@ final class Variables
     public static function getMemberProperties(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
+
+        if (\is_int($stackPtr) === false) {
+            throw TypeError::create(2, '$stackPtr', 'integer', $stackPtr);
+        }
 
         if (isset($tokens[$stackPtr]) === false) {
             throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
@@ -41,6 +41,39 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
     ];
 
     /**
+     * Test receiving an expected exception when an non-integer token pointer is passed.
+     *
+     * @return void
+     */
+    public function testNonIntegerToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, boolean given');
+
+        $mockObj = $this->getMockedClassUnderTest();
+
+        $mockObj->expects($this->never())
+            ->method('processOpenClose');
+
+        $mockObj->expects($this->never())
+            ->method('processKey');
+
+        $mockObj->expects($this->never())
+            ->method('processNoKey');
+
+        $mockObj->expects($this->never())
+            ->method('processArrow');
+
+        $mockObj->expects($this->never())
+            ->method('processValue');
+
+        $mockObj->expects($this->never())
+            ->method('processComma');
+
+        $mockObj->process(self::$phpcsFile, false);
+    }
+
+    /**
      * Test receiving an expected exception when an invalid token pointer is passed.
      *
      * @return void

--- a/Tests/Fixers/SpacesFixer/SpacesFixerExceptionsTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerExceptionsTest.php
@@ -24,6 +24,32 @@ final class SpacesFixerExceptionsTest extends PolyfilledTestCase
 {
 
     /**
+     * Test passing a non-integer token pointer for the stackPtr token (like an unchecked result of File::findPrevious()).
+     *
+     * @return void
+     */
+    public function testNonIntegerFirstToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, boolean given');
+
+        SpacesFixer::checkAndFix(self::$phpcsFile, false, 10, 0, 'Dummy');
+    }
+
+    /**
+     * Test passing a non-integer token pointer for the second token (like an unchecked result of File::findNext()).
+     *
+     * @return void
+     */
+    public function testNonIntegerSecondToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #3 ($secondPtr) must be of type integer, boolean given');
+
+        SpacesFixer::checkAndFix(self::$phpcsFile, 10, false, 0, 'Dummy');
+    }
+
+    /**
      * Test passing a non-existent token pointer for the stackPtr token.
      *
      * @return void

--- a/Tests/Internal/IsShortArrayOrList/ConstructorTest.php
+++ b/Tests/Internal/IsShortArrayOrList/ConstructorTest.php
@@ -24,6 +24,19 @@ final class ConstructorTest extends PolyfilledTestCase
 {
 
     /**
+     * Test receiving an exception when passing a non-integer token pointer.
+     *
+     * @return void
+     */
+    public function testNonIntegerToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, boolean given');
+
+        new IsShortArrayOrList(self::$phpcsFile, false);
+    }
+
+    /**
      * Test receiving an exception when passing a non-existent token pointer.
      *
      * @return void

--- a/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
+++ b/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
@@ -62,6 +62,32 @@ final class GetDoubleArrowPtrTest extends PolyfilledTestCase
      *
      * @return void
      */
+    public function testNonIntegerStartException()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($start) must be of type integer, boolean given');
+
+        Arrays::getDoubleArrowPtr(self::$phpcsFile, false, 10);
+    }
+
+    /**
+     * Test receiving an expected exception when an invalid end position is passed.
+     *
+     * @return void
+     */
+    public function testNonIntegerEndException()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #3 ($end) must be of type integer, boolean given');
+
+        Arrays::getDoubleArrowPtr(self::$phpcsFile, 0, false);
+    }
+
+    /**
+     * Test receiving an expected exception when an invalid start position is passed.
+     *
+     * @return void
+     */
     public function testInvalidStartPositionException()
     {
         $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');

--- a/Tests/Utils/ControlStructures/GetCaughtExceptionsTest.php
+++ b/Tests/Utils/ControlStructures/GetCaughtExceptionsTest.php
@@ -24,6 +24,19 @@ final class GetCaughtExceptionsTest extends PolyfilledTestCase
 {
 
     /**
+     * Test receiving an expected exception when a non-integer token is passed.
+     *
+     * @return void
+     */
+    public function testNonIntegerToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, boolean given');
+
+        ControlStructures::getCaughtExceptions(self::$phpcsFile, false);
+    }
+
+    /**
      * Test receiving an expected exception when a non-existent token is passed.
      *
      * @return void

--- a/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersDiffTest.php
@@ -42,6 +42,19 @@ final class GetParametersDiffTest extends PolyfilledTestCase
     }
 
     /**
+     * Test passing a non-integer token pointer.
+     *
+     * @return void
+     */
+    public function testNonIntegerToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, boolean given');
+
+        FunctionDeclarations::getParameters(self::$phpcsFile, false);
+    }
+
+    /**
      * Test passing a non-existent token pointer.
      *
      * @return void

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
@@ -31,6 +31,19 @@ final class GetPropertiesDiffTest extends PolyfilledTestCase
 {
 
     /**
+     * Test passing a non-integer token pointer.
+     *
+     * @return void
+     */
+    public function testNonIntegerToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, boolean given');
+
+        FunctionDeclarations::getProperties(self::$phpcsFile, false);
+    }
+
+    /**
      * Test passing a non-existent token pointer.
      *
      * @return void

--- a/Tests/Utils/GetTokensAsString/GetTokensAsStringTest.php
+++ b/Tests/Utils/GetTokensAsString/GetTokensAsStringTest.php
@@ -69,10 +69,8 @@ final class GetTokensAsStringTest extends PolyfilledTestCase
      */
     public function testNonIntegerStart()
     {
-        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
-        $this->expectExceptionMessage(
-            'Argument #2 ($start) must be a stack pointer which exists in the $phpcsFile object, false given'
-        );
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($start) must be of type integer, boolean given');
 
         GetTokensAsString::noEmpties(self::$phpcsFile, false, 10);
     }

--- a/Tests/Utils/Namespaces/NamespaceTypeTest.php
+++ b/Tests/Utils/Namespaces/NamespaceTypeTest.php
@@ -28,6 +28,19 @@ final class NamespaceTypeTest extends PolyfilledTestCase
 {
 
     /**
+     * Test receiving an expected exception when passing a non-integer token pointer.
+     *
+     * @return void
+     */
+    public function testNonIntegerToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, boolean given');
+
+        Namespaces::getType(self::$phpcsFile, false);
+    }
+
+    /**
      * Test receiving an expected exception when passing a non-existent token pointer.
      *
      * @return void

--- a/Tests/Utils/Numbers/GetCompleteNumberTest.php
+++ b/Tests/Utils/Numbers/GetCompleteNumberTest.php
@@ -24,6 +24,19 @@ final class GetCompleteNumberTest extends PolyfilledTestCase
 {
 
     /**
+     * Test receiving an exception when a non-integer stackPtr is passed to the method.
+     *
+     * @return void
+     */
+    public function testNonIntegerTokenException()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, double given');
+
+        Numbers::getCompleteNumber(self::$phpcsFile, 1.5);
+    }
+
+    /**
      * Test receiving an exception when a non-existent token is passed to the method.
      *
      * @return void

--- a/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetClassPropertiesDiffTest.php
@@ -29,6 +29,19 @@ final class GetClassPropertiesDiffTest extends PolyfilledTestCase
 {
 
     /**
+     * Test passing a non-integer token pointer.
+     *
+     * @return void
+     */
+    public function testNonIntegerToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, string given');
+
+        ObjectDeclarations::getClassProperties(self::$phpcsFile, 'string');
+    }
+
+    /**
      * Test passing a non-existent token pointer.
      *
      * @return void

--- a/Tests/Utils/ObjectDeclarations/GetNameDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameDiffTest.php
@@ -10,7 +10,7 @@
 
 namespace PHPCSUtils\Tests\Utils\ObjectDeclarations;
 
-use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Tests\PolyfilledTestCase;
 use PHPCSUtils\Utils\ObjectDeclarations;
 
 /**
@@ -25,8 +25,21 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  *
  * @since 1.0.0
  */
-final class GetNameDiffTest extends UtilityMethodTestCase
+final class GetNameDiffTest extends PolyfilledTestCase
 {
+
+    /**
+     * Test receiving an expected exception when a non-integer token is passed.
+     *
+     * @return void
+     */
+    public function testNonIntegerTokenPassed()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, boolean given');
+
+        ObjectDeclarations::getName(self::$phpcsFile, false);
+    }
 
     /**
      * Test passing a non-existent token pointer.

--- a/Tests/Utils/PassedParameters/HasParametersTest.php
+++ b/Tests/Utils/PassedParameters/HasParametersTest.php
@@ -25,6 +25,19 @@ final class HasParametersTest extends PolyfilledTestCase
 {
 
     /**
+     * Test receiving an expected exception when a non-integer token pointer is passed.
+     *
+     * @return void
+     */
+    public function testNonIntegerToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, array given');
+
+        PassedParameters::hasParameters(self::$phpcsFile, []);
+    }
+
+    /**
      * Test receiving an expected exception when an invalid token pointer is passed.
      *
      * @return void

--- a/Tests/Utils/TextStrings/GetCompleteTextStringTest.php
+++ b/Tests/Utils/TextStrings/GetCompleteTextStringTest.php
@@ -39,6 +39,23 @@ final class GetCompleteTextStringTest extends PolyfilledTestCase
     ];
 
     /**
+     * Test passing a non-integer token pointer.
+     *
+     * @dataProvider dataExceptions
+     *
+     * @param string $method The name of the method to test the exception for.
+     *
+     * @return void
+     */
+    public function testNonIntegerToken($method)
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, boolean given');
+
+        TextStrings::$method(self::$phpcsFile, false);
+    }
+
+    /**
      * Test passing a non-existent token pointer.
      *
      * @dataProvider dataExceptions

--- a/Tests/Utils/UseStatements/SplitAndMergeImportUseStatementTest.php
+++ b/Tests/Utils/UseStatements/SplitAndMergeImportUseStatementTest.php
@@ -26,6 +26,19 @@ final class SplitAndMergeImportUseStatementTest extends PolyfilledTestCase
 {
 
     /**
+     * Test passing a non-integer token pointer.
+     *
+     * @return void
+     */
+    public function testNonIntegerToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, NULL given');
+
+        UseStatements::splitAndMergeImportUseStatement(self::$phpcsFile, null, []);
+    }
+
+    /**
      * Test passing a non-existent token pointer.
      *
      * @return void

--- a/Tests/Utils/UseStatements/SplitImportUseStatementTest.php
+++ b/Tests/Utils/UseStatements/SplitImportUseStatementTest.php
@@ -25,6 +25,19 @@ final class SplitImportUseStatementTest extends PolyfilledTestCase
 {
 
     /**
+     * Test passing a non-integer token pointer.
+     *
+     * @return void
+     */
+    public function testNonIntegerToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, NULL given');
+
+        UseStatements::splitImportUseStatement(self::$phpcsFile, null);
+    }
+
+    /**
      * Test passing a non-existent token pointer.
      *
      * @return void

--- a/Tests/Utils/UseStatements/UseTypeTest.php
+++ b/Tests/Utils/UseStatements/UseTypeTest.php
@@ -30,6 +30,19 @@ final class UseTypeTest extends PolyfilledTestCase
 {
 
     /**
+     * Test passing a non-integer token pointer.
+     *
+     * @return void
+     */
+    public function testNonIntegerToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, NULL given');
+
+        UseStatements::getType(self::$phpcsFile, null);
+    }
+
+    /**
      * Test receiving an expected exception when passing a non-existent token pointer.
      *
      * @return void

--- a/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
@@ -29,6 +29,19 @@ final class GetMemberPropertiesDiffTest extends PolyfilledTestCase
 {
 
     /**
+     * Test passing a non-integer token pointer.
+     *
+     * @return void
+     */
+    public function testNonIntegerToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, boolean given');
+
+        Variables::getMemberProperties(self::$phpcsFile, false);
+    }
+
+    /**
      * Test passing a non-existent token pointer.
      *
      * @return void

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -74,11 +74,10 @@ parameters:
         -
             message: '`^Parameter #[0-9]+ \$\S+ of static method PHPCSUtils\\(?!Tests)[A-Za-z]+\\[A-Za-z]+::[A-Za-z]+\(\) expects [^,]+, \S+ given\.$`'
             paths:
-                - Tests/BackCompat/Helper/GetCommandLineDataTest.php
-                - Tests/BackCompat/BCFile/GetTokensAsStringTest.php
-                - Tests/Exceptions/TestTargetNotFound/TestTargetNotFoundTest.php
-                - Tests/Fixers/SpacesFixer/SpacesFixerExceptionsTest.php
-                - Tests/Utils/GetTokensAsString/GetTokensAsStringTest.php
-                - Tests/Utils/NamingConventions/IsValidIdentifierNameTest.php
+                - Tests/*
+        -
+            message: '`^Parameter #[0-9]+ \$\S+ of class PHPCSUtils\\(?!Tests)[A-Za-z]+\\[A-Za-z]+ [A-Za-z]+ expects [^,]+, \S+ given\.$`'
+            path: Tests/Internal/IsShortArrayOrList/ConstructorTest.php
+            count: 1
 
-                # yamllint enable rule:line-length
+            # yamllint enable rule:line-length


### PR DESCRIPTION
Add more defensive coding against incorrect stack pointers being passed.

It is common to pass the result of a call to `File::findPrevious()` or `File::findNext()` to functions expecting a stack pointer, but these `File` functions can return `false`, which would be juggled to `0` when used in the typical `isset($tokens[$stackPtr])` checks. This would then lead to that check passing, while the value should have been rejected, as the method may now try to act on a completely different token than intended (and more defensive coding should have been added to the originating sniff).

Adding a preliminary check to make sure the received parameter is an integer prevents this problem and should surface any such bugs in sniffs using the updated PHPCSUtils methods.

Includes tests.