### PR TITLE
Ruleset: update schema URL

### DIFF
--- a/PHPCSUtils/ruleset.xml
+++ b/PHPCSUtils/ruleset.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCSUtils" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCSUtils" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
     <description>Utility methods for external PHPCS standards.</description>
 </ruleset>


### PR DESCRIPTION
PHPCS now offers permalinks for the schema.

Refs:
* PHPCSStandards/PHP_CodeSniffer#1094
* https://github.com/PHPCSStandards/schema.phpcodesniffer.com