### PR TITLE
Context::inForeachCondition(): bug fix - improve handling of array declaration in foreach

### DIFF
--- a/Tests/Utils/Context/InForeachConditionTest.inc
+++ b/Tests/Utils/Context/InForeachConditionTest.inc
@@ -47,6 +47,36 @@ add_action('something', function($array) {
     return;
 });
 
+foreach(
+    array(
+        'anon class' => new class {
+            use A, B {
+                /* testForeachBeforeContainsAsInLongArrayBefore1 */
+                B::bigTalk as talk;
+            }
+            /* testForeachBeforeContainsAsInLongArrayBefore2 */
+            use HelloWorld { sayHello as protected; }
+        },
+    )
+    /* testForeachBeforeContainsAsInLongArrayAs */
+    as $key => $value
+) {}
+
+foreach(
+    [
+        'anon class' => new class {
+            use A, B {
+                /* testForeachBeforeContainsAsInShortArrayBefore1 */
+                B::bigTalk as talk;
+            }
+            /* testForeachBeforeContainsAsInShortArrayBefore2 */
+            use HelloWorld { sayHello as protected; }
+        },
+    ]
+    /* testForeachBeforeContainsAsInShortArrayAs */
+    as $key => $value
+) {}
+
 // Intentional parse error. This has to be the last test in the file.
 /* testParseError */
 foreach ($array as $target {}

--- a/Tests/Utils/Context/InForeachConditionTest.php
+++ b/Tests/Utils/Context/InForeachConditionTest.php
@@ -178,6 +178,58 @@ final class InForeachConditionTest extends UtilityMethodTestCase
                 'testMarker' => '/* testNestedForeach */',
                 'expected'   => 'afterAs',
             ],
+            'before-trait-use-as-in-anon-class-nested-in-long-array-as-token-1' => [
+                'testMarker' => '/* testForeachBeforeContainsAsInLongArrayBefore1 */',
+                'expected'   => 'beforeAs',
+                'targetType' => \T_AS,
+            ],
+            'before-trait-use-in-anon-class-nested-in-long-array-after-as-token-1' => [
+                'testMarker'    => '/* testForeachBeforeContainsAsInLongArrayBefore1 */',
+                'expected'      => 'beforeAs',
+                'targetType'    => \T_STRING,
+                'targetContent' => 'talk',
+            ],
+            'before-trait-use-as-in-anon-class-nested-in-long-array-as-token-2' => [
+                'testMarker' => '/* testForeachBeforeContainsAsInLongArrayBefore2 */',
+                'expected'   => 'beforeAs',
+                'targetType' => \T_AS,
+            ],
+            'before-trait-use-in-anon-class-nested-in-long-array-after-as-token-2' => [
+                'testMarker' => '/* testForeachBeforeContainsAsInLongArrayBefore2 */',
+                'expected'   => 'beforeAs',
+                'targetType' => \T_PROTECTED,
+            ],
+            'as-with-as-used-in-long-array-before' => [
+                'testMarker' => '/* testForeachBeforeContainsAsInLongArrayAs */',
+                'expected'   => 'as',
+                'targetType' => \T_AS,
+            ],
+            'before-trait-use-as-in-anon-class-nested-in-short-array-as-token-1' => [
+                'testMarker' => '/* testForeachBeforeContainsAsInShortArrayBefore1 */',
+                'expected'   => 'beforeAs',
+                'targetType' => \T_AS,
+            ],
+            'before-trait-use-in-anon-class-nested-in-short-array-after-as-token-1' => [
+                'testMarker'    => '/* testForeachBeforeContainsAsInShortArrayBefore1 */',
+                'expected'      => 'beforeAs',
+                'targetType'    => \T_STRING,
+                'targetContent' => 'talk',
+            ],
+            'before-trait-use-as-in-anon-class-nested-in-short-array-as-token-2' => [
+                'testMarker' => '/* testForeachBeforeContainsAsInShortArrayBefore2 */',
+                'expected'   => 'beforeAs',
+                'targetType' => \T_AS,
+            ],
+            'before-trait-use-in-anon-class-nested-in-short-array-after-as-token-2' => [
+                'testMarker' => '/* testForeachBeforeContainsAsInShortArrayBefore2 */',
+                'expected'   => 'beforeAs',
+                'targetType' => \T_PROTECTED,
+            ],
+            'as-with-as-used-in-short-array-before' => [
+                'testMarker' => '/* testForeachBeforeContainsAsInShortArrayAs */',
+                'expected'   => 'as',
+                'targetType' => \T_AS,
+            ],
         ];
     }
 }


### PR DESCRIPTION
PHP allows for not just having an (array/iterable object) variable in the "iterable" (before as) part, it also allows for those to be passed as an expression.

While this is surely more rare, it does mean that it is _possible_ for an `as` keyword to exist in the expression.

This commit makes the `Context::inForeachCondition()` method more robust by explicitly skipping over array declarations while searching for the `as` keyword belonging to the `foreach`. This fixes the bug.

Includes tests.