### PR TITLE
BCTokens::functionNameTokens(): simplify

### DIFF
--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -116,7 +116,6 @@ final class BCTokens
     public static function functionNameTokens()
     {
         $tokens  = Tokens::$functionNameTokens;
-        $tokens += Collections::ooHierarchyKeywords();
         $tokens += Collections::nameTokens();
 
         return $tokens;


### PR DESCRIPTION
The `T_SELF` and `T_STATIC` tokens are part of the `functionNameTokens` array since PHPCS 3.1.0.
The `T_PARENT` token since 3.7.2.

As the minimum supported PHPCS version is beyond both these versions now, there is no need to adjust the array for hierarchy keywords anymore as they will be inherited from the upstream `Tokens` class.