### PR TITLE
GH Actions: always quote variables

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -48,9 +48,9 @@ jobs:
         id: set_ini
         run: |
           if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
           else
-            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install PHP
@@ -87,20 +87,20 @@ jobs:
       - name: Grab PHPUnit version
         id: phpunit_version
         # yamllint disable-line rule:line-length
-        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
 
       - name: Determine PHPUnit config file to use
         id: phpunit_config
         run: |
           if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
-            echo 'FILE=phpunit10.xml.dist' >> $GITHUB_OUTPUT
-            echo 'EXTRA_ARGS=' >> $GITHUB_OUTPUT
+            echo 'FILE=phpunit10.xml.dist' >> "$GITHUB_OUTPUT"
+            echo 'EXTRA_ARGS=' >> "$GITHUB_OUTPUT"
           elif [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}" == "true" ]; then
-            echo 'FILE=phpunit10.xml.dist' >> $GITHUB_OUTPUT
-            echo 'EXTRA_ARGS=' >> $GITHUB_OUTPUT
+            echo 'FILE=phpunit10.xml.dist' >> "$GITHUB_OUTPUT"
+            echo 'EXTRA_ARGS=' >> "$GITHUB_OUTPUT"
           else
-            echo 'FILE=phpunit.xml.dist' >> $GITHUB_OUTPUT
-            echo 'EXTRA_ARGS= --repeat 2' >> $GITHUB_OUTPUT
+            echo 'FILE=phpunit.xml.dist' >> "$GITHUB_OUTPUT"
+            echo 'EXTRA_ARGS= --repeat 2' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run the unit tests without caching

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,9 +159,9 @@ jobs:
         id: set_ini
         run: |
           if [[ "${{ matrix.phpcs_version }}" != "dev-master" && "${{ matrix.phpcs_version }}" != "4.0.x-dev" ]]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
           else
-            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install PHP
@@ -208,20 +208,20 @@ jobs:
       - name: Grab PHPUnit version
         id: phpunit_version
         # yamllint disable-line rule:line-length
-        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
 
       - name: Determine PHPUnit config file to use
         id: phpunit_config
         run: |
           if [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '11.' ) }}" == "true" ]; then
-            echo 'FILE=phpunit10.xml.dist' >> $GITHUB_OUTPUT
-            echo 'EXTRA_ARGS=' >> $GITHUB_OUTPUT
+            echo 'FILE=phpunit10.xml.dist' >> "$GITHUB_OUTPUT"
+            echo 'EXTRA_ARGS=' >> "$GITHUB_OUTPUT"
           elif [ "${{ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}" == "true" ]; then
-            echo 'FILE=phpunit10.xml.dist' >> $GITHUB_OUTPUT
-            echo 'EXTRA_ARGS=' >> $GITHUB_OUTPUT
+            echo 'FILE=phpunit10.xml.dist' >> "$GITHUB_OUTPUT"
+            echo 'EXTRA_ARGS=' >> "$GITHUB_OUTPUT"
           else
-            echo 'FILE=phpunit.xml.dist' >> $GITHUB_OUTPUT
-            echo 'EXTRA_ARGS= --repeat 2' >> $GITHUB_OUTPUT
+            echo 'FILE=phpunit.xml.dist' >> "$GITHUB_OUTPUT"
+            echo 'EXTRA_ARGS= --repeat 2' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run the unit tests without caching (non-risky)
@@ -295,9 +295,9 @@ jobs:
         id: set_ini
         run: |
           if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
-            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
           else
-            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> $GITHUB_OUTPUT
+            echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install PHP
@@ -332,7 +332,7 @@ jobs:
       - name: Grab PHPUnit version
         id: phpunit_version
         # yamllint disable-line rule:line-length
-        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> "$GITHUB_OUTPUT"
 
       - name: "DEBUG: Show grabbed version"
         run: echo ${{ steps.phpunit_version.outputs.VERSION }}

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -52,9 +52,9 @@ jobs:
           REF: ${{ github.ref }}
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "BRANCH=$REF" >> $GITHUB_OUTPUT
+            echo "BRANCH=$REF" >> "$GITHUB_OUTPUT"
           else
-            echo 'BRANCH=${{ env.DEFAULT_BRANCH }}' >> $GITHUB_OUTPUT
+            echo 'BRANCH=${{ env.DEFAULT_BRANCH }}' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout code
@@ -86,9 +86,9 @@ jobs:
         # yamllint disable rule:line-length
         run: |
           if [[ "${{ github.event_name }}" == 'release' && "${{ github.ref_type }}" == 'published' && "$REF_NAME" == "${{ env.DEFAULT_BRANCH }}" ]]; then
-            echo "LAST_TAG=$REF_NAME" >> $GITHUB_OUTPUT
+            echo "LAST_TAG=$REF_NAME" >> "$GITHUB_OUTPUT"
           else # = Pushed tag.
-            echo "LAST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+            echo "LAST_TAG=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
           fi
         # yamllint enable rule:line-length
 

--- a/.github/workflows/update-phpcs-versionnr.yml
+++ b/.github/workflows/update-phpcs-versionnr.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Grab latest tag name from API response
         id: version
         run: |
-          echo "TAG=${{ fromJson(steps.get_latest_release.outputs.data).tag_name }}" >> $GITHUB_OUTPUT
+          echo "TAG=${{ fromJson(steps.get_latest_release.outputs.data).tag_name }}" >> "$GITHUB_OUTPUT"
 
       - name: Show tag name found in API response
         run: "echo latest release: ${{ steps.version.outputs.TAG }}"
@@ -48,8 +48,8 @@ jobs:
       - name: Set branches to use
         id: branches
         run: |
-          echo "BASE=develop" >> $GITHUB_OUTPUT
-          echo "PR_BRANCH=feature/getversiontest-update-phpcs-version" >> $GITHUB_OUTPUT
+          echo "BASE=develop" >> "$GITHUB_OUTPUT"
+          echo "PR_BRANCH=feature/getversiontest-update-phpcs-version" >> "$GITHUB_OUTPUT"
 
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
... to satisfy shellcheck rule SC2086: "Double quote to prevent globbing and word splitting".

Ref: https://www.shellcheck.net/wiki/SC2086