### PR TITLE
SkipJSCSSTestsOnPHPCS4Test: fix compatibility with PHPUnit >= 10

### DIFF
--- a/Tests/TestUtils/UtilityMethodTestCase/SkipJSCSSTestsOnPHPCS4Test.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/SkipJSCSSTestsOnPHPCS4Test.php
@@ -51,7 +51,11 @@ final class SkipJSCSSTestsOnPHPCS4Test extends PolyfilledTestCase
         if (\version_compare(parent::$phpcsVersion, '3.99.99', '>') === true) {
             $msg       = 'JS and CSS support has been removed in PHPCS 4.';
             $exception = 'PHPUnit\Framework\SkippedTestError';
-            if (\class_exists('PHPUnit_Framework_SkippedTestError')) {
+
+            if (\class_exists('PHPUnit\Framework\SkippedWithMessageException')) {
+                // PHPUnit 10+.
+                $exception = 'PHPUnit\Framework\SkippedWithMessageException';
+            } elseif (\class_exists('PHPUnit_Framework_SkippedTestError')) {
                 // PHPUnit < 6.
                 $exception = 'PHPUnit_Framework_SkippedTestError';
             }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -81,10 +81,4 @@ parameters:
                 - Tests/Utils/GetTokensAsString/GetTokensAsStringTest.php
                 - Tests/Utils/NamingConventions/IsValidIdentifierNameTest.php
 
-        # Ignoring as this is fine.
-        -
-            message: '`^Parameter #1 \$exception of method PHPUnit\\Framework\\TestCase::expectException\(\) expects class-string<Throwable>, string given\.$`'
-            path: Tests/TestUtils/UtilityMethodTestCase/SkipJSCSSTestsOnPHPCS4Test.php
-            count: 1
-
-            # yamllint enable rule:line-length
+                # yamllint enable rule:line-length


### PR DESCRIPTION
Looks like the exception thrown for a test skip has been renamed.

Ref: https://github.com/sebastianbergmann/phpunit/commit/7dfe3dd0a93c1f69e53aa321a6a2a618547370f3