### PR TITLE
AbstractArrayDeclarationSniff::getActualArrayKey(): minor simplification

### DIFF
--- a/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
+++ b/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
@@ -478,31 +478,15 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
                 continue;
             }
 
-            // Handle FQN true/false/null.
-            if ($this->tokens[$i]['code'] === \T_NAME_FULLY_QUALIFIED) {
-                $compareReadyKeyword = \strtolower($this->tokens[$i]['content']);
-                if ($compareReadyKeyword === '\true'
-                    || $compareReadyKeyword === '\false'
-                    || $compareReadyKeyword === '\null'
-                ) {
-                    // FQN true/false/null on PHPCS 4.x. This can be handled.
-                    $content .= $this->tokens[$i]['content'];
-                    continue;
-                }
-            } elseif ($this->tokens[$i]['code'] === \T_NS_SEPARATOR) {
-                // PHPCS 3.x.
+            // Handle FQN true/false/null for PHPCS 3.x.
+            if ($this->tokens[$i]['code'] === \T_NS_SEPARATOR) {
                 $nextNonEmpty   = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
                 $nextNonEmptyLC = \strtolower($this->tokens[$nextNonEmpty]['content']);
                 if ($nextNonEmpty !== false
-                    // PHPCS 3.x with PHP < 8.0.
                     && ($this->tokens[$nextNonEmpty]['code'] === \T_TRUE
                     || $this->tokens[$nextNonEmpty]['code'] === \T_FALSE
-                    || $this->tokens[$nextNonEmpty]['code'] === \T_NULL
-                    // PHPCS 3.x with PHP >= 8.0 where the namespaced name tokenization has been undone.
-                    || ($this->tokens[$nextNonEmpty]['code'] === \T_STRING
-                        && ($nextNonEmptyLC === 'true' || $nextNonEmptyLC === 'false' || $nextNonEmptyLC === 'null')))
+                    || $this->tokens[$nextNonEmpty]['code'] === \T_NULL)
                 ) {
-                    // FQN true/false/null on PHPCS 3.x. This can be handled.
                     $content .= $this->tokens[$nextNonEmpty]['content'];
                     $i        = $nextNonEmpty;
                     continue;


### PR DESCRIPTION
The tokenization of fully qualified `true`/`false`/`null` has been changed for both PHPCS 3.x (as of 3.13.3) as well as PHPCS 4.0.

The new tokenization means we don't need to take these tokens being tokenized as `T_STRING` or `T_NAME_FULLY_QUALIFIED` into account anymore, as long as the minimum supported PHPCS version will be PHPCS 3.13.3 (which it will be since the merge of PR #698).

This commit removes the code which has now become redundant.

Ref:
* PHPCSStandards/PHP_CodeSniffer#1201
* PHPCSStandards/PHP_CodeSniffer#1206