### PR TITLE
GH Actions: update for the release of PHP 8.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,11 +30,11 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', '7.0', '7.4', '8.0', '8.3', '8.4']
+        php: ['5.4', '7.0', '7.4', '8.0', '8.4', '8.5']
 
     name: "Lint: PHP ${{ matrix.php }}"
 
-    continue-on-error: ${{ matrix.php == '8.4' }}
+    continue-on-error: ${{ matrix.php == '8.5' }}
 
     steps:
       - name: Checkout code
@@ -49,7 +49,7 @@ jobs:
           tools: cs2pr
 
       - name: Install Composer dependencies - normal
-        if: ${{ matrix.php < 8.4 }}
+        if: ${{ matrix.php < 8.5 }}
         uses: "ramsey/composer-install@v3"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
@@ -57,7 +57,7 @@ jobs:
 
       # For the PHP "nightly", we need to install with ignore platform reqs as not all dependencies allow it yet.
       - name: Install Composer dependencies - with ignore platform
-        if: ${{ matrix.php >= 8.4 }}
+        if: ${{ matrix.php >= 8.5 }}
         uses: "ramsey/composer-install@v3"
         with:
           composer-options: --ignore-platform-req=php+
@@ -91,7 +91,7 @@ jobs:
         # IMPORTANT: test runs shouldn't fail because of PHPCS being incompatible with a PHP version.
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
-        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         phpcs_version: ['lowest', 'dev-master']
         risky: [false]
         experimental: [false]
@@ -109,7 +109,7 @@ jobs:
             extensions: ':iconv' # Run with iconv disabled.
 
           # Experimental builds. These are allowed to fail.
-          - php: '8.4'
+          - php: '8.5'
             phpcs_version: 'dev-master'
             risky: false
             experimental: true
@@ -135,12 +135,12 @@ jobs:
             risky: true
             experimental: true
 
-          - php: '8.3'
+          - php: '8.4'
             phpcs_version: 'lowest'
             risky: true
             experimental: true
 
-          - php: '8.3'
+          - php: '8.4'
             phpcs_version: 'dev-master'
             risky: true
             experimental: true
@@ -187,7 +187,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies - normal
-        if: ${{ matrix.php < 8.4 }}
+        if: ${{ matrix.php < 8.5 }}
         uses: "ramsey/composer-install@v3"
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
@@ -195,7 +195,7 @@ jobs:
 
       # For PHP "nightly", we need to install with ignore platform reqs as not all dependencies allow it yet.
       - name: Install Composer dependencies - with ignore platform
-        if: ${{ matrix.php >= 8.4 }}
+        if: ${{ matrix.php >= 8.5 }}
         uses: "ramsey/composer-install@v3"
         with:
           composer-options: --ignore-platform-req=php+
@@ -273,9 +273,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: '8.3'
+          - php: '8.4'
             phpcs_version: 'dev-master'
-          - php: '8.3'
+          - php: '8.4'
             phpcs_version: 'lowest'
             extensions: ':iconv' # Run one build with iconv disabled.
           - php: '5.4'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/PHPCSStandards/PHPCSUtils/badge.svg?branch=develop)](https://coveralls.io/github/PHPCSStandards/PHPCSUtils?branch=develop)
 
 [![Minimum PHP Version](https://img.shields.io/packagist/dependency-v/phpcsstandards/phpcsutils/php.svg)][phpcsutils-packagist]
-[![Tested on PHP 5.4 to 8.3](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3-brightgreen.svg?maxAge=2419200)][phpcsutils-tests-gha]
+[![Tested on PHP 5.4 to 8.4](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3%20|%208.4-brightgreen.svg?maxAge=2419200)][phpcsutils-tests-gha]
 
 [![License: LGPLv3](https://img.shields.io/github/license/PHPCSStandards/PHPCSUtils)](https://github.com/PHPCSStandards/PHPCSUtils/blob/stable/LICENSE)
 ![Awesome](https://img.shields.io/badge/awesome%3F-yes!-brightgreen.svg)


### PR DESCRIPTION
... which is expected later this month.

* Builds against PHP 8.4 are no longer allowed to fail.
* Update PHP version on which code coverage is run (high should now be 8.4).
* Add _allowed to fail_ build against PHP 8.5.
* Update the "tested against" badge in the README.