### PR TITLE
PHPUnit config: remove outdated comments

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -57,7 +57,6 @@
 
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
-            <!-- Not recording coverage for PHPCS23Utils as there is nothing directly testable. -->
             <directory suffix=".php">./PHPCSUtils/</directory>
         </whitelist>
     </filter>

--- a/phpunit10.xml.dist
+++ b/phpunit10.xml.dist
@@ -63,7 +63,6 @@
 
     <source>
         <include>
-            <!-- Not recording coverage for PHPCS23Utils as there is nothing directly testable. -->
             <directory suffix=".php">./PHPCSUtils/</directory>
         </include>
     </source>


### PR DESCRIPTION
The PHPCS23Utils standard was removed ages ago (via PR #410).