### PR TITLE
TypeString: improve handling of FQN `true`/`false`/`null`

### DIFF
--- a/PHPCSUtils/Utils/TypeString.php
+++ b/PHPCSUtils/Utils/TypeString.php
@@ -218,7 +218,7 @@ final class TypeString
 
         // Check for nullable union type.
         $matched = \preg_match(
-            '`(?<before>^|[^|&(?\s]+\s*\|)\s*null\s*(?<after>\|\s*[^|&)?\s]+|$)`i',
+            '`(?<before>^|[^|&(?\s]+\s*\|)\s*[\\\\]?null\s*(?<after>\|\s*[^|&)?\s]+|$)`i',
             $typeString,
             $matches
         );

--- a/PHPCSUtils/Utils/TypeString.php
+++ b/PHPCSUtils/Utils/TypeString.php
@@ -129,7 +129,7 @@ final class TypeString
             return false;
         }
 
-        $typeLC = \strtolower(\trim($type));
+        $typeLC = \strtolower(\ltrim(\trim($type), '\\'));
         return isset(self::$keywordTypes[$typeLC]);
     }
 

--- a/PHPCSUtils/Utils/TypeString.php
+++ b/PHPCSUtils/Utils/TypeString.php
@@ -137,6 +137,8 @@ final class TypeString
      * Normalize the case for a single type.
      *
      * - Types which are recognized PHP "keyword" types will be returned in lowercase.
+     * - Types which are recognized PHP "keyword" types and can be fully qualified (true/false/null)
+     *   will be returned as unqualified.
      * - Class/Interface/Enum names will be returned in their original case.
      *
      * @since 1.1.0
@@ -152,7 +154,7 @@ final class TypeString
         }
 
         if (self::isKeyword($type)) {
-            return \strtolower($type);
+            return \strtolower(\ltrim($type, '\\'));
         }
 
         return $type;

--- a/Tests/Utils/TypeString/FilterTypesTest.php
+++ b/Tests/Utils/TypeString/FilterTypesTest.php
@@ -290,6 +290,14 @@ final class FilterTypesTest extends TestCase
                     '\Fully\Qualified'    => '\Fully\Qualified',
                 ],
             ],
+            'keyed array containing FQN and uppercase true/false/null keywords' => [
+                'keywords' => [
+                    '\FALSE' => '\FALSE',
+                    '\NULL'  => '\NULL',
+                    '\TRUE'  => '\TRUE',
+                ],
+                'oonames'  => [],
+            ],
             'keyed array containing both keywords and oo names, keys not the same as values' => [
                 'keywords' => [
                     'float'  => 'callable',

--- a/Tests/Utils/TypeString/IsKeywordTest.php
+++ b/Tests/Utils/TypeString/IsKeywordTest.php
@@ -117,6 +117,13 @@ final class IsKeywordTest extends TestCase
             ];
         }
 
+        $data['true: fully qualified']             = ['type' => '\true'];
+        $data['false: fully qualified']            = ['type' => '\false'];
+        $data['null: fully qualified']             = ['type' => '\null'];
+        $data['true: fully qualified, uppercase']  = ['type' => '\TRUE'];
+        $data['false: fully qualified, uppercase'] = ['type' => '\FALSE'];
+        $data['null: fully qualified, uppercase']  = ['type' => '\NULL'];
+
         return $data;
     }
 

--- a/Tests/Utils/TypeString/IsTypeTest.php
+++ b/Tests/Utils/TypeString/IsTypeTest.php
@@ -319,6 +319,16 @@ final class IsTypeTest extends TestCase
                     'dnf'          => false,
                 ],
             ],
+            'nullable union type: \true|\null (FQN)' => [
+                'type'     => '\true|\null',
+                'expected' => [
+                    'singular'     => false,
+                    'nullable'     => true,
+                    'union'        => true,
+                    'intersection' => false,
+                    'dnf'          => false,
+                ],
+            ],
 
             'intersection type: UnqualifiedName&Package\Partially&\Vendor\FullyQualified&namespace\Relative\Name' => [
                 'type'     => 'UnqualifiedName&Package\Partially&\Vendor\FullyQualified&namespace\Relative\Name',
@@ -383,6 +393,36 @@ final class IsTypeTest extends TestCase
             ],
             'DNF type: null at start and whitespace rich' => [
                 'type'     => ' null | ( Foo & Bar & \Baz )',
+                'expected' => [
+                    'singular'     => false,
+                    'nullable'     => true,
+                    'union'        => false,
+                    'intersection' => false,
+                    'dnf'          => true,
+                ],
+            ],
+            'DNF type: FQN null at end' => [
+                'type'     => '(Foo&Bar)|\null',
+                'expected' => [
+                    'singular'     => false,
+                    'nullable'     => true,
+                    'union'        => false,
+                    'intersection' => false,
+                    'dnf'          => true,
+                ],
+            ],
+            'DNF type: FQN null in the middle' => [
+                'type'     => '(Foo&Bar)|\null|(Baz&Countable)',
+                'expected' => [
+                    'singular'     => false,
+                    'nullable'     => true,
+                    'union'        => false,
+                    'intersection' => false,
+                    'dnf'          => true,
+                ],
+            ],
+            'DNF type: FQN null at start and whitespace rich' => [
+                'type'     => ' \null | ( Foo & Bar & \Baz )',
                 'expected' => [
                     'singular'     => false,
                     'nullable'     => true,

--- a/Tests/Utils/TypeString/NormalizeCaseTest.php
+++ b/Tests/Utils/TypeString/NormalizeCaseTest.php
@@ -135,6 +135,31 @@ final class NormalizeCaseTest extends TestCase
             ];
         }
 
+        $data['true: fully qualified']             = [
+            'type'     => '\true',
+            'expected' => 'true',
+        ];
+        $data['false: fully qualified']            = [
+            'type'     => '\false',
+            'expected' => 'false',
+        ];
+        $data['null: fully qualified']             = [
+            'type'     => '\null',
+            'expected' => 'null',
+        ];
+        $data['true: fully qualified, uppercase']  = [
+            'type'     => '\TRUE',
+            'expected' => 'true',
+        ];
+        $data['false: fully qualified, uppercase'] = [
+            'type'     => '\FALSE',
+            'expected' => 'false',
+        ];
+        $data['null: fully qualified, uppercase']  = [
+            'type'     => '\NULL',
+            'expected' => 'null',
+        ];
+
         $data['Classname: UnqualifiedName'] = [
             'type'     => 'UnqualifiedName',
             'expected' => 'UnqualifiedName',

--- a/Tests/Utils/TypeString/ToArrayTest.php
+++ b/Tests/Utils/TypeString/ToArrayTest.php
@@ -372,6 +372,23 @@ final class ToArrayTest extends TestCase
                     'void'      => 'void',
                 ],
             ],
+            'union type: \true|\false|\null (FQN)' => [
+                'type'     => '\true|\false|\null',
+                'expected' => [
+                    'true'  => 'true',
+                    'false' => 'false',
+                    'null'  => 'null',
+                ],
+            ],
+            'union type: \TRUE|\FALSE|\NULL (FQN + uppercase)' => [
+                'type'     => '\TRUE|\FALSE|\NULL',
+                'expected' => [
+                    'true'  => 'true',
+                    'false' => 'false',
+                    'null'  => 'null',
+                ],
+            ],
+
             'DNF type: keywords in mixed case' => [
                 'type'     => 'FALSE|(B&A)|Null',
                 'expected' => [
@@ -423,6 +440,23 @@ final class ToArrayTest extends TestCase
                     'void'      => 'void',
                 ],
             ],
+            'union type: \true|\false|\null (FQN)' => [
+                'type'     => '\true|\false|\null',
+                'expected' => [
+                    '\true'  => '\true',
+                    '\false' => '\false',
+                    '\null'  => '\null',
+                ],
+            ],
+            'union type: \TRUE|\FALSE|\NULL (FQN + uppercase)' => [
+                'type'     => '\TRUE|\FALSE|\NULL',
+                'expected' => [
+                    '\TRUE'  => '\TRUE',
+                    '\FALSE' => '\FALSE',
+                    '\NULL'  => '\NULL',
+                ],
+            ],
+
             'DNF type: keywords in mixed case' => [
                 'type'     => 'FALSE|(B&A)|Null',
                 'expected' => [


### PR DESCRIPTION
### TypeString::isNullable(): correctly handle FQN null 

Includes tests.

### TypeString::isKeyword(): correctly handle FQN null/true/false 

Includes tests.

### TypeString::normalizeCase(): normalize FQN true/false/null to unqualified

Includes tests.

### TypeString: add more tests with FQN true/false/null