### PR TITLE
GH Actions: improve "don't run on forks" condition

### DIFF
--- a/.github/workflows/update-phpcs-versionnr.yml
+++ b/.github/workflows/update-phpcs-versionnr.yml
@@ -21,7 +21,7 @@ jobs:
   phpcs-version-check:
     name: "Check latest PHPCS version"
     # Don't run the cron job on forks.
-    if: ${{ github.event_name != 'schedule' || github.repository == 'PHPCSStandards/PHPCSUtils' }}
+    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Remove the condition containing a hard-coded repository name in favour of a more generic condition which should safeguard that the cron job doesn't run on forks just the same.