### PR TITLE
GetVersionTest: update to allow for PHPCS 4.x releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,7 +214,7 @@ jobs:
         if: ${{ matrix.risky == false }}
         run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }} --no-coverage
         env:
-          PHPCS_VERSION: ${{ matrix.phpcs_version == '4.x-dev' && '4.0.0' || matrix.phpcs_version }}
+          PHPCS_VERSION: ${{ matrix.phpcs_version }}
           PHPCSUTILS_USE_CACHE: false
 
       - name: Run the unit tests with caching (non-risky)
@@ -223,7 +223,7 @@ jobs:
           vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }}
           --testsuite PHPCSUtils --no-coverage ${{ steps.phpunit_config.outputs.EXTRA_ARGS }}
         env:
-          PHPCS_VERSION: ${{ matrix.phpcs_version == '4.x-dev' && '4.0.0' || matrix.phpcs_version }}
+          PHPCS_VERSION: ${{ matrix.phpcs_version }}
           PHPCSUTILS_USE_CACHE: true
 
       # Only run the "compare with PHPCS" group against dev-master as it ensures that PHPCSUtils
@@ -233,7 +233,7 @@ jobs:
         # "nothing" is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
         run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }} --no-coverage --group compareWithPHPCS --exclude-group nothing
         env:
-          PHPCS_VERSION: ${{ matrix.phpcs_version == '4.x-dev' && '4.0.0' || matrix.phpcs_version }}
+          PHPCS_VERSION: ${{ matrix.phpcs_version }}
 
       # Run the "xtra" group against high and low PHPCS as these are tests safeguarding PHPCS itself.
       - name: Run the unit tests (risky, xtra)
@@ -241,7 +241,7 @@ jobs:
         # "nothing" is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
         run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }} --no-coverage --group xtra --exclude-group nothing
         env:
-          PHPCS_VERSION: ${{ matrix.phpcs_version == '4.x-dev' && '4.0.0' || matrix.phpcs_version }}
+          PHPCS_VERSION: ${{ matrix.phpcs_version }}
 
 
   #### CODE COVERAGE STAGE ####

--- a/.github/workflows/update-phpcs-versionnr.yml
+++ b/.github/workflows/update-phpcs-versionnr.yml
@@ -56,11 +56,21 @@ jobs:
         with:
           ref: ${{ steps.branches.outputs.BASE }}
 
-      - name: Update the version constant in the test file
+      - name: Update the version constant in the test file (PHPCS 3)
+        if: ${{ startsWith( steps.version.outputs.TAG, '3.' ) }}
         uses: jacobtomlinson/gha-find-replace@v3
         with:
-          find: "const DEVMASTER = '[^']+';"
-          replace: "const DEVMASTER = '${{ steps.version.outputs.TAG }}';"
+          find: "const LATEST_3X_VERSION = '[^']+';"
+          replace: "const LATEST_3X_VERSION = '${{ steps.version.outputs.TAG }}';"
+          include: "Tests/BackCompat/Helper/GetVersionTest.php"
+          regex: true
+
+      - name: Update the version constant in the test file (PHPCS 4)
+        if: ${{ startsWith( steps.version.outputs.TAG, '4.' ) }}
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: "const LATEST_4X_VERSION = '[^']+';"
+          replace: "const LATEST_4X_VERSION = '${{ steps.version.outputs.TAG }}';"
           include: "Tests/BackCompat/Helper/GetVersionTest.php"
           regex: true
 

--- a/Tests/BackCompat/Helper/GetVersionTest.php
+++ b/Tests/BackCompat/Helper/GetVersionTest.php
@@ -24,13 +24,22 @@ final class GetVersionTest extends TestCase
 {
 
     /**
-     * Version number of the last PHPCS release.
+     * Version number of the last PHPCS 3.x release.
      *
      * {@internal This should be updated regularly, but shouldn't cause issues if it isn't.}
      *
      * @var string
      */
-    const DEVMASTER = '3.13.0';
+    const LATEST_3X_VERSION = '3.13.0';
+
+    /**
+     * Version number of the last PHPCS 4.x release.
+     *
+     * {@internal This should be updated regularly, but shouldn't cause issues if it isn't.}
+     *
+     * @var string
+     */
+    const LATEST_4X_VERSION = '4.0.0';
 
     /**
      * Test the method.
@@ -53,9 +62,9 @@ final class GetVersionTest extends TestCase
         $result = Helper::getVersion();
 
         if ($expected === 'dev-master') {
-            $this->assertTrue(\version_compare(self::DEVMASTER, $result, '<='));
+            $this->assertTrue(\version_compare(self::LATEST_3X_VERSION, $result, '<='));
         } elseif ($expected === '4.x-dev') {
-            $this->assertTrue(\version_compare('4.0.0', $result, '=='));
+            $this->assertTrue(\version_compare(self::LATEST_4X_VERSION, $result, '<='));
         } else {
             $this->assertSame($expected, $result);
         }


### PR DESCRIPTION
This commit updates both the `GetVersionTest` class, as well as the GH Actions script which auto-updates the script, to allow for the `4.x-dev` branch.

It also removes the work-around which was in place for the experimental job against `4.x-dev` in the GH Actions test script. This should no longer be needed.