### PR TITLE
BCFile::findStartOfStatement(): sync tests with upstream

### DIFF
--- a/Tests/BackCompat/BCFile/FindStartOfStatementTest.inc
+++ b/Tests/BackCompat/BCFile/FindStartOfStatementTest.inc
@@ -157,11 +157,19 @@ switch ($foo) {
         /* testInsideCaseThrowStatement */
         throw new Exception();
 
+    case 6:
+        $var = doSomething();
+        /* testInsideCaseGotoStatement */
+        goto myLabel;
+
     /* testDefaultStatement */
     default:
         /* testInsideDefaultContinueStatement */
         continue $var;
 }
+
+myLabel:
+do_something();
 
 match ($var) {
     true =>

--- a/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
@@ -605,6 +605,16 @@ final class FindStartOfStatementTest extends UtilityMethodTestCase
                 'targets'        => \T_CLOSE_PARENTHESIS,
                 'expectedTarget' => \T_THROW,
             ],
+            'Goto should be start for contents of the goto statement - goto label'                    => [
+                'testMarker'     => '/* testInsideCaseGotoStatement */',
+                'targets'        => \T_STRING,
+                'expectedTarget' => \T_GOTO,
+            ],
+            'Goto should be start for contents of the goto statement - semicolon'                     => [
+                'testMarker'     => '/* testInsideCaseGotoStatement */',
+                'targets'        => \T_SEMICOLON,
+                'expectedTarget' => \T_GOTO,
+            ],
             'Default keyword should be start of default statement - default itself' => [
                 'testMarker'     => '/* testDefaultStatement */',
                 'targets'        => \T_DEFAULT,


### PR DESCRIPTION
Update the test files to align with PHPCS 3.12.1, which added support for `goto` as a (switch) `case` terminating statement.

No changes needed in the `BCFile` class, as by now, the PHPCSUtils minimum PHPCS version is already at `3.13.0` (this test change is being synced a bit late... oops).

Ref: PHPCSStandards/PHP_CodeSniffer# 916