### PR TITLE
TestUtils/ConfigDouble: bug fix - always reset Config statics after use

### DIFF
--- a/PHPCSUtils/TestUtils/ConfigDouble.php
+++ b/PHPCSUtils/TestUtils/ConfigDouble.php
@@ -91,6 +91,22 @@ final class ConfigDouble extends Config
     }
 
     /**
+     * Ensures the static properties in the Config class are reset to their default values
+     * when the ConfigDouble is no longer used.
+     *
+     * @since 1.1.0
+     *
+     * @return void
+     */
+    public function __destruct()
+    {
+        $this->setStaticConfigProperty('overriddenDefaults', []);
+        $this->setStaticConfigProperty('executablePaths', []);
+        $this->setStaticConfigProperty('configData', null);
+        $this->setStaticConfigProperty('configDataFile', null);
+    }
+
+    /**
      * Sets the command line values and optionally prevents a file system search for a custom ruleset.
      *
      * {@internal Note: `array` type declaration can't be added as the parent class does not have a type declaration

--- a/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+++ b/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
@@ -310,6 +310,16 @@ abstract class UtilityMethodTestCase extends TestCase
      */
     public static function resetTestFile()
     {
+        /*
+         * Explicitly trigger __destruct() on the ConfigDouble to reset the Config statics.
+         * The explicit method call prevents potential stray test-local references to the $config object
+         * preventing the destructor from running the clean up (which without stray references would be
+         * automagically triggered when `self::$phpcsFile` is reset, but we can't definitively rely on that).
+         */
+        if (isset(self::$phpcsFile)) {
+            self::$phpcsFile->config->__destruct();
+        }
+
         self::$phpcsVersion  = '0';
         self::$fileExtension = 'inc';
         self::$caseFile      = '';

--- a/Tests/TestUtils/UtilityMethodTestCase/ResetTestFileTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/ResetTestFileTest.php
@@ -10,7 +10,10 @@
 
 namespace PHPCSUtils\Tests\TestUtils\UtilityMethodTestCase;
 
+use PHP_CodeSniffer\Config;
+use PHPCSUtils\BackCompat\Helper;
 use PHPCSUtils\Tests\PolyfilledTestCase;
+use ReflectionProperty;
 
 /**
  * Tests for the \PHPCSUtils\TestUtils\UtilityMethodTestCase class.
@@ -40,7 +43,7 @@ final class ResetTestFileTest extends PolyfilledTestCase
      *
      * @return void
      */
-    public function testTearDown()
+    public function testTearDownCleansUpStaticTestCaseClassProperties()
     {
         // Initialize a test, which should change the values of most static properties.
         self::$tabWidth      = 2;
@@ -65,5 +68,115 @@ final class ResetTestFileTest extends PolyfilledTestCase
         $this->assertSame(4, self::$tabWidth, 'tabWidth was not reset');
         $this->assertNull(self::$phpcsFile, 'phpcsFile was not reset');
         $this->assertSame(['Dummy.Dummy.Dummy'], self::$selectedSniff, 'selectedSniff was not reset');
+    }
+
+    /**
+     * Test that the static properties in the Config class are correctly reset.
+     *
+     * Ensure that Config set for one test does not influence the next test.
+     *
+     * @return void
+     */
+    public function testTearDownCleansUpStaticConfigProperties()
+    {
+        $fakeConfFile = 'path/to/file.conf';
+        $toolName     = 'a_tool';
+
+        // Set up preconditions.
+        self::setUpTestFile();
+        parent::setUpTestFile();
+
+        $config = self::$phpcsFile->config;
+        Helper::setConfigData('arbitraryKey', 'arbitraryValue', true, $config);
+        $config->setStaticConfigProperty('configDataFile', $fakeConfFile);
+        $config::getExecutablePath($toolName);
+
+        // Verify the static properties in the Config are set to something other than their default value.
+        $this->assertSame(['PSR1'], $config->standards, 'Precondition check: Standards was not set to PSR1');
+
+        $overriddenDefaults = $this->getStaticConfigProperty('overriddenDefaults', $config);
+        $this->assertIsArray($overriddenDefaults, 'Precondition check: overriddenDefaults property is not an array');
+        $this->assertNotEmpty($overriddenDefaults, 'Precondition check: overriddenDefaults property is an empty array');
+
+        $this->assertSame(
+            [$toolName => null],
+            $this->getStaticConfigProperty('executablePaths', $config),
+            'Precondition check: executablePaths is still an empty array'
+        );
+
+        $configData = $this->getStaticConfigProperty('configData', $config);
+        $this->assertIsArray($configData, 'Precondition check: configData property is not an array');
+        $this->assertNotEmpty($configData, 'Precondition check: configData property is an empty array');
+
+        $this->assertSame(
+            $fakeConfFile,
+            $this->getStaticConfigProperty('configDataFile', $config),
+            'Precondition check: configDataFile property has not been set'
+        );
+
+        // Reset the file as per the "afterClass"/tear down method.
+        parent::resetTestFile();
+
+        // Verify that the reset also reset the static properties on the Config class.
+        $this->assertSame(
+            [],
+            $this->getStaticConfigProperty('overriddenDefaults'),
+            'overriddenDefaults reset failed'
+        );
+        $this->assertSame([], $this->getStaticConfigProperty('executablePaths'), 'executablePaths reset failed');
+        $this->assertNull($this->getStaticConfigProperty('configData'), 'configData reset failed');
+        $this->assertNull($this->getStaticConfigProperty('configDataFile'), 'configDataFile reset failed');
+
+        $this->assertNull(Helper::getConfigData('arbitraryKey'), 'arbitraryKey property is still set');
+
+        // Now check that if a new Config is created for another test, that previously overridden defaults can be set again.
+        $newConfig = new Config(['--standard=Squiz']);
+
+        // Verify the new Config does not have leaked property values from the Config from the "previous test".
+        $this->assertSame(['Squiz'], $newConfig->standards, 'New standards choice was not set to Squiz');
+        $this->assertSame(
+            ['standards' => true],
+            $this->getStaticConfigProperty('overriddenDefaults', $newConfig),
+            'overriddenDefaults has not been reinitialized'
+        );
+
+        // Verify that previously overridden config property can be written to.
+        $newValue = 'new value';
+        $this->assertTrue(
+            Helper::setConfigData('arbitraryKey', $newValue, true, $newConfig),
+            'New value for arbitraryKey is not accepted'
+        );
+        $this->assertSame(
+            $newValue,
+            Helper::getConfigData('arbitraryKey'),
+            'Previously overridden default was not allowed to be set'
+        );
+    }
+
+    /**
+     * Helper function to retrieve the value of a private static property on the Config class.
+     *
+     * @param string                  $name   The name of the property to retrieve.
+     * @param \PHP_CodeSniffer\Config $config Optional. The config object.
+     *
+     * @return mixed
+     */
+    private function getStaticConfigProperty($name, $config = null)
+    {
+        $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
+        $property->setAccessible(true);
+
+        if ($name === 'overriddenDefaults'
+            && (self::$phpcsVersion === '0' || \version_compare(self::$phpcsVersion, '3.99.99', '>'))
+        ) {
+            // The `overriddenDefaults` property is no longer static on PHPCS 4.0+.
+            if (isset($config)) {
+                return $property->getValue($config);
+            } else {
+                return [];
+            }
+        }
+
+        return $property->getValue();
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -35,6 +35,17 @@ parameters:
             count: 1
 
         # Level 2
+        # The __destruct() method exists on the ConfigDouble, not the PHPCS native Config. This is 100% okay.
+        -
+            message: '`^Call to an undefined method PHP_CodeSniffer\\Config::__destruct\(\)\.$`'
+            path: PHPCSUtils\TestUtils\UtilityMethodTestCase.php
+            count: 1
+        # The setStaticConfigProperty() method exists on the ConfigDouble, not the PHPCS native Config. This is 100% okay.
+        -
+            message: '`^Call to an undefined method PHP_CodeSniffer\\Config::setStaticConfigProperty\(\)\.$`'
+            path: Tests\TestUtils\UtilityMethodTestCase\ResetTestFileTest.php
+            count: 1
+
         # Ignoring as this refers to a non-mocked method on the original class. This is 100% okay.
         -
             message: '`^Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::process\(\)\.$`'


### PR DESCRIPTION
The PHPCS native `Config` class uses a number of static properties, which may be updated during tests. These were previously reset to their default values in the `UtilityMethodTestCase::resetTestFile()` method, but this reset was inadvertently removed in commit https://github.com/PHPCSStandards/PHPCSUtils/pull/550/commits/4f0f9a4af04db6a3de28d657d06e707187c0c152 with the reasoning that, if all tests use the `ConfigDouble`, the reset would no longer be needed as the `ConfigDouble` resets on being initialized.

The flaw in this logic is that not all tests are guaranteed to use the `ConfigDouble`, which means that without the reset, the `Config` class may be left "dirty" after tests using the `ConfigDouble`, which could break tests.

This commit fixes this issue by:
* Adding a `__destruct()` method to the `ConfigDouble` class which will reset the static properties on the PHPCS native `Config` class whenever an object created from this class is destroyed.
* Explicitly calling the `__destruct()` method from the `UtilityMethodTestCase::resetTestFile()` method to ensure it is always run after a test has finished ("after class"), even if there would still be a lingering reference to the object.

Includes tests for the new `__destruct()` method.
Includes an additional test for the `UtilityMethodTestCase` class to ensure this snafu cannot come back without tests failing on it.

Props to @fredden for helping me debug this issue.