### PR TITLE
ConfigDoubleTest::setStaticConfigProperty(): fix logic error

### DIFF
--- a/Tests/TestUtils/ConfigDouble/ConfigDoubleTest.php
+++ b/Tests/TestUtils/ConfigDouble/ConfigDoubleTest.php
@@ -324,14 +324,14 @@ final class ConfigDoubleTest extends TestCase
      */
     public static function setStaticConfigProperty($name, $value)
     {
-        $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
-        $property->setAccessible(true);
-
         // The `overriddenDefaults` property is no longer static on PHPCS 4.0+, so ignore it.
-        if ($name !== 'overriddenDefaults' && \version_compare(Helper::getVersion(), '3.99.99', '<=')) {
-            $property->setValue(null, $value);
+        if ($name === 'overriddenDefaults' && \version_compare(Helper::getVersion(), '3.99.99', '>')) {
+            return;
         }
 
+        $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
+        $property->setAccessible(true);
+        $property->setValue(null, $value);
         $property->setAccessible(false);
     }
 }


### PR DESCRIPTION
Bit surprising that no tests were failing due to the error, but should be okay now.

Includes minor efficiency fix by not creating a new ReflectionProperty object when not needed.