### PR TITLE
BCTokens/UnchangedTokenArraysTest: compare arrays independently of array order

### DIFF
--- a/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
+++ b/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
@@ -462,7 +462,12 @@ final class UnchangedTokenArraysTest extends TestCase
      */
     public function testUnchangedTokenArrays($name, $expected)
     {
-        $this->assertSame($expected, BCTokens::$name());
+        \asort($expected);
+
+        $result = BCTokens::$name();
+        \asort($result);
+
+        $this->assertSame($expected, $result);
     }
 
     /**


### PR DESCRIPTION
In PHPCS 4.0, the order of some of the tokens in these arrays will change. The order of these tokens in the arrays is irrelevant anyway, so let's make the test compare the arrays without the order of the tokens being a factor in the comparison.