### PR TITLE
PHP 8.4: updates for exit as function call

### DIFF
--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -692,6 +692,10 @@ final class Collections
         $tokens[\T_ANON_CLASS] = \T_ANON_CLASS;
         $tokens               += self::$ooHierarchyKeywords;
 
+        // As of PHP 8.4, exit()/die() should be treated as function call tokens.
+        // Sniffs using this collection should safeguard against use as a constant.
+        $tokens[\T_EXIT] = \T_EXIT;
+
         return $tokens;
     }
 

--- a/PHPCSUtils/Utils/PassedParameters.php
+++ b/PHPCSUtils/Utils/PassedParameters.php
@@ -65,6 +65,9 @@ final class PassedParameters
      *   a short array opener.
      * - If passed a `T_ISSET` or `T_UNSET` stack pointer, it will detect whether those
      *   language constructs have "parameters".
+     * - If passed a `T_EXIT` stack pointer, it will treat it as a function call and detect whether
+     *   it has been passed parameters. When the `T_EXIT` is used as a constant, the return value
+     *   will be `false` (no parameters).
      *
      * @since 1.0.0
      *
@@ -94,7 +97,7 @@ final class PassedParameters
             throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);
         }
 
-        $acceptedTokens = 'function call, array, isset or unset';
+        $acceptedTokens = 'function call, array, isset, unset or exit';
         if (isset(Collections::parameterPassingTokens()[$tokens[$stackPtr]['code']]) === false) {
             throw UnexpectedTokenType::create(2, '$stackPtr', $acceptedTokens, $tokens[$stackPtr]['type']);
         }
@@ -131,7 +134,7 @@ final class PassedParameters
             return true;
         }
 
-        // Deal with function calls, long arrays, isset and unset.
+        // Deal with function calls, long arrays, isset, unset and exit/die.
         // Next non-empty token should be the open parenthesis.
         if ($tokens[$next]['code'] !== \T_OPEN_PARENTHESIS) {
             return false;

--- a/Tests/Tokens/Collections/FunctionCallTokensTest.php
+++ b/Tests/Tokens/Collections/FunctionCallTokensTest.php
@@ -40,6 +40,7 @@ final class FunctionCallTokensTest extends TestCase
             \T_PARENT               => \T_PARENT,
             \T_SELF                 => \T_SELF,
             \T_STATIC               => \T_STATIC,
+            \T_EXIT                 => \T_EXIT,
         ];
 
         $this->assertSame($expected, Collections::functionCallTokens());

--- a/Tests/Tokens/Collections/ParameterPassingTokensTest.php
+++ b/Tests/Tokens/Collections/ParameterPassingTokensTest.php
@@ -40,6 +40,7 @@ final class ParameterPassingTokensTest extends TestCase
             \T_PARENT               => \T_PARENT,
             \T_SELF                 => \T_SELF,
             \T_STATIC               => \T_STATIC,
+            \T_EXIT                 => \T_EXIT,
             \T_ISSET                => \T_ISSET,
             \T_UNSET                => \T_UNSET,
             \T_ARRAY                => \T_ARRAY,

--- a/Tests/Utils/PassedParameters/GetParametersNamedTest.inc
+++ b/Tests/Utils/PassedParameters/GetParametersNamedTest.inc
@@ -53,6 +53,9 @@ foo( label: $cond ? true : false, more: $cond ? CONSTANT_A : CONSTANT_B );
 /* testTernaryWithFunctionCallsInThenElse */
 echo $cond ? foo( label: $something ) : /* testTernaryWithFunctionCallsInElse */ bar( more: $something_else );
 
+/* testExitWithNamedParam */
+exit( status: 1 );
+
 /* testCompileErrorNamedBeforePositional */
 // Not the concern of PHPCSUtils. Should still be handled.
 test(param: $bar, $foo);

--- a/Tests/Utils/PassedParameters/GetParametersNamedTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersNamedTest.php
@@ -426,6 +426,20 @@ final class GetParametersNamedTest extends UtilityMethodTestCase
                     ],
                 ],
             ],
+            'named-args-for-exit' => [
+                'testMarker' => '/* testExitWithNamedParam */',
+                'targetType' => \T_EXIT,
+                'expected'   => [
+                    'status' => [
+                        'name'       => 'status',
+                        'name_token' => 3,
+                        'start'      => 5,
+                        'end'        => 7,
+                        'raw'        => '1',
+                    ],
+                ],
+            ],
+
             'named-args-compile-error-named-before-positional' => [
                 'testMarker' => '/* testCompileErrorNamedBeforePositional */',
                 'targetType' => \T_STRING,

--- a/Tests/Utils/PassedParameters/GetParametersSkipShortArrayCheckTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersSkipShortArrayCheckTest.php
@@ -45,7 +45,7 @@ final class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase
         if ($expectException === true) {
             $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
             $this->expectExceptionMessage(
-                'Argument #2 ($stackPtr) must be of type function call, array, isset or unset;'
+                'Argument #2 ($stackPtr) must be of type function call, array, isset, unset or exit;'
             );
         }
 
@@ -96,7 +96,7 @@ final class GetParametersSkipShortArrayCheckTest extends PolyfilledTestCase
         if ($targetType === \T_OPEN_SQUARE_BRACKET) {
             $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
             $this->expectExceptionMessage(
-                'Argument #2 ($stackPtr) must be of type function call, array, isset or unset;'
+                'Argument #2 ($stackPtr) must be of type function call, array, isset, unset or exit;'
             );
         }
 

--- a/Tests/Utils/PassedParameters/GetParametersTest.inc
+++ b/Tests/Utils/PassedParameters/GetParametersTest.inc
@@ -120,6 +120,9 @@ if ( isset(
 /* testUnset */
 unset( $variable, $object->property, static::$property, $array[$name], );
 
+/* testDie */
+die( $status );
+
 /* testAnonClass */
 $anon = new class( $param1, $param2 ) {
     public function __construct($param1, $param2) {}

--- a/Tests/Utils/PassedParameters/GetParametersTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersTest.php
@@ -523,6 +523,18 @@ final class GetParametersTest extends UtilityMethodTestCase
                     ],
                 ],
             ],
+            'die' => [
+                'testMarker' => '/* testDie */',
+                'targetType' => \T_EXIT,
+                'expected'   => [
+                    1 => [
+                        'start' => 2,
+                        'end'   => 4,
+                        'raw'   => '$status',
+                    ],
+                ],
+            ],
+
             'anon-class' => [
                 'testMarker' => '/* testAnonClass */',
                 'targetType' => \T_ANON_CLASS,

--- a/Tests/Utils/PassedParameters/HasParametersTest.inc
+++ b/Tests/Utils/PassedParameters/HasParametersTest.inc
@@ -19,6 +19,13 @@ class Foo {
 /* testShortListNotShortArray */
 [ $a, $b ] = $array;
 
+/* testExitAsConstant */
+exit;
+
+/* testDieAsConstant */
+die;
+
+
 // Function calls: no parameters.
 
 /* testNoParamsFunctionCall1 */
@@ -162,6 +169,18 @@ unset(
       $hello,
 
 );
+
+/* testNoParamsExit */
+exit();
+
+/* testHasParamsExit */
+exit( $code );
+
+/* testNoParamsDie */
+die( /*comment*/ );
+
+/* testHasParamsDie */
+die( $status );
 
 /* testNoParamsNoParensAnonClass */
 $anon = new class extends FooBar {};

--- a/Tests/Utils/PassedParameters/HasParametersTest.php
+++ b/Tests/Utils/PassedParameters/HasParametersTest.php
@@ -62,7 +62,7 @@ final class HasParametersTest extends PolyfilledTestCase
     {
         $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
         $this->expectExceptionMessage(
-            'Argument #2 ($stackPtr) must be of type function call, array, isset or unset;'
+            'Argument #2 ($stackPtr) must be of type function call, array, isset, unset or exit;'
         );
 
         $interface = $this->getTargetToken('/* testNotAnAcceptedToken */', \T_INTERFACE);
@@ -83,7 +83,7 @@ final class HasParametersTest extends PolyfilledTestCase
     {
         $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
         $this->expectExceptionMessage(
-            'Argument #2 ($stackPtr) must be of type function call, array, isset or unset;'
+            'Argument #2 ($stackPtr) must be of type function call, array, isset, unset or exit;'
         );
 
         $self = $this->getTargetToken($testMarker, $targetType);
@@ -124,7 +124,7 @@ final class HasParametersTest extends PolyfilledTestCase
     {
         $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
         $this->expectExceptionMessage(
-            'Argument #2 ($stackPtr) must be of type function call, array, isset or unset;'
+            'Argument #2 ($stackPtr) must be of type function call, array, isset, unset or exit;'
         );
 
         $self = $this->getTargetToken(
@@ -384,6 +384,38 @@ final class HasParametersTest extends PolyfilledTestCase
             'has-params-unset' => [
                 'testMarker' => '/* testHasParamsUnset */',
                 'targetType' => \T_UNSET,
+                'expected'   => true,
+            ],
+
+            // Exit/die.
+            'exit as a constant' => [
+                'testMarker' => '/* testExitAsConstant */',
+                'targetType' => \T_EXIT,
+                'expected'   => false,
+            ],
+            'die as a constant' => [
+                'testMarker' => '/* testDieAsConstant */',
+                'targetType' => \T_EXIT,
+                'expected'   => false,
+            ],
+            'no-params-exit' => [
+                'testMarker' => '/* testNoParamsExit */',
+                'targetType' => \T_EXIT,
+                'expected'   => false,
+            ],
+            'has-params-exit' => [
+                'testMarker' => '/* testHasParamsExit */',
+                'targetType' => \T_EXIT,
+                'expected'   => true,
+            ],
+            'no-params-die' => [
+                'testMarker' => '/* testNoParamsDie */',
+                'targetType' => \T_EXIT,
+                'expected'   => false,
+            ],
+            'has-params-die' => [
+                'testMarker' => '/* testHasParamsDie */',
+                'targetType' => \T_EXIT,
                 'expected'   => true,
             ],
 


### PR DESCRIPTION
### PHP 8.4 | Collections::functionCallTokens(): add T_EXIT

As of PHP 8.4, `exit` and `die` will become "special" function calls and when used as a constant, it will be transformed to a function call at compile time. See the RFC for full details.

With this in mind, it is appropriate to add `T_EXIT` to the `functionCallTokens()` and by inheritance to the `parameterPassingTokens()`.

Includes unit tests.

Ref: https://wiki.php.net/rfc/exit-as-function

### PassedParameters: minor update for support of exit

As the `Collections::parameterPassingTokens()` array now contains `T_EXIT`, `exit` and `die` will now also be analyzable via the methods in the `PassedParameters` class.

This commit:
* Updates the documentation and the exception message to reflect this.
* Adds various tests with `exit` and `die`.