### PR TITLE
Numbers::is*(): remove fault tolerance for invalid numeric literals with underscores

### DIFF
--- a/PHPCSUtils/Utils/Numbers.php
+++ b/PHPCSUtils/Utils/Numbers.php
@@ -42,7 +42,7 @@ final class Numbers
      *
      * @var string
      */
-    const REGEX_DECIMAL_INT = '`^(?:0|[1-9][0-9]*)$`D';
+    const REGEX_DECIMAL_INT = '`^(?:0|[1-9](?:[0-9_]*[0-9])?)$`D';
 
     /**
      * Regex to determine whether the contents of an arbitrary string represents an octal integer.
@@ -51,7 +51,7 @@ final class Numbers
      *
      * @var string
      */
-    const REGEX_OCTAL_INT = '`^0[o]?[0-7]+$`iD';
+    const REGEX_OCTAL_INT = '`^0[o]?[0-7](?:[0-7_]*[0-7])?$`iD';
 
     /**
      * Regex to determine whether the contents of an arbitrary string represents a binary integer.
@@ -60,7 +60,7 @@ final class Numbers
      *
      * @var string
      */
-    const REGEX_BINARY_INT = '`^0b[0-1]+$`iD';
+    const REGEX_BINARY_INT = '`^0b[0-1](?:[0-1_]*[0-1])?$`iD';
 
     /**
      * Regex to determine whether the contents of an arbitrary string represents a hexidecimal integer.
@@ -69,7 +69,7 @@ final class Numbers
      *
      * @var string
      */
-    const REGEX_HEX_INT = '`^0x[0-9A-F]+$`iD';
+    const REGEX_HEX_INT = '`^0x[0-9A-F](?:[0-9A-F_]*[0-9A-F])?$`iD';
 
     /**
      * Regex to determine whether the contents of an arbitrary string represents a float.
@@ -84,16 +84,16 @@ final class Numbers
         ^(?:
             (?:
                 (?:
-                    (?P<LNUM>[0-9]+)
+                    (?P<LNUM>[0-9](?:[0-9_]*[0-9])?)
                 |
-                    (?P<DNUM>([0-9]*\.(?P>LNUM)|(?P>LNUM)\.[0-9]*))
+                    (?P<DNUM>((?:[0-9](?:[0-9_]*[0-9])?)*\.(?P>LNUM)|(?P>LNUM)\.(?:[0-9](?:[0-9_]*[0-9])?)*))
                 )
                 [e][+-]?(?P>LNUM)
             )
             |
             (?P>DNUM)
             |
-            (?:0|[1-9][0-9]*)
+            (?:0|[1-9](?:[0-9_]*[0-9])?)
         )$
         `ixD';
 
@@ -215,7 +215,7 @@ final class Numbers
     /**
      * Verify whether the contents of an arbitrary string represents a decimal integer.
      *
-     * Takes PHP 7.4 numeric literal separators in numbers into account.
+     * Takes PHP 7.4 numeric literal separators in numbers into account in the regex.
      *
      * @since 1.0.0
      *
@@ -229,16 +229,13 @@ final class Numbers
             return false;
         }
 
-        // Remove potential PHP 7.4 numeric literal separators.
-        $textString = \str_replace('_', '', $textString);
-
         return (\preg_match(self::REGEX_DECIMAL_INT, $textString) === 1);
     }
 
     /**
      * Verify whether the contents of an arbitrary string represents a hexidecimal integer.
      *
-     * Takes PHP 7.4 numeric literal separators in numbers into account.
+     * Takes PHP 7.4 numeric literal separators in numbers into account in the regex.
      *
      * @since 1.0.0
      *
@@ -252,16 +249,13 @@ final class Numbers
             return false;
         }
 
-        // Remove potential PHP 7.4 numeric literal separators.
-        $textString = \str_replace('_', '', $textString);
-
         return (\preg_match(self::REGEX_HEX_INT, $textString) === 1);
     }
 
     /**
      * Verify whether the contents of an arbitrary string represents a binary integer.
      *
-     * Takes PHP 7.4 numeric literal separators in numbers into account.
+     * Takes PHP 7.4 numeric literal separators in numbers into account in the regex.
      *
      * @since 1.0.0
      *
@@ -275,16 +269,13 @@ final class Numbers
             return false;
         }
 
-        // Remove potential PHP 7.4 numeric literal separators.
-        $textString = \str_replace('_', '', $textString);
-
         return (\preg_match(self::REGEX_BINARY_INT, $textString) === 1);
     }
 
     /**
      * Verify whether the contents of an arbitrary string represents an octal integer.
      *
-     * Takes PHP 7.4 numeric literal separators and explicit octal literals in numbers into account.
+     * Takes PHP 7.4 numeric literal separators and explicit octal literals in numbers into account in the regex.
      *
      * @since 1.0.0
      *
@@ -298,16 +289,13 @@ final class Numbers
             return false;
         }
 
-        // Remove potential PHP 7.4 numeric literal separators.
-        $textString = \str_replace('_', '', $textString);
-
         return (\preg_match(self::REGEX_OCTAL_INT, $textString) === 1);
     }
 
     /**
      * Verify whether the contents of an arbitrary string represents a floating point number.
      *
-     * Takes PHP 7.4 numeric literal separators in numbers into account.
+     * Takes PHP 7.4 numeric literal separators in numbers into account in the regex.
      *
      * @since 1.0.0
      *
@@ -320,9 +308,6 @@ final class Numbers
         if (\is_string($textString) === false || $textString === '') {
             return false;
         }
-
-        // Remove potential PHP 7.4 numeric literal separators.
-        $textString = \str_replace('_', '', $textString);
 
         return (\preg_match(self::REGEX_FLOAT, $textString) === 1);
     }

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.inc
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.inc
@@ -136,3 +136,13 @@ $\{abc}
 EOD
               => 3,
 ];
+
+/* testStringLiteralsWithNumbers */
+$validStringKeys = array(
+    '_1'  => 'value1',
+    '_2'  => 'value2',
+    '3_'  => 'value3',
+    '4_'  => 'value4',
+    '_5_' => 'value5',
+    '_6_' => 'value6',
+);

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.php
@@ -138,4 +138,40 @@ final class GetActualArrayKeyTest extends UtilityMethodTestCase
             );
         }
     }
+
+    /**
+     * Test retrieving the actual array key when string keys look like numeric literals with underscores.
+     *
+     * @return void
+     */
+    public function testStringLiteralsWithNumbers()
+    {
+        $testObj         = new ArrayDeclarationSniffTestDouble();
+        $testObj->tokens = self::$phpcsFile->getTokens();
+
+        $stackPtr   = $this->getTargetToken('/* testStringLiteralsWithNumbers */', [\T_ARRAY, \T_OPEN_SHORT_ARRAY]);
+        $arrayItems = PassedParameters::getParameters(self::$phpcsFile, $stackPtr);
+
+        $expected = [
+            1 => '_1',
+            2 => '_2',
+            3 => '3_',
+            4 => '4_',
+            5 => '_5_',
+            6 => '_6_',
+        ];
+
+        $this->assertCount(\count($expected), $arrayItems);
+
+        foreach ($arrayItems as $itemNr => $arrayItem) {
+            $arrowPtr = Arrays::getDoubleArrowPtr(self::$phpcsFile, $arrayItem['start'], $arrayItem['end']);
+            $result   = $testObj->getActualArrayKey(self::$phpcsFile, $arrayItem['start'], ($arrowPtr - 1));
+            $this->assertSame(
+                $expected[$itemNr],
+                $result,
+                'Failed: actual key ' . \var_export($result, true) . ' is not the same as the expected key '
+                    . \var_export($expected[$itemNr], true) . ' for item number ' . $itemNr
+            );
+        }
+    }
 }

--- a/Tests/Utils/Numbers/NumberTypesTest.php
+++ b/Tests/Utils/Numbers/NumberTypesTest.php
@@ -402,6 +402,269 @@ final class NumberTypesTest extends TestCase
                 ],
             ],
 
+            // Invalid numeric literal with separator look-a-like strings
+            'invalid-numeric-literal-leading-underscore-decimal' => [
+                'input'    => '_1',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-trailing-underscore-decimal' => [
+                'input'    => '1_',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-leading-and-trailing-underscore-decimal' => [
+                'input'    => '_1_',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-leading-underscore-octal' => [
+                'input'    => '_072',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-leading-underscore-after-prefix-octal' => [
+                'input'    => '0o_1256',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-trailing-underscore-octal' => [
+                'input'    => '0O271_',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-leading-and-trailing-underscore-octal' => [
+                'input'    => '_0o_1561_',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-leading-underscore-binary' => [
+                'input'    => '_0b01',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-leading-underscore-after-prefix-binary' => [
+                'input'    => '0b_101011',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-trailing-underscore-binary' => [
+                'input'    => '0b10001_',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-leading-and-trailing-underscore-binary' => [
+                'input'    => '_0b_00101_',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-leading-underscore-hex' => [
+                'input'    => '_0xAF451212',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-leading-underscore-after-prefix-hex' => [
+                'input'    => '0x_241FB4C',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-trailing-underscore-hex' => [
+                'input'    => '0x12_',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-leading-and-trailing-underscore-hex' => [
+                'input'    => '_0x_213CAD1_',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+
+            'invalid-numeric-literal-leading-underscore-next-to-leading-zero-float' => [
+                'input'    => '_012.12',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-leading-underscore-next-to-number-float' => [
+                'input'    => '_12.12',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-leading-underscore-next-to-decimalpoint-float' => [
+                'input'    => '_.1212',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-trailing-underscore-next-to-number-float' => [
+                'input'    => '12.21378_',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-trailing-underscore-next-to-zero-float' => [
+                'input'    => '12.700_',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-trailing-underscore-next-to-decimalpoint-float' => [
+                'input'    => '12._',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-underscore-before-decimalpoint-float' => [
+                'input'    => '1_.0',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-trailing-underscore-after-decimalpoint-float' => [
+                'input'    => '1._0',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-underscore-before-e-float' => [
+                'input'    => '1_e2',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-trailing-underscore-after-e-float' => [
+                'input'    => '1e_2',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+            'invalid-numeric-literal-underscores-everywhere-float' => [
+                'input'    => '_002781_._219_28173_E_+56_',
+                'expected' => [
+                    'decimal' => false,
+                    'hex'     => false,
+                    'binary'  => false,
+                    'octal'   => false,
+                    'float'   => false,
+                ],
+            ],
+
             // Decimal numeric strings.
             'decimal-single-digit-zero' => [
                 'input'    => '0',


### PR DESCRIPTION
### Numbers::is*(): remove fault tolerance for invalid numeric literals with underscores

Numeric literals with underscores have restrictions as to where the underscores are allowed.

The `Numbers` class did not take this into account to have some allowance for developer error, but as a bug has now been reported for the `AbstractArrayDeclarationSniff::getActualArrayKey()` method, which is due to this fault tolerance, the fault tolerance will be removed and the `Numbers::is*()` methods will now only allow underscore separators in places where PHP allows them.

Note: There is still one restriction which is not yet handled: `1__1`, i.e. two underscores next to each.
If at some point in the future a bug for this would be reported, this can be reconsidered.

Includes a plenitude of additional tests.

Fixes #619

Refs:
* https://wiki.php.net/rfc/numeric_literal_separator#restrictions

### AbstractArrayDeclarationSniff::getActualArrayKey(): add extra tests 