### PR TITLE
Allow for PHPUnit 11

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -92,7 +92,10 @@ jobs:
       - name: Determine PHPUnit config file to use
         id: phpunit_config
         run: |
-          if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}" == "true" ]; then
+          if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
+            echo 'FILE=phpunit10.xml.dist' >> $GITHUB_OUTPUT
+            echo 'EXTRA_ARGS=' >> $GITHUB_OUTPUT
+          elif [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}" == "true" ]; then
             echo 'FILE=phpunit10.xml.dist' >> $GITHUB_OUTPUT
             echo 'EXTRA_ARGS=' >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -213,7 +213,10 @@ jobs:
       - name: Determine PHPUnit config file to use
         id: phpunit_config
         run: |
-          if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}" == "true" ]; then
+          if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
+            echo 'FILE=phpunit10.xml.dist' >> $GITHUB_OUTPUT
+            echo 'EXTRA_ARGS=' >> $GITHUB_OUTPUT
+          elif [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}" == "true" ]; then
             echo 'FILE=phpunit10.xml.dist' >> $GITHUB_OUTPUT
             echo 'EXTRA_ARGS=' >> $GITHUB_OUTPUT
           else
@@ -338,20 +341,20 @@ jobs:
       # As of PHPUnit 9.3.4, a cache warming option is available.
       # Using that option prevents issues with PHP-Parser backfilling PHP tokens when PHPCS does not (yet),
       # which would otherwise cause tests to fail on tokens being available when they shouldn't be.
-      # As coverage is only run on high/low PHP, the high PHP version will use PHPUnit 10, so just check for that.
+      # As coverage is only run on high/low PHP, the high PHP version will use PHPUnit 11, so just check for that.
       - name: "Warm the PHPUnit cache (PHPUnit 9.3+)"
-        if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
+        if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}
         run: vendor/bin/phpunit -c phpunit10.xml.dist --coverage-cache ./build/phpunit-cache --warm-coverage-cache
 
       - name: "Run the unit tests without caching with code coverage (PHPUnit < 10)"
-        if: ${{ ! startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
+        if: ${{ ! startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}
         run: vendor/bin/phpunit
         env:
           PHPCS_VERSION: ${{ matrix.phpcs_version }}
           PHPCSUTILS_USE_CACHE: false
 
       - name: "Run the unit tests without caching with code coverage (PHPUnit 10+)"
-        if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}
+        if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}
         run: vendor/bin/phpunit -c phpunit10.xml.dist --coverage-cache ./build/phpunit-cache
         env:
           PHPCS_VERSION: ${{ matrix.phpcs_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -344,7 +344,7 @@ jobs:
       # As coverage is only run on high/low PHP, the high PHP version will use PHPUnit 11, so just check for that.
       - name: "Warm the PHPUnit cache (PHPUnit 9.3+)"
         if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}
-        run: vendor/bin/phpunit -c phpunit10.xml.dist --coverage-cache ./build/phpunit-cache --warm-coverage-cache
+        run: vendor/bin/phpunit -c phpunit10.xml.dist --warm-coverage-cache
 
       - name: "Run the unit tests without caching with code coverage (PHPUnit < 10)"
         if: ${{ ! startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}
@@ -355,7 +355,7 @@ jobs:
 
       - name: "Run the unit tests without caching with code coverage (PHPUnit 10+)"
         if: ${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}
-        run: vendor/bin/phpunit -c phpunit10.xml.dist --coverage-cache ./build/phpunit-cache
+        run: vendor/bin/phpunit -c phpunit10.xml.dist
         env:
           PHPCS_VERSION: ${{ matrix.phpcs_version }}
           PHPCSUTILS_USE_CACHE: false

--- a/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+++ b/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
@@ -20,6 +20,9 @@ use PHPCSUtils\Exceptions\TestFileNotFound;
 use PHPCSUtils\Exceptions\TestMarkerNotFound;
 use PHPCSUtils\Exceptions\TestTargetNotFound;
 use PHPCSUtils\TestUtils\ConfigDouble;
+use PHPUnit\Framework\Attributes\AfterClass;
+use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\Attributes\BeforeClass;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionProperty;
@@ -30,7 +33,7 @@ use ReflectionProperty;
  * This class is compatible with PHP_CodeSniffer 3.x and contains preliminary compatibility with 4.x
  * based on its currently known state/roadmap.
  *
- * This class is compatible with {@link https://phpunit.de/ PHPUnit} 4.5 - 9.x providing the PHPCSUtils
+ * This class is compatible with {@link https://phpunit.de/ PHPUnit} 4.5 - 11.x providing the PHPCSUtils
  * autoload file is included in the test bootstrap. For more information about that, please consult
  * the project's {@link https://github.com/PHPCSStandards/PHPCSUtils/blob/develop/README.md README}.
  *
@@ -105,6 +108,8 @@ use ReflectionProperty;
  *   for the PHPCSUtils utility functions themselves.
  *
  * @since 1.0.0
+ * @since 1.0.7 Compatible with PHPUnit 10.
+ * @since 1.1.0 Compatible with PHPUnit 11.
  */
 abstract class UtilityMethodTestCase extends TestCase
 {
@@ -194,6 +199,7 @@ abstract class UtilityMethodTestCase extends TestCase
      *
      * @return void
      */
+    #[BeforeClass]
     public static function setUpTestFile()
     {
         parent::setUpBeforeClass();
@@ -283,6 +289,7 @@ abstract class UtilityMethodTestCase extends TestCase
      *
      * @return void
      */
+    #[Before]
     public function skipJSCSSTestsOnPHPCS4()
     {
         if (static::$fileExtension !== 'js' && static::$fileExtension !== 'css') {
@@ -308,6 +315,7 @@ abstract class UtilityMethodTestCase extends TestCase
      *
      * @return void
      */
+    #[AfterClass]
     public static function resetTestFile()
     {
         /*

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ These classes take most of the heavy lifting away for some frequently occurring 
 ### Test utilities
 
 An abstract `UtilityMethodTestCase` class to support testing of your utility methods written for PHP_CodeSniffer.
-Supports PHPUnit 4.x up to 9.x.
+Supports PHPUnit 4.x up to 11.x.
 
 ### Use the latest version of PHP_CodeSniffer native utility functions
 

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
@@ -287,8 +287,9 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
                 [self::$phpcsFile, $target + 7, $target + 8, 1],
                 [self::$phpcsFile, $target + 15, $target + 16, 2],
                 [self::$phpcsFile, $target + 23, $target + 24, 3],
-            ]
-        )->will($this->onConsecutiveCalls(null, null, true)); // Testing short-circuiting the loop.
+            ],
+            [null, null, true] // Testing short-circuiting the loop.
+        );
 
         $this->setExpectationWithConsecutiveArgs(
             $mockObj,

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
@@ -665,16 +665,18 @@ final class AbstractArrayDeclarationSniffTest extends PolyfilledTestCase
      */
     private function getMockedClassUnderTest()
     {
-        $mockedObj = $this->getMockBuilder('\PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff');
+        $mockedObj = $this->getMockBuilder(
+            '\PHPCSUtils\Tests\AbstractSniffs\AbstractArrayDeclaration\ArrayDeclarationSniffMock'
+        );
 
         if (\method_exists($mockedObj, 'onlyMethods')) {
             // PHPUnit 8+.
             return $mockedObj->onlyMethods($this->methodsToMock)
-                ->getMockForAbstractClass();
+                ->getMock();
         }
 
         // PHPUnit < 8.
         return $mockedObj->setMethods($this->methodsToMock)
-            ->getMockForAbstractClass();
+            ->getMock();
     }
 }

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/ArrayDeclarationSniffMock.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/ArrayDeclarationSniffMock.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\AbstractSniffs\AbstractArrayDeclaration;
+
+use PHPCSUtils\AbstractSniffs\AbstractArrayDeclarationSniff;
+
+/**
+ * Test mock for the AbstractArrayDeclarationSniff to allow for testing the logic of the abstract class.
+ *
+ * @since 1.1.0
+ */
+class ArrayDeclarationSniffMock extends AbstractArrayDeclarationSniff
+{
+}

--- a/Tests/PolyfilledTestCase.php
+++ b/Tests/PolyfilledTestCase.php
@@ -79,7 +79,7 @@ if (\version_compare(Autoload::VERSION, '3.0.0', '>=')) {
     }
 } elseif (\version_compare(Autoload::VERSION, '2.0.0', '>=')) {
     /**
-     * Abstract utility method base test case which includes all available polyfills (PHPUnit Polyfills 2.x compaible).
+     * Abstract utility method base test case which includes all available polyfills (PHPUnit Polyfills 2.x compatible).
      *
      * This test case includes all polyfills from the PHPUnit Polyfill library to make them
      * available to the tests.
@@ -116,7 +116,7 @@ if (\version_compare(Autoload::VERSION, '3.0.0', '>=')) {
     }
 } else {
     /**
-     * Abstract utility method base test case which includes all available polyfills (PHPUnit Polyfills 1.x compaible).
+     * Abstract utility method base test case which includes all available polyfills (PHPUnit Polyfills 1.x compatible).
      *
      * This test case includes all polyfills from the PHPUnit Polyfill library to make them
      * available to the tests.

--- a/Tests/PolyfilledTestCase.php
+++ b/Tests/PolyfilledTestCase.php
@@ -17,6 +17,7 @@ use PHPCSUtils\Tests\AssertPropertySame;
 use PHPCSUtils\Tests\ExpectWithConsecutiveArgs;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 use Yoast\PHPUnitPolyfills\Autoload;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertArrayWithListKeys;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertEqualsSpecializations;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertFileDirectory;
@@ -27,6 +28,7 @@ use Yoast\PHPUnitPolyfills\Polyfills\AssertIsList;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertNumericType;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertObjectEquals;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertObjectNotEquals;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertObjectProperty;
 use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
 use Yoast\PHPUnitPolyfills\Polyfills\EqualToSpecializations;
@@ -34,8 +36,48 @@ use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionObject;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectUserDeprecation;
 
-if (\version_compare(Autoload::VERSION, '2.0.0', '>=')) {
+if (\version_compare(Autoload::VERSION, '3.0.0', '>=')) {
+    /**
+     * Abstract utility method base test case which includes all available polyfills (PHPUnit Polyfills 3.x compatible).
+     *
+     * This test case includes all polyfills from the PHPUnit Polyfill library to make them
+     * available to the tests.
+     *
+     * Generally speaking, this testcase only needs to be used when the concrete test class will
+     * use functionality which has changed in PHPUnit cross-version.
+     * In all other cases, the `UtilityMethodTestCase` can be extended directly.
+     *
+     * {@internal The list of included polyfill traits should be reviewed after each new
+     * release of the PHPUnit Polyfill library.}
+     *
+     * @since 1.1.0
+     */
+    abstract class PolyfilledTestCase extends UtilityMethodTestCase
+    {
+        // PHPCSUtils native helpers.
+        use AssertPropertySame;
+        use ExpectWithConsecutiveArgs;
+
+        // PHPUnit Polyfills.
+        use AssertArrayWithListKeys;
+        use AssertClosedResource;
+        use AssertEqualsSpecializations;
+        use AssertFileEqualsSpecializations;
+        use AssertIgnoringLineEndings;
+        use AssertionRenames;
+        use AssertIsList;
+        use AssertIsType;
+        use AssertObjectEquals;
+        use AssertObjectNotEquals;
+        use AssertObjectProperty;
+        use AssertStringContains;
+        use EqualToSpecializations;
+        use ExpectExceptionMessageMatches;
+        use ExpectUserDeprecation;
+    }
+} elseif (\version_compare(Autoload::VERSION, '2.0.0', '>=')) {
     /**
      * Abstract utility method base test case which includes all available polyfills (PHPUnit Polyfills 2.x compaible).
      *

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "phpcsstandards/phpcsdevcs": "^1.1.6",
         "php-parallel-lint/php-parallel-lint": "^1.3.2",
         "php-parallel-lint/php-console-highlighter": "^1.0",
-        "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
+        "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,7 +27,7 @@
             <!--
             A number of tests need process isolation to allow for recording code coverage on
             the setting of function local static variables.
-            However, using process isolation runs into trouble with PHPUnit 4.x/PHPCS 2.6.0.
+            However, using process isolation runs into trouble with PHPUnit 4.x.
             Executing these specific tests in a separate testsuite, which is run
             before the full test suite, will allow for the code coverage for these methods
             to be recorded properly, while still allowing the tests to run on all supported

--- a/phpunit10.xml.dist
+++ b/phpunit10.xml.dist
@@ -5,6 +5,7 @@
         backupGlobals="true"
         bootstrap="./Tests/bootstrap.php"
         beStrictAboutTestsThatDoNotTestAnything="true"
+        cacheDirectory="build/.phpunit-cache"
         colors="true"
         displayDetailsOnTestsThatTriggerErrors="true"
         displayDetailsOnTestsThatTriggerWarnings="true"

--- a/phpunit10.xml.dist
+++ b/phpunit10.xml.dist
@@ -33,7 +33,7 @@
             <!--
             A number of tests need process isolation to allow for recording code coverage on
             the setting of function local static variables.
-            However, using process isolation runs into trouble with PHPUnit 4.x/PHPCS 2.6.0.
+            However, using process isolation runs into trouble with PHPUnit 4.x.
             Executing these specific tests in a separate testsuite, which is run
             before the full test suite, will allow for the code coverage for these methods
             to be recorded properly, while still allowing the tests to run on all supported

--- a/phpunit10.xml.dist
+++ b/phpunit10.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/10.1/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/10.5/phpunit.xsd"
         backupGlobals="true"
         bootstrap="./Tests/bootstrap.php"
         beStrictAboutTestsThatDoNotTestAnything="true"
@@ -12,9 +12,11 @@
         displayDetailsOnTestsThatTriggerDeprecations="true"
         displayDetailsOnIncompleteTests="true"
         displayDetailsOnSkippedTests="true"
+        displayDetailsOnPhpunitDeprecations="false"
         failOnWarning="true"
         failOnNotice="true"
         failOnDeprecation="true"
+        failOnPhpunitDeprecation="false"
         requireCoverageMetadata="true"
     >
     <testsuites>


### PR DESCRIPTION
### Composer: update the PHPUnit Polyfills to v 3.0

A PHPUnit 11 compatible version of the PHPUnit Polyfills has been released, so let's start using it.

Mind: PHPUnit 11 throws deprecation notices about the use of annotations instead of attributes.
On PHPUnit < 10.5.32 and PHPUnit < 11.3.3, these deprecation notices would fail the test run.

PHPUnit 10.5.32 and 11.3.3 introduce two new options for both the configuration file and as CLI arguments: `displayDetailsOnPhpunitDeprecations` and `failOnPhpunitDeprecation`, both of which will now default to `false`.

These options have been added to the PHPUnit configuration for PHPUnit 10/11 to safeguard them against changes in the default value.
This does mean that the configuration is no longer compatible with PHPUnit 10.0 - 10.5.31 and 11.0 - 11.3.2 and would fail the test run on seeing those config options.

With this in mind, it could be considered to set an explicit PHPUnit dependency to ensure the test suite isn't run on lower PHPUnit 10/11 versions, but as that is unlikely anyway, as Composer should always install the most recent version of PHPUnit, I deem this unnecessary.

Ref:
* https://github.com/Yoast/PHPUnit-Polyfills/releases/tag/3.0.0

### GH Actions/PHPUnit config: deal with removed `--coverage-cache` CLI option

The `--coverage-cache` flag was silently deprecated in PHPUnit 10 and has been removed in PHPUnit 11.

The `--cache-directory` flag replaces it and can also be set in the XML file.

This commit removes the outdated flag from the commands used in GH Actions and adds the attribute to the PHPUnit config file.

Ref:
* sebastianbergmann/phpunit#4599

### UtilityMethodTestCase: add Before/After[Class] attributes

PHPUnit 10 introduced attributes as replacements for docblock annotations.
PHPUnit 11 deprecates the use of docblock annotations in favour of attributes.

If both an attribute as well as an annotation are found, no PHPUnit deprecation warning will be thrown.

This commit adds the `Before/After*` attributes in the user-facing `UtilityMethodTestCase` class to prevent such deprecation notices.

_The "annotations to attributes" conversion for the PHPCSUtils native test suite is not yet necessary and is left for the update to PHPUnit 12._

The `@before/after*` annotations remain as the tests also still need to run on PHP 5.4 - 8.0 using PHPUnit 4.x - 9.x.
These can be removed once the codebase has a PHP 8.1/PHPUnit 10 minimum requirement.

Note: due to the syntax for attributes, these can be safely added as they are ignored as comments on PHP < 8.0.
Along the same line, if there is no "listener" for the attributes (PHP 8.0/PHPUnit 9.x), they are ignored by PHP as well.

Also note that the addition of the attributes, now adds an _explicit_ runtime dependency on PHPUnit for the `UtilityMethodTestCase`, while previously this dependency was _implicit_.
By rights, this means that the `phpunit/phpunit` package dependency should be moved in the `composer.json` file from `require-dev` to `require`. I deem this undesirable though, as for most _end-users_, who use external standards which use PHPCSUtils, it won't be a dependency. The dependency is realistically only for the _tests_ of external standards using the `UtilityMethodTestCase`, in which case, the external standard is expected to have a dependency on PHPUnit anyway.

### Tests/PolyfilledTestCase: make compatible with PHPUnit Polyfills 3.x

As the available polyfill traits are different between the 1.x, 2.x and 3.x versions of the PHPUnit Polyfills, a different class definition is needed for PHPUnit Polyfills 3, which removes two traits (one used in this class) and introduces three new traits.

This commit adds the version-conditional class declaration for PHPUnit Polyfills 3.0.

Ref:
* https://github.com/Yoast/PHPUnit-Polyfills/releases/tag/3.0.0

### Tests/AbstractArrayDeclarationSniffTest: work around for `MockBuilder::getMockForAbstractClass()` deprecation

The `MockBuilder::getMockForAbstractClass()` is soft deprecated in PHPUnit 10, hard deprecated in PHPUnit 11 and will be removed in PHPUnit 12.

While it is not strictly necessary to address this deprecation now, I've chosen to do so anyway.

Please note:
* The `getMockBuilder()` class is also deprecated now, so replacing with another method call on the `MockBuilder` class will only work in the short/medium term and in a future iteration, this will have to be refactored again.

Refs:
* sebastianbergmann/phpunit#5241
* sebastianbergmann/phpunit#5247
* sebastianbergmann/phpunit#5252

### Tests/AbstractArrayDeclarationSniffTest: work around for `TestCase::onConsecutiveCalls()` deprecation

The `TestCase::onConsecutiveCalls()` is soft deprecated in PHPUnit 10, hard deprecated in PHPUnit 11 and will be removed in PHPUnit 12.

While it is not strictly necessary to address this deprecation now, I've chosen to do so anyway.

Note: the method call is not directly changed from `->will($this->onConsecutiveCalls(...))` to `->willReturn(...)` - which is the PHPUnit native recommendation -, as this would make the test incompatible with older PHPUnit versions.

Additionally, a previous fix to work around the deprecation of `InvocationMocker->withConsecutive()` already uses the `willReturnCallback()` method, so the return value expectations will now need to be set via the `ExpectWithConsecutiveArgs::setExpectationWithConsecutiveArgs()` method.

Refs:
* sebastianbergmann/phpunit#5423
* sebastianbergmann/phpunit 5424

### Docs: minor fixes

... picked up along the way.