### PR TITLE
PHP 8.2: add support for DNF types

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -228,7 +228,9 @@ final class BCFile
             // it's likely to be an array which might have arguments in it. This
             // could cause problems in our parsing below, so lets just skip to the
             // end of it.
-            if (isset($tokens[$i]['parenthesis_opener']) === true) {
+            if ($tokens[$i]['code'] !== T_TYPE_OPEN_PARENTHESIS
+                && isset($tokens[$i]['parenthesis_opener']) === true
+            ) {
                 // Don't do this if it's the close parenthesis for the method.
                 if ($i !== $tokens[$i]['parenthesis_closer']) {
                     $i = ($tokens[$i]['parenthesis_closer'] + 1);
@@ -324,6 +326,8 @@ final class BCFile
                 case T_NS_SEPARATOR:
                 case T_TYPE_UNION:
                 case T_TYPE_INTERSECTION:
+                case T_TYPE_OPEN_PARENTHESIS:
+                case T_TYPE_CLOSE_PARENTHESIS:
                 case T_FALSE:
                 case T_TRUE:
                 case T_NULL:

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -400,14 +400,16 @@ final class Collections
      * @var array<int|string, int|string>
      */
     private static $parameterTypeTokens = [
-        \T_CALLABLE          => \T_CALLABLE,
-        \T_SELF              => \T_SELF,
-        \T_PARENT            => \T_PARENT,
-        \T_FALSE             => \T_FALSE,
-        \T_TRUE              => \T_TRUE,
-        \T_NULL              => \T_NULL,
-        \T_TYPE_UNION        => \T_TYPE_UNION,
-        \T_TYPE_INTERSECTION => \T_TYPE_INTERSECTION,
+        \T_CALLABLE               => \T_CALLABLE,
+        \T_SELF                   => \T_SELF,
+        \T_PARENT                 => \T_PARENT,
+        \T_FALSE                  => \T_FALSE,
+        \T_TRUE                   => \T_TRUE,
+        \T_NULL                   => \T_NULL,
+        \T_TYPE_UNION             => \T_TYPE_UNION,
+        \T_TYPE_INTERSECTION      => \T_TYPE_INTERSECTION,
+        \T_TYPE_OPEN_PARENTHESIS  => \T_TYPE_OPEN_PARENTHESIS,
+        \T_TYPE_CLOSE_PARENTHESIS => \T_TYPE_CLOSE_PARENTHESIS,
     ];
 
     /**
@@ -446,14 +448,16 @@ final class Collections
      * @var array<int|string, int|string>
      */
     private static $propertyTypeTokens = [
-        \T_CALLABLE          => \T_CALLABLE, // Not allowed in PHP, but in this list to allow for (flagging) code errors.
-        \T_SELF              => \T_SELF,
-        \T_PARENT            => \T_PARENT,
-        \T_FALSE             => \T_FALSE,
-        \T_TRUE              => \T_TRUE,
-        \T_NULL              => \T_NULL,
-        \T_TYPE_UNION        => \T_TYPE_UNION,
-        \T_TYPE_INTERSECTION => \T_TYPE_INTERSECTION,
+        \T_CALLABLE               => \T_CALLABLE, // Not allowed in PHP, but in this list to allow for flagging code errors.
+        \T_SELF                   => \T_SELF,
+        \T_PARENT                 => \T_PARENT,
+        \T_FALSE                  => \T_FALSE,
+        \T_TRUE                   => \T_TRUE,
+        \T_NULL                   => \T_NULL,
+        \T_TYPE_UNION             => \T_TYPE_UNION,
+        \T_TYPE_INTERSECTION      => \T_TYPE_INTERSECTION,
+        \T_TYPE_OPEN_PARENTHESIS  => \T_TYPE_OPEN_PARENTHESIS,
+        \T_TYPE_CLOSE_PARENTHESIS => \T_TYPE_CLOSE_PARENTHESIS,
     ];
 
     /**
@@ -464,12 +468,14 @@ final class Collections
      * @var array<int|string, int|string>
      */
     private static $returnTypeTokens = [
-        \T_CALLABLE          => \T_CALLABLE,
-        \T_FALSE             => \T_FALSE,
-        \T_TRUE              => \T_TRUE,
-        \T_NULL              => \T_NULL,
-        \T_TYPE_UNION        => \T_TYPE_UNION,
-        \T_TYPE_INTERSECTION => \T_TYPE_INTERSECTION,
+        \T_CALLABLE               => \T_CALLABLE,
+        \T_FALSE                  => \T_FALSE,
+        \T_TRUE                   => \T_TRUE,
+        \T_NULL                   => \T_NULL,
+        \T_TYPE_UNION             => \T_TYPE_UNION,
+        \T_TYPE_INTERSECTION      => \T_TYPE_INTERSECTION,
+        \T_TYPE_OPEN_PARENTHESIS  => \T_TYPE_OPEN_PARENTHESIS,
+        \T_TYPE_CLOSE_PARENTHESIS => \T_TYPE_CLOSE_PARENTHESIS,
     ];
 
     /**

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.inc
@@ -339,3 +339,18 @@ class WhitespaceAndCommentsInTypes {
     /* testIntersectionTypeWithWhitespaceAndComment */
     public \Foo /*comment*/ & Bar $hasWhitespaceAndComment;
 }
+
+trait DNFTypes {
+    /* testPHP82DNFTypeStatic */
+    public static (Foo&\Bar)|bool $propA;
+
+    /* testPHP82DNFTypeReadonlyA */
+    protected readonly float|(Partially\Qualified&Traversable) $propB;
+
+    /* testPHP82DNFTypeReadonlyB */
+    private readonly (namespace\Foo&Bar)|string $propC;
+
+    /* testPHP82DNFTypeIllegalNullable */
+    // Intentional fatal error - nullable operator cannot be combined with DNF.
+    var ?(A&\Pck\B)|bool $propD;
+}

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -1101,6 +1101,59 @@ class GetMemberPropertiesTest extends UtilityMethodTestCase
                     'nullable_type'   => false,
                 ],
             ],
+
+            'php8.2-dnf-with-static' => [
+                'identifier' => '/* testPHP82DNFTypeStatic */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_specified' => true,
+                    'is_static'       => true,
+                    'is_readonly'     => false,
+                    'type'            => '(Foo&\Bar)|bool',
+                    'type_token'      => ($php8Names === true) ? -8 : -9,
+                    'type_end_token'  => -2,
+                    'nullable_type'   => false,
+                ],
+            ],
+            'php8.2-dnf-with-readonly-1' => [
+                'identifier' => '/* testPHP82DNFTypeReadonlyA */',
+                'expected'   => [
+                    'scope'           => 'protected',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'is_readonly'     => true,
+                    'type'            => 'float|(Partially\Qualified&Traversable)',
+                    'type_token'      => ($php8Names === true) ? -8 : -10,
+                    'type_end_token'  => -2,
+                    'nullable_type'   => false,
+                ],
+            ],
+            'php8.2-dnf-with-readonly-2' => [
+                'identifier' => '/* testPHP82DNFTypeReadonlyB */',
+                'expected'   => [
+                    'scope'           => 'private',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'is_readonly'     => true,
+                    'type'            => '(namespace\Foo&Bar)|string',
+                    'type_token'      => ($php8Names === true) ? -8 : -10,
+                    'type_end_token'  => -2,
+                    'nullable_type'   => false,
+                ],
+            ],
+            'php8.2-dnf-with-illegal-nullable' => [
+                'identifier' => '/* testPHP82DNFTypeIllegalNullable */',
+                'expected'   => [
+                    'scope'           => 'public',
+                    'scope_specified' => false,
+                    'is_static'       => false,
+                    'is_readonly'     => false,
+                    'type'            => '?(A&\Pck\B)|bool',
+                    'type_token'      => ($php8Names === true) ? -8 : -11,
+                    'type_end_token'  => -2,
+                    'nullable_type'   => true,
+                ],
+            ],
         ];
     }
 

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.inc
@@ -280,6 +280,23 @@ function newInInitializers(
     \Package\TypeB $newToo = new \Package\TypeB(10, 'string'),
 ) {}
 
+/* testPHP82DNFTypes */
+function dnfTypes(
+    #[MyAttribute]
+    false|(Foo&Bar)|true $obj1,
+    (\Boo&\Pck\Bar)|(Boo&Baz) $obj2 = new Boo()
+) {}
+
+/* testPHP82DNFTypesWithSpreadOperatorAndReference */
+function dnfInGlobalFunctionWithSpreadAndReference((Countable&MeMe)|iterable &$paramA, true|(Foo&Bar) ...$paramB) {}
+
+/* testPHP82DNFTypesIllegalNullable */
+// Intentional fatal error - nullable operator cannot be combined with DNF.
+$dnf_closure = function (? ( MyClassA & /*comment*/ \Package\MyClassB & \Package\MyClassC ) $var): void {};
+
+/* testPHP82DNFTypesInArrow */
+$dnf_arrow = fn((Hi&Ho)|FALSE &...$range): string => $a;
+
 /* testFunctionCallFnPHPCS353-354 */
 $value = $obj->fn(true);
 

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -2602,6 +2602,157 @@ class GetMethodParametersTest extends UtilityMethodTestCase
     }
 
     /**
+     * Verify recognition of 8.2 DNF parameter type declarations.
+     *
+     * @return void
+     */
+    public function testPHP82DNFTypes()
+    {
+        $php8Names = parent::usesPhp8NameTokens();
+
+        // Offsets are relative to the T_FUNCTION token.
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 21,
+            'name'                => '$obj1',
+            'content'             => '#[MyAttribute]
+    false|(Foo&Bar)|true $obj1',
+            'has_attributes'      => true,
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => 'false|(Foo&Bar)|true',
+            'type_hint_token'     => 11,
+            'type_hint_end_token' => 19,
+            'nullable_type'       => false,
+            'comma_token'         => 22,
+        ];
+        $expected[1] = [
+            'token'               => ($php8Names === true) ? 37 : 41,
+            'name'                => '$obj2',
+            'content'             => '(\Boo&\Pck\Bar)|(Boo&Baz) $obj2 = new Boo()',
+            'default'             => 'new Boo()',
+            'default_token'       => ($php8Names === true) ? 41 : 45,
+            'default_equal_token' => ($php8Names === true) ? 39 : 43,
+            'has_attributes'      => false,
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '(\Boo&\Pck\Bar)|(Boo&Baz)',
+            'type_hint_token'     => 25,
+            'type_hint_end_token' => ($php8Names === true) ? 35 : 39,
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify recognition of PHP 8.2 DNF parameter type declarations when the variable
+     * has either a spread operator or a reference.
+     *
+     * @return void
+     */
+    public function testPHP82DNFTypesWithSpreadOperatorAndReference()
+    {
+        // Offsets are relative to the T_FUNCTION token.
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 13,
+            'name'                => '$paramA',
+            'content'             => '(Countable&MeMe)|iterable &$paramA',
+            'has_attributes'      => false,
+            'pass_by_reference'   => true,
+            'reference_token'     => 12,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '(Countable&MeMe)|iterable',
+            'type_hint_token'     => 4,
+            'type_hint_end_token' => 10,
+            'nullable_type'       => false,
+            'comma_token'         => 14,
+        ];
+        $expected[1] = [
+            'token'               => 25,
+            'name'                => '$paramB',
+            'content'             => 'true|(Foo&Bar) ...$paramB',
+            'has_attributes'      => false,
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => true,
+            'variadic_token'      => 24,
+            'type_hint'           => 'true|(Foo&Bar)',
+            'type_hint_token'     => 16,
+            'type_hint_end_token' => 22,
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify recognition of PHP 8.2 DNF parameter type declarations using the nullability operator (not allowed).
+     *
+     * @return void
+     */
+    public function testPHP82DNFTypesIllegalNullable()
+    {
+        $php8Names = parent::usesPhp8NameTokens();
+
+        // Offsets are relative to the T_FUNCTION token.
+        $expected    = [];
+        $expected[0] = [
+            'token'               => ($php8Names === true) ? 21 : 27,
+            'name'                => '$var',
+            'content'             => '? ( MyClassA & /*comment*/ \Package\MyClassB & \Package\MyClassC ) $var',
+            'has_attributes'      => false,
+            'pass_by_reference'   => false,
+            'reference_token'     => false,
+            'variable_length'     => false,
+            'variadic_token'      => false,
+            'type_hint'           => '?(MyClassA&\Package\MyClassB&\Package\MyClassC)',
+            'type_hint_token'     => 5,
+            'type_hint_end_token' => ($php8Names === true) ? 19 : 25,
+            'nullable_type'       => true,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify recognition of PHP 8.2 DNF parameter type declarations in an arrow function.
+     *
+     * @return void
+     */
+    public function testPHP82DNFTypesInArrow()
+    {
+        // Offsets are relative to the T_FUNCTION token.
+        $expected    = [];
+        $expected[0] = [
+            'token'               => 12,
+            'name'                => '$range',
+            'content'             => '(Hi&Ho)|FALSE &...$range',
+            'has_attributes'      => false,
+            'pass_by_reference'   => true,
+            'reference_token'     => 10,
+            'variable_length'     => true,
+            'variadic_token'      => 11,
+            'type_hint'           => '(Hi&Ho)|FALSE',
+            'type_hint_token'     => 2,
+            'type_hint_end_token' => 8,
+            'nullable_type'       => false,
+            'comma_token'         => false,
+        ];
+
+        $this->getMethodParametersTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Verify handling of a closure.
      *
      * @return void

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
@@ -165,6 +165,25 @@ function pseudoTypeTrue(): ?true {}
 // Intentional fatal error - Type contains both true and false, bool should be used instead, but that's not the concern of the method.
 function pseudoTypeFalseAndTrue(): true|false {}
 
+/* testPHP82DNFType */
+function hasDNFType() : bool|(Foo&Bar)|string {}
+
+abstract class AbstractClass {
+    /* testPHP82DNFTypeAbstractMethod */
+    abstract protected function abstractMethodDNFType() : float|(Foo&Bar);
+}
+
+/* testPHP82DNFTypeIllegalNullable */
+// Intentional fatal error - nullable operator cannot be combined with DNF.
+function illegalNullableDNF(): ?(A&\Pck\B)|bool {}
+
+/* testPHP82DNFTypeClosure */
+$closure = function() : object|(namespace\Foo&Countable) {};
+
+/* testPHP82DNFTypeFn */
+// Intentional fatal error - void type cannot be combined with DNF.
+$arrow = fn() : null|(Partially\Qualified&Traversable)|void => do_something();
+
 /* testNotAFunction */
 return true;
 

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -1097,6 +1097,132 @@ class GetMethodPropertiesTest extends UtilityMethodTestCase
     }
 
     /**
+     * Verify recognition of PHP 8.2 DNF return type declaration.
+     *
+     * @return void
+     */
+    public function testPHP82DNFType()
+    {
+        // Offsets are relative to the T_FUNCTION token.
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'bool|(Foo&Bar)|string',
+            'return_type_token'     => 8,
+            'return_type_end_token' => 16,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify recognition of PHP 8.2 DNF return type declaration on an abstract method.
+     *
+     * @return void
+     */
+    public function testPHP82DNFTypeAbstractMethod()
+    {
+        // Offsets are relative to the T_FUNCTION token.
+        $expected = [
+            'scope'                 => 'protected',
+            'scope_specified'       => true,
+            'return_type'           => 'float|(Foo&Bar)',
+            'return_type_token'     => 8,
+            'return_type_end_token' => 14,
+            'nullable_return_type'  => false,
+            'is_abstract'           => true,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => false,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify recognition of PHP 8.2 DNF return type declaration with illegal nullability.
+     *
+     * @return void
+     */
+    public function testPHP82DNFTypeIllegalNullable()
+    {
+        $php8Names = parent::usesPhp8NameTokens();
+
+        // Offsets are relative to the T_FUNCTION token.
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '?(A&\Pck\B)|bool',
+            'return_type_token'     => 8,
+            'return_type_end_token' => ($php8Names === true) ? 14 : 17,
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify recognition of PHP 8.2 DNF return type declaration on a closure.
+     *
+     * @return void
+     */
+    public function testPHP82DNFTypeClosure()
+    {
+        $php8Names = parent::usesPhp8NameTokens();
+
+        // Offsets are relative to the T_CLOSURE token.
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'object|(namespace\Foo&Countable)',
+            'return_type_token'     => 6,
+            'return_type_end_token' => ($php8Names === true) ? 12 : 14,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
+     * Verify recognition of PHP 8.2 DNF return type declaration on an arrow function.
+     *
+     * @return void
+     */
+    public function testPHP82DNFTypeFn()
+    {
+        $php8Names = parent::usesPhp8NameTokens();
+
+        // Offsets are relative to the T_FN token.
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => 'null|(Partially\Qualified&Traversable)|void',
+            'return_type_token'     => 6,
+            'return_type_end_token' => ($php8Names === true) ? 14 : 16,
+            'nullable_return_type'  => false,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Test for incorrect tokenization of array return type declarations in PHPCS < 2.8.0.
      *
      * @link https://github.com/squizlabs/PHP_CodeSniffer/pull/1264

--- a/Tests/BackCompat/BCFile/IsReferenceTest.inc
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.inc
@@ -201,6 +201,12 @@ $closure = function &($param) use ($value) {};
 /* testBitwiseAndArrowFunctionInDefault */
 $fn = fn( $one = E_NOTICE & E_STRICT) => 1;
 
+/* testIntersectionIsNotReference */
+function intersect(Foo&Bar $param) {}
+
+/* testDNFTypeIsNotReference */
+$fn = fn((Foo&\Bar)|null /* testParamPassByReference */ &$param) => $param;
+
 /* testTokenizerIssue1284PHPCSlt280A */
 if ($foo) {}
 [&$a, /* testTokenizerIssue1284PHPCSlt280B */ &$b] = $c;

--- a/Tests/BackCompat/BCFile/IsReferenceTest.php
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.php
@@ -49,14 +49,45 @@ class IsReferenceTest extends UtilityMethodTestCase
     /**
      * Test that false is returned when a non-"bitwise and" token is passed.
      *
+     * @param string            $testMarker   Comment which precedes the test case.
+     * @param array<int|string> $targetTokens Type of tokens to look for.
+     *
+     * @dataProvider dataNotBitwiseAndToken
+     *
      * @return void
      */
-    public function testNotBitwiseAndToken()
+    public function testNotBitwiseAndToken($testMarker, $targetTokens)
     {
-        $testClass = static::TEST_CLASS;
+        $testClass      = static::TEST_CLASS;
+        $targetTokens[] = T_BITWISE_AND;
 
-        $target = $this->getTargetToken('/* testBitwiseAndA */', T_STRING);
+        $target = $this->getTargetToken($testMarker, $targetTokens);
         $this->assertFalse($testClass::isReference(self::$phpcsFile, $target));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNotBitwiseAndToken()
+     *
+     * @return array<string, array<string, string|array<int|string>>>
+     */
+    public static function dataNotBitwiseAndToken()
+    {
+        return [
+            'Not ampersand token at all' => [
+                'testMarker'   => '/* testBitwiseAndA */',
+                'targetTokens' => [T_STRING],
+            ],
+            'ampersand in intersection type' => [
+                'testMarker'   => '/* testIntersectionIsNotReference */',
+                'targetTokens' => [T_TYPE_INTERSECTION],
+            ],
+            'ampersand in DNF type' => [
+                'testMarker'   => '/* testDNFTypeIsNotReference */',
+                'targetTokens' => [T_TYPE_INTERSECTION],
+            ],
+        ];
     }
 
     /**
@@ -363,6 +394,10 @@ class IsReferenceTest extends UtilityMethodTestCase
             'bitwise and: param default value in arrow fn declaration' => [
                 'testMarker' => '/* testBitwiseAndArrowFunctionInDefault */',
                 'expected'   => false,
+            ],
+            'reference: param pass by ref in arrow function' => [
+                'testMarker' => '/* testParamPassByReference */',
+                'expected'   => true,
             ],
             'issue-1284-short-list-directly-after-close-curly-control-structure' => [
                 'testMarker' => '/* testTokenizerIssue1284PHPCSlt280A */',

--- a/Tests/Tokens/Collections/ParameterTypeTokensTest.php
+++ b/Tests/Tokens/Collections/ParameterTypeTokensTest.php
@@ -31,20 +31,22 @@ final class ParameterTypeTokensTest extends TestCase
     public function testParameterTypeTokens()
     {
         $expected = [
-            \T_CALLABLE             => \T_CALLABLE,
-            \T_SELF                 => \T_SELF,
-            \T_PARENT               => \T_PARENT,
-            \T_FALSE                => \T_FALSE,
-            \T_TRUE                 => \T_TRUE,
-            \T_NULL                 => \T_NULL,
-            \T_TYPE_UNION           => \T_TYPE_UNION,
-            \T_TYPE_INTERSECTION    => \T_TYPE_INTERSECTION,
-            \T_NS_SEPARATOR         => \T_NS_SEPARATOR,
-            \T_NAMESPACE            => \T_NAMESPACE,
-            \T_STRING               => \T_STRING,
-            \T_NAME_QUALIFIED       => \T_NAME_QUALIFIED,
-            \T_NAME_FULLY_QUALIFIED => \T_NAME_FULLY_QUALIFIED,
-            \T_NAME_RELATIVE        => \T_NAME_RELATIVE,
+            \T_CALLABLE               => \T_CALLABLE,
+            \T_SELF                   => \T_SELF,
+            \T_PARENT                 => \T_PARENT,
+            \T_FALSE                  => \T_FALSE,
+            \T_TRUE                   => \T_TRUE,
+            \T_NULL                   => \T_NULL,
+            \T_TYPE_UNION             => \T_TYPE_UNION,
+            \T_TYPE_INTERSECTION      => \T_TYPE_INTERSECTION,
+            \T_TYPE_OPEN_PARENTHESIS  => \T_TYPE_OPEN_PARENTHESIS,
+            \T_TYPE_CLOSE_PARENTHESIS => \T_TYPE_CLOSE_PARENTHESIS,
+            \T_NS_SEPARATOR           => \T_NS_SEPARATOR,
+            \T_NAMESPACE              => \T_NAMESPACE,
+            \T_STRING                 => \T_STRING,
+            \T_NAME_QUALIFIED         => \T_NAME_QUALIFIED,
+            \T_NAME_FULLY_QUALIFIED   => \T_NAME_FULLY_QUALIFIED,
+            \T_NAME_RELATIVE          => \T_NAME_RELATIVE,
         ];
 
         $this->assertSame($expected, Collections::parameterTypeTokens());

--- a/Tests/Tokens/Collections/PropertyTypeTokensTest.php
+++ b/Tests/Tokens/Collections/PropertyTypeTokensTest.php
@@ -31,20 +31,22 @@ final class PropertyTypeTokensTest extends TestCase
     public function testPropertyTypeTokens()
     {
         $expected = [
-            \T_CALLABLE             => \T_CALLABLE,
-            \T_SELF                 => \T_SELF,
-            \T_PARENT               => \T_PARENT,
-            \T_FALSE                => \T_FALSE,
-            \T_TRUE                 => \T_TRUE,
-            \T_NULL                 => \T_NULL,
-            \T_TYPE_UNION           => \T_TYPE_UNION,
-            \T_TYPE_INTERSECTION    => \T_TYPE_INTERSECTION,
-            \T_NS_SEPARATOR         => \T_NS_SEPARATOR,
-            \T_NAMESPACE            => \T_NAMESPACE,
-            \T_STRING               => \T_STRING,
-            \T_NAME_QUALIFIED       => \T_NAME_QUALIFIED,
-            \T_NAME_FULLY_QUALIFIED => \T_NAME_FULLY_QUALIFIED,
-            \T_NAME_RELATIVE        => \T_NAME_RELATIVE,
+            \T_CALLABLE               => \T_CALLABLE,
+            \T_SELF                   => \T_SELF,
+            \T_PARENT                 => \T_PARENT,
+            \T_FALSE                  => \T_FALSE,
+            \T_TRUE                   => \T_TRUE,
+            \T_NULL                   => \T_NULL,
+            \T_TYPE_UNION             => \T_TYPE_UNION,
+            \T_TYPE_INTERSECTION      => \T_TYPE_INTERSECTION,
+            \T_TYPE_OPEN_PARENTHESIS  => \T_TYPE_OPEN_PARENTHESIS,
+            \T_TYPE_CLOSE_PARENTHESIS => \T_TYPE_CLOSE_PARENTHESIS,
+            \T_NS_SEPARATOR           => \T_NS_SEPARATOR,
+            \T_NAMESPACE              => \T_NAMESPACE,
+            \T_STRING                 => \T_STRING,
+            \T_NAME_QUALIFIED         => \T_NAME_QUALIFIED,
+            \T_NAME_FULLY_QUALIFIED   => \T_NAME_FULLY_QUALIFIED,
+            \T_NAME_RELATIVE          => \T_NAME_RELATIVE,
         ];
 
         $this->assertSame($expected, Collections::propertyTypeTokens());

--- a/Tests/Tokens/Collections/ReturnTypeTokensTest.php
+++ b/Tests/Tokens/Collections/ReturnTypeTokensTest.php
@@ -31,21 +31,23 @@ final class ReturnTypeTokensTest extends TestCase
     public function testReturnTypeTokens()
     {
         $expected = [
-            \T_CALLABLE             => \T_CALLABLE,
-            \T_FALSE                => \T_FALSE,
-            \T_TRUE                 => \T_TRUE,
-            \T_NULL                 => \T_NULL,
-            \T_TYPE_UNION           => \T_TYPE_UNION,
-            \T_TYPE_INTERSECTION    => \T_TYPE_INTERSECTION,
-            \T_PARENT               => \T_PARENT,
-            \T_SELF                 => \T_SELF,
-            \T_STATIC               => \T_STATIC,
-            \T_NS_SEPARATOR         => \T_NS_SEPARATOR,
-            \T_NAMESPACE            => \T_NAMESPACE,
-            \T_STRING               => \T_STRING,
-            \T_NAME_QUALIFIED       => \T_NAME_QUALIFIED,
-            \T_NAME_FULLY_QUALIFIED => \T_NAME_FULLY_QUALIFIED,
-            \T_NAME_RELATIVE        => \T_NAME_RELATIVE,
+            \T_CALLABLE               => \T_CALLABLE,
+            \T_FALSE                  => \T_FALSE,
+            \T_TRUE                   => \T_TRUE,
+            \T_NULL                   => \T_NULL,
+            \T_TYPE_UNION             => \T_TYPE_UNION,
+            \T_TYPE_INTERSECTION      => \T_TYPE_INTERSECTION,
+            \T_TYPE_OPEN_PARENTHESIS  => \T_TYPE_OPEN_PARENTHESIS,
+            \T_TYPE_CLOSE_PARENTHESIS => \T_TYPE_CLOSE_PARENTHESIS,
+            \T_PARENT                 => \T_PARENT,
+            \T_SELF                   => \T_SELF,
+            \T_STATIC                 => \T_STATIC,
+            \T_NS_SEPARATOR           => \T_NS_SEPARATOR,
+            \T_NAMESPACE              => \T_NAMESPACE,
+            \T_STRING                 => \T_STRING,
+            \T_NAME_QUALIFIED         => \T_NAME_QUALIFIED,
+            \T_NAME_FULLY_QUALIFIED   => \T_NAME_FULLY_QUALIFIED,
+            \T_NAME_RELATIVE          => \T_NAME_RELATIVE,
         ];
 
         $this->assertSame($expected, Collections::returnTypeTokens());


### PR DESCRIPTION
### PHP 8.2 | Collections: add support for DNF types

Upstream PR PHPCSStandards/PHP_CodeSniffer#387 introduced support for DNF types to PHPCS itself, introducing two new tokens for the DNF parentheses: `T_TYPE_OPEN_PARENTHESIS` and `T_TYPE_CLOSE_PARENTHESIS`.

This commit adds these new tokens to the appropriate token collections in the `Collections` class.

This will automatically add support for DNF types to various methods in PHPCSUtils.

Includes updated unit tests.

### PHP 8.2 | BCFile/FunctionDeclarations::get[Method]Parameters(): add support for DNF types

The changes in the `BCFile` class mirror the upstream changes.

As for the `FunctionDeclarations` class: support was automatically added when the `Collections::parameterTypeTokens()` were updated.

Includes tests.

Closes #567

### PHP 8.2 | BCFile/FunctionDeclarations::get[Method]Properties(): add tests for DNF types

The `BCFile` method inherits the necessary changes from PHPCS 3.10.0..

As for the `FunctionDeclarations` class: support was automatically added when the `Collections::returnTypeTokens()` were updated.

Includes tests.

### PHP 8.2 | BCFile/Variables::getMemberProperties(): add tests for DNF types

The `BCFile` method inherites the necessary changes from PHPCS 3.10.0..

As for the `Variables` class: support was automatically added when the `Collections::propertyTypeTokens()` were updated.

Includes tests.

### IsReferenceTest: add extra tests with intersection/DNF types 