### PR TITLE
Make PHPCS 4.x support official

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -36,6 +36,12 @@ jobs:
         php: ['5.4', 'latest']
         phpcs_version: ['lowest', 'dev-master']
 
+        include:
+          - php: '7.2'
+            phpcs_version: '4.x-dev'
+          - php: 'latest'
+            phpcs_version: '4.x-dev'
+
     name: "QTest${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 
     steps:
@@ -47,7 +53,7 @@ jobs:
       - name: Setup ini config
         id: set_ini
         run: |
-          if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
+          if [ "${{ matrix.phpcs_version }}" == "lowest" ]; then
             echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
           else
             echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
@@ -60,8 +66,12 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      - name: "Composer: set PHPCS version for tests (master)"
-        if: ${{ matrix.phpcs_version != 'lowest' }}
+      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
+      - name: 'Composer: remove PHPCSDevCS'
+        run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
+
+      - name: "Composer: set PHPCS version for tests (dev)"
+        if: ${{ contains( matrix.phpcs_version, 'dev') }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
       - name: "Composer: use lock file when necessary"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v3"
         with:
-          # For the PHP "nightly", we need to install with ignore platform reqs as not all dependencies may allow it yet.
+          # For PHP "nightly", we need to install with ignore platform reqs as not all dependencies may allow it yet.
           composer-options: ${{ matrix.php == '8.5' && '--ignore-platform-req=php+' || '' }}
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
@@ -85,9 +85,19 @@ jobs:
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
         php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
-        phpcs_version: ['lowest', 'dev-master']
+        phpcs_version: ['lowest', 'dev-master', '4.x-dev']
         risky: [false]
         experimental: [false]
+
+        exclude:
+          - php: '5.5'
+            phpcs_version: '4.x-dev'
+          - php: '5.6'
+            phpcs_version: '4.x-dev'
+          - php: '7.0'
+            phpcs_version: '4.x-dev'
+          - php: '7.1'
+            phpcs_version: '4.x-dev'
 
         include:
           - php: '5.6'
@@ -107,27 +117,22 @@ jobs:
             risky: false
             experimental: true
 
-          - php: '7.4'
-            phpcs_version: '4.x-dev'
-            risky: false
-            experimental: true
-
           # Run risky tests separately.
-          - php: '7.4'
+          - php: '5.4'
+            phpcs_version: 'lowest'
+            risky: true
+            experimental: true
+
+          - php: '5.4'
+            phpcs_version: 'dev-master'
+            risky: true
+            experimental: true
+
+          - php: '7.2'
             phpcs_version: '4.x-dev'
             risky: true
             experimental: true
 
-          - php: '5.4'
-            phpcs_version: 'lowest'
-            risky: true
-            experimental: true
-
-          - php: '5.4'
-            phpcs_version: 'dev-master'
-            risky: true
-            experimental: true
-
           - php: '8.4'
             phpcs_version: 'lowest'
             risky: true
@@ -135,6 +140,11 @@ jobs:
 
           - php: '8.4'
             phpcs_version: 'dev-master'
+            risky: true
+            experimental: true
+
+          - php: '8.4'
+            phpcs_version: '4.x-dev'
             risky: true
             experimental: true
 
@@ -165,13 +175,13 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      - name: "Composer: set PHPCS version for tests (master)"
-        if: ${{ matrix.phpcs_version != 'lowest' }}
-        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
-
       # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
       - name: 'Composer: remove PHPCSDevCS'
-        run: composer remove --dev --no-update phpcsstandards/phpcsdevcs
+        run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
+
+      - name: "Composer: set PHPCS version for tests (dev)"
+        if: ${{ contains( matrix.phpcs_version, 'dev') }}
+        run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
       - name: "Composer: use lock file when necessary"
         if: ${{ matrix.phpcs_version == 'lowest' }}
@@ -182,7 +192,7 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v3"
         with:
-          # For the PHP "nightly", we need to install with ignore platform reqs as not all dependencies may allow it yet.
+          # For PHP "nightly", we need to install with ignore platform reqs as not all dependencies may allow it yet.
           composer-options: ${{ matrix.php == '8.5' && '--ignore-platform-req=php+' || '' }}
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
@@ -227,9 +237,9 @@ jobs:
           PHPCSUTILS_USE_CACHE: true
 
       # Only run the "compare with PHPCS" group against dev-master as it ensures that PHPCSUtils
-      # functionality is up to date with `dev-master`, so would quickly fail on older PHPCS.
+      # functionality is up to date with `dev` versions, so would quickly fail on older PHPCS.
       - name: Run the unit tests (risky, comparewithPHPCS)
-        if: ${{ matrix.risky && matrix.phpcs_version == 'dev-master' }}
+        if: ${{ matrix.risky && contains( matrix.phpcs_version, 'dev') }}
         # "nothing" is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
         run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }} --no-coverage --group compareWithPHPCS --exclude-group nothing
         env:
@@ -260,10 +270,14 @@ jobs:
       matrix:
         include:
           - php: '8.4'
+            phpcs_version: '4.x-dev'
+          - php: '8.4'
             phpcs_version: 'dev-master'
           - php: '8.4'
             phpcs_version: 'lowest'
             extensions: ':iconv' # Run one build with iconv disabled.
+          - php: '7.2'
+            phpcs_version: '4.x-dev'
           - php: '5.4'
             phpcs_version: 'dev-master'
           - php: '5.4'
@@ -280,7 +294,7 @@ jobs:
       - name: Setup ini config
         id: set_ini
         run: |
-          if [ "${{ matrix.phpcs_version }}" != "dev-master" ]; then
+          if [[ "${{ matrix.phpcs_version }}" != "dev-master" && "${{ matrix.phpcs_version }}" != "4.x-dev" ]]; then
             echo 'PHP_INI=error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On' >> "$GITHUB_OUTPUT"
           else
             echo 'PHP_INI=error_reporting=-1, display_errors=On' >> "$GITHUB_OUTPUT"
@@ -297,8 +311,12 @@ jobs:
       - name: "DEBUG: Show version details"
         run: php -v
 
-      - name: "Composer: set PHPCS version for tests (master)"
-        if: ${{ matrix.phpcs_version != 'lowest' }}
+      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
+      - name: 'Composer: remove PHPCSDevCS'
+        run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
+
+      - name: "Composer: set PHPCS version for tests (dev)"
+        if: ${{ contains( matrix.phpcs_version, 'dev') }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
       - name: "Composer: use lock file when necessary"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Whether you need to split an `array` into the individual items, are trying to de
 
 Includes improved versions of the PHPCS native utility functions and plenty of new utility functions.
 
-These functions are compatible with PHPCS 3.13.0 up to PHPCS `master`.
+These functions are compatible with PHPCS 3.13.0 up to PHPCS `4.x`.
 
 ### A collection of static properties and methods for often-used token groups
 
@@ -78,7 +78,7 @@ To see detailed information about all the available abstract sniffs, utility fun
 ## Minimum Requirements
 
 * PHP 5.4 or higher.
-* [PHP_CodeSniffer] 3.13.0+.
+* [PHP_CodeSniffer] 3.13.0+/4.0.0+.
 * Recommended PHP extensions for optimal functionality:
     - PCRE with Unicode support (normally enabled by default)
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name" : "phpcsstandards/phpcsutils",
     "description" : "A suite of utility functions for use with PHP_CodeSniffer",
     "type" : "phpcodesniffer-standard",
-    "keywords" : [ "phpcs", "phpcbf", "standards", "static analysis", "php_codesniffer", "phpcs3", "tokens", "utility", "phpcodesniffer-standard" ],
+    "keywords" : [ "phpcs", "phpcbf", "standards", "static analysis", "php_codesniffer", "phpcs3", "phpcs4", "tokens", "utility", "phpcodesniffer-standard" ],
     "license" : "LGPL-3.0-or-later",
     "homepage": "https://phpcsutils.com/",
     "authors" : [
@@ -24,7 +24,7 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.13.0 || 4.x-dev@dev",
+        "squizlabs/php_codesniffer" : "^3.13.0 || ^4.0",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0"
     },
     "require-dev" : {


### PR DESCRIPTION
* Allow for Composer installation with PHPCS `^4.0`.
* Update GH Actions workflows to test all PHP versions against PHPCS 4.x and those builds are no longer allowed to fail.

Note: once PHPCS 4.0 has been released, the workflows will get another update to also test against "low" 4.x, but that should wait until the release.