### PR TITLE
Composer: raise minimum PHPCS to 3.10.1 and sync some tests with upstream

### DIFF
--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -76,7 +76,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.10.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.1.
      *
      * @see \PHP_CodeSniffer\Files\File::getDeclarationName() Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::getName()   PHPCSUtils native improved version.
@@ -466,7 +466,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.10.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.1.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodProperties()      Original source.
      * @see \PHPCSUtils\Utils\FunctionDeclarations::getProperties() PHPCSUtils native improved version.
@@ -511,7 +511,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.10.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.1.
      *
      * @see \PHP_CodeSniffer\Files\File::getMemberProperties() Original source.
      * @see \PHPCSUtils\Utils\Variables::getMemberProperties() PHPCSUtils native improved version.
@@ -549,7 +549,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.3.0.
-     * - The upstream method has received no significant updates since PHPCS 3.10.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.1.
      *
      * @see \PHP_CodeSniffer\Files\File::getClassProperties()          Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::getClassProperties() PHPCSUtils native improved version.
@@ -577,7 +577,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.10.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.1.
      *
      * @see \PHP_CodeSniffer\Files\File::isReference() Original source.
      * @see \PHPCSUtils\Utils\Operators::isReference() PHPCSUtils native improved version.
@@ -603,7 +603,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.10.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.1.
      *
      * @see \PHP_CodeSniffer\Files\File::getTokensAsString() Original source.
      * @see \PHPCSUtils\Utils\GetTokensAsString              Related set of functions.
@@ -632,7 +632,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.1.0.
-     * - The upstream method has received no significant updates since PHPCS 3.10.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.1.
      *
      * @see \PHP_CodeSniffer\Files\File::findStartOfStatement() Original source.
      *
@@ -656,7 +656,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.1.0.
-     * - The upstream method has received no significant updates since PHPCS 3.10.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.1.
      *
      * @see \PHP_CodeSniffer\Files\File::findEndOfStatement() Original source.
      *
@@ -680,7 +680,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.10.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.1.
      *
      * @see \PHP_CodeSniffer\Files\File::hasCondition()  Original source.
      * @see \PHPCSUtils\Utils\Conditions::hasCondition() PHPCSUtils native alternative.
@@ -705,7 +705,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.3.0.
-     * - The upstream method has received no significant updates since PHPCS 3.10.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.1.
      *
      * @see \PHP_CodeSniffer\Files\File::getCondition()  Original source.
      * @see \PHPCSUtils\Utils\Conditions::getCondition() More versatile alternative.
@@ -736,7 +736,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.2.0.
-     * - The upstream method has received no significant updates since PHPCS 3.10.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.1.
      *
      * @see \PHP_CodeSniffer\Files\File::findExtendedClassName()          Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::findExtendedClassName() PHPCSUtils native improved version.
@@ -761,7 +761,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.7.0.
-     * - The upstream method has received no significant updates since PHPCS 3.10.0.
+     * - The upstream method has received no significant updates since PHPCS 3.10.1.
      *
      * @see \PHP_CodeSniffer\Files\File::findImplementedInterfaceNames()          Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::findImplementedInterfaceNames() PHPCSUtils native improved version.

--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -74,7 +74,7 @@ final class BCTokens
 
     /**
      * Handle calls to (undeclared) methods for token arrays which haven't received any
-     * changes since PHPCS 3.10.0.
+     * changes since PHPCS 3.10.1.
      *
      * @since 1.0.0
      *

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Whether you need to split an `array` into the individual items, are trying to de
 
 Includes improved versions of the PHPCS native utility functions and plenty of new utility functions.
 
-These functions are compatible with PHPCS 3.10.0 up to PHPCS `master`.
+These functions are compatible with PHPCS 3.10.1 up to PHPCS `master`.
 
 ### A collection of static properties and methods for often-used token groups
 
@@ -78,7 +78,7 @@ To see detailed information about all the available abstract sniffs, utility fun
 ## Minimum Requirements
 
 * PHP 5.4 or higher.
-* [PHP_CodeSniffer] 3.10.0+.
+* [PHP_CodeSniffer] 3.10.1+.
 * Recommended PHP extensions for optimal functionality:
     - PCRE with Unicode support (normally enabled by default)
 

--- a/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
@@ -22,6 +22,7 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
@@ -34,6 +35,40 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  */
 final class FindEndOfStatementTest extends UtilityMethodTestCase
 {
+
+    /**
+     * Test that end of statement is NEVER before the "current" token.
+     *
+     * @return void
+     */
+    public function testEndIsNeverLessThanCurrentToken()
+    {
+        $tokens = self::$phpcsFile->getTokens();
+        $errors = [];
+
+        for ($i = 0; $i < self::$phpcsFile->numTokens; $i++) {
+            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+                continue;
+            }
+
+            $end = BCFile::findEndOfStatement(self::$phpcsFile, $i);
+
+            // Collect all the errors.
+            if ($end < $i) {
+                $errors[] = sprintf(
+                    'End of statement for token %1$d (%2$s: %3$s) on line %4$d is %5$d (%6$s), which is less than %1$d',
+                    $i,
+                    $tokens[$i]['type'],
+                    $tokens[$i]['content'],
+                    $tokens[$i]['line'],
+                    $end,
+                    $tokens[$end]['type']
+                );
+            }
+        }
+
+        $this->assertSame([], $errors);
+    }
 
     /**
      * Test a simple assignment.

--- a/Tests/BackCompat/BCFile/FindStartOfStatementTest.inc
+++ b/Tests/BackCompat/BCFile/FindStartOfStatementTest.inc
@@ -192,3 +192,9 @@ callMe($paramA, match ($var) {
     'c' => fn($p1, /* test437FnSecondParamWithinNestedMatch */ $p2) => $p1 + $p2,
     default => false
 });
+
+match ($var) {
+    /* test437NestedShortArrayWithinMatch */
+    'a' => [ 1, 2.5, $var],
+    default => false
+};

--- a/Tests/BackCompat/BCFile/FindStartOfStatementTest.inc
+++ b/Tests/BackCompat/BCFile/FindStartOfStatementTest.inc
@@ -14,7 +14,7 @@ while(true) {}
 $a = 1;
 
 /* testClosureAssignment */
-$a = function($b=false;){};
+$a = function($b=false){};
 
 /* testHeredocFunctionArg */
 myFunction(<<<END
@@ -39,8 +39,8 @@ use Vendor\Package\{ClassA as A, ClassB, ClassC as C};
 
 $a = [
     /* testArrowFunctionArrayValue */
-    'a' => fn() => return 1,
-    'b' => fn() => return 1,
+    'a' => fn() => 1,
+    'b' => fn() => 1,
 ];
 
 /* testStaticArrowFunction */
@@ -139,11 +139,11 @@ switch ($foo) {
         /* testInsideCaseStatement */
         $var = doSomething();
         /* testInsideCaseBreakStatement */
-        break 2;
+        break 1;
 
     case 2:
         /* testInsideCaseContinueStatement */
-        continue 2;
+        continue 1;
 
     case 3:
         /* testInsideCaseReturnStatement */

--- a/Tests/BackCompat/BCFile/FindStartOfStatementTest.inc
+++ b/Tests/BackCompat/BCFile/FindStartOfStatementTest.inc
@@ -162,3 +162,13 @@ switch ($foo) {
         /* testInsideDefaultContinueStatement */
         continue $var;
 }
+
+match ($var) {
+    true =>
+        /* test437ClosureDeclaration */
+        function ($var) {
+            /* test437EchoNestedWithinClosureWithinMatch */
+            echo $var, 'text', PHP_EOL;
+        },
+    default => false
+};

--- a/Tests/BackCompat/BCFile/FindStartOfStatementTest.inc
+++ b/Tests/BackCompat/BCFile/FindStartOfStatementTest.inc
@@ -172,3 +172,23 @@ match ($var) {
         },
     default => false
 };
+
+match ($var) {
+    /* test437NestedLongArrayWithinMatch */
+    'a' => array( 1, 2.5, $var),
+    /* test437NestedFunctionCallWithinMatch */
+    'b' => functionCall( 11, $var, 50.50),
+    /* test437NestedArrowFunctionWithinMatch */
+    'c' => fn($p1, /* test437FnSecondParamWithinMatch */ $p2) => $p1 + $p2,
+    default => false
+};
+
+callMe($paramA, match ($var) {
+    /* test437NestedLongArrayWithinNestedMatch */
+    'a' => array( 1, 2.5, $var),
+    /* test437NestedFunctionCallWithinNestedMatch */
+    'b' => functionCall( 11, $var, 50.50),
+    /* test437NestedArrowFunctionWithinNestedMatch */
+    'c' => fn($p1, /* test437FnSecondParamWithinNestedMatch */ $p2) => $p1 + $p2,
+    default => false
+});

--- a/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
@@ -813,4 +813,53 @@ final class FindStartOfStatementTest extends UtilityMethodTestCase
             ],
         ];
     }
+
+    /**
+     * Test finding the start of a statement for a token within a short array within a match expressions.
+     *
+     * @param string     $testMarker     The comment which prefaces the target token in the test file.
+     * @param int|string $target         The token to search for after the test marker.
+     * @param int|string $expectedTarget Token code of the expected start of statement stack pointer.
+     *
+     * @link https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/437
+     *
+     * @dataProvider dataFindStartInsideShortArrayNestedWithinMatch
+     *
+     * @return void
+     */
+    public function testFindStartInsideShortArrayNestedWithinMatch($testMarker, $target, $expectedTarget)
+    {
+        $testToken = $this->getTargetToken($testMarker, $target);
+        $expected  = $this->getTargetToken($testMarker, $expectedTarget);
+
+        $found = BCFile::findStartOfStatement(self::$phpcsFile, $testToken);
+
+        $this->assertSame($expected, $found);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<string, array<string, int|string>>
+     */
+    public static function dataFindStartInsideShortArrayNestedWithinMatch()
+    {
+        return [
+            'Array item itself should be start for first array item'  => [
+                'testMarker'     => '/* test437NestedShortArrayWithinMatch */',
+                'target'         => T_LNUMBER,
+                'expectedTarget' => T_LNUMBER,
+            ],
+            'Array item itself should be start for second array item' => [
+                'testMarker'     => '/* test437NestedShortArrayWithinMatch */',
+                'target'         => T_DNUMBER,
+                'expectedTarget' => T_DNUMBER,
+            ],
+            'Array item itself should be start for third array item'  => [
+                'testMarker'     => '/* test437NestedShortArrayWithinMatch */',
+                'target'         => T_VARIABLE,
+                'expectedTarget' => T_VARIABLE,
+            ],
+        ];
+    }
 }

--- a/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
@@ -582,4 +582,82 @@ final class FindStartOfStatementTest extends UtilityMethodTestCase
             ],
         ];
     }
+
+    /**
+     * Test finding the start of a statement inside a closed scope nested within a match expressions.
+     *
+     * @param string     $testMarker     The comment which prefaces the target token in the test file.
+     * @param int|string $target         The token to search for after the test marker.
+     * @param int|string $expectedTarget Token code of the expected start of statement stack pointer.
+     *
+     * @link https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/437
+     *
+     * @dataProvider dataFindStartInsideClosedScopeNestedWithinMatch
+     *
+     * @return void
+     */
+    public function testFindStartInsideClosedScopeNestedWithinMatch($testMarker, $target, $expectedTarget)
+    {
+        $testToken = $this->getTargetToken($testMarker, $target);
+        $expected  = $this->getTargetToken($testMarker, $expectedTarget);
+
+        $found = BCFile::findStartOfStatement(self::$phpcsFile, $testToken);
+
+        $this->assertSame($expected, $found);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<string, array<string, int|string>>
+     */
+    public static function dataFindStartInsideClosedScopeNestedWithinMatch()
+    {
+        return [
+            // These were already working correctly.
+            'Closure function keyword should be start of closure - closure keyword'                   => [
+                'testMarker'     => '/* test437ClosureDeclaration */',
+                'target'         => T_CLOSURE,
+                'expectedTarget' => T_CLOSURE,
+            ],
+            'Open curly is a statement/expression opener - open curly'                                => [
+                'testMarker'     => '/* test437ClosureDeclaration */',
+                'target'         => T_OPEN_CURLY_BRACKET,
+                'expectedTarget' => T_OPEN_CURLY_BRACKET,
+            ],
+
+            'Echo should be start for expression - echo keyword'                                      => [
+                'testMarker'     => '/* test437EchoNestedWithinClosureWithinMatch */',
+                'target'         => T_ECHO,
+                'expectedTarget' => T_ECHO,
+            ],
+            'Echo should be start for expression - variable'                                          => [
+                'testMarker'     => '/* test437EchoNestedWithinClosureWithinMatch */',
+                'target'         => T_VARIABLE,
+                'expectedTarget' => T_ECHO,
+            ],
+            'Echo should be start for expression - comma'                                             => [
+                'testMarker'     => '/* test437EchoNestedWithinClosureWithinMatch */',
+                'target'         => T_COMMA,
+                'expectedTarget' => T_ECHO,
+            ],
+
+            // These were not working correctly and would previously return the close curly of the match expression.
+            'First token after comma in echo expression should be start for expression - text string' => [
+                'testMarker'     => '/* test437EchoNestedWithinClosureWithinMatch */',
+                'target'         => T_CONSTANT_ENCAPSED_STRING,
+                'expectedTarget' => T_CONSTANT_ENCAPSED_STRING,
+            ],
+            'First token after comma in echo expression - PHP_EOL constant'                           => [
+                'testMarker'     => '/* test437EchoNestedWithinClosureWithinMatch */',
+                'target'         => T_STRING,
+                'expectedTarget' => T_STRING,
+            ],
+            'First token after comma in echo expression - semicolon'                                  => [
+                'testMarker'     => '/* test437EchoNestedWithinClosureWithinMatch */',
+                'target'         => T_SEMICOLON,
+                'expectedTarget' => T_STRING,
+            ],
+        ];
+    }
 }

--- a/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\TestUtils\UtilityMethodTestCase;
 
@@ -22,6 +23,40 @@ use PHPCSUtils\TestUtils\UtilityMethodTestCase;
  */
 final class FindStartOfStatementTest extends UtilityMethodTestCase
 {
+
+    /**
+     * Test that start of statement is NEVER beyond the "current" token.
+     *
+     * @return void
+     */
+    public function testStartIsNeverMoreThanCurrentToken()
+    {
+        $tokens = self::$phpcsFile->getTokens();
+        $errors = [];
+
+        for ($i = 0; $i < self::$phpcsFile->numTokens; $i++) {
+            if (isset(Tokens::$emptyTokens[$tokens[$i]['code']]) === true) {
+                continue;
+            }
+
+            $start = BCFile::findStartOfStatement(self::$phpcsFile, $i);
+
+            // Collect all the errors.
+            if ($start > $i) {
+                $errors[] = sprintf(
+                    'Start of statement for token %1$d (%2$s: %3$s) on line %4$d is %5$d (%6$s), which is more than %1$d',
+                    $i,
+                    $tokens[$i]['type'],
+                    $tokens[$i]['content'],
+                    $tokens[$i]['line'],
+                    $start,
+                    $tokens[$start]['type']
+                );
+            }
+        }
+
+        $this->assertSame([], $errors);
+    }
 
     /**
      * Test a simple assignment.

--- a/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
@@ -85,7 +85,7 @@ final class FindStartOfStatementTest extends UtilityMethodTestCase
         $start = $this->getTargetToken('/* testClosureAssignment */', T_CLOSE_CURLY_BRACKET);
         $found = BCFile::findStartOfStatement(self::$phpcsFile, $start);
 
-        $this->assertSame(($start - 12), $found);
+        $this->assertSame(($start - 11), $found);
     }
 
     /**
@@ -208,7 +208,7 @@ final class FindStartOfStatementTest extends UtilityMethodTestCase
         $start = $this->getTargetToken('/* testArrowFunctionArrayValue */', T_COMMA);
         $found = BCFile::findStartOfStatement(self::$phpcsFile, $start);
 
-        $this->assertSame(($start - 9), $found);
+        $this->assertSame(($start - 7), $found);
     }
 
     /**

--- a/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
@@ -660,4 +660,157 @@ final class FindStartOfStatementTest extends UtilityMethodTestCase
             ],
         ];
     }
+
+    /**
+     * Test finding the start of a statement for a token within a set of parentheses within a match expressions.
+     *
+     * @param string     $testMarker     The comment which prefaces the target token in the test file.
+     * @param int|string $target         The token to search for after the test marker.
+     * @param int|string $expectedTarget Token code of the expected start of statement stack pointer.
+     *
+     * @link https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/437
+     *
+     * @dataProvider dataFindStartInsideParenthesesNestedWithinMatch
+     *
+     * @return void
+     */
+    public function testFindStartInsideParenthesesNestedWithinMatch($testMarker, $target, $expectedTarget)
+    {
+        $testToken = $this->getTargetToken($testMarker, $target);
+        $expected  = $this->getTargetToken($testMarker, $expectedTarget);
+
+        $found = BCFile::findStartOfStatement(self::$phpcsFile, $testToken);
+
+        $this->assertSame($expected, $found);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<string, array<string, int|string>>
+     */
+    public static function dataFindStartInsideParenthesesNestedWithinMatch()
+    {
+        return [
+            'Array item itself should be start for first array item'                       => [
+                'testMarker'     => '/* test437NestedLongArrayWithinMatch */',
+                'target'         => T_LNUMBER,
+                'expectedTarget' => T_LNUMBER,
+            ],
+            'Array item itself should be start for second array item'                      => [
+                'testMarker'     => '/* test437NestedLongArrayWithinMatch */',
+                'target'         => T_DNUMBER,
+                'expectedTarget' => T_DNUMBER,
+            ],
+            'Array item itself should be start for third array item'                       => [
+                'testMarker'     => '/* test437NestedLongArrayWithinMatch */',
+                'target'         => T_VARIABLE,
+                'expectedTarget' => T_VARIABLE,
+            ],
+
+            'Parameter itself should be start for first param passed to function call'     => [
+                'testMarker'     => '/* test437NestedFunctionCallWithinMatch */',
+                'target'         => T_LNUMBER,
+                'expectedTarget' => T_LNUMBER,
+            ],
+            'Parameter itself should be start for second param passed to function call'    => [
+                'testMarker'     => '/* test437NestedFunctionCallWithinMatch */',
+                'target'         => T_VARIABLE,
+                'expectedTarget' => T_VARIABLE,
+            ],
+            'Parameter itself should be start for third param passed to function call'     => [
+                'testMarker'     => '/* test437NestedFunctionCallWithinMatch */',
+                'target'         => T_DNUMBER,
+                'expectedTarget' => T_DNUMBER,
+            ],
+
+            'Parameter itself should be start for first param declared in arrow function'  => [
+                'testMarker'     => '/* test437NestedArrowFunctionWithinMatch */',
+                'target'         => T_VARIABLE,
+                'expectedTarget' => T_VARIABLE,
+            ],
+            'Parameter itself should be start for second param declared in arrow function' => [
+                'testMarker'     => '/* test437FnSecondParamWithinMatch */',
+                'target'         => T_VARIABLE,
+                'expectedTarget' => T_VARIABLE,
+            ],
+        ];
+    }
+
+    /**
+     * Test finding the start of a statement for a token within a set of parentheses within a match expressions,
+     * which itself is nested within parentheses.
+     *
+     * @param string     $testMarker     The comment which prefaces the target token in the test file.
+     * @param int|string $target         The token to search for after the test marker.
+     * @param int|string $expectedTarget Token code of the expected start of statement stack pointer.
+     *
+     * @link https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/437
+     *
+     * @dataProvider dataFindStartInsideParenthesesNestedWithinNestedMatch
+     *
+     * @return void
+     */
+    public function testFindStartInsideParenthesesNestedWithinNestedMatch($testMarker, $target, $expectedTarget)
+    {
+        $testToken = $this->getTargetToken($testMarker, $target);
+        $expected  = $this->getTargetToken($testMarker, $expectedTarget);
+
+        $found = BCFile::findStartOfStatement(self::$phpcsFile, $testToken);
+
+        $this->assertSame($expected, $found);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array<string, array<string, int|string>>
+     */
+    public static function dataFindStartInsideParenthesesNestedWithinNestedMatch()
+    {
+        return [
+            'Array item itself should be start for first array item'                       => [
+                'testMarker'     => '/* test437NestedLongArrayWithinNestedMatch */',
+                'target'         => T_LNUMBER,
+                'expectedTarget' => T_LNUMBER,
+            ],
+            'Array item itself should be start for second array item'                      => [
+                'testMarker'     => '/* test437NestedLongArrayWithinNestedMatch */',
+                'target'         => T_DNUMBER,
+                'expectedTarget' => T_DNUMBER,
+            ],
+            'Array item itself should be start for third array item'                       => [
+                'testMarker'     => '/* test437NestedLongArrayWithinNestedMatch */',
+                'target'         => T_VARIABLE,
+                'expectedTarget' => T_VARIABLE,
+            ],
+
+            'Parameter itself should be start for first param passed to function call'     => [
+                'testMarker'     => '/* test437NestedFunctionCallWithinNestedMatch */',
+                'target'         => T_LNUMBER,
+                'expectedTarget' => T_LNUMBER,
+            ],
+            'Parameter itself should be start for second param passed to function call'    => [
+                'testMarker'     => '/* test437NestedFunctionCallWithinNestedMatch */',
+                'target'         => T_VARIABLE,
+                'expectedTarget' => T_VARIABLE,
+            ],
+            'Parameter itself should be start for third param passed to function call'     => [
+                'testMarker'     => '/* test437NestedFunctionCallWithinNestedMatch */',
+                'target'         => T_DNUMBER,
+                'expectedTarget' => T_DNUMBER,
+            ],
+
+            'Parameter itself should be start for first param declared in arrow function'  => [
+                'testMarker'     => '/* test437NestedArrowFunctionWithinNestedMatch */',
+                'target'         => T_VARIABLE,
+                'expectedTarget' => T_VARIABLE,
+            ],
+            'Parameter itself should be start for second param declared in arrow function' => [
+                'testMarker'     => '/* test437FnSecondParamWithinNestedMatch */',
+                'target'         => T_VARIABLE,
+                'expectedTarget' => T_VARIABLE,
+            ],
+        ];
+    }
 }

--- a/Tests/BackCompat/Helper/GetVersionTest.php
+++ b/Tests/BackCompat/Helper/GetVersionTest.php
@@ -47,7 +47,7 @@ final class GetVersionTest extends TestCase
         }
 
         if ($expected === 'lowest') {
-            $expected = '3.10.0';
+            $expected = '3.10.1';
         }
 
         $result = Helper::getVersion();

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.10.0 || 4.0.x-dev@dev",
+        "squizlabs/php_codesniffer" : "^3.10.1 || 4.0.x-dev@dev",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0"
     },
     "require-dev" : {


### PR DESCRIPTION
### Composer: raise the minimum supported PHPCS version to 3.10.1

... to benefit from fixes made to the `File::findStartOfStatement()` method  and a tokenizer fix related to DNF types.

Includes updating references to the PHPCS version whenever relevant throughout the codebase.

### Tests/BCFile::findStartOfStatement(): sync in new test from upstream [1]

See PR PHPCSStandards/PHP_CodeSniffer#502 / PHPCSStandards/PHP_CodeSniffer@467d284

### Tests/BCFile::findStartOfStatement(): sync in new tests from upstream [2]

See PR PHPCSStandards/PHP_CodeSniffer#502 / PHPCSStandards/PHP_CodeSniffer@b82438f

### Tests/BCFile::findStartOfStatement(): sync in new tests from upstream [3]

See PR PHPCSStandards/PHP_CodeSniffer#502 / PHPCSStandards/PHP_CodeSniffer@d3abcd6

### Tests/BCFile::findStartOfStatement(): sync in test fixes from upstream [4]

See PR PHPCSStandards/PHP_CodeSniffer#509 / PHPCSStandards/PHP_CodeSniffer@83373f9

### Tests/BCFile::find[Start|End]OfStatement(): sync in new tests from upstream [5]

See PR PHPCSStandards/PHP_CodeSniffer#509 / PHPCSStandards/PHP_CodeSniffer@a82f02e