### PR TITLE
PHP 8.5 | TestUtils: prevent deprecation notice for Reflection*::setAccessible()

### DIFF
--- a/PHPCSUtils/TestUtils/ConfigDouble.php
+++ b/PHPCSUtils/TestUtils/ConfigDouble.php
@@ -211,7 +211,7 @@ final class ConfigDouble extends Config
     public function getStaticConfigProperty($name)
     {
         $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
-        $property->setAccessible(true);
+        (\PHP_VERSION_ID < 80100) && $property->setAccessible(true);
 
         if ($name === 'overriddenDefaults' && \version_compare($this->phpcsVersion, '3.99.99', '>')) {
             return $property->getValue($this);
@@ -236,7 +236,7 @@ final class ConfigDouble extends Config
     public function setStaticConfigProperty($name, $value)
     {
         $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
-        $property->setAccessible(true);
+        (\PHP_VERSION_ID < 80100) && $property->setAccessible(true);
 
         if ($name === 'overriddenDefaults' && \version_compare($this->phpcsVersion, '3.99.99', '>')) {
             $property->setValue($this, $value);
@@ -244,6 +244,6 @@ final class ConfigDouble extends Config
             $property->setValue(null, $value);
         }
 
-        $property->setAccessible(false);
+        (\PHP_VERSION_ID < 80100) && $property->setAccessible(false);
     }
 }

--- a/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
+++ b/PHPCSUtils/TestUtils/UtilityMethodTestCase.php
@@ -349,9 +349,9 @@ abstract class UtilityMethodTestCase extends TestCase
     public static function setStaticConfigProperty($name, $value)
     {
         $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
-        $property->setAccessible(true);
+        (\PHP_VERSION_ID < 80100) && $property->setAccessible(true);
         $property->setValue(null, $value);
-        $property->setAccessible(false);
+        (\PHP_VERSION_ID < 80100) && $property->setAccessible(false);
     }
 
     /**

--- a/Tests/AssertPropertySame.php
+++ b/Tests/AssertPropertySame.php
@@ -78,9 +78,9 @@ trait AssertPropertySame
                     return $objectUnderTest->$propertyName;
                 }
 
-                $property->setAccessible(true);
+                (\PHP_VERSION_ID < 80100) && $property->setAccessible(true);
                 $value = $property->getValue($objectUnderTest);
-                $property->setAccessible(false);
+                (\PHP_VERSION_ID < 80100) && $property->setAccessible(false);
 
                 return $value;
             } catch (ReflectionException $e) {

--- a/Tests/TestUtils/ConfigDouble/ConfigDoubleTest.php
+++ b/Tests/TestUtils/ConfigDouble/ConfigDoubleTest.php
@@ -300,7 +300,7 @@ final class ConfigDoubleTest extends TestCase
     private function getStaticConfigProperty($name, $config = null)
     {
         $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
-        $property->setAccessible(true);
+        (\PHP_VERSION_ID < 80100) && $property->setAccessible(true);
 
         if ($name === 'overriddenDefaults' && \version_compare(Helper::getVersion(), '3.99.99', '>')) {
             // The `overriddenDefaults` property is no longer static on PHPCS 4.0+.
@@ -330,8 +330,8 @@ final class ConfigDoubleTest extends TestCase
         }
 
         $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
-        $property->setAccessible(true);
+        (\PHP_VERSION_ID < 80100) && $property->setAccessible(true);
         $property->setValue(null, $value);
-        $property->setAccessible(false);
+        (\PHP_VERSION_ID < 80100) && $property->setAccessible(false);
     }
 }

--- a/Tests/TestUtils/UtilityMethodTestCase/ResetTestFileTest.php
+++ b/Tests/TestUtils/UtilityMethodTestCase/ResetTestFileTest.php
@@ -183,7 +183,7 @@ final class ResetTestFileTest extends PolyfilledTestCase
     private function getStaticConfigProperty($name, $config = null)
     {
         $property = new ReflectionProperty('PHP_CodeSniffer\Config', $name);
-        $property->setAccessible(true);
+        (\PHP_VERSION_ID < 80100) && $property->setAccessible(true);
 
         if ($name === 'overriddenDefaults'
             && (self::$phpcsVersion === '0' || \version_compare(self::$phpcsVersion, '3.99.99', '>'))

--- a/Tests/Tokens/Collections/PropertyBasedTokenArraysTest.php
+++ b/Tests/Tokens/Collections/PropertyBasedTokenArraysTest.php
@@ -36,9 +36,9 @@ final class PropertyBasedTokenArraysTest extends TestCase
     public function testPropertyBasedTokenArrays($name)
     {
         $reflProp = new ReflectionProperty('PHPCSUtils\Tokens\Collections', $name);
-        $reflProp->setAccessible(true);
+        (\PHP_VERSION_ID < 80100) && $reflProp->setAccessible(true);
         $expected = $reflProp->getValue();
-        $reflProp->setAccessible(false);
+        (\PHP_VERSION_ID < 80100) && $reflProp->setAccessible(false);
 
         $this->assertSame($expected, Collections::$name());
     }


### PR DESCRIPTION
### PHP 8.5 | TestUtils: prevent deprecation notice for Reflection*::setAccessible()

Since PHP 8.1, calling the `Reflection*::setAccessible()` methods is no longer necessary as reflected properties/methods/etc will always be accessible.
However, the method calls are still needed for PHP < 8.1.

As of PHP 8.5, calling the `Reflection*::setAccessible()` methods is now formally deprecated and will yield a deprecation notice, which will fail test runs.
As of PHP 9.0, the `setAccessible()` method(s) will be removed.

With the latter in mind, this commit prevents the deprecation notice by making the calls to `setAccessible()` conditional.

Silencing the deprecation would mean, this would need to be "fixed" again come PHP 9.0, while the current solution should be stable, including for PHP 9.0.

Ref: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations

### PHP 8.5 | Tests: prevent deprecation notice for Reflection*::setAccessible()

Do the same for uses of `Reflection*::setAccessible()` within our own test suite.