### PR TITLE
Composer: raise the minimum supported PHPCS version to 3.10.0

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -462,7 +462,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - PHPCS 3.9.2: skip over closure use statements. PHPCS #421.
+     * - The upstream method has received no significant updates since PHPCS 3.10.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodProperties()      Original source.
      * @see \PHPCSUtils\Utils\FunctionDeclarations::getProperties() PHPCSUtils native improved version.
@@ -480,147 +480,7 @@ final class BCFile
      */
     public static function getMethodProperties(File $phpcsFile, $stackPtr)
     {
-        $tokens = $phpcsFile->getTokens();
-
-        if ($tokens[$stackPtr]['code'] !== T_FUNCTION
-            && $tokens[$stackPtr]['code'] !== T_CLOSURE
-            && $tokens[$stackPtr]['code'] !== T_FN
-        ) {
-            throw new RuntimeException('$stackPtr must be of type T_FUNCTION or T_CLOSURE or T_FN');
-        }
-
-        if ($tokens[$stackPtr]['code'] === T_FUNCTION) {
-            $valid = [
-                T_PUBLIC      => T_PUBLIC,
-                T_PRIVATE     => T_PRIVATE,
-                T_PROTECTED   => T_PROTECTED,
-                T_STATIC      => T_STATIC,
-                T_FINAL       => T_FINAL,
-                T_ABSTRACT    => T_ABSTRACT,
-                T_WHITESPACE  => T_WHITESPACE,
-                T_COMMENT     => T_COMMENT,
-                T_DOC_COMMENT => T_DOC_COMMENT,
-            ];
-        } else {
-            $valid = [
-                T_STATIC      => T_STATIC,
-                T_WHITESPACE  => T_WHITESPACE,
-                T_COMMENT     => T_COMMENT,
-                T_DOC_COMMENT => T_DOC_COMMENT,
-            ];
-        }
-
-        $scope          = 'public';
-        $scopeSpecified = false;
-        $isAbstract     = false;
-        $isFinal        = false;
-        $isStatic       = false;
-
-        for ($i = ($stackPtr - 1); $i > 0; $i--) {
-            if (isset($valid[$tokens[$i]['code']]) === false) {
-                break;
-            }
-
-            switch ($tokens[$i]['code']) {
-                case T_PUBLIC:
-                    $scope          = 'public';
-                    $scopeSpecified = true;
-                    break;
-                case T_PRIVATE:
-                    $scope          = 'private';
-                    $scopeSpecified = true;
-                    break;
-                case T_PROTECTED:
-                    $scope          = 'protected';
-                    $scopeSpecified = true;
-                    break;
-                case T_ABSTRACT:
-                    $isAbstract = true;
-                    break;
-                case T_FINAL:
-                    $isFinal = true;
-                    break;
-                case T_STATIC:
-                    $isStatic = true;
-                    break;
-            }
-        }
-
-        $returnType         = '';
-        $returnTypeToken    = false;
-        $returnTypeEndToken = false;
-        $nullableReturnType = false;
-        $hasBody            = true;
-        $returnTypeTokens   = Collections::returnTypeTokens();
-
-        if (isset($tokens[$stackPtr]['parenthesis_closer']) === true) {
-            $scopeOpener = null;
-            if (isset($tokens[$stackPtr]['scope_opener']) === true) {
-                $scopeOpener = $tokens[$stackPtr]['scope_opener'];
-            }
-
-            for ($i = $tokens[$stackPtr]['parenthesis_closer']; $i < $phpcsFile->numTokens; $i++) {
-                if (($scopeOpener === null && $tokens[$i]['code'] === T_SEMICOLON)
-                    || ($scopeOpener !== null && $i === $scopeOpener)
-                ) {
-                    // End of function definition.
-                    break;
-                }
-
-                if ($tokens[$i]['code'] === T_USE) {
-                    // Skip over closure use statements.
-                    for ($j = ($i + 1); $j < $phpcsFile->numTokens && isset(Tokens::$emptyTokens[$tokens[$j]['code']]) === true; $j++);
-                    if ($tokens[$j]['code'] === T_OPEN_PARENTHESIS) {
-                        if (isset($tokens[$j]['parenthesis_closer']) === false) {
-                            // Live coding/parse error, stop parsing.
-                            break;
-                        }
-
-                        $i = $tokens[$j]['parenthesis_closer'];
-                        continue;
-                    }
-                }
-
-                if ($tokens[$i]['code'] === T_NULLABLE) {
-                    $nullableReturnType = true;
-                }
-
-                if (isset($returnTypeTokens[$tokens[$i]['code']]) === true) {
-                    if ($returnTypeToken === false) {
-                        $returnTypeToken = $i;
-                    }
-
-                    $returnType        .= $tokens[$i]['content'];
-                    $returnTypeEndToken = $i;
-                }
-            }
-
-            if ($tokens[$stackPtr]['code'] === T_FN) {
-                $bodyToken = T_FN_ARROW;
-            } else {
-                $bodyToken = T_OPEN_CURLY_BRACKET;
-            }
-
-            $end     = $phpcsFile->findNext([$bodyToken, T_SEMICOLON], $tokens[$stackPtr]['parenthesis_closer']);
-            $hasBody = ($end !== false && $tokens[$end]['code'] === $bodyToken);
-        }
-
-        if ($returnType !== '' && $nullableReturnType === true) {
-            $returnType = '?' . $returnType;
-        }
-
-        return [
-            'scope'                 => $scope,
-            'scope_specified'       => $scopeSpecified,
-            'return_type'           => $returnType,
-            'return_type_token'     => $returnTypeToken,
-            'return_type_end_token' => $returnTypeEndToken,
-            'nullable_return_type'  => $nullableReturnType,
-            'is_abstract'           => $isAbstract,
-            'is_final'              => $isFinal,
-            'is_static'             => $isStatic,
-            'has_body'              => $hasBody,
-        ];
+        return $phpcsFile->getMethodProperties($stackPtr);
     }
 
     /**

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -76,7 +76,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.9.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getDeclarationName() Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::getName()   PHPCSUtils native improved version.
@@ -647,7 +647,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.9.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getMemberProperties() Original source.
      * @see \PHPCSUtils\Utils\Variables::getMemberProperties() PHPCSUtils native improved version.
@@ -685,7 +685,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.3.0.
-     * - The upstream method has received no significant updates since PHPCS 3.9.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getClassProperties()          Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::getClassProperties() PHPCSUtils native improved version.
@@ -713,7 +713,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.9.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.0.
      *
      * @see \PHP_CodeSniffer\Files\File::isReference() Original source.
      * @see \PHPCSUtils\Utils\Operators::isReference() PHPCSUtils native improved version.
@@ -739,7 +739,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.9.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getTokensAsString() Original source.
      * @see \PHPCSUtils\Utils\GetTokensAsString              Related set of functions.
@@ -768,7 +768,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.1.0.
-     * - The upstream method has received no significant updates since PHPCS 3.9.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.0.
      *
      * @see \PHP_CodeSniffer\Files\File::findStartOfStatement() Original source.
      *
@@ -792,7 +792,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.1.0.
-     * - The upstream method has received no significant updates since PHPCS 3.9.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.0.
      *
      * @see \PHP_CodeSniffer\Files\File::findEndOfStatement() Original source.
      *
@@ -816,7 +816,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.9.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.0.
      *
      * @see \PHP_CodeSniffer\Files\File::hasCondition()  Original source.
      * @see \PHPCSUtils\Utils\Conditions::hasCondition() PHPCSUtils native alternative.
@@ -841,7 +841,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.3.0.
-     * - The upstream method has received no significant updates since PHPCS 3.9.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getCondition()  Original source.
      * @see \PHPCSUtils\Utils\Conditions::getCondition() More versatile alternative.
@@ -872,7 +872,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.2.0.
-     * - The upstream method has received no significant updates since PHPCS 3.9.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.0.
      *
      * @see \PHP_CodeSniffer\Files\File::findExtendedClassName()          Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::findExtendedClassName() PHPCSUtils native improved version.
@@ -897,7 +897,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.7.0.
-     * - The upstream method has received no significant updates since PHPCS 3.9.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.0.
      *
      * @see \PHP_CodeSniffer\Files\File::findImplementedInterfaceNames()          Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::findImplementedInterfaceNames() PHPCSUtils native improved version.

--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -74,7 +74,7 @@ final class BCTokens
 
     /**
      * Handle calls to (undeclared) methods for token arrays which haven't received any
-     * changes since PHPCS 3.9.0.
+     * changes since PHPCS 3.10.0.
      *
      * @since 1.0.0
      *

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Whether you need to split an `array` into the individual items, are trying to de
 
 Includes improved versions of the PHPCS native utility functions and plenty of new utility functions.
 
-These functions are compatible with PHPCS 3.9.0 up to PHPCS `master`.
+These functions are compatible with PHPCS 3.10.0 up to PHPCS `master`.
 
 ### A collection of static properties and methods for often-used token groups
 
@@ -66,7 +66,7 @@ Supports PHPUnit 4.x up to 9.x.
 
 Normally to use the latest version of PHP_CodeSniffer native utility functions, you would have to raise the minimum requirements of your external PHPCS standard.
 
-Now you won't have to anymore. This package allows you to use the latest version of those utility functions in all PHP_CodeSniffer versions from PHPCS 3.9.0 and up.
+Now you won't have to anymore. This package allows you to use the latest version of those utility functions in all PHP_CodeSniffer versions from PHPCS 3.10.0 and up.
 
 ### Fully documented
 
@@ -78,7 +78,7 @@ To see detailed information about all the available abstract sniffs, utility fun
 ## Minimum Requirements
 
 * PHP 5.4 or higher.
-* [PHP_CodeSniffer] 3.9.0+.
+* [PHP_CodeSniffer] 3.10.0+.
 * Recommended PHP extensions for optimal functionality:
     - PCRE with Unicode support (normally enabled by default)
 

--- a/Tests/BackCompat/Helper/GetVersionTest.php
+++ b/Tests/BackCompat/Helper/GetVersionTest.php
@@ -47,7 +47,7 @@ final class GetVersionTest extends TestCase
         }
 
         if ($expected === 'lowest') {
-            $expected = '3.9.0';
+            $expected = '3.10.0';
         }
 
         $result = Helper::getVersion();

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.9.0 || 4.0.x-dev@dev",
+        "squizlabs/php_codesniffer" : "^3.10.0 || 4.0.x-dev@dev",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0"
     },
     "require-dev" : {


### PR DESCRIPTION
### Composer: raise the minimum supported PHPCS version to 3.10.0

... to benefit from the DNF type syntax support for PHP 8.2 which has been added to PHPCS itself.

Includes updating references to the PHPCS version whenever relevant throughout the codebase.

### BCFile::getMethodProperties(): defer to upstream

Partial revert of #573

No BC-layer is needed at this time with a minimum supported PHPCS version of PHPCS 3.10.0.