### PR TITLE
PHPStan 2.0: update configuration

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -92,7 +92,7 @@ jobs:
     name: "PHPStan"
     uses: PHPCSStandards/.github/.github/workflows/reusable-phpstan.yml@main
     with:
-      phpstanVersion: '1.x'
+      phpstanVersion: '2.x'
 
   markdownlint:
     name: 'Lint Markdown'

--- a/PHPCSUtils/Internal/IsShortArrayOrList.php
+++ b/PHPCSUtils/Internal/IsShortArrayOrList.php
@@ -163,7 +163,7 @@ final class IsShortArrayOrList
      *
      * @var string
      */
-    private $phpcsVersion; // @phpstan-ignore-line
+    private $phpcsVersion; // @phpstan-ignore property.onlyWritten
 
     /**
      * Tokens which can open a short array or short list (PHPCS cross-version compatible).

--- a/Tests/TestUtils/UtilityMethodTestCase/SkipJSCSSTestsOnPHPCS4Test.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/SkipJSCSSTestsOnPHPCS4Test.php
@@ -64,7 +64,7 @@ final class SkipJSCSSTestsOnPHPCS4Test extends PolyfilledTestCase
             $this->expectExceptionMessage($msg);
         } else {
             // Get rid of the "does not perform assertions" warning when run with PHPCS 3.x.
-            $this->assertTrue(true);
+            $this->assertTrue(true); // @phpstan-ignore method.alreadyNarrowedType
         }
 
         parent::skipJSCSSTestsOnPHPCS4();

--- a/Tests/Utils/Lists/GetAssignmentsTest.php
+++ b/Tests/Utils/Lists/GetAssignmentsTest.php
@@ -127,7 +127,7 @@ final class GetAssignmentsTest extends PolyfilledTestCase
      *
      * @see testGetAssignments() For the array format.
      *
-     * @return array<string, array<string, int|string|array<int, array<string, int|string|bool>>>>
+     * @return array<string, array<string, int|string|array<int|string, int|string|array<string, int|string|bool>>>>
      */
     public static function dataGetAssignments()
     {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,9 @@ parameters:
     excludePaths:
         # This file needs to be excluded as the availability of the traits depends on which PHPUnit Polyfills version is loaded/installed.
         - Tests/PolyfilledTestCase.php
+        # These will be seen as unused due to these only being used in conjunction with the above excluded TestCase.
+        - Tests/AssertPropertySame.php
+        - Tests/ExpectWithConsecutiveArgs.php
     bootstrapFiles:
         - Tests/bootstrap.php
     treatPhpDocTypesAsCertain: false
@@ -40,6 +43,7 @@ parameters:
             message: '`^Call to an undefined method PHP_CodeSniffer\\Config::__destruct\(\)\.$`'
             path: PHPCSUtils\TestUtils\UtilityMethodTestCase.php
             count: 1
+
         # The setStaticConfigProperty() method exists on the ConfigDouble, not the PHPCS native Config. This is 100% okay.
         -
             message: '`^Call to an undefined method PHP_CodeSniffer\\Config::setStaticConfigProperty\(\)\.$`'
@@ -50,6 +54,7 @@ parameters:
         -
             message: '`^Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::process\(\)\.$`'
             path: Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
+
         # Ignoring as availability depends on which PHPUnit version is loaded/installed. This is 100% okay.
         -
             message: '`^Call to an undefined method PHPUnit\\Framework\\MockObject\\MockBuilder<[^>]+>::setMethods\(\)\.$`'
@@ -64,28 +69,46 @@ parameters:
             path: Tests/BackCompat/Helper/GetCommandLineDataTest.php
 
         # Level 4
+        # Defensive coding as this project is not type safe. This is okay.
+        -
+            message: '`^Call to function is_string\(\) with string will always evaluate to true\.$`'
+            path: PHPCSUtils/Utils/TypeString.php
+            count: 1
+
         # This is by design.
         -
             message: '`^Static method PHPCSUtils\\Tokens\\Collections::triggerDeprecation\(\) is unused\.$`'
             path: PHPCSUtils/Tokens/Collections.php
             count: 1
 
-        # Ignoring this as availability depends on which PHPUnit Polyfills version is loaded/installed. This is 100% okay.
+        # Ignoring these as availability depends on which PHPUnit/PHPUnit Polyfills version is loaded/installed. This is 100% okay.
         -
             message: "`^Call to function method_exists\\(\\) with \\$this\\([^)]+\\) and 'expectError' will always evaluate to false\\.$`"
             path: Tests/Utils/TypeString/FilterTypesTest.php
             count: 2
+        -
+            message: "`^Call to function method_exists\\(\\) with \\$this\\([^)]+\\) and 'expectException' will always evaluate to true\\.$`"
+            path: PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+            count: 1
+        -
+            message: "`^Call to function method_exists\\(\\) with PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder and 'onlyMethods' will always evaluate to true\\.$`"
+            path: Tests/AbstractSniffs/AbstractArrayDeclaration/AbstractArrayDeclarationSniffTest.php
+            count: 1
 
         # Level 5
         # This is by design to test handling of incorrect input.
         -
             message: '`^Parameter #[0-9]+ \$\S+ of static method PHPCSUtils\\(?!Tests)[A-Za-z]+\\[A-Za-z]+::[A-Za-z]+\(\) expects [^,]+, \S+ given\.$`'
             paths:
-                - Tests/*
+                - Tests/
         -
             message: '`^Parameter #[0-9]+ \$\S+ of class PHPCSUtils\\(?!Tests)[A-Za-z]+\\[A-Za-z]+ [A-Za-z]+ expects [^,]+, \S+ given\.$`'
             path: Tests/Internal/IsShortArrayOrList/ConstructorTest.php
             count: 1
+        -
+            message: '`^Parameter #1 \$types of static method PHPCSUtils\\Utils\\TypeString::filter\S+\(\) expects array<[^<>]+(<[^<>]+>[^<>]+)*>, array<[^<>]+(<[^<>]+>[^<>]+)*> given\.$`'
+            path: Tests/Utils/TypeString/FilterTypesTest.php
+            count: 2
 
         # Ignoring as this is fine.
         -
@@ -93,4 +116,10 @@ parameters:
             path: Tests/Utils/TypeString/FilterTypesTest.php
             count: 2
 
-            # yamllint enable rule:line-length
+        # Shortcoming of PHPStan, not a real error.
+        -
+            message: '`^Parameter #1 \$expected of method PHPUnit\\Framework\\Assert::assertSame\(\) contains unresolvable type\.$`'
+            paths:
+                - Tests/
+
+                # yamllint enable rule:line-length


### PR DESCRIPTION
PHPStan 2.0 has been released :tada:

This commit makes the necessary updates to switch to PHPStan 2.0.

Refs:
* https://phpstan.org/blog/phpstan-2-0-released-level-10-elephpants
* https://github.com/phpstan/phpstan/blob/2.0.x/UPGRADING.md
* https://github.com/phpstan/phpstan/releases/tag/2.0.0