### PR TITLE
Parentheses/PassedParameters: add tests with FQN exit/die

### DIFF
--- a/Tests/Utils/Parentheses/ParenthesesTest.inc
+++ b/Tests/Utils/Parentheses/ParenthesesTest.inc
@@ -65,6 +65,9 @@ eval($a . $b . $c );
 /* testExit */
 if (defined('FOO') || die('message')) {}
 
+/* testFQNExit */
+if (defined('FOO') || \exit(10)) {}
+
 /* testMatch */
 $m = match(count($a)) {
     1 => true,

--- a/Tests/Utils/Parentheses/ParenthesesTest.php
+++ b/Tests/Utils/Parentheses/ParenthesesTest.php
@@ -182,6 +182,14 @@ final class ParenthesesTest extends UtilityMethodTestCase
             'code'    => \T_CONSTANT_ENCAPSED_STRING,
             'content' => "'message'",
         ],
+        'testIfFQNExitDie-boolean-or' => [
+            'marker'  => '/* testFQNExit */',
+            'code'    => \T_BOOLEAN_OR,
+        ],
+        'testIfFQNExitDie-statuscode' => [
+            'marker'  => '/* testFQNExit */',
+            'code'    => \T_LNUMBER,
+        ],
         'testMatch-count' => [
             'marker'  => '/* testMatch */',
             'code'    => \T_STRING,
@@ -637,6 +645,8 @@ final class ParenthesesTest extends UtilityMethodTestCase
      */
     public static function dataWalkParentheses()
     {
+        $php8Names = parent::usesPhp8NameTokens();
+
         $data = [
             'testIfWithArray-$a' => [
                 'testName'        => 'testIfWithArray-$a',
@@ -927,6 +937,40 @@ final class ParenthesesTest extends UtilityMethodTestCase
                     'lastIfElseOwner'       => -12,
                 ],
             ],
+            'testIfFQNExitDie-boolean-or' => [
+                'testName'        => 'testIfFQNExitDie-boolean-or',
+                'expectedResults' => [
+                    'firstOpener'           => -6,
+                    'firstCloser'           => ($php8Names === true) ? 6 : 7,
+                    'firstOwner'            => -8,
+                    'firstScopeOwnerOpener' => -6,
+                    'firstScopeOwnerCloser' => ($php8Names === true) ? 6 : 7,
+                    'firstScopeOwnerOwner'  => -8,
+                    'lastOpener'            => -6,
+                    'lastCloser'            => ($php8Names === true) ? 6 : 7,
+                    'lastOwner'             => -8,
+                    'lastArrayOpener'       => false,
+                    'lastFunctionCloser'    => false,
+                    'lastIfElseOwner'       => -8,
+                ],
+            ],
+            'testIfFQNExitDie-message' => [
+                'testName'        => 'testIfFQNExitDie-statuscode',
+                'expectedResults' => [
+                    'firstOpener'           => ($php8Names === true) ? -10 : -11,
+                    'firstCloser'           => 2,
+                    'firstOwner'            => ($php8Names === true) ? -12 : -13,
+                    'firstScopeOwnerOpener' => ($php8Names === true) ? -10 : -11,
+                    'firstScopeOwnerCloser' => 2,
+                    'firstScopeOwnerOwner'  => ($php8Names === true) ? -12 : -13,
+                    'lastOpener'            => -1,
+                    'lastCloser'            => 1,
+                    'lastOwner'             => -2,
+                    'lastArrayOpener'       => false,
+                    'lastFunctionCloser'    => false,
+                    'lastIfElseOwner'       => ($php8Names === true) ? -12 : -13,
+                ],
+            ],
             'testMatch-count' => [
                 'testName'        => 'testMatch-count',
                 'expectedResults' => [
@@ -1205,6 +1249,17 @@ final class ParenthesesTest extends UtilityMethodTestCase
             ],
             'testIfExitDie-message' => [
                 'testName'        => 'testIfExitDie-message',
+                'expectedResults' => [
+                    'T_IF'   => true,
+                    'T_EXIT' => true,
+                ],
+            ],
+            'testIfFQNExitDie-boolean-or' => [
+                'testName'        => 'testIfFQNExitDie-boolean-or',
+                'expectedResults' => ['T_IF' => true],
+            ],
+            'testIfFQNExitDie-statuscode' => [
+                'testName'        => 'testIfFQNExitDie-statuscode',
                 'expectedResults' => [
                     'T_IF'   => true,
                     'T_EXIT' => true,

--- a/Tests/Utils/PassedParameters/GetParametersNamedTest.inc
+++ b/Tests/Utils/PassedParameters/GetParametersNamedTest.inc
@@ -56,6 +56,9 @@ echo $cond ? foo( label: $something ) : /* testTernaryWithFunctionCallsInElse */
 /* testExitWithNamedParam */
 exit( status: 1 );
 
+/* testFQNDieWithNamedParam */
+\die( status: 1 );
+
 /* testCompileErrorNamedBeforePositional */
 // Not the concern of PHPCSUtils. Should still be handled.
 test(param: $bar, $foo);

--- a/Tests/Utils/PassedParameters/GetParametersNamedTest.php
+++ b/Tests/Utils/PassedParameters/GetParametersNamedTest.php
@@ -439,6 +439,19 @@ final class GetParametersNamedTest extends UtilityMethodTestCase
                     ],
                 ],
             ],
+            'named-args-for-FQN-die' => [
+                'testMarker' => '/* testFQNDieWithNamedParam */',
+                'targetType' => \T_EXIT,
+                'expected'   => [
+                    'status' => [
+                        'name'       => 'status',
+                        'name_token' => 3,
+                        'start'      => 5,
+                        'end'        => 7,
+                        'raw'        => '1',
+                    ],
+                ],
+            ],
 
             'named-args-compile-error-named-before-positional' => [
                 'testMarker' => '/* testCompileErrorNamedBeforePositional */',

--- a/Tests/Utils/PassedParameters/HasParametersTest.inc
+++ b/Tests/Utils/PassedParameters/HasParametersTest.inc
@@ -174,10 +174,10 @@ unset(
 exit();
 
 /* testHasParamsExit */
-exit( $code );
+\exit( $code );
 
 /* testNoParamsDie */
-die( /*comment*/ );
+\die( /*comment*/ );
 
 /* testHasParamsDie */
 die( $status );


### PR DESCRIPTION
To safeguard that PHPCSUtils handles this correctly in light of PHPCSStandards/PHP_CodeSniffer#1201.