### PR TITLE
BCFile::getMethodProperties(): sync tests with upstream

### DIFF
--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.inc
@@ -79,6 +79,11 @@ class ReturnMe {
     private function myFunction(): static {
         return $this;
     }
+
+    /* testReturnTypeNullableStatic */
+    function myNullableFunction(): ?static {
+        return $this;
+    }
 }
 
 /* testPHP8MixedTypeHint */

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -535,6 +535,30 @@ class GetMethodPropertiesTest extends PolyfilledTestCase
     }
 
     /**
+     * Test a function with return type "?static".
+     *
+     * @return void
+     */
+    public function testReturnTypeNullableStatic()
+    {
+        // Offsets are relative to the T_FUNCTION token.
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => '?static',
+            'return_type_token'     => 8,
+            'return_type_end_token' => 8,
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
+        ];
+
+        $this->getMethodPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Test a function with return type "mixed".
      *
      * @return void


### PR DESCRIPTION
Update the test files to align with PHPCS 3.9.0.

Nullable static return types were already supported, the test just safeguards it.

Ref: PHPCSStandards/PHP_CodeSniffer#320