### PR TITLE
UseStatements::getType(): bug fix for unfinished closures

### DIFF
--- a/Tests/Utils/UseStatements/UseTypeParseError1Test.inc
+++ b/Tests/Utils/UseStatements/UseTypeParseError1Test.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Intentional parse error. Live coding. This has to be the last test in the file.
+/* testLiveCoding */
+use

--- a/Tests/Utils/UseStatements/UseTypeParseError1Test.php
+++ b/Tests/Utils/UseStatements/UseTypeParseError1Test.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\UseStatements;
+
+use PHPCSUtils\Tests\PolyfilledTestCase;
+use PHPCSUtils\Utils\UseStatements;
+
+/**
+ * Test for the \PHPCSUtils\Utils\UseStatements::getType() methods.
+ *
+ * @covers \PHPCSUtils\Utils\UseStatements::getType
+ *
+ * @since 1.0.0
+ */
+final class UseTypeParseError1Test extends PolyfilledTestCase
+{
+
+    /**
+     * Test that a `use` keyword for which the type cannot be determined returns an empty string.
+     *
+     * @return void
+     */
+    public function testUndeterminedUse()
+    {
+        $stackPtr = $this->getTargetToken('/* testLiveCoding */', \T_USE);
+
+        $result = UseStatements::getType(self::$phpcsFile, $stackPtr);
+        $this->assertSame('', $result);
+    }
+}

--- a/Tests/Utils/UseStatements/UseTypeParseError2Test.inc
+++ b/Tests/Utils/UseStatements/UseTypeParseError2Test.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Intentional parse error. Live coding. This has to be the last test in the file.
+/* testLiveCoding */
+use // TODO

--- a/Tests/Utils/UseStatements/UseTypeParseError2Test.php
+++ b/Tests/Utils/UseStatements/UseTypeParseError2Test.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\UseStatements;
+
+use PHPCSUtils\Tests\PolyfilledTestCase;
+use PHPCSUtils\Utils\UseStatements;
+
+/**
+ * Test for the \PHPCSUtils\Utils\UseStatements::getType() methods.
+ *
+ * @covers \PHPCSUtils\Utils\UseStatements::getType
+ *
+ * @since 1.1.0
+ */
+final class UseTypeParseError2Test extends PolyfilledTestCase
+{
+
+    /**
+     * Test that a `use` keyword for which the type cannot be determined returns an empty string.
+     *
+     * @return void
+     */
+    public function testUndeterminedUse()
+    {
+        $stackPtr = $this->getTargetToken('/* testLiveCoding */', \T_USE);
+
+        $result = UseStatements::getType(self::$phpcsFile, $stackPtr);
+        $this->assertSame('', $result);
+    }
+}

--- a/Tests/Utils/UseStatements/UseTypeParseError3Test.inc
+++ b/Tests/Utils/UseStatements/UseTypeParseError3Test.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Intentional parse error. Missing closure use parentheses. This should be the only test in the file.
+/* testLiveCoding */
+$cl = function ($a) use

--- a/Tests/Utils/UseStatements/UseTypeParseError3Test.php
+++ b/Tests/Utils/UseStatements/UseTypeParseError3Test.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\UseStatements;
+
+use PHPCSUtils\Tests\PolyfilledTestCase;
+use PHPCSUtils\Utils\UseStatements;
+
+/**
+ * Test for the \PHPCSUtils\Utils\UseStatements::getType() methods.
+ *
+ * @covers \PHPCSUtils\Utils\UseStatements::getType
+ *
+ * @since 1.1.0
+ */
+final class UseTypeParseError3Test extends PolyfilledTestCase
+{
+
+    /**
+     * Test that a `use` keyword for an unfinished closure, still returns 'closure'.
+     *
+     * @return void
+     */
+    public function testUndeterminedUse()
+    {
+        $stackPtr = $this->getTargetToken('/* testLiveCoding */', \T_USE);
+
+        $result = UseStatements::getType(self::$phpcsFile, $stackPtr);
+        $this->assertSame('closure', $result);
+    }
+}

--- a/Tests/Utils/UseStatements/UseTypeParseError4Test.inc
+++ b/Tests/Utils/UseStatements/UseTypeParseError4Test.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Intentional parse error. Missing closure use close parenthesis. This should be the only test in the file.
+/* testLiveCoding */
+$cl = function ($a) use (

--- a/Tests/Utils/UseStatements/UseTypeParseError4Test.php
+++ b/Tests/Utils/UseStatements/UseTypeParseError4Test.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\UseStatements;
+
+use PHPCSUtils\Tests\PolyfilledTestCase;
+use PHPCSUtils\Utils\UseStatements;
+
+/**
+ * Test for the \PHPCSUtils\Utils\UseStatements::getType() methods.
+ *
+ * @covers \PHPCSUtils\Utils\UseStatements::getType
+ *
+ * @since 1.1.0
+ */
+final class UseTypeParseError4Test extends PolyfilledTestCase
+{
+
+    /**
+     * Test that a `use` keyword for an unfinished closure, still returns 'closure'.
+     *
+     * @return void
+     */
+    public function testClosureUseWithParseError()
+    {
+        $stackPtr = $this->getTargetToken('/* testLiveCoding */', \T_USE);
+
+        $result = UseStatements::getType(self::$phpcsFile, $stackPtr);
+        $this->assertSame('closure', $result);
+    }
+}

--- a/Tests/Utils/UseStatements/UseTypeParseError5Test.inc
+++ b/Tests/Utils/UseStatements/UseTypeParseError5Test.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Intentional parse error. Missing closure curly braces. This should be the only test in the file.
+/* testLiveCoding */
+$cl = function ($a) use ()

--- a/Tests/Utils/UseStatements/UseTypeParseError5Test.php
+++ b/Tests/Utils/UseStatements/UseTypeParseError5Test.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\UseStatements;
+
+use PHPCSUtils\Tests\PolyfilledTestCase;
+use PHPCSUtils\Utils\UseStatements;
+
+/**
+ * Test for the \PHPCSUtils\Utils\UseStatements::getType() methods.
+ *
+ * @covers \PHPCSUtils\Utils\UseStatements::getType
+ *
+ * @since 1.1.0
+ */
+final class UseTypeParseError5Test extends PolyfilledTestCase
+{
+
+    /**
+     * Test that a `use` keyword for which the type cannot be determined returns an empty string.
+     *
+     * @return void
+     */
+    public function testClosureUseWithParseError()
+    {
+        $stackPtr = $this->getTargetToken('/* testLiveCoding */', \T_USE);
+
+        $result = UseStatements::getType(self::$phpcsFile, $stackPtr);
+        $this->assertSame('closure', $result);
+    }
+}

--- a/Tests/Utils/UseStatements/UseTypeTest.inc
+++ b/Tests/Utils/UseStatements/UseTypeTest.inc
@@ -69,7 +69,3 @@ class PHPCS2ScopeConditionIssue {
     /* testUseImportPHPCS2DefaultNoSwitchB */
     use TraitD { oldfunction as Fool; }
 }
-
-// Intentional parse error. Live coding. This has to be the last test in the file.
-/* testLiveCoding */
-use

--- a/Tests/Utils/UseStatements/UseTypeTest.php
+++ b/Tests/Utils/UseStatements/UseTypeTest.php
@@ -274,15 +274,6 @@ final class UseTypeTest extends PolyfilledTestCase
                     'trait'   => true,
                 ],
             ],
-
-            'live-coding' => [
-                'testMarker' => '/* testLiveCoding */',
-                'expected'   => [
-                    'closure' => false,
-                    'import'  => false,
-                    'trait'   => false,
-                ],
-            ],
         ];
     }
 }


### PR DESCRIPTION
### UseStatements tests: move parse error test to own file 

... and add an extra variant of the same test.

### UseStatements::getType(): bug fix for unfinished closures 

Of the new tests, test case 4 and 5, would previously both return `"import"` as the use statement type determination. This is clearly wrong.
Additionally, for test case 3, it can also still be reliably determined that this is a closure `use`, while it would previously return an empty string as indicator of "undetermined".

So when there is a parse error, but it can still be reliably determined that the `use` keyword is used for a closure `use` statement, the `UseStatements::getType()` method will now return `"closure"`.

Includes tests.