### PR TITLE
Update for new upstream PHPCS 4.x branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,13 +108,13 @@ jobs:
             experimental: true
 
           - php: '7.4'
-            phpcs_version: '4.0.x-dev'
+            phpcs_version: '4.x-dev'
             risky: false
             experimental: true
 
           # Run risky tests separately.
           - php: '7.4'
-            phpcs_version: '4.0.x-dev'
+            phpcs_version: '4.x-dev'
             risky: true
             experimental: true
 
@@ -151,7 +151,7 @@ jobs:
       - name: Setup ini config
         id: set_ini
         run: |
-          if [[ "${{ matrix.phpcs_version }}" != "dev-master" && "${{ matrix.phpcs_version }}" != "4.0.x-dev" ]]; then
+          if [[ "${{ matrix.phpcs_version }}" != "dev-master" && "${{ matrix.phpcs_version }}" != "4.x-dev" ]]; then
             echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
           else
             echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
@@ -214,7 +214,7 @@ jobs:
         if: ${{ matrix.risky == false }}
         run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }} --no-coverage
         env:
-          PHPCS_VERSION: ${{ matrix.phpcs_version == '4.0.x-dev' && '4.0.0' || matrix.phpcs_version }}
+          PHPCS_VERSION: ${{ matrix.phpcs_version == '4.x-dev' && '4.0.0' || matrix.phpcs_version }}
           PHPCSUTILS_USE_CACHE: false
 
       - name: Run the unit tests with caching (non-risky)
@@ -223,7 +223,7 @@ jobs:
           vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }}
           --testsuite PHPCSUtils --no-coverage ${{ steps.phpunit_config.outputs.EXTRA_ARGS }}
         env:
-          PHPCS_VERSION: ${{ matrix.phpcs_version == '4.0.x-dev' && '4.0.0' || matrix.phpcs_version }}
+          PHPCS_VERSION: ${{ matrix.phpcs_version == '4.x-dev' && '4.0.0' || matrix.phpcs_version }}
           PHPCSUTILS_USE_CACHE: true
 
       # Only run the "compare with PHPCS" group against dev-master as it ensures that PHPCSUtils
@@ -233,7 +233,7 @@ jobs:
         # "nothing" is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
         run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }} --no-coverage --group compareWithPHPCS --exclude-group nothing
         env:
-          PHPCS_VERSION: ${{ matrix.phpcs_version == '4.0.x-dev' && '4.0.0' || matrix.phpcs_version }}
+          PHPCS_VERSION: ${{ matrix.phpcs_version == '4.x-dev' && '4.0.0' || matrix.phpcs_version }}
 
       # Run the "xtra" group against high and low PHPCS as these are tests safeguarding PHPCS itself.
       - name: Run the unit tests (risky, xtra)
@@ -241,7 +241,7 @@ jobs:
         # "nothing" is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
         run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }} --no-coverage --group xtra --exclude-group nothing
         env:
-          PHPCS_VERSION: ${{ matrix.phpcs_version == '4.0.x-dev' && '4.0.0' || matrix.phpcs_version }}
+          PHPCS_VERSION: ${{ matrix.phpcs_version == '4.x-dev' && '4.0.0' || matrix.phpcs_version }}
 
 
   #### CODE COVERAGE STAGE ####

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -905,7 +905,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.2.0.
-     * - The upstream method has received no significant updates since PHPCS 3.13.0.
+     * - PHPCS 4.0.0: Handling of the namespace relative parent class using the namespace keyword as operator.
      *
      * @see \PHP_CodeSniffer\Files\File::findExtendedClassName()          Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::findExtendedClassName() PHPCSUtils native improved version.
@@ -920,7 +920,42 @@ final class BCFile
      */
     public static function findExtendedClassName(File $phpcsFile, $stackPtr)
     {
-        return $phpcsFile->findExtendedClassName($stackPtr);
+        $tokens = $phpcsFile->getTokens();
+
+        // Check for the existence of the token.
+        if (isset($tokens[$stackPtr]) === false) {
+            return false;
+        }
+
+        if ($tokens[$stackPtr]['code'] !== T_CLASS
+            && $tokens[$stackPtr]['code'] !== T_ANON_CLASS
+            && $tokens[$stackPtr]['code'] !== T_INTERFACE
+        ) {
+            return false;
+        }
+
+        if (isset($tokens[$stackPtr]['scope_opener']) === false) {
+            return false;
+        }
+
+        $classOpenerIndex = $tokens[$stackPtr]['scope_opener'];
+        $extendsIndex     = $phpcsFile->findNext(T_EXTENDS, $stackPtr, $classOpenerIndex);
+        if ($extendsIndex === false) {
+            return false;
+        }
+
+        $find   = Collections::namespacedNameTokens();
+        $find[] = T_WHITESPACE;
+
+        $end  = $phpcsFile->findNext($find, ($extendsIndex + 1), ($classOpenerIndex + 1), true);
+        $name = $phpcsFile->getTokensAsString(($extendsIndex + 1), ($end - $extendsIndex - 1));
+        $name = trim($name);
+
+        if ($name === '') {
+            return false;
+        }
+
+        return $name;
     }
 
     /**

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -965,7 +965,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.7.0.
-     * - The upstream method has received no significant updates since PHPCS 3.13.0.
+     * - PHPCS 4.0.0: Handling of the namespace relative parent class using the namespace keyword as operator.
      *
      * @see \PHP_CodeSniffer\Files\File::findImplementedInterfaceNames()          Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::findImplementedInterfaceNames() PHPCSUtils native improved version.
@@ -980,6 +980,44 @@ final class BCFile
      */
     public static function findImplementedInterfaceNames(File $phpcsFile, $stackPtr)
     {
-        return $phpcsFile->findImplementedInterfaceNames($stackPtr);
+        $tokens = $phpcsFile->getTokens();
+
+        // Check for the existence of the token.
+        if (isset($tokens[$stackPtr]) === false) {
+            return false;
+        }
+
+        if ($tokens[$stackPtr]['code'] !== T_CLASS
+            && $tokens[$stackPtr]['code'] !== T_ANON_CLASS
+            && $tokens[$stackPtr]['code'] !== T_ENUM
+        ) {
+            return false;
+        }
+
+        if (isset($tokens[$stackPtr]['scope_closer']) === false) {
+            return false;
+        }
+
+        $classOpenerIndex = $tokens[$stackPtr]['scope_opener'];
+        $implementsIndex  = $phpcsFile->findNext(T_IMPLEMENTS, $stackPtr, $classOpenerIndex);
+        if ($implementsIndex === false) {
+            return false;
+        }
+
+        $find   = Collections::namespacedNameTokens();
+        $find[] = T_WHITESPACE;
+        $find[] = T_COMMA;
+
+        $end  = $phpcsFile->findNext($find, ($implementsIndex + 1), ($classOpenerIndex + 1), true);
+        $name = $phpcsFile->getTokensAsString(($implementsIndex + 1), ($end - $implementsIndex - 1));
+        $name = trim($name);
+
+        if ($name === '') {
+            return false;
+        } else {
+            $names = explode(',', $name);
+            $names = array_map('trim', $names);
+            return $names;
+        }
     }
 }

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -512,7 +512,8 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.13.0.
+     * - PHPCS 4.0: properties in interfaces (PHP 8.4+) are accepted.
+     * - PHPCS 4.0: will no longer throw a parse error warning.
      *
      * @see \PHP_CodeSniffer\Files\File::getMemberProperties() Original source.
      * @see \PHPCSUtils\Utils\Variables::getMemberProperties() PHPCSUtils native improved version.
@@ -531,7 +532,137 @@ final class BCFile
      */
     public static function getMemberProperties(File $phpcsFile, $stackPtr)
     {
-        return $phpcsFile->getMemberProperties($stackPtr);
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['code'] !== T_VARIABLE) {
+            throw new RuntimeException('$stackPtr must be of type T_VARIABLE');
+        }
+
+        $conditions = $tokens[$stackPtr]['conditions'];
+        $conditions = array_keys($conditions);
+        $ptr        = array_pop($conditions);
+        if (isset($tokens[$ptr]) === false
+            || isset(Tokens::$ooScopeTokens[$tokens[$ptr]['code']]) === false
+            || $tokens[$ptr]['code'] === T_ENUM
+        ) {
+            throw new RuntimeException('$stackPtr is not a class member var');
+        }
+
+        // Make sure it's not a method parameter.
+        if (empty($tokens[$stackPtr]['nested_parenthesis']) === false) {
+            $parenthesis = array_keys($tokens[$stackPtr]['nested_parenthesis']);
+            $deepestOpen = array_pop($parenthesis);
+            if ($deepestOpen > $ptr
+                && isset($tokens[$deepestOpen]['parenthesis_owner']) === true
+                && $tokens[$tokens[$deepestOpen]['parenthesis_owner']]['code'] === T_FUNCTION
+            ) {
+                throw new RuntimeException('$stackPtr is not a class member var');
+            }
+        }
+
+        $valid = [
+            T_PUBLIC    => T_PUBLIC,
+            T_PRIVATE   => T_PRIVATE,
+            T_PROTECTED => T_PROTECTED,
+            T_STATIC    => T_STATIC,
+            T_VAR       => T_VAR,
+            T_READONLY  => T_READONLY,
+            T_FINAL     => T_FINAL,
+        ];
+
+        $valid += Tokens::$emptyTokens;
+
+        $scope          = 'public';
+        $scopeSpecified = false;
+        $isStatic       = false;
+        $isReadonly     = false;
+        $isFinal        = false;
+
+        $startOfStatement = $phpcsFile->findPrevious(
+            [
+                T_SEMICOLON,
+                T_OPEN_CURLY_BRACKET,
+                T_CLOSE_CURLY_BRACKET,
+                T_ATTRIBUTE_END,
+            ],
+            ($stackPtr - 1)
+        );
+
+        for ($i = ($startOfStatement + 1); $i < $stackPtr; $i++) {
+            if (isset($valid[$tokens[$i]['code']]) === false) {
+                break;
+            }
+
+            switch ($tokens[$i]['code']) {
+                case T_PUBLIC:
+                    $scope          = 'public';
+                    $scopeSpecified = true;
+                    break;
+                case T_PRIVATE:
+                    $scope          = 'private';
+                    $scopeSpecified = true;
+                    break;
+                case T_PROTECTED:
+                    $scope          = 'protected';
+                    $scopeSpecified = true;
+                    break;
+                case T_STATIC:
+                    $isStatic = true;
+                    break;
+                case T_READONLY:
+                    $isReadonly = true;
+                    break;
+                case T_FINAL:
+                    $isFinal = true;
+                    break;
+            }
+        }
+
+        $type         = '';
+        $typeToken    = false;
+        $typeEndToken = false;
+        $nullableType = false;
+
+        if ($i < $stackPtr) {
+            // We've found a type.
+            $valid = Collections::propertyTypeTokens();
+
+            for ($i; $i < $stackPtr; $i++) {
+                if ($tokens[$i]['code'] === T_VARIABLE) {
+                    // Hit another variable in a group definition.
+                    break;
+                }
+
+                if ($tokens[$i]['code'] === T_NULLABLE) {
+                    $nullableType = true;
+                }
+
+                if (isset($valid[$tokens[$i]['code']]) === true) {
+                    $typeEndToken = $i;
+                    if ($typeToken === false) {
+                        $typeToken = $i;
+                    }
+
+                    $type .= $tokens[$i]['content'];
+                }
+            }
+
+            if ($type !== '' && $nullableType === true) {
+                $type = '?' . $type;
+            }
+        }
+
+        return [
+            'scope'           => $scope,
+            'scope_specified' => $scopeSpecified,
+            'is_static'       => $isStatic,
+            'is_readonly'     => $isReadonly,
+            'is_final'        => $isFinal,
+            'type'            => $type,
+            'type_token'      => $typeToken,
+            'type_end_token'  => $typeEndToken,
+            'nullable_type'   => $nullableType,
+        ];
     }
 
     /**

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -76,7 +76,8 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.13.0.
+     * - PHPCS 4.0: The method no longer accepts `T_CLOSURE` and `T_ANON_CLASS` tokens.
+     * - PHPCS 4.0: The method will now always return a string.
      *
      * @see \PHP_CodeSniffer\Files\File::getDeclarationName() Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::getName()   PHPCSUtils native improved version.
@@ -88,17 +89,53 @@ final class BCFile
      *                                               which declared the class, interface,
      *                                               trait, enum or function.
      *
-     * @return string|null The name of the class, interface, trait, enum, or function;
-     *                     or `NULL` if the function or class is anonymous or
-     *                     in case of a parse error/live coding.
+     * @return string The name of the class, interface, trait, or function or an empty string
+     *                if the name could not be determined (live coding).
      *
      * @throws \PHP_CodeSniffer\Exceptions\RuntimeException If the specified token is not of type
-     *                                                      `T_FUNCTION`, `T_CLASS`, `T_ANON_CLASS`,
-     *                                                      `T_CLOSURE`, `T_TRAIT`, `T_ENUM` or `T_INTERFACE`.
+     *                                                      `T_FUNCTION`, `T_CLASS`, `T_TRAIT`, `T_ENUM`, or `T_INTERFACE`.
      */
     public static function getDeclarationName(File $phpcsFile, $stackPtr)
     {
-        return $phpcsFile->getDeclarationName($stackPtr);
+        $tokens = $phpcsFile->getTokens();
+
+        $tokenCode = $tokens[$stackPtr]['code'];
+
+        if ($tokenCode !== T_FUNCTION
+            && $tokenCode !== T_CLASS
+            && $tokenCode !== T_INTERFACE
+            && $tokenCode !== T_TRAIT
+            && $tokenCode !== T_ENUM
+        ) {
+            throw new RuntimeException('Token type "' . $tokens[$stackPtr]['type'] . '" is not T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT or T_ENUM');
+        }
+
+        if ($tokenCode === T_FUNCTION
+            && strtolower($tokens[$stackPtr]['content']) !== 'function'
+        ) {
+            // This is a function declared without the "function" keyword.
+            // So this token is the function name.
+            return $tokens[$stackPtr]['content'];
+        }
+
+        $stopPoint = $phpcsFile->numTokens;
+        if (isset($tokens[$stackPtr]['parenthesis_opener']) === true) {
+            // For functions, stop searching at the parenthesis opener.
+            $stopPoint = $tokens[$stackPtr]['parenthesis_opener'];
+        } elseif (isset($tokens[$stackPtr]['scope_opener']) === true) {
+            // For OO tokens, stop searching at the open curly.
+            $stopPoint = $tokens[$stackPtr]['scope_opener'];
+        }
+
+        $content = '';
+        for ($i = $stackPtr; $i < $stopPoint; $i++) {
+            if ($tokens[$i]['code'] === T_STRING) {
+                $content = $tokens[$i]['content'];
+                break;
+            }
+        }
+
+        return $content;
     }
 
     /**

--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -169,6 +169,25 @@ final class BCTokens
     }
 
     /**
+     * Tokens used for "names", be it namespace, OO, function or constant names.
+     *
+     * Retrieve the PHPCS name tokens array in a cross-version compatible manner.
+     *
+     * Changelog for the PHPCS native array:
+     * - Introduced in PHPCS 4.0.0.
+     *
+     * @see \PHP_CodeSniffer\Util\Tokens::NAME_TOKENS Original array.
+     *
+     * @since 1.1.0
+     *
+     * @return array<int|string, int|string> Token array.
+     */
+    public static function nameTokens()
+    {
+        return Collections::nameTokens();
+    }
+
+    /**
      * Token types that open parentheses.
      *
      * Retrieve the PHPCS parenthesis openers tokens array in a cross-version compatible manner.

--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -175,13 +175,13 @@ final class BCTokens
      *
      * Changelog for the PHPCS native array:
      * - Introduced in PHPCS 0.0.5.
-     * - PHPCS 4.0.0: `T_USE` added to the array.
+     * - PHPCS 4.0.0: `T_USE` (for closures), `T_ISSET`, `T_UNSET`, `T_EMPTY`, `T_EVAL` and `T_EXIT` added to the array.
      *
-     * Note: While `T_USE` will be included in the return value for this method, the
-     * associated parentheses will not have the `'parenthesis_owner'` index set
-     * until PHPCS 4.0.0. Use the {@see \PHPCSUtils\Utils\Parentheses::getOwner()}
-     * or {@see \PHPCSUtils\Utils\Parentheses::hasOwner()} methods if you need to check
-     * for a `T_USE` parentheses owner.
+     * **Important**: While `T_USE`, `T_ISSET`, `T_UNSET`, `T_EMPTY`, `T_EVAL` and `T_EXIT` will be included
+     * in the return value for this method, the associated parentheses will not have the `'parenthesis_owner'` index
+     * set until PHPCS 4.0.0.
+     * Use the {@see \PHPCSUtils\Utils\Parentheses::getOwner()} or {@see \PHPCSUtils\Utils\Parentheses::hasOwner()} methods
+     * if you need to check for whether any of these tokens are a parentheses owner.
      *
      * @see \PHP_CodeSniffer\Util\Tokens::$parenthesisOpeners Original array.
      * @see \PHPCSUtils\Utils\Parentheses                     Class holding utility methods for
@@ -194,8 +194,13 @@ final class BCTokens
      */
     public static function parenthesisOpeners()
     {
-        $tokens         = Tokens::$parenthesisOpeners;
-        $tokens[\T_USE] = \T_USE;
+        $tokens           = Tokens::$parenthesisOpeners;
+        $tokens[\T_USE]   = \T_USE;
+        $tokens[\T_ISSET] = \T_ISSET;
+        $tokens[\T_UNSET] = \T_UNSET;
+        $tokens[\T_EMPTY] = \T_EMPTY;
+        $tokens[\T_EVAL]  = \T_EVAL;
+        $tokens[\T_EXIT]  = \T_EXIT;
 
         return $tokens;
     }

--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -59,7 +59,6 @@ use PHPCSUtils\Tokens\Collections;
  * @method static array<int|string, int|string> methodPrefixes()           Tokens that can prefix a method name.
  * @method static array<int|string, int|string> ooScopeTokens()            Tokens that open class and object scopes.
  * @method static array<int|string, int|string> operators()                Tokens that perform operations.
- * @method static array<int|string, int|string> parenthesisOpeners()       Token types that open parenthesis.
  * @method static array<int|string, int|string> phpcsCommentTokens()       Tokens that are comments containing PHPCS
  *                                                                         instructions.
  * @method static array<int|string, int|string> scopeModifiers()           Tokens that represent scope modifiers.
@@ -165,6 +164,38 @@ final class BCTokens
         $tokens                = Tokens::$functionNameTokens;
         $tokens               += Collections::nameTokens();
         $tokens[\T_ANON_CLASS] = \T_ANON_CLASS;
+
+        return $tokens;
+    }
+
+    /**
+     * Token types that open parentheses.
+     *
+     * Retrieve the PHPCS parenthesis openers tokens array in a cross-version compatible manner.
+     *
+     * Changelog for the PHPCS native array:
+     * - Introduced in PHPCS 0.0.5.
+     * - PHPCS 4.0.0: `T_USE` added to the array.
+     *
+     * Note: While `T_USE` will be included in the return value for this method, the
+     * associated parentheses will not have the `'parenthesis_owner'` index set
+     * until PHPCS 4.0.0. Use the {@see \PHPCSUtils\Utils\Parentheses::getOwner()}
+     * or {@see \PHPCSUtils\Utils\Parentheses::hasOwner()} methods if you need to check
+     * for a `T_USE` parentheses owner.
+     *
+     * @see \PHP_CodeSniffer\Util\Tokens::$parenthesisOpeners Original array.
+     * @see \PHPCSUtils\Utils\Parentheses                     Class holding utility methods for
+     *                                                        working with the `'parenthesis_...'`
+     *                                                        index keys in a token array.
+     *
+     * @since 1.0.0
+     *
+     * @return array<int|string, int|string> Token array.
+     */
+    public static function parenthesisOpeners()
+    {
+        $tokens         = Tokens::$parenthesisOpeners;
+        $tokens[\T_USE] = \T_USE;
 
         return $tokens;
     }

--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -152,7 +152,7 @@ final class BCTokens
      *
      * Changelog for the PHPCS native array:
      * - Introduced in PHPCS 2.3.3.
-     * - PHPCS 4.0.0: `T_NAME_QUALIFIED`, `T_NAME_FULLY_QUALIFIED` and `T_NAME_RELATIVE` added to the array.
+     * - PHPCS 4.0.0: `T_NAME_QUALIFIED`, `T_NAME_FULLY_QUALIFIED`, `T_NAME_RELATIVE` and `T_ANON_CLASS` added to the array.
      *
      * @see \PHP_CodeSniffer\Util\Tokens::$functionNameTokens Original array.
      *
@@ -162,8 +162,9 @@ final class BCTokens
      */
     public static function functionNameTokens()
     {
-        $tokens  = Tokens::$functionNameTokens;
-        $tokens += Collections::nameTokens();
+        $tokens                = Tokens::$functionNameTokens;
+        $tokens               += Collections::nameTokens();
+        $tokens[\T_ANON_CLASS] = \T_ANON_CLASS;
 
         return $tokens;
     }

--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -44,8 +44,6 @@ use PHPCSUtils\Tokens\Collections;
  * @since 1.0.0
  *
  * @method static array<int|string, int|string> arithmeticTokens()         Tokens that represent arithmetic operators.
- * @method static array<int|string, int|string> assignmentTokens()         Tokens that represent assignments.
- * @method static array<int|string, int|string> blockOpeners()             Tokens that open code blocks.
  * @method static array<int|string, int|string> booleanOperators()         Tokens that perform boolean operations.
  * @method static array<int|string, int|string> bracketTokens()            Tokens that represent brackets and parenthesis.
  * @method static array<int|string, int|string> castTokens()               Tokens that represent type casting.
@@ -65,7 +63,6 @@ use PHPCSUtils\Tokens\Collections;
  * @method static array<int|string, int|string> phpcsCommentTokens()       Tokens that are comments containing PHPCS
  *                                                                         instructions.
  * @method static array<int|string, int|string> scopeModifiers()           Tokens that represent scope modifiers.
- * @method static array<int|string, int|string> scopeOpeners()             Tokens that are allowed to open scopes.
  * @method static array<int|string, int|string> stringTokens()             Tokens that represent strings.
  *                                                                         Note that `T_STRING`s are NOT represented in this
  *                                                                         list as this list is about _text_ strings.
@@ -99,6 +96,56 @@ final class BCTokens
     }
 
     /**
+     * Tokens that represent assignments.
+     *
+     * Retrieve the PHPCS assignments tokens array in a cross-version compatible manner.
+     *
+     * Changelog for the PHPCS native array:
+     * - PHPCS 4.0.0: The JS specific `T_ZSR_EQUAL` token is no longer available and has been removed from the array.
+     *
+     * @see \PHP_CodeSniffer\Util\Tokens::$assignmentTokens Original array.
+     *
+     * @since 1.0.0
+     *
+     * @return array<int|string, int|string> Token array.
+     */
+    public static function assignmentTokens()
+    {
+        $tokens = Tokens::$assignmentTokens;
+
+        if (\defined('T_ZSR_EQUAL') && isset($tokens[\T_ZSR_EQUAL])) {
+            unset($tokens[\T_ZSR_EQUAL]);
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * Tokens that open code blocks.
+     *
+     * Retrieve the PHPCS block opener tokens array in a cross-version compatible manner.
+     *
+     * Changelog for the PHPCS native array:
+     * - PHPCS 4.0.0: The JS specific `T_OBJECT` token is no longer available and has been removed from the array.
+     *
+     * @see \PHP_CodeSniffer\Util\Tokens::$blockOpeners Original array.
+     *
+     * @since 1.0.0
+     *
+     * @return array<int|string, int|string> Token array.
+     */
+    public static function blockOpeners()
+    {
+        $tokens = Tokens::$blockOpeners;
+
+        if (\defined('T_OBJECT') && isset($tokens[\T_OBJECT])) {
+            unset($tokens[\T_OBJECT]);
+        }
+
+        return $tokens;
+    }
+
+    /**
      * Tokens that represent the names of called functions.
      *
      * Retrieve the PHPCS function name tokens array in a cross-version compatible manner.
@@ -117,6 +164,36 @@ final class BCTokens
     {
         $tokens  = Tokens::$functionNameTokens;
         $tokens += Collections::nameTokens();
+
+        return $tokens;
+    }
+
+    /**
+     * Tokens that are allowed to open scopes.
+     *
+     * Retrieve the PHPCS scope opener tokens array in a cross-version compatible manner.
+     *
+     * Changelog for the PHPCS native array:
+     * - PHPCS 4.0.0: The JS specific `T_PROPERTY` and `T_OBJECT` tokens are no longer available
+     *   and have been removed from the array.
+     *
+     * @see \PHP_CodeSniffer\Util\Tokens::$scopeOpeners Original array.
+     *
+     * @since 1.0.0
+     *
+     * @return array<int|string, int|string> Token array.
+     */
+    public static function scopeOpeners()
+    {
+        $tokens = Tokens::$scopeOpeners;
+
+        if (\defined('T_PROPERTY') && isset($tokens[\T_PROPERTY])) {
+            unset($tokens[\T_PROPERTY]);
+        }
+
+        if (\defined('T_OBJECT') && isset($tokens[\T_OBJECT])) {
+            unset($tokens[\T_OBJECT]);
+        }
 
         return $tokens;
     }

--- a/PHPCSUtils/TestUtils/RulesetDouble.php
+++ b/PHPCSUtils/TestUtils/RulesetDouble.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2024 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\TestUtils;
+
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Ruleset;
+
+/**
+ * Ruleset class for use in the tests.
+ *
+ * The PHP_CodeSniffer Ruleset will throw an error when no (valid) sniffs are registered,
+ * but for utility method tests, we're not concerned about that.
+ *
+ * This ruleset double will catch this error and discard it.
+ *
+ * @since 1.1.0
+ */
+final class RulesetDouble extends Ruleset
+{
+
+    /**
+     * Initialise the ruleset that the run will use.
+     *
+     * @since 1.1.0
+     *
+     * @param \PHP_CodeSniffer\Config $config The config data for the run.
+     *
+     * @return void
+     */
+    public function __construct(Config $config)
+    {
+        try {
+            parent::__construct($config);
+        } catch (RuntimeException $e) {
+            /*
+             * In the UtilityMethodTestCase, we're using a fake sniff name for the tests.
+             * As PHPCS 4.0 will check more strictly that sniffs exist and comply with naming conventions,
+             * this means, as of PHPCS 4.0, the ruleset creation will end with an error.
+             * This error is not something we are concerned about, as we're not testing sniffs,
+             * so we should be able to safely ignore it.
+             */
+            if (\rtrim($e->getMessage()) !== 'ERROR: No sniffs were registered.') {
+                // Rethrow the exception to fail the test, as this is not the exception we expected.
+                throw $e;
+            }
+        }
+    }
+}

--- a/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+++ b/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
@@ -20,6 +20,7 @@ use PHPCSUtils\Exceptions\TestFileNotFound;
 use PHPCSUtils\Exceptions\TestMarkerNotFound;
 use PHPCSUtils\Exceptions\TestTargetNotFound;
 use PHPCSUtils\TestUtils\ConfigDouble;
+use PHPCSUtils\TestUtils\RulesetDouble;
 use PHPUnit\Framework\Attributes\AfterClass;
 use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\BeforeClass;
@@ -30,8 +31,7 @@ use ReflectionProperty;
 /**
  * Base class for use when testing utility methods for PHP_CodeSniffer.
  *
- * This class is compatible with PHP_CodeSniffer 3.x and contains preliminary compatibility with 4.x
- * based on its currently known state/roadmap.
+ * This class is compatible with PHP_CodeSniffer 3.x and 4.x.
  *
  * This class is compatible with {@link https://phpunit.de/ PHPUnit} 4.5 - 11.x providing the PHPCSUtils
  * autoload file is included in the test bootstrap. For more information about that, please consult
@@ -110,6 +110,7 @@ use ReflectionProperty;
  * @since 1.0.0
  * @since 1.0.7 Compatible with PHPUnit 10.
  * @since 1.1.0 Compatible with PHPUnit 11.
+ * @since 1.1.0 Compatible with PHP_CodeSniffer 4.0.0.
  */
 abstract class UtilityMethodTestCase extends TestCase
 {
@@ -226,7 +227,7 @@ abstract class UtilityMethodTestCase extends TestCase
         // Also set a tab-width to enable testing tab-replaced vs `orig_content`.
         $config->tabWidth = static::$tabWidth;
 
-        $ruleset = new Ruleset($config);
+        $ruleset = new RulesetDouble($config);
 
         self::$phpcsFile = self::parseFile($caseFile, $ruleset, $config);
     }

--- a/PHPCSUtils/Tokens/Collections.php
+++ b/PHPCSUtils/Tokens/Collections.php
@@ -415,7 +415,7 @@ final class Collections
     /**
      * OO scopes in which properties can be declared.
      *
-     * Note: interfaces can not declare properties.
+     * - PHP 8.4 added support for properties in interfaces.
      *
      * @since 1.0.0 Use the {@see Collections::ooPropertyScopes()} method for access.
      *
@@ -424,6 +424,7 @@ final class Collections
     private static $ooPropertyScopes = [
         \T_CLASS      => \T_CLASS,
         \T_ANON_CLASS => \T_ANON_CLASS,
+        \T_INTERFACE  => \T_INTERFACE,
         \T_TRAIT      => \T_TRAIT,
     ];
 

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -242,7 +242,6 @@ final class ObjectDeclarations
      * - Bugs fixed:
      *   - Handling of PHPCS annotations.
      *   - Handling of comments.
-     *   - Handling of the namespace keyword used as operator.
      * - Improved handling of parse errors.
      * - The returned name will be clean of superfluous whitespace and/or comments.
      * - Support for PHP 8.0 tokenization of identifier/namespaced names, cross-version PHP & PHPCS.

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -46,6 +46,10 @@ final class ObjectDeclarations
      *   being extended/interface being implemented.
      *   Using this version of the utility method, either the complete name (invalid or not) will
      *   be returned or `null` in case of no name (parse error).
+     * - The PHPCS 4.0 change to no longer accept tokens for anonymous structures (T_CLOSURE/T_ANON_CLASS)
+     *   has not been applied to this method (yet). This will change in PHPCSUtils 2.0.
+     * - The PHPCS 4.0 change to normalize the return type to `string` and no longer return `null`
+     *   has not been applied to this method (yet). This will change in PHPCSUtils 2.0.
      *
      * @see \PHP_CodeSniffer\Files\File::getDeclarationName()   Original source.
      * @see \PHPCSUtils\BackCompat\BCFile::getDeclarationName() Cross-version compatible version of the original.

--- a/PHPCSUtils/Utils/ObjectDeclarations.php
+++ b/PHPCSUtils/Utils/ObjectDeclarations.php
@@ -277,7 +277,6 @@ final class ObjectDeclarations
      * - Bugs fixed:
      *   - Handling of PHPCS annotations.
      *   - Handling of comments.
-     *   - Handling of the namespace keyword used as operator.
      * - Improved handling of parse errors.
      * - The returned name(s) will be clean of superfluous whitespace and/or comments.
      * - Support for PHP 8.0 tokenization of identifier/namespaced names, cross-version PHP & PHPCS.

--- a/PHPCSUtils/Utils/Parentheses.php
+++ b/PHPCSUtils/Utils/Parentheses.php
@@ -17,8 +17,8 @@ use PHP_CodeSniffer\Util\Tokens;
  * Utility functions for use when examining parenthesis tokens and arbitrary tokens wrapped
  * in parentheses.
  *
- * In contrast to PHPCS natively, `isset()`, `unset()`, `empty()`, `exit()`, `die()` and `eval()`
- * will be considered parentheses owners by the functions in this class.
+ * In contrast to PHPCS natively (< 4.0), `isset()`, `unset()`, `empty()`, `exit()`, `die()`, `eval()`
+ * and closure `use()` will be considered parentheses owners by the functions in this class.
  *
  * @since 1.0.0
  */
@@ -29,8 +29,9 @@ final class Parentheses
      * Extra tokens which should be considered parentheses owners.
      *
      * - `T_ISSET`, `T_UNSET`, `T_EMPTY`, `T_EXIT` and `T_EVAL` are not PHPCS native parentheses
-     *    owners, but are considered such for the purposes of this class.
+     *    owners until PHPCS 4.0.0, but are considered such for the purposes of this class.
      *    Also see {@link https://github.com/squizlabs/PHP_CodeSniffer/issues/3118 PHPCS#3118}.
+     * - `T_USE` when used for a closure use statement also became a parentheses owner in PHPCS 4.0.0.
      *
      * @since 1.0.0
      *
@@ -42,6 +43,7 @@ final class Parentheses
         \T_EMPTY => \T_EMPTY,
         \T_EXIT  => \T_EXIT,
         \T_EVAL  => \T_EVAL,
+        \T_USE   => \T_USE,
     ];
 
     /**

--- a/PHPCSUtils/Utils/Variables.php
+++ b/PHPCSUtils/Utils/Variables.php
@@ -80,7 +80,7 @@ final class Variables
      * Retrieve the visibility and implementation properties of a class member variable.
      *
      * Main differences with the PHPCS version:
-     * - Removed the parse error warning for properties in interfaces.
+     * - Removed the parse error warning for properties in enums (PHPCS 4.0 makes the same change).
      *   This will now throw the same _"$stackPtr is not a class member var"_ runtime exception as
      *   other non-property variables passed to the method.
      * - Defensive coding against incorrect calls to this method.

--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.inc
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.inc
@@ -15,6 +15,9 @@ class testFECNNamespacedClass extends \PHP_CodeSniffer\Tests\Core\File\testFECNC
 /* testExtendsPartiallyQualifiedClass */
 class testFECNQualifiedClass extends Core\File\RelativeClass {}
 
+/* testExtendsNamespaceRelativeClass */
+class testWithNSOperator extends namespace\Bar {}
+
 /* testNonExtendedInterface */
 interface testFECNInterface {}
 

--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
@@ -121,6 +121,10 @@ class FindExtendedClassNameTest extends UtilityMethodTestCase
                 'identifier' => '/* testExtendsPartiallyQualifiedClass */',
                 'expected'   => 'Core\File\RelativeClass',
             ],
+            'class extends namespace relative class' => [
+                'identifier' => '/* testExtendsNamespaceRelativeClass */',
+                'expected'   => 'namespace\Bar',
+            ],
             'interface does not extend' => [
                 'identifier' => '/* testNonExtendedInterface */',
                 'expected'   => false,

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.inc
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.inc
@@ -21,6 +21,9 @@ class testFIINNamespacedClass implements \PHP_CodeSniffer\Tests\Core\File\testFI
 /* testImplementsPartiallyQualified */
 class testFIINQualifiedClass implements Core\File\RelativeInterface {}
 
+/* testImplementsMultipleNamespaceRelativeInterfaces */
+class testMultiImplementedNSOperator implements namespace\testInterfaceA, namespace\testInterfaceB {}
+
 /* testClassThatExtendsAndImplements */
 class testFECNClassThatExtendsAndImplements extends testFECNClass implements InterfaceA, \NameSpaced\Cat\InterfaceB {}
 

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
@@ -130,6 +130,13 @@ class FindImplementedInterfaceNamesTest extends UtilityMethodTestCase
                 'identifier' => '/* testImplementsPartiallyQualified */',
                 'expected'   => ['Core\File\RelativeInterface'],
             ],
+            'class implements multiple interfaces, namespace relative' => [
+                'identifier' => '/* testImplementsMultipleNamespaceRelativeInterfaces */',
+                'expected'   => [
+                    'namespace\testInterfaceA',
+                    'namespace\testInterfaceB',
+                ],
+            ],
             'class extends and implements' => [
                 'identifier' => '/* testClassThatExtendsAndImplements */',
                 'expected'   => [

--- a/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindStartOfStatementTest.php
@@ -473,8 +473,10 @@ final class FindStartOfStatementTest extends UtilityMethodTestCase
      */
     public function testOpenTag()
     {
+        $php8Names = parent::usesPhp8NameTokens();
+
         $start  = $this->getTargetToken('/* testOpenTag */', T_OPEN_TAG);
-        $start += 2;
+        $start += ($php8Names === true) ? 3 : 2;
         $found  = BCFile::findStartOfStatement(self::$phpcsFile, $start);
 
         $this->assertSame(($start - 1), $found);

--- a/Tests/BackCompat/BCFile/GetConditionTest.php
+++ b/Tests/BackCompat/BCFile/GetConditionTest.php
@@ -116,8 +116,6 @@ class GetConditionTest extends UtilityMethodTestCase
         'T_TRY'        => false,
         'T_CATCH'      => false,
         'T_FINALLY'    => false,
-        'T_PROPERTY'   => false,
-        'T_OBJECT'     => false,
         'T_USE'        => false,
     ];
 

--- a/Tests/BackCompat/BCFile/GetDeclarationNameJSTest.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameJSTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\Tests\PolyfilledTestCase;
 
@@ -35,43 +36,38 @@ class GetDeclarationNameJSTest extends PolyfilledTestCase
     /**
      * Test receiving an expected exception when a non-supported token is passed.
      *
-     * @return void
-     */
-    public function testInvalidTokenPassed()
-    {
-        $this->expectPhpcsException('Token type "T_STRING" is not T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT or T_ENUM');
-
-        $target = $this->getTargetToken('/* testInvalidTokenPassed */', \T_STRING);
-        BCFile::getDeclarationName(self::$phpcsFile, $target);
-    }
-
-    /**
-     * Test receiving "null" when passed an anonymous construct or in case of a parse error.
-     *
-     * @dataProvider dataGetDeclarationNameNull
+     * @dataProvider dataInvalidTokenPassed
      *
      * @param string     $testMarker The comment which prefaces the target token in the test file.
      * @param int|string $targetType Token type of the token to get as stackPtr.
      *
      * @return void
      */
-    public function testGetDeclarationNameNull($testMarker, $targetType)
+    public function testInvalidTokenPassed($testMarker, $targetType)
     {
+        $tokenName = Tokens::tokenName($targetType);
+        $this->expectPhpcsException(
+            'Token type "' . $tokenName . '" is not T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT or T_ENUM'
+        );
+
         $target = $this->getTargetToken($testMarker, $targetType);
-        $result = BCFile::getDeclarationName(self::$phpcsFile, $target);
-        $this->assertNull($result);
+        BCFile::getDeclarationName(self::$phpcsFile, $target);
     }
 
     /**
      * Data provider.
      *
-     * @see GetDeclarationNameTest::testGetDeclarationNameNull()
+     * @see testInvalidTokenPassed() For the array format.
      *
      * @return array<string, array<string, int|string>>
      */
-    public static function dataGetDeclarationNameNull()
+    public static function dataInvalidTokenPassed()
     {
         return [
+            'unsupported token T_STRING' => [
+                'testMarker' => '/* testInvalidTokenPassed */',
+                'targetType' => \T_STRING,
+            ],
             'closure' => [
                 'testMarker' => '/* testClosure */',
                 'targetType' => \T_CLOSURE,

--- a/Tests/BackCompat/BCFile/GetDeclarationNameParseError1Test.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameParseError1Test.php
@@ -26,30 +26,30 @@ class GetDeclarationNameParseError1Test extends PolyfilledTestCase
 {
 
     /**
-     * Test receiving "null" in case of a parse error.
+     * Test receiving an empty string in case of a parse error.
      *
-     * @dataProvider dataGetDeclarationNameNull
+     * @dataProvider dataGetDeclarationName
      *
      * @param string     $testMarker The comment which prefaces the target token in the test file.
      * @param int|string $targetType Token type of the token to get as stackPtr.
      *
      * @return void
      */
-    public function testGetDeclarationNameNull($testMarker, $targetType)
+    public function testGetDeclarationName($testMarker, $targetType)
     {
         $target = $this->getTargetToken($testMarker, $targetType);
         $result = BCFile::getDeclarationName(self::$phpcsFile, $target);
-        $this->assertNull($result);
+        $this->assertSame('', $result);
     }
 
     /**
      * Data provider.
      *
-     * @see testGetDeclarationNameNull() For the array format.
+     * @see testGetDeclarationName() For the array format.
      *
      * @return array<string, array<string, int|string>>
      */
-    public static function dataGetDeclarationNameNull()
+    public static function dataGetDeclarationName()
     {
         return [
             'unfinished function/live coding' => [

--- a/Tests/BackCompat/BCFile/GetDeclarationNameParseError2Test.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameParseError2Test.php
@@ -26,30 +26,30 @@ class GetDeclarationNameParseError2Test extends PolyfilledTestCase
 {
 
     /**
-     * Test receiving "null" in case of a parse error.
+     * Test receiving an empty string in case of a parse error.
      *
-     * @dataProvider dataGetDeclarationNameNull
+     * @dataProvider dataGetDeclarationName
      *
      * @param string     $testMarker The comment which prefaces the target token in the test file.
      * @param int|string $targetType Token type of the token to get as stackPtr.
      *
      * @return void
      */
-    public function testGetDeclarationNameNull($testMarker, $targetType)
+    public function testGetDeclarationName($testMarker, $targetType)
     {
         $target = $this->getTargetToken($testMarker, $targetType);
         $result = BCFile::getDeclarationName(self::$phpcsFile, $target);
-        $this->assertNull($result);
+        $this->assertSame('', $result);
     }
 
     /**
      * Data provider.
      *
-     * @see testGetDeclarationNameNull() For the array format.
+     * @see testGetDeclarationName() For the array format.
      *
      * @return array<string, array<string, int|string>>
      */
-    public static function dataGetDeclarationNameNull()
+    public static function dataGetDeclarationName()
     {
         return [
             'unfinished closure/live coding' => [

--- a/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
+++ b/Tests/BackCompat/BCFile/GetDeclarationNameTest.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;
 
+use PHP_CodeSniffer\Util\Tokens;
 use PHPCSUtils\BackCompat\BCFile;
 use PHPCSUtils\Tests\PolyfilledTestCase;
 
@@ -28,43 +29,38 @@ class GetDeclarationNameTest extends PolyfilledTestCase
     /**
      * Test receiving an expected exception when a non-supported token is passed.
      *
-     * @return void
-     */
-    public function testInvalidTokenPassed()
-    {
-        $this->expectPhpcsException('Token type "T_STRING" is not T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT or T_ENUM');
-
-        $target = $this->getTargetToken('/* testInvalidTokenPassed */', \T_STRING);
-        BCFile::getDeclarationName(self::$phpcsFile, $target);
-    }
-
-    /**
-     * Test receiving "null" when passed an anonymous construct or in case of a parse error.
-     *
-     * @dataProvider dataGetDeclarationNameNull
+     * @dataProvider dataInvalidTokenPassed
      *
      * @param string     $testMarker The comment which prefaces the target token in the test file.
      * @param int|string $targetType Token type of the token to get as stackPtr.
      *
      * @return void
      */
-    public function testGetDeclarationNameNull($testMarker, $targetType)
+    public function testInvalidTokenPassed($testMarker, $targetType)
     {
+        $tokenName = Tokens::tokenName($targetType);
+        $this->expectPhpcsException(
+            'Token type "' . $tokenName . '" is not T_FUNCTION, T_CLASS, T_INTERFACE, T_TRAIT or T_ENUM'
+        );
+
         $target = $this->getTargetToken($testMarker, $targetType);
-        $result = BCFile::getDeclarationName(self::$phpcsFile, $target);
-        $this->assertNull($result);
+        BCFile::getDeclarationName(self::$phpcsFile, $target);
     }
 
     /**
      * Data provider.
      *
-     * @see testGetDeclarationNameNull() For the array format.
+     * @see testInvalidTokenPassed() For the array format.
      *
      * @return array<string, array<string, int|string>>
      */
-    public static function dataGetDeclarationNameNull()
+    public static function dataInvalidTokenPassed()
     {
         return [
+            'unsupported token T_STRING' => [
+                'testMarker' => '/* testInvalidTokenPassed */',
+                'targetType' => \T_STRING,
+            ],
             'closure' => [
                 'testMarker' => '/* testClosure */',
                 'targetType' => \T_CLOSURE,

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -636,9 +636,19 @@ class GetMemberPropertiesTest extends PolyfilledTestCase
                     'nullable_type'   => false,
                 ],
             ],
-            'invalid-property-in-interface' => [
+            'property-in-interface' => [
                 'identifier' => '/* testInterfaceProperty */',
-                'expected'   => [],
+                'expected'   => [
+                    'scope'           => 'protected',
+                    'scope_specified' => true,
+                    'is_static'       => false,
+                    'is_readonly'     => false,
+                    'is_final'        => false,
+                    'type'            => '',
+                    'type_token'      => false,
+                    'type_end_token'  => false,
+                    'nullable_type'   => false,
+                ],
             ],
             'property-in-nested-class-1' => [
                 'identifier' => '/* testNestedProperty 1 */',
@@ -1033,10 +1043,6 @@ class GetMemberPropertiesTest extends PolyfilledTestCase
                     'nullable_type'   => false,
                 ],
             ],
-            'invalid-property-in-enum' => [
-                'identifier' => '/* testEnumProperty */',
-                'expected'   => [],
-            ],
             'php8.1-single-intersection-type' => [
                 'identifier' => '/* testPHP81IntersectionTypes */',
                 'expected'   => [
@@ -1400,6 +1406,7 @@ class GetMemberPropertiesTest extends PolyfilledTestCase
             'method parameter in anon class nested in ternary'       => ['/* testNestedMethodParam 1 */'],
             'method parameter in anon class nested in function call' => ['/* testNestedMethodParam 2 */'],
             'method parameter in enum'                               => ['/* testEnumMethodParamNotProperty */'],
+            'property in enum (parse error)'                         => ['/* testEnumProperty */'],
         ];
     }
 

--- a/Tests/BackCompat/BCFile/GetMethodParametersParseError3Test.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersParseError3Test.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Intentional parse error. Missing closure use parentheses. This should be the only test in the file.
+/* testParseError */
+$cl = function ($a) use

--- a/Tests/BackCompat/BCFile/GetMethodParametersParseError3Test.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersParseError3Test.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCFile;
+
+use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+
+/**
+ * Tests for the \PHPCSUtils\BackCompat\BCFile::getMethodParameters method.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCFile::getMethodParameters
+ *
+ * @group functiondeclarations
+ *
+ * @since 1.1.0
+ */
+final class GetMethodParametersParseError3Test extends UtilityMethodTestCase
+{
+
+    /**
+     * Test receiving an exception when encountering a specific parse error.
+     *
+     * @return void
+     */
+    public function testParseError()
+    {
+        $this->expectPhpcsException('$stackPtr was not a valid T_USE');
+
+        $target = $this->getTargetToken('/* testParseError */', [\T_USE]);
+        BCFile::getMethodParameters(self::$phpcsFile, $target);
+    }
+}

--- a/Tests/BackCompat/BCFile/GetMethodParametersParseError4Test.inc
+++ b/Tests/BackCompat/BCFile/GetMethodParametersParseError4Test.inc
@@ -1,0 +1,5 @@
+<?php
+
+// Intentional parse error. Missing closure use close parenthesis. This should be the only test in the file.
+/* testParseError */
+$cl = function ($a) use (

--- a/Tests/BackCompat/BCFile/GetMethodParametersParseError4Test.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersParseError4Test.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCFile;
+
+use PHPCSUtils\BackCompat\BCFile;
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+
+/**
+ * Tests for the \PHPCSUtils\BackCompat\BCFile::getMethodParameters method.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCFile::getMethodParameters
+ *
+ * @group functiondeclarations
+ *
+ * @since 1.1.0
+ */
+final class GetMethodParametersParseError4Test extends UtilityMethodTestCase
+{
+
+    /**
+     * Test receiving an empty array when encountering a specific parse error.
+     *
+     * @return void
+     */
+    public function testParseError()
+    {
+        $target = $this->getTargetToken('/* testParseError */', [\T_USE]);
+        $result = BCFile::getMethodParameters(self::$phpcsFile, $target);
+
+        $this->assertSame([], $result);
+    }
+}

--- a/Tests/BackCompat/BCTokens/AssignmentTokensTest.php
+++ b/Tests/BackCompat/BCTokens/AssignmentTokensTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCTokens;
+
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\BackCompat\Helper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCTokens::assignmentTokens
+ *
+ * @group tokens
+ *
+ * @since 1.1.0
+ */
+final class AssignmentTokensTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testAssignmentTokens()
+    {
+        $expected = [
+            \T_EQUAL          => \T_EQUAL,
+            \T_AND_EQUAL      => \T_AND_EQUAL,
+            \T_OR_EQUAL       => \T_OR_EQUAL,
+            \T_CONCAT_EQUAL   => \T_CONCAT_EQUAL,
+            \T_DIV_EQUAL      => \T_DIV_EQUAL,
+            \T_MINUS_EQUAL    => \T_MINUS_EQUAL,
+            \T_POW_EQUAL      => \T_POW_EQUAL,
+            \T_MOD_EQUAL      => \T_MOD_EQUAL,
+            \T_MUL_EQUAL      => \T_MUL_EQUAL,
+            \T_PLUS_EQUAL     => \T_PLUS_EQUAL,
+            \T_XOR_EQUAL      => \T_XOR_EQUAL,
+            \T_DOUBLE_ARROW   => \T_DOUBLE_ARROW,
+            \T_SL_EQUAL       => \T_SL_EQUAL,
+            \T_SR_EQUAL       => \T_SR_EQUAL,
+            \T_COALESCE_EQUAL => \T_COALESCE_EQUAL,
+        ];
+
+        $this->assertSame($expected, BCTokens::assignmentTokens());
+    }
+
+    /**
+     * Test whether the method in BCTokens is still in sync with the latest version of PHPCS.
+     *
+     * This group is not run by default and has to be specifically requested to be run.
+     *
+     * @group compareWithPHPCS
+     *
+     * @return void
+     */
+    public function testPHPCSAssignmentTokens()
+    {
+        $version = Helper::getVersion();
+
+        if (\version_compare($version, '3.99.99', '>') === true) {
+            $this->assertSame(Tokens::$assignmentTokens, BCTokens::assignmentTokens());
+        } else {
+            /*
+             * Don't fail this test on the difference between PHPCS 4.x and 3.x.
+             * This test is only run against `dev-master` and `dev-master` is still PHPCS 3.x.
+             */
+            $expected = Tokens::$assignmentTokens;
+            unset($expected[\T_ZSR_EQUAL]);
+
+            $result = BCTokens::assignmentTokens();
+
+            $this->assertSame($expected, $result);
+        }
+    }
+}

--- a/Tests/BackCompat/BCTokens/BlockOpenersTest.php
+++ b/Tests/BackCompat/BCTokens/BlockOpenersTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCTokens;
+
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\BackCompat\Helper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCTokens::blockOpeners
+ *
+ * @group tokens
+ *
+ * @since 1.1.0
+ */
+final class BlockOpenersTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testBlockOpeners()
+    {
+        $expected = [
+            \T_OPEN_CURLY_BRACKET  => \T_OPEN_CURLY_BRACKET,
+            \T_OPEN_SQUARE_BRACKET => \T_OPEN_SQUARE_BRACKET,
+            \T_OPEN_PARENTHESIS    => \T_OPEN_PARENTHESIS,
+        ];
+
+        $this->assertSame($expected, BCTokens::blockOpeners());
+    }
+
+    /**
+     * Test whether the method in BCTokens is still in sync with the latest version of PHPCS.
+     *
+     * This group is not run by default and has to be specifically requested to be run.
+     *
+     * @group compareWithPHPCS
+     *
+     * @return void
+     */
+    public function testPHPCSBlockOpeners()
+    {
+        $version = Helper::getVersion();
+
+        if (\version_compare($version, '3.99.99', '>') === true) {
+            $this->assertSame(Tokens::$blockOpeners, BCTokens::blockOpeners());
+        } else {
+            /*
+             * Don't fail this test on the difference between PHPCS 4.x and 3.x.
+             * This test is only run against `dev-master` and `dev-master` is still PHPCS 3.x.
+             */
+            $expected = Tokens::$blockOpeners;
+            unset($expected[\T_OBJECT]);
+
+            $result = BCTokens::blockOpeners();
+
+            $this->assertSame($expected, $result);
+        }
+    }
+}

--- a/Tests/BackCompat/BCTokens/FunctionNameTokensTest.php
+++ b/Tests/BackCompat/BCTokens/FunctionNameTokensTest.php
@@ -51,6 +51,7 @@ final class FunctionNameTokensTest extends TestCase
             \T_NAME_QUALIFIED       => \T_NAME_QUALIFIED,
             \T_NAME_FULLY_QUALIFIED => \T_NAME_FULLY_QUALIFIED,
             \T_NAME_RELATIVE        => \T_NAME_RELATIVE,
+            \T_ANON_CLASS           => \T_ANON_CLASS,
         ];
 
         \asort($expected);
@@ -85,6 +86,7 @@ final class FunctionNameTokensTest extends TestCase
             $expected[\T_NAME_QUALIFIED] = \T_NAME_QUALIFIED;
             $expected[\T_NAME_FULLY_QUALIFIED] = \T_NAME_FULLY_QUALIFIED;
             $expected[\T_NAME_RELATIVE]        = \T_NAME_RELATIVE;
+            $expected[\T_ANON_CLASS]           = \T_ANON_CLASS;
 
             \asort($expected);
 

--- a/Tests/BackCompat/BCTokens/NameTokensTest.php
+++ b/Tests/BackCompat/BCTokens/NameTokensTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCTokens;
+
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\BackCompat\Helper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCTokens::nameTokens
+ *
+ * @group tokens
+ *
+ * @since 1.1.0
+ */
+final class NameTokensTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testNameTokens()
+    {
+        $expected = [
+            \T_STRING               => \T_STRING,
+            \T_NAME_QUALIFIED       => \T_NAME_QUALIFIED,
+            \T_NAME_FULLY_QUALIFIED => \T_NAME_FULLY_QUALIFIED,
+            \T_NAME_RELATIVE        => \T_NAME_RELATIVE,
+        ];
+
+        $this->assertSame($expected, BCTokens::nameTokens());
+    }
+
+    /**
+     * Test whether the method in BCTokens is still in sync with the latest version of PHPCS.
+     *
+     * This group is not run by default and has to be specifically requested to be run.
+     *
+     * @group compareWithPHPCS
+     *
+     * @return void
+     */
+    public function testPHPCSNameTokens()
+    {
+        if (\version_compare(Helper::getVersion(), '3.99.99', '>') === false) {
+            $this->markTestSkipped('Test only applicable to PHPCS >= 4.x');
+        }
+
+        $this->assertSame(Tokens::NAME_TOKENS, BCTokens::nameTokens()); // @phpstan-ignore classConstant.notFound
+    }
+}

--- a/Tests/BackCompat/BCTokens/ParenthesisOpenersTest.php
+++ b/Tests/BackCompat/BCTokens/ParenthesisOpenersTest.php
@@ -50,6 +50,11 @@ final class ParenthesisOpenersTest extends TestCase
             \T_CATCH      => \T_CATCH,
             \T_DECLARE    => \T_DECLARE,
             \T_MATCH      => \T_MATCH,
+            \T_ISSET      => \T_ISSET,
+            \T_EMPTY      => \T_EMPTY,
+            \T_UNSET      => \T_UNSET,
+            \T_EVAL       => \T_EVAL,
+            \T_EXIT       => \T_EXIT,
         ];
 
         \asort($expected);
@@ -80,8 +85,13 @@ final class ParenthesisOpenersTest extends TestCase
              * Don't fail this test on the difference between PHPCS 4.x and 3.x.
              * This test is only run against `dev-master` and `dev-master` is still PHPCS 3.x.
              */
-            $expected         = Tokens::$parenthesisOpeners;
-            $expected[\T_USE] = \T_USE;
+            $expected           = Tokens::$parenthesisOpeners;
+            $expected[\T_USE]   = \T_USE;
+            $expected[\T_ISSET] = \T_ISSET;
+            $expected[\T_EMPTY] = \T_EMPTY;
+            $expected[\T_UNSET] = \T_UNSET;
+            $expected[\T_EVAL]  = \T_EVAL;
+            $expected[\T_EXIT]  = \T_EXIT;
 
             \asort($expected);
 

--- a/Tests/BackCompat/BCTokens/ParenthesisOpenersTest.php
+++ b/Tests/BackCompat/BCTokens/ParenthesisOpenersTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Test class.
  *
- * @covers \PHPCSUtils\BackCompat\BCTokens::__callStatic
+ * @covers \PHPCSUtils\BackCompat\BCTokens::parenthesisOpeners
  *
  * @group tokens
  *
@@ -34,12 +34,12 @@ final class ParenthesisOpenersTest extends TestCase
      */
     public function testParenthesisOpeners()
     {
-        $version  = Helper::getVersion();
         $expected = [
             \T_ARRAY      => \T_ARRAY,
             \T_LIST       => \T_LIST,
             \T_FUNCTION   => \T_FUNCTION,
             \T_CLOSURE    => \T_CLOSURE,
+            \T_USE        => \T_USE,
             \T_ANON_CLASS => \T_ANON_CLASS,
             \T_WHILE      => \T_WHILE,
             \T_FOR        => \T_FOR,
@@ -51,10 +51,6 @@ final class ParenthesisOpenersTest extends TestCase
             \T_DECLARE    => \T_DECLARE,
             \T_MATCH      => \T_MATCH,
         ];
-
-        if (\version_compare($version, '3.99.99', '>=') === true) {
-            $expected[\T_USE] = \T_USE;
-        }
 
         \asort($expected);
 
@@ -75,6 +71,24 @@ final class ParenthesisOpenersTest extends TestCase
      */
     public function testPHPCSParenthesisOpeners()
     {
-        $this->assertSame(Tokens::$parenthesisOpeners, BCTokens::parenthesisOpeners());
+        $version = Helper::getVersion();
+
+        if (\version_compare($version, '3.99.99', '>') === true) {
+            $this->assertSame(Tokens::$parenthesisOpeners, BCTokens::parenthesisOpeners());
+        } else {
+            /*
+             * Don't fail this test on the difference between PHPCS 4.x and 3.x.
+             * This test is only run against `dev-master` and `dev-master` is still PHPCS 3.x.
+             */
+            $expected         = Tokens::$parenthesisOpeners;
+            $expected[\T_USE] = \T_USE;
+
+            \asort($expected);
+
+            $result = BCTokens::parenthesisOpeners();
+            \asort($result);
+
+            $this->assertSame($expected, $result);
+        }
     }
 }

--- a/Tests/BackCompat/BCTokens/ScopeOpenersTest.php
+++ b/Tests/BackCompat/BCTokens/ScopeOpenersTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCTokens;
+
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\BackCompat\Helper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCTokens::scopeOpeners
+ *
+ * @group tokens
+ *
+ * @since 1.1.0
+ */
+final class ScopeOpenersTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testScopeOpeners()
+    {
+        $expected = [
+            \T_CLASS      => \T_CLASS,
+            \T_ANON_CLASS => \T_ANON_CLASS,
+            \T_INTERFACE  => \T_INTERFACE,
+            \T_TRAIT      => \T_TRAIT,
+            \T_ENUM       => \T_ENUM,
+            \T_NAMESPACE  => \T_NAMESPACE,
+            \T_FUNCTION   => \T_FUNCTION,
+            \T_CLOSURE    => \T_CLOSURE,
+            \T_IF         => \T_IF,
+            \T_SWITCH     => \T_SWITCH,
+            \T_CASE       => \T_CASE,
+            \T_DECLARE    => \T_DECLARE,
+            \T_DEFAULT    => \T_DEFAULT,
+            \T_WHILE      => \T_WHILE,
+            \T_ELSE       => \T_ELSE,
+            \T_ELSEIF     => \T_ELSEIF,
+            \T_FOR        => \T_FOR,
+            \T_FOREACH    => \T_FOREACH,
+            \T_DO         => \T_DO,
+            \T_TRY        => \T_TRY,
+            \T_CATCH      => \T_CATCH,
+            \T_FINALLY    => \T_FINALLY,
+            \T_USE        => \T_USE,
+            \T_MATCH      => \T_MATCH,
+        ];
+
+        $this->assertSame($expected, BCTokens::scopeOpeners());
+    }
+
+    /**
+     * Test whether the method in BCTokens is still in sync with the latest version of PHPCS.
+     *
+     * This group is not run by default and has to be specifically requested to be run.
+     *
+     * @group compareWithPHPCS
+     *
+     * @return void
+     */
+    public function testPHPCSScopeOpeners()
+    {
+        $version = Helper::getVersion();
+
+        if (\version_compare($version, '3.99.99', '>') === true) {
+            $this->assertSame(Tokens::$scopeOpeners, BCTokens::scopeOpeners());
+        } else {
+            /*
+             * Don't fail this test on the difference between PHPCS 4.x and 3.x.
+             * This test is only run against `dev-master` and `dev-master` is still PHPCS 3.x.
+             */
+            $expected = Tokens::$scopeOpeners;
+            unset($expected[\T_PROPERTY], $expected[\T_OBJECT]);
+
+            $result = BCTokens::scopeOpeners();
+
+            $this->assertSame($expected, $result);
+        }
+    }
+}

--- a/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
+++ b/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
@@ -27,30 +27,6 @@ final class UnchangedTokenArraysTest extends TestCase
 {
 
     /**
-     * Tokens that represent assignments.
-     *
-     * @var array<int|string, int|string>
-     */
-    private $assignmentTokens = [
-        \T_EQUAL          => \T_EQUAL,
-        \T_AND_EQUAL      => \T_AND_EQUAL,
-        \T_OR_EQUAL       => \T_OR_EQUAL,
-        \T_CONCAT_EQUAL   => \T_CONCAT_EQUAL,
-        \T_DIV_EQUAL      => \T_DIV_EQUAL,
-        \T_MINUS_EQUAL    => \T_MINUS_EQUAL,
-        \T_POW_EQUAL      => \T_POW_EQUAL,
-        \T_MOD_EQUAL      => \T_MOD_EQUAL,
-        \T_MUL_EQUAL      => \T_MUL_EQUAL,
-        \T_PLUS_EQUAL     => \T_PLUS_EQUAL,
-        \T_XOR_EQUAL      => \T_XOR_EQUAL,
-        \T_DOUBLE_ARROW   => \T_DOUBLE_ARROW,
-        \T_SL_EQUAL       => \T_SL_EQUAL,
-        \T_SR_EQUAL       => \T_SR_EQUAL,
-        \T_COALESCE_EQUAL => \T_COALESCE_EQUAL,
-        \T_ZSR_EQUAL      => \T_ZSR_EQUAL,
-    ];
-
-    /**
      * Tokens that represent equality comparisons.
      *
      * @var array<int|string, int|string>
@@ -147,40 +123,6 @@ final class UnchangedTokenArraysTest extends TestCase
     ];
 
     /**
-     * Tokens that are allowed to open scopes.
-     *
-     * @var array<int|string, int|string>
-     */
-    private $scopeOpeners = [
-        \T_CLASS      => \T_CLASS,
-        \T_ANON_CLASS => \T_ANON_CLASS,
-        \T_INTERFACE  => \T_INTERFACE,
-        \T_TRAIT      => \T_TRAIT,
-        \T_ENUM       => \T_ENUM,
-        \T_NAMESPACE  => \T_NAMESPACE,
-        \T_FUNCTION   => \T_FUNCTION,
-        \T_CLOSURE    => \T_CLOSURE,
-        \T_IF         => \T_IF,
-        \T_SWITCH     => \T_SWITCH,
-        \T_CASE       => \T_CASE,
-        \T_DECLARE    => \T_DECLARE,
-        \T_DEFAULT    => \T_DEFAULT,
-        \T_WHILE      => \T_WHILE,
-        \T_ELSE       => \T_ELSE,
-        \T_ELSEIF     => \T_ELSEIF,
-        \T_FOR        => \T_FOR,
-        \T_FOREACH    => \T_FOREACH,
-        \T_DO         => \T_DO,
-        \T_TRY        => \T_TRY,
-        \T_CATCH      => \T_CATCH,
-        \T_FINALLY    => \T_FINALLY,
-        \T_PROPERTY   => \T_PROPERTY,
-        \T_OBJECT     => \T_OBJECT,
-        \T_USE        => \T_USE,
-        \T_MATCH      => \T_MATCH,
-    ];
-
-    /**
      * Tokens that represent scope modifiers.
      *
      * @var array<int|string, int|string>
@@ -206,18 +148,6 @@ final class UnchangedTokenArraysTest extends TestCase
         \T_ABSTRACT  => \T_ABSTRACT,
         \T_STATIC    => \T_STATIC,
         \T_FINAL     => \T_FINAL,
-    ];
-
-    /**
-     * Tokens that open code blocks.
-     *
-     * @var array<int|string, int|string>
-     */
-    private $blockOpeners = [
-        \T_OPEN_CURLY_BRACKET  => \T_OPEN_CURLY_BRACKET,
-        \T_OPEN_SQUARE_BRACKET => \T_OPEN_SQUARE_BRACKET,
-        \T_OPEN_PARENTHESIS    => \T_OPEN_PARENTHESIS,
-        \T_OBJECT              => \T_OBJECT,
     ];
 
     /**

--- a/Tests/BackCompat/Helper/GetVersionTest.php
+++ b/Tests/BackCompat/Helper/GetVersionTest.php
@@ -54,7 +54,7 @@ final class GetVersionTest extends TestCase
 
         if ($expected === 'dev-master') {
             $this->assertTrue(\version_compare(self::DEVMASTER, $result, '<='));
-        } elseif ($expected === '4.0.x-dev@dev') {
+        } elseif ($expected === '4.x-dev') {
             $this->assertTrue(\version_compare('4.0.0', $result, '=='));
         } else {
             $this->assertSame($expected, $result);

--- a/Tests/Fixers/SpacesFixer/SpacesFixerExceptionsTest.php
+++ b/Tests/Fixers/SpacesFixer/SpacesFixerExceptionsTest.php
@@ -89,8 +89,9 @@ final class SpacesFixerExceptionsTest extends PolyfilledTestCase
         $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
         $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type any, except whitespace;');
 
-        $stackPtr = $this->getTargetToken('/* testPassingWhitespace1 */', \T_WHITESPACE);
-        SpacesFixer::checkAndFix(self::$phpcsFile, $stackPtr, 10, 0, 'Dummy');
+        $stackPtr  = $this->getTargetToken('/* testPassingWhitespace1 */', \T_WHITESPACE);
+        $secondPtr = $this->getTargetToken('/* testPassingWhitespace1 */', \T_ECHO);
+        SpacesFixer::checkAndFix(self::$phpcsFile, $stackPtr, $secondPtr, 0, 'Dummy');
     }
 
     /**
@@ -103,8 +104,9 @@ final class SpacesFixerExceptionsTest extends PolyfilledTestCase
         $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
         $this->expectExceptionMessage('Argument #3 ($secondPtr) must be of type any, except whitespace;');
 
+        $stackPtr  = $this->getTargetToken('/* testPassingWhitespace1 */', \T_CONSTANT_ENCAPSED_STRING);
         $secondPtr = $this->getTargetToken('/* testPassingWhitespace2 */', \T_WHITESPACE);
-        SpacesFixer::checkAndFix(self::$phpcsFile, 10, $secondPtr, 0, 'Dummy');
+        SpacesFixer::checkAndFix(self::$phpcsFile, $stackPtr, $secondPtr, 0, 'Dummy');
     }
 
     /**

--- a/Tests/TestUtils/RulesetDouble/InvalidSniffRef.xml
+++ b/Tests/TestUtils/RulesetDouble/InvalidSniffRef.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="RulesetDoubleTest" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
+
+    <!-- This test deliberately includes an XML file which doesn't exist. -->
+    <rule ref="./MissingFile.xml"/>
+</ruleset>

--- a/Tests/TestUtils/RulesetDouble/RulesetDoubleTest.php
+++ b/Tests/TestUtils/RulesetDouble/RulesetDoubleTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2025 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\TestUtils\RulesetDouble;
+
+use PHPCSUtils\TestUtils\ConfigDouble;
+use PHPCSUtils\TestUtils\RulesetDouble;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Tests for the \PHPCSUtils\TestUtils\RulesetDouble class.
+ *
+ * @covers \PHPCSUtils\TestUtils\RulesetDouble
+ *
+ * @group testutils
+ *
+ * @since 1.1.0
+ */
+final class RulesetDoubleTest extends TestCase
+{
+
+    /**
+     * Verify that creating a ruleset object while limiting the ruleset to a single valid sniff succeeds.
+     *
+     * @return void
+     */
+    public function testRegisteringValidSingleSniff()
+    {
+        $config = new ConfigDouble();
+
+        // Limit the ruleset to just one sniff.
+        $config->sniffs = ['Generic.Files.ByteOrderMark'];
+
+        $ruleset = new RulesetDouble($config);
+
+        $this->assertInstanceOf('\PHP_CodeSniffer\Ruleset', $ruleset);
+        $this->assertCount(1, $ruleset->sniffs, 'Ruleset did not register exactly 1 sniff');
+    }
+
+    /**
+     * Verify that creating a ruleset object while limiting the ruleset to a sniff which doesn't exist,
+     * creates a Ruleset object without any sniffs registered and does not throw an exception.
+     *
+     * @return void
+     */
+    public function testRegisteringSniffWhichDoesntExist()
+    {
+        $config = new ConfigDouble();
+
+        // Limit the ruleset to just one sniff.
+        $config->sniffs = ['Dummy.Dummy.Dummy'];
+
+        $ruleset = new RulesetDouble($config);
+
+        $this->assertInstanceOf('\PHP_CodeSniffer\Ruleset', $ruleset);
+        $this->assertCount(0, $ruleset->sniffs, 'Ruleset has registered a sniff, even though it doesn\'t exist');
+    }
+
+    /**
+     * Verify that if creating a ruleset object would lead to an exception other than the "no sniffs registered"
+     * exception, the exception will still be thrown.
+     *
+     * @return void
+     */
+    public function testOtherExceptionsAreRethrown()
+    {
+        $message  = 'ERROR: Referenced sniff "./MissingFile.xml" does not exist.' . \PHP_EOL;
+        $message .= 'ERROR: No sniffs were registered.' . \PHP_EOL . \PHP_EOL;
+
+        $exception = 'PHP_CodeSniffer\Exceptions\RuntimeException';
+
+        $this->expectException($exception);
+        $this->expectExceptionMessage($message);
+
+        $standard = __DIR__ . '/InvalidSniffRef.xml';
+        $config   = new ConfigDouble(["--standard=$standard"]);
+        new RulesetDouble($config);
+    }
+}

--- a/Tests/TestUtils/UtilityMethodTestCase/GetTargetTokenTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/GetTargetTokenTest.php
@@ -67,7 +67,8 @@ final class GetTargetTokenTest extends PolyfilledTestCase
      */
     public static function dataGetTargetToken()
     {
-        return [
+        // Token offsets based on PHPCS 3.x tokenization.
+        $data = [
             'single-token-type' => [
                 'expected'      => 6,
                 'commentString' => '/* testFindingTarget */',
@@ -120,6 +121,15 @@ final class GetTargetTokenTest extends PolyfilledTestCase
                 'tokenContent'  => "'bar'",
             ],
         ];
+
+        // The PHP open tag + whitespace is two tokens in PHPCS 4.x, while it is one in PHPCS 3.x.
+        if (parent::usesPhp8NameTokens() === true) {
+            foreach ($data as $key => $dataset) {
+                ++$data[$key]['expected'];
+            }
+        }
+
+        return $data;
     }
 
     /**

--- a/Tests/TestUtils/UtilityMethodTestCase/SetUpTestFileTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/SetUpTestFileTest.php
@@ -75,7 +75,14 @@ final class SetUpTestFileTest extends PolyfilledTestCase
         $this->assertNotSame('0', self::$phpcsVersion, 'phpcsVersion was not set');
 
         $this->assertInstanceOf('PHP_CodeSniffer\Files\File', self::$phpcsFile);
-        $this->assertSame(57, self::$phpcsFile->numTokens);
+
+        if (parent::usesPhp8NameTokens() === true) {
+            // The PHP open tag + whitespace is two tokens in PHPCS 4.x.
+            $this->assertSame(58, self::$phpcsFile->numTokens);
+        } else {
+            // PHPCS 3.x.
+            $this->assertSame(57, self::$phpcsFile->numTokens);
+        }
 
         $tokens = self::$phpcsFile->getTokens();
         $this->assertIsArray($tokens);

--- a/Tests/Utils/FilePath/GetNameTest.php
+++ b/Tests/Utils/FilePath/GetNameTest.php
@@ -11,8 +11,8 @@
 namespace PHPCSUtils\Tests\Utils\FilePath;
 
 use PHP_CodeSniffer\Files\DummyFile;
-use PHP_CodeSniffer\Ruleset;
 use PHPCSUtils\TestUtils\ConfigDouble;
+use PHPCSUtils\TestUtils\RulesetDouble;
 use PHPCSUtils\Utils\FilePath;
 use PHPUnit\Framework\TestCase;
 
@@ -55,7 +55,7 @@ final class GetNameTest extends TestCase
         self::$config->sniffs = ['Dummy.Dummy.Dummy']; // Limiting it to just one (dummy) sniff.
         self::$config->cache  = false;
 
-        self::$ruleset = new Ruleset(self::$config);
+        self::$ruleset = new RulesetDouble(self::$config);
     }
 
     /**

--- a/Tests/Utils/FilePath/IsStdinTest.php
+++ b/Tests/Utils/FilePath/IsStdinTest.php
@@ -11,8 +11,8 @@
 namespace PHPCSUtils\Tests\Utils\FilePath;
 
 use PHP_CodeSniffer\Files\DummyFile;
-use PHP_CodeSniffer\Ruleset;
 use PHPCSUtils\TestUtils\ConfigDouble;
+use PHPCSUtils\TestUtils\RulesetDouble;
 use PHPCSUtils\Utils\FilePath;
 use PHPUnit\Framework\TestCase;
 
@@ -55,7 +55,7 @@ final class IsStdinTest extends TestCase
         self::$config->sniffs = ['Dummy.Dummy.Dummy']; // Limiting it to just one (dummy) sniff.
         self::$config->cache  = false;
 
-        self::$ruleset = new Ruleset(self::$config);
+        self::$ruleset = new RulesetDouble(self::$config);
     }
 
     /**

--- a/Tests/Utils/FunctionDeclarations/GetParametersParseError3Test.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersParseError3Test.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\FunctionDeclarations;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\FunctionDeclarations;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\FunctionDeclarations::getParameters method.
+ *
+ * @covers \PHPCSUtils\Utils\FunctionDeclarations::getParameters
+ *
+ * @group functiondeclarations
+ *
+ * @since 1.1.0
+ */
+final class GetParametersParseError3Test extends UtilityMethodTestCase
+{
+
+    /**
+     * Full path to the test case file associated with this test class.
+     *
+     * @var string
+     */
+    protected static $caseFile = '';
+
+    /**
+     * Initialize PHPCS & tokenize the test case file.
+     *
+     * Overloaded to re-use the `$caseFile` from the BCFile test.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        self::$caseFile = \dirname(\dirname(__DIR__)) . '/BackCompat/BCFile/GetMethodParametersParseError3Test.inc';
+        parent::setUpTestFile();
+    }
+
+    /**
+     * Test receiving an exception when encountering a specific parse error.
+     *
+     * @return void
+     */
+    public function testParseError()
+    {
+        $this->expectPhpcsException('The value of argument #2 ($stackPtr) must be the pointer to a closure use statement');
+
+        $target = $this->getTargetToken('/* testParseError */', [\T_USE]);
+        FunctionDeclarations::getParameters(self::$phpcsFile, $target);
+    }
+}

--- a/Tests/Utils/FunctionDeclarations/GetParametersParseError4Test.php
+++ b/Tests/Utils/FunctionDeclarations/GetParametersParseError4Test.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\FunctionDeclarations;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\FunctionDeclarations;
+
+/**
+ * Tests for the \PHPCSUtils\Utils\FunctionDeclarations::getParameters method.
+ *
+ * @covers \PHPCSUtils\Utils\FunctionDeclarations::getParameters
+ *
+ * @group functiondeclarations
+ *
+ * @since 1.1.0
+ */
+final class GetParametersParseError4Test extends UtilityMethodTestCase
+{
+
+    /**
+     * Full path to the test case file associated with this test class.
+     *
+     * @var string
+     */
+    protected static $caseFile = '';
+
+    /**
+     * Initialize PHPCS & tokenize the test case file.
+     *
+     * Overloaded to re-use the `$caseFile` from the BCFile test.
+     *
+     * @beforeClass
+     *
+     * @return void
+     */
+    public static function setUpTestFile()
+    {
+        self::$caseFile = \dirname(\dirname(__DIR__)) . '/BackCompat/BCFile/GetMethodParametersParseError4Test.inc';
+        parent::setUpTestFile();
+    }
+
+    /**
+     * Test receiving an empty array when encountering a specific parse error.
+     *
+     * @return void
+     */
+    public function testParseError()
+    {
+        $target = $this->getTargetToken('/* testParseError */', [\T_USE]);
+        $result = FunctionDeclarations::getParameters(self::$phpcsFile, $target);
+
+        $this->assertSame([], $result);
+    }
+}

--- a/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.inc
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.inc
@@ -6,8 +6,5 @@ class testDeclarationWithComments
     // phpcs:ignore Stnd.Cat.Sniff -- For reasons.
     \Package\SubDir /* comment */ \ /* comment */ SomeClass /* comment */ {}
 
-/* testExtendedClassUsingNamespaceOperator */
-class testWithNSOperator extends namespace\Bar {}
-
 /* testExtendedClassStrayComma */
 class testExtendedClassStrayComma extends , testClass {} // Intentional parse error.

--- a/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindExtendedClassNameDiffTest.php
@@ -60,10 +60,6 @@ final class FindExtendedClassNameDiffTest extends UtilityMethodTestCase
                 'testMarker' => '/* testDeclarationWithComments */',
                 'expected'   => '\Package\SubDir\SomeClass',
             ],
-            'namespace-operator' => [
-                'testMarker' => '/* testExtendedClassUsingNamespaceOperator */',
-                'expected'   => 'namespace\Bar',
-            ],
             'parse-error-stray-comma' => [
                 'testMarker' => '/* testExtendedClassStrayComma */',
                 'expected'   => 'testClass',

--- a/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.inc
+++ b/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.inc
@@ -13,8 +13,5 @@ class testDeclarationWithComments
         // comment
         InterfaceB {}
 
-/* testDeclarationMultiImplementedNamespaceOperator */
-class testMultiImplementedNSOperator implements namespace\testInterfaceA, namespace\testInterfaceB {}
-
 /* testMultiImplementedStrayComma */
 class testMultiImplementedStrayComma implements testInterfaceA, , testInterfaceB {} // Intentional parse error.

--- a/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.php
+++ b/Tests/Utils/ObjectDeclarations/FindImplementedInterfaceNamesDiffTest.php
@@ -63,13 +63,6 @@ final class FindImplementedInterfaceNamesDiffTest extends UtilityMethodTestCase
                     'InterfaceB',
                 ],
             ],
-            'namespace-operator' => [
-                'testMarker' => '/* testDeclarationMultiImplementedNamespaceOperator */',
-                'expected'   => [
-                    'namespace\testInterfaceA',
-                    'namespace\testInterfaceB',
-                ],
-            ],
             'parse-error-stray-comma' => [
                 'testMarker' => '/* testMultiImplementedStrayComma */',
                 'expected'   => [

--- a/Tests/Utils/ObjectDeclarations/GetNameJSTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameJSTest.php
@@ -52,7 +52,7 @@ final class GetNameJSTest extends BCFile_GetDeclarationNameJSTest
      *
      * @return void
      */
-    public function testInvalidTokenPassed()
+    public function testTrulyInvalidTokenPassed()
     {
         $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
         $this->expectExceptionMessage(
@@ -66,20 +66,38 @@ final class GetNameJSTest extends BCFile_GetDeclarationNameJSTest
     /**
      * Test receiving "null" when passed an anonymous construct or in case of a parse error.
      *
+     * Note: the upstream and the BCFile method no longer returns `null`, but throws an exception.
+     * For PHPCSUtils, this change needs to wait for the next major.
+     *
      * {@internal Method name not adjusted as otherwise it wouldn't overload the parent method.}
      *
-     * @dataProvider dataGetDeclarationNameNull
+     * @dataProvider dataInvalidTokenPassed
      *
      * @param string     $testMarker The comment which prefaces the target token in the test file.
      * @param int|string $targetType Token type of the token to get as stackPtr.
      *
      * @return void
      */
-    public function testGetDeclarationNameNull($testMarker, $targetType)
+    public function testInvalidTokenPassed($testMarker, $targetType)
     {
         $target = $this->getTargetToken($testMarker, $targetType);
         $result = ObjectDeclarations::getName(self::$phpcsFile, $target);
         $this->assertNull($result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testInvalidTokenPassed() For the array format.
+     *
+     * @return array<string, array<string, int|string>>
+     */
+    public static function dataInvalidTokenPassed()
+    {
+        $data = parent::dataInvalidTokenPassed();
+        unset($data['unsupported token T_STRING']);
+
+        return $data;
     }
 
     /**

--- a/Tests/Utils/ObjectDeclarations/GetNameParseError1Test.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameParseError1Test.php
@@ -50,14 +50,17 @@ final class GetNameParseError1Test extends BCFile_GetDeclarationNameParseError1T
     /**
      * Test receiving "null" in case of a parse error.
      *
-     * @dataProvider dataGetDeclarationNameNull
+     * Note: the upstream and the BCFile method no longer returns `null`, but an empty string.
+     * For PHPCSUtils, this change needs to wait for the next major.
+     *
+     * @dataProvider dataGetDeclarationName
      *
      * @param string     $testMarker The comment which prefaces the target token in the test file.
      * @param int|string $targetType Token type of the token to get as stackPtr.
      *
      * @return void
      */
-    public function testGetDeclarationNameNull($testMarker, $targetType)
+    public function testGetDeclarationName($testMarker, $targetType)
     {
         $target = $this->getTargetToken($testMarker, $targetType);
         $result = ObjectDeclarations::getName(self::$phpcsFile, $target);

--- a/Tests/Utils/ObjectDeclarations/GetNameParseError2Test.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameParseError2Test.php
@@ -50,14 +50,17 @@ final class GetNameParseError2Test extends BCFile_GetDeclarationNameParseError2T
     /**
      * Test receiving "null" in case of a parse error.
      *
-     * @dataProvider dataGetDeclarationNameNull
+     * Note: the upstream and the BCFile method no longer returns `null`, but an empty string.
+     * For PHPCSUtils, this change needs to wait for the next major.
+     *
+     * @dataProvider dataGetDeclarationName
      *
      * @param string     $testMarker The comment which prefaces the target token in the test file.
      * @param int|string $targetType Token type of the token to get as stackPtr.
      *
      * @return void
      */
-    public function testGetDeclarationNameNull($testMarker, $targetType)
+    public function testGetDeclarationName($testMarker, $targetType)
     {
         $target = $this->getTargetToken($testMarker, $targetType);
         $result = ObjectDeclarations::getName(self::$phpcsFile, $target);

--- a/Tests/Utils/ObjectDeclarations/GetNameTest.php
+++ b/Tests/Utils/ObjectDeclarations/GetNameTest.php
@@ -52,7 +52,7 @@ final class GetNameTest extends BCFile_GetDeclarationNameTest
      *
      * @return void
      */
-    public function testInvalidTokenPassed()
+    public function testTrulyInvalidTokenPassed()
     {
         $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
         $this->expectExceptionMessage(
@@ -66,20 +66,38 @@ final class GetNameTest extends BCFile_GetDeclarationNameTest
     /**
      * Test receiving "null" when passed an anonymous construct or in case of a parse error.
      *
+     * Note: the upstream and the BCFile method no longer returns `null`, but throws an exception.
+     * For PHPCSUtils, this change needs to wait for the next major.
+     *
      * {@internal Method name not adjusted as otherwise it wouldn't overload the parent method.}
      *
-     * @dataProvider dataGetDeclarationNameNull
+     * @dataProvider dataInvalidTokenPassed
      *
      * @param string     $testMarker The comment which prefaces the target token in the test file.
      * @param int|string $targetType Token type of the token to get as stackPtr.
      *
      * @return void
      */
-    public function testGetDeclarationNameNull($testMarker, $targetType)
+    public function testInvalidTokenPassed($testMarker, $targetType)
     {
         $target = $this->getTargetToken($testMarker, $targetType);
         $result = ObjectDeclarations::getName(self::$phpcsFile, $target);
         $this->assertNull($result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testInvalidTokenPassed() For the array format.
+     *
+     * @return array<string, array<string, int|string>>
+     */
+    public static function dataInvalidTokenPassed()
+    {
+        $data = parent::dataInvalidTokenPassed();
+        unset($data['unsupported token T_STRING']);
+
+        return $data;
     }
 
     /**

--- a/Tests/Utils/Parentheses/ParenthesesTest.inc
+++ b/Tests/Utils/Parentheses/ParenthesesTest.inc
@@ -72,6 +72,11 @@ $m = match(count($a)) {
     default => false,
 };
 
+/* testClosureUseInArray */
+$array = array(
+    'cl' => function () use /*comment*/ ($var) {},
+);
+
 // Intentional parse error. This has to be the last test in the file.
 /* testParseError */
 declare(ticks=1

--- a/Tests/Utils/Parentheses/ParenthesesTest.php
+++ b/Tests/Utils/Parentheses/ParenthesesTest.php
@@ -192,6 +192,11 @@ final class ParenthesesTest extends UtilityMethodTestCase
             'code'    => \T_VARIABLE,
             'content' => '$a',
         ],
+        'testClosureUseInArray' => [
+            'marker'  => '/* testClosureUseInArray */',
+            'code'    => \T_VARIABLE,
+            'content' => '$var',
+        ],
         'testParseError-1' => [
             'marker'  => '/* testParseError */',
             'code'    => \T_LNUMBER,
@@ -225,6 +230,7 @@ final class ParenthesesTest extends UtilityMethodTestCase
         'T_LIST'       => false,
         'T_FUNCTION'   => false,
         'T_CLOSURE'    => false,
+        'T_USE'        => false,
         'T_ANON_CLASS' => false,
         'T_WHILE'      => false,
         'T_FOR'        => false,
@@ -955,6 +961,24 @@ final class ParenthesesTest extends UtilityMethodTestCase
                     'lastIfElseOwner'       => false,
                 ],
             ],
+            'testClosureUseInArray' => [
+                'testName'        => 'testClosureUseInArray',
+                'expectedResults' => [
+                    'firstOpener'           => -17,
+                    'firstCloser'           => 7,
+                    'firstOwner'            => -18,
+                    // T_USE is not really a scope opener here, but it is what it is.
+                    'firstScopeOwnerOpener' => -1,
+                    'firstScopeOwnerCloser' => 1,
+                    'firstScopeOwnerOwner'  => -5,
+                    'lastOpener'            => -1,
+                    'lastCloser'            => 1,
+                    'lastOwner'             => -5,
+                    'lastArrayOpener'       => -17,
+                    'lastFunctionCloser'    => false,
+                    'lastIfElseOwner'       => false,
+                ],
+            ],
             'testParseError-1' => [
                 'testName'        => 'testParseError-1',
                 'expectedResults' => [
@@ -1198,6 +1222,13 @@ final class ParenthesesTest extends UtilityMethodTestCase
                     'T_MATCH' => true,
                 ],
             ],
+            'testClosureUseInArray' => [
+                'testName'        => 'testClosureUseInArray',
+                'expectedResults' => [
+                    'T_ARRAY' => true,
+                    'T_USE'   => true,
+                ],
+            ],
             'testParseError-1' => [
                 'testName'        => 'testParseError-1',
                 'expectedResults' => [],
@@ -1340,6 +1371,11 @@ final class ParenthesesTest extends UtilityMethodTestCase
                 'validOwners' => [\T_CATCH],
                 'expected'    => false,
             ],
+            'testClosureUseInArray' => [
+                'testName'    => 'testClosureUseInArray',
+                'validOwners' => [\T_USE],
+                'expected'    => false,
+            ],
         ];
     }
 
@@ -1371,7 +1407,7 @@ final class ParenthesesTest extends UtilityMethodTestCase
      *
      * @see testLastOwnerIn() For the array format.
      *
-     * @return array<string, array<int|string|array<int|string>|false>>
+     * @return array<string, array<string, int|string|array<int|string>|false>>
      */
     public static function dataLastOwnerIn()
     {
@@ -1461,6 +1497,11 @@ final class ParenthesesTest extends UtilityMethodTestCase
                 'testName'    => 'testMatch-$a',
                 'validOwners' => [\T_CATCH, \T_MATCH],
                 'expected'    => false,
+            ],
+            'testClosureUseInArray' => [
+                'testName'    => 'testClosureUseInArray',
+                'validOwners' => [\T_USE],
+                'expected'    => -5,
             ],
         ];
     }

--- a/Tests/Utils/Scopes/IsOOPropertyTest.inc
+++ b/Tests/Utils/Scopes/IsOOPropertyTest.inc
@@ -41,7 +41,7 @@ $a = new class {
 };
 
 interface MyInterface {
-    // Intentional parse error. Properties are not allowed in interfaces.
+    // Properties are allowed in interfaces since PHP 8.4 (with a property hook).
     /* testInterfaceProp */
     public $interfaceProp = false;
 

--- a/Tests/Utils/Scopes/IsOOPropertyTest.php
+++ b/Tests/Utils/Scopes/IsOOPropertyTest.php
@@ -125,7 +125,7 @@ final class IsOOPropertyTest extends UtilityMethodTestCase
             ],
             'interface-property' => [
                 'testMarker' => '/* testInterfaceProp */',
-                'expected'   => false,
+                'expected'   => true,
             ],
             'interface-method-param' => [
                 'testMarker' => '/* testInterfaceMethodParameter */',

--- a/Tests/Utils/Variables/GetMemberPropertiesDiffTest.inc
+++ b/Tests/Utils/Variables/GetMemberPropertiesDiffTest.inc
@@ -1,13 +1,3 @@
 <?php
 
-interface Base
-{
-    /* testInterfaceProperty */
-    protected $anonymous;
-}
-
-enum Suit
-{
-    /* testEnumProperty */
-    protected $anonymous;
-}
+// Placeholder file.

--- a/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesDiffTest.php
@@ -55,37 +55,4 @@ final class GetMemberPropertiesDiffTest extends PolyfilledTestCase
 
         Variables::getMemberProperties(self::$phpcsFile, 10000);
     }
-
-    /**
-     * Test receiving an expected exception when an (invalid) interface or enum property is passed.
-     *
-     * @dataProvider dataNotClassPropertyException
-     *
-     * @param string $testMarker Comment which precedes the test case.
-     *
-     * @return void
-     */
-    public function testNotClassPropertyException($testMarker)
-    {
-        $this->expectException('PHPCSUtils\Exceptions\ValueError');
-        $this->expectExceptionMessage('The value of argument #2 ($stackPtr) must be the pointer to a class member var');
-
-        $variable = $this->getTargetToken($testMarker, \T_VARIABLE);
-        Variables::getMemberProperties(self::$phpcsFile, $variable);
-    }
-
-    /**
-     * Data provider.
-     *
-     * @see testNotClassPropertyException()
-     *
-     * @return array<string, array<string>>
-     */
-    public static function dataNotClassPropertyException()
-    {
-        return [
-            'interface property' => ['/* testInterfaceProperty */'],
-            'enum property'      => ['/* testEnumProperty */'],
-        ];
-    }
 }

--- a/Tests/Utils/Variables/GetMemberPropertiesTest.php
+++ b/Tests/Utils/Variables/GetMemberPropertiesTest.php
@@ -91,26 +91,6 @@ final class GetMemberPropertiesTest extends BCFile_GetMemberPropertiesTest
     }
 
     /**
-     * Data provider.
-     *
-     * @see testGetMemberProperties()
-     *
-     * @return array<string, array<string|array<string, string|int|bool>>>
-     */
-    public static function dataGetMemberProperties()
-    {
-        $data = parent::dataGetMemberProperties();
-
-        /*
-         * Remove the data sets related to the invalid interface/enum properties.
-         * These will now throw an exception instead.
-         */
-        unset($data['invalid-property-in-interface'], $data['invalid-property-in-enum']);
-
-        return $data;
-    }
-
-    /**
      * Verify that the build-in caching is used when caching is enabled.
      *
      * @return void

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.13.0 || 4.0.x-dev@dev",
+        "squizlabs/php_codesniffer" : "^3.13.0 || 4.x-dev@dev",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0"
     },
     "require-dev" : {


### PR DESCRIPTION
## Context

The PHPCS 4 branch has been recreated - see PHPCSStandards/PHP_CodeSniffer#120

The new branch is called `4.x` - in contrast to the "old" `4.0` branch.

PHPCSUtils needs to be made compatible with the additional changes made for PHPCS 4.x, as well as start testing against the _new_ PHPCS 4 branch.

This PR intends to do that.

## Commits

### GH Actions: update for new upstream 4.x branch

### BCTokens: sync with PHPCS 4.0 [1] / removed JS tokens 

PHPCSStandards/PHP_CodeSniffer#983 (JS/CSS support drop) removes the `T_ZSR_EQUAL`, `T__PROPERTY` and `T_OBJECT` tokens, including removing them from the `Tokens::$assignmentTokens`, `Tokens::$blockOpeners` and `Tokens::$scopeOpeners` token arrays.

This commit aligns these token arrays in the `BCFile` class with their PHPCS 4.0 contents.

Includes updated tests.

### BCTokens: sync with PHPCS 4.0 [2] / anon class is function name token 

PHPCSStandards/PHP_CodeSniffer#47 adds the `T_ANON_CLASS` token to the `Tokens::$functionNameTokens` array.

Includes updated tests.

### BCTokens: sync with PHPCS 4.0 [3] / closure use is parenthesis owner 

PHPCSStandards/PHP_CodeSniffer#1013 made `T_USE` for closure use a parenthesis owner.

While the token will now be included in the `BCTokens::parenthesisOpeners()` return value, while on PHPCS 3.x, it will still not be a parentheses owner.
Use the methods in the `Parentheses` class to work out whether `T_USE` is actually a parenthesis owner in a PHPCS cross-version compatible manner (commit upcoming).

Includes updated tests.

### BCTokens: sync with PHPCS 4.0 [4] / more parenthesis owners 

PHPCSStandards/PHP_CodeSniffer#1014 made `T_ISSET`, `T_UNSET`, `T_EMPTY`, `T_EVAL` and `T_EXIT` parenthesis owners.

While the token will now be included in the `BCTokens::parenthesisOpeners()` return value, while on PHPCS 3.x, they will still not be parentheses owners.
Use the methods in the `Parentheses` class to work out whether any of these tokens is actually a parenthesis owner in a PHPCS cross-version compatible manner.

Note: The `Parentheses` methods have supported these tokens as parenthesis owners since PHPCSUtils 1.0.0.

Includes updated tests.

### BCTokens: sync with PHPCS 4.0 [5] / namespaced name tokens 

PHPCSStandards/PHP_CodeSniffer#1020 (namespaced names) adds a new `Tokens::NAME_TOKENS` token array and also adds these tokens to the `Tokens::$functionNameTokens` token array. This last bit was already handled previously.

This commit now adds the mirror function for the `Tokens::NAME_TOKENS` token array.

Includes updated tests.

### UtilityMethodTestCase: make compatible with PHPCS 4.0 

This commit introduces a test double for the PHPCS native `Ruleset` class.

PHPCS >= 4.0 is stricter about registering sniffs, so when "mocking" a registered sniff, it will throw a "No sniffs were registered." `RuntimeException`.

Most utility method tests don't need for any sniffs to be registered, they just need a `Ruleset` object to be available to allow for creating a `File` object. This test double accommodates that by catching the exception.

### Tests: deal with difference in tokenization of PHP open tag in PHPCS 4.0 

The whitespace which may be included in a long PHP open tag is tokenized as a separate `T_WHITESPACE` token as of PHPCS 4.0.

This commit updates token position expectations to take this into account.

Related to upstream:
* PHPCSStandards/PHP_CodeSniffer#593
* PHPCSStandards/PHP_CodeSniffer#1015

### Parentheses::getOwner(): T_USE is now a parenthesis owner 

`T_USE` tokens used for closure use statements are parentheses owners as of PHPCS 4.0.0.

This commit updated the `Parentheses::getOwner()` method to treat closure `T_USE` tokens as parentheses owners, PHPCS cross-version.

Includes additional unit tests for this case.

Refs:
* PHPCSStandards/PHP_CodeSniffer#1013
* squizlabs/PHP_CodeSniffer#2593
* squizlabs/PHP_CodeSniffer#3104

### BCFile::getMethodParameters(): sync with PHPCS 4.0 / T_USE is parenthesis owner

This change was already previously handled in PHPCSUtils. This commit just syncs in the new tests as introduced upstream.

Ref: PHPCSStandards/PHP_CodeSniffer#1013

### BCFile::getMemberProperties(): sync with PHPCS 4.0 / remove parse error warning + PHP 8.4 interface properties

As of PHPCS 4.0, the `File::getMemberProperties()` method:
* ... will handle properties in interfaces to support PHP 8.4, in which this is now allowed.
* ... will no longer throw a parse error warning.

This commit makes the necessary updates in PHPCSUtils for the same:
* Adds `T_INTERFACE` to the `Collections::ooPropertyScopes()` for PHP 8.4 properties in interfaces support.
* Updates the test expectations for the `Scopes::isOOProperty()` method to allow for PHP 8.4 properties in interfaces.
* Updates the `BCFile::getMemberProperties()` polyfill to mirror the PHPCS 4.0 version of the method.
* Updates various tests for both the `BCFile::getMemberProperties()` and the `Variables::getMemberProperties()` methods to be in line with the changes.

Ref: PHPCSStandards/PHP_CodeSniffer#991

### BCFile::getDeclarationName(): sync with PHPCS 4.0 / stop accepting tokens for non-named structures

The `[BC]File::getDeclarationName()` method - for historic reasons - accepted the `T_CLOSURE` and `T_ANON_CLASS` tokens, even though these structures will never have a name, and returned `null` for those tokens.

This commit changes the `BCFile::getDeclarationName()` method to no longer accept those tokens and throw an exception if they are passed to the method instead.

As a secondary change, when the name of a valid structure cannot be determined, the method will now no longer return `null`, but will return an empty string.
This normalizes the return type of the method to always return a string (or throw an exception).

Includes updated unit tests to match.

This change mirrors the upstream change made to the `File::getDeclarationName()` method in PHPCS 4.0.

Note: this change is NOT mirrored in the `ObjectDeclarations::getName()` method, as changing it there would constitute a breaking change for PHPCSUtils, so that change needs to wait until PHPCSUtils 2.0.

Ref: PHPCSStandards/PHP_CodeSniffer#1007

### BCFile::findExtendedClassName(): sync with PHPCS 4.0 / handling of namespace relative parent classes

The PHPCS `File::findExtendedClassName()` method did not handle namespace relative parent classes correctly prior to PHPCS 4.0.

The PHPCSUtils native `ObjectDeclarations::findExtendedClassName()` method **_did_** already handle this correctly.

This commit adds the PHPCS 4.x version of the `findExtendedClassName()` method to the `BCFile` class.

Includes moving related tests from the "Diff" test file to the "normal" test file and updating the docs to annotate this is no longer a difference between the PHPCS native and PHPCSUtils versions of the method.

### BCFile::findImplementedInterfaceNames(): sync with PHPCS 4.0 / handling of namespace relative interfaces

The PHPCS `File::findImplementedInterfaceNames()` method did not handle namespace relative interfaces correctly prior to PHPCS 4.0.

The PHPCSUtils native `ObjectDeclarations::findImplementedInterfaceNames()` method **_did_** already handle this correctly.

This commit adds the PHPCS 4.x version of the `findImplementedInterfaceNames()` method to the `BCFile` class.

Includes moving related tests from the "Diff" test file to the "normal" test file and updating the docs to annotate this is no longer a difference between the PHPCS native and PHPCSUtils versions of the method.