### PR TITLE
FilterTypesTest: improve condition order

### DIFF
--- a/Tests/Utils/TypeString/FilterTypesTest.php
+++ b/Tests/Utils/TypeString/FilterTypesTest.php
@@ -38,12 +38,12 @@ final class FilterTypesTest extends TestCase
      */
     public function testFilterKeywordTypesNonArrayInput($input)
     {
-        if (\method_exists($this, 'expectError')) {
-            // PHP 5.4 + 5.5 with PHPUnit Polyfills 1.x.
-            $this->expectError();
-        } elseif (\PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             // PHP 7.0+
             $this->expectException('\TypeError');
+        } elseif (\method_exists($this, 'expectError')) {
+            // PHP 5.4 + 5.5 with PHPUnit Polyfills 1.x.
+            $this->expectError();
         } else {
             // PHP 5.6 with PHPUnit 5.2+ and PHPUnit Polyfills 2.x.
             $this->expectException('\PHPUnit_Framework_Error');
@@ -63,12 +63,12 @@ final class FilterTypesTest extends TestCase
      */
     public function testFilterOOTypesNonArrayInput($input)
     {
-        if (\method_exists($this, 'expectError')) {
-            // PHP 5.4 + 5.5 with PHPUnit Polyfills 1.x.
-            $this->expectError();
-        } elseif (\PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000) {
             // PHP 7.0+
             $this->expectException('\TypeError');
+        } elseif (\method_exists($this, 'expectError')) {
+            // PHP 5.4 + 5.5 with PHPUnit Polyfills 1.x.
+            $this->expectError();
         } else {
             // PHP 5.6 with PHPUnit 5.2+ and PHPUnit Polyfills 2.x.
             $this->expectException('\PHPUnit_Framework_Error');


### PR DESCRIPTION
... to prevent seeing a PHPUnit "Expecting E_ERROR and E_USER_ERROR is deprecated and will no longer be possible in PHPUnit 10." warning when running the tests against PHP 7+.