### PR TITLE
Autoloader: minor tweak

### DIFF
--- a/phpcsutils-autoload.php
+++ b/phpcsutils-autoload.php
@@ -32,7 +32,7 @@ if (defined('PHPCSUTILS_AUTOLOAD') === false) {
      */
     spl_autoload_register(function ($fqClassName) {
         // Only try & load our own classes.
-        if (stripos($fqClassName, 'PHPCSUtils') !== 0) {
+        if (stripos($fqClassName, 'PHPCSUtils\\') !== 0) {
             return;
         }
 


### PR DESCRIPTION
More precisely match the namespace prefix of this project (to prevent matching on projects extending this project and using an overlapping namespace name).