### PR TITLE
AbstractArrayDeclarationSniff::getActualArrayKey(): handle FQN true/false/null

### DIFF
--- a/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
+++ b/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
@@ -478,6 +478,37 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
                 continue;
             }
 
+            // Handle FQN true/false/null.
+            if ($this->tokens[$i]['code'] === \T_NAME_FULLY_QUALIFIED) {
+                $compareReadyKeyword = \strtolower($this->tokens[$i]['content']);
+                if ($compareReadyKeyword === '\true'
+                    || $compareReadyKeyword === '\false'
+                    || $compareReadyKeyword === '\null'
+                ) {
+                    // FQN true/false/null on PHPCS 4.x. This can be handled.
+                    $content .= $this->tokens[$i]['content'];
+                    continue;
+                }
+            } elseif ($this->tokens[$i]['code'] === \T_NS_SEPARATOR) {
+                // PHPCS 3.x.
+                $nextNonEmpty   = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
+                $nextNonEmptyLC = \strtolower($this->tokens[$nextNonEmpty]['content']);
+                if ($nextNonEmpty !== false
+                    // PHPCS 3.x with PHP < 8.0.
+                    && ($this->tokens[$nextNonEmpty]['code'] === \T_TRUE
+                    || $this->tokens[$nextNonEmpty]['code'] === \T_FALSE
+                    || $this->tokens[$nextNonEmpty]['code'] === \T_NULL
+                    // PHPCS 3.x with PHP >= 8.0 where the namespaced name tokenization has been undone.
+                    || ($this->tokens[$nextNonEmpty]['code'] === \T_STRING
+                        && ($nextNonEmptyLC === 'true' || $nextNonEmptyLC === 'false' || $nextNonEmptyLC === 'null')))
+                ) {
+                    // FQN true/false/null on PHPCS 3.x. This can be handled.
+                    $content .= $this->tokens[$nextNonEmpty]['content'];
+                    $i        = $nextNonEmpty;
+                    continue;
+                }
+            }
+
             if (isset($this->acceptedTokens[$this->tokens[$i]['code']]) === false) {
                 // This is not a key we can evaluate. Might be a variable or constant.
                 return;

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.inc
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.inc
@@ -10,6 +10,9 @@ $excluded = [
     $obj->get_key()             => 'excluded',
     $obj->prop                  => 'excluded',
     "my $var text"              => 'excluded',
+    \some\ true\name            => 'excluded',
+    \false\some\name            => 'excluded',
+    \some\name\null             => 'excluded',
     <<<EOD
 my $var text
 EOD
@@ -30,6 +33,7 @@ $emptyStringKey = array(
     ''             => 'empty',
     null           => 'null',
     (string) false => 'false',
+    \null          => 'null',
 );
 
 /* testAllZero */
@@ -56,6 +60,7 @@ $everythingZero = [
     .0               => 's',
     (true) ? 0 : 1   => 't',
     ! true           => 'u',
+    \false           => 'v',
 ];
 
 /* testAllOne */
@@ -83,6 +88,7 @@ $everythingOne = [
     (true) ? 1 : 0   => 's',
     ! false          => 't',
     (string) true    => 'u',
+    \true            => 'v',
 ];
 
 /* testAllEleven */


### PR DESCRIPTION
The special constants `true`/`false`/`null` can be used in fully qualified form, even though this is rarely done in practice.

This commit adds support for handling this to the `AbstractArrayDeclarationSniff::getActualArrayKey()` method in a PHPCS 3/4 cross-version compatible manner.

Includes tests.