### PR TITLE
Update for final PHPCS 4.0.0 release and main branch rename

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -44,8 +44,9 @@ jobs:
         run: |
           # The sniff stage doesn't run the unit tests, so no need for PHPUnit.
           composer remove --no-update --dev phpunit/phpunit --no-scripts
-          # Using PHPCS `master` as an early detection system for bugs upstream.
-          composer require --no-update squizlabs/php_codesniffer:"dev-master"
+          # Using PHPCS `3.x` as an early detection system for bugs upstream.
+          # This should be changed to 4.x, but we'll need to wait for PHPCSDevCS to be compatible with 4.x.
+          composer require --no-update squizlabs/php_codesniffer:"3.x-dev"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -34,15 +34,19 @@ jobs:
     strategy:
       matrix:
         php: ['5.4', 'latest']
-        phpcs_version: ['lowest', 'dev-master']
+        phpcs_version: ['lowest', '3.x-dev']
 
         include:
           - php: '7.2'
+            phpcs_version: '4.0.0'
+          - php: '7.2'
             phpcs_version: '4.x-dev'
+          - php: 'latest'
+            phpcs_version: '4.0.0'
           - php: 'latest'
             phpcs_version: '4.x-dev'
 
-    name: "QTest${{ matrix.phpcs_version == 'dev-master' && ' + Lint' || '' }}: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
+    name: "QTest: PHP ${{ matrix.php }} - PHPCS ${{ matrix.phpcs_version }}"
 
     steps:
       - name: Checkout code
@@ -70,8 +74,8 @@ jobs:
       - name: 'Composer: remove PHPCSDevCS'
         run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
 
-      - name: "Composer: set PHPCS version for tests (dev)"
-        if: ${{ contains( matrix.phpcs_version, 'dev') }}
+      - name: "Composer: set PHPCS version for tests"
+        if: ${{ matrix.phpcs_version != 'lowest' }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
       - name: "Composer: use lock file when necessary"
@@ -90,9 +94,13 @@ jobs:
         if: ${{ matrix.phpcs_version == 'lowest' }}
         run: composer update squizlabs/php_codesniffer --prefer-lowest --no-scripts --no-interaction
 
-      - name: Lint against parse errors
-        if: matrix.phpcs_version == 'dev-master'
+      - name: Lint against parse errors (PHP < 7.2)
+        if: ${{ matrix.php == '5.4' && matrix.phpcs_version == '3.x-dev' }}
         run: composer lint-lt72
+
+      - name: Lint against parse errors (PHP 7.2+)
+        if: ${{ matrix.phpcs_version == '4.x-dev' }}
+        run: composer lint
 
       - name: Grab PHPUnit version
         id: phpunit_version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,20 +85,30 @@ jobs:
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
         php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
-        phpcs_version: ['lowest', 'dev-master', '4.x-dev']
+        phpcs_version: ['lowest', '3.x-dev', '4.0.0', '4.x-dev']
         risky: [false]
         experimental: [false]
 
         exclude:
           - php: '5.5'
+            phpcs_version: '4.0.0'
+          - php: '5.5'
             phpcs_version: '4.x-dev'
+          - php: '5.6'
+            phpcs_version: '4.0.0'
           - php: '5.6'
             phpcs_version: '4.x-dev'
           - php: '7.0'
+            phpcs_version: '4.0.0'
+          - php: '7.0'
             phpcs_version: '4.x-dev'
           - php: '7.1'
+            phpcs_version: '4.0.0'
+          - php: '7.1'
             phpcs_version: '4.x-dev'
-          # Also exclude the 7.2 build as that's run in code coverage, no need to duplicate.
+          # Also exclude the 7.2 builds as those are run in code coverage, no need to duplicate.
+          - php: '7.2'
+            phpcs_version: '4.0.0'
           - php: '7.2'
             phpcs_version: '4.x-dev'
 
@@ -109,14 +119,14 @@ jobs:
             experimental: false
             extensions: ':iconv' # Run with iconv disabled.
           - php: '8.0'
-            phpcs_version: 'dev-master'
+            phpcs_version: '4.x-dev'
             risky: false
             experimental: false
             extensions: ':iconv' # Run with iconv disabled.
 
           # Experimental builds. These are allowed to fail.
           - php: '8.5'
-            phpcs_version: 'dev-master'
+            phpcs_version: '3.x-dev'
             risky: false
             experimental: true
           - php: '8.5'
@@ -131,7 +141,7 @@ jobs:
             experimental: true
 
           - php: '5.4'
-            phpcs_version: 'dev-master'
+            phpcs_version: '3.x-dev'
             risky: true
             experimental: true
 
@@ -146,7 +156,12 @@ jobs:
             experimental: true
 
           - php: '8.4'
-            phpcs_version: 'dev-master'
+            phpcs_version: '3.x-dev'
+            risky: true
+            experimental: true
+
+          - php: '8.4'
+            phpcs_version: '4.0.0'
             risky: true
             experimental: true
 
@@ -186,8 +201,8 @@ jobs:
       - name: 'Composer: remove PHPCSDevCS'
         run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
 
-      - name: "Composer: set PHPCS version for tests (dev)"
-        if: ${{ contains( matrix.phpcs_version, 'dev') }}
+      - name: "Composer: set PHPCS version for tests"
+        if: ${{ matrix.phpcs_version != 'lowest' }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
       - name: "Composer: use lock file when necessary"
@@ -243,10 +258,10 @@ jobs:
           PHPCS_VERSION: ${{ matrix.phpcs_version }}
           PHPCSUTILS_USE_CACHE: true
 
-      # Only run the "compare with PHPCS" group against dev-master as it ensures that PHPCSUtils
-      # functionality is up to date with `dev` versions, so would quickly fail on older PHPCS.
+      # Only run the "compare with PHPCS" group against 4.x-dev as it ensures that PHPCSUtils
+      # functionality is up to date with `4.x-dev`, so would quickly fail on older PHPCS.
       - name: Run the unit tests (risky, comparewithPHPCS)
-        if: ${{ matrix.risky && contains( matrix.phpcs_version, 'dev') }}
+        if: ${{ matrix.risky && matrix.phpcs_version == '4.x-dev' }}
         # "nothing" is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
         run: vendor/bin/phpunit -c ${{ steps.phpunit_config.outputs.FILE }} --no-coverage --group compareWithPHPCS --exclude-group nothing
         env:
@@ -278,15 +293,19 @@ jobs:
         include:
           - php: '8.4'
             phpcs_version: '4.x-dev'
+            extensions: ':iconv' # Run one build with iconv disabled.
           - php: '8.4'
-            phpcs_version: 'dev-master'
+            phpcs_version: '4.0.0'
+          - php: '8.4'
+            phpcs_version: '3.x-dev'
           - php: '8.4'
             phpcs_version: 'lowest'
-            extensions: ':iconv' # Run one build with iconv disabled.
           - php: '7.2'
             phpcs_version: '4.x-dev'
+          - php: '7.2'
+            phpcs_version: '4.0.0'
           - php: '5.4'
-            phpcs_version: 'dev-master'
+            phpcs_version: '3.x-dev'
           - php: '5.4'
             phpcs_version: 'lowest'
 
@@ -322,8 +341,8 @@ jobs:
       - name: 'Composer: remove PHPCSDevCS'
         run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
 
-      - name: "Composer: set PHPCS version for tests (dev)"
-        if: ${{ contains( matrix.phpcs_version, 'dev') }}
+      - name: "Composer: set PHPCS version for tests"
+        if: ${{ matrix.phpcs_version != 'lowest' }}
         run: composer require squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-update --no-scripts --no-interaction
 
       - name: "Composer: use lock file when necessary"

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -29,7 +29,7 @@
  * @author    Klaus Purer <klaus.purer@protonmail.ch>
  *
  * @copyright 2006-2019 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 
 namespace PHPCSUtils\BackCompat;

--- a/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
+++ b/Tests/BackCompat/BCFile/FindEndOfStatementTest.php
@@ -17,7 +17,7 @@
  * @author    Phil Davis <phil@jankaritech.com>
  *
  * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;

--- a/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
+++ b/Tests/BackCompat/BCFile/FindExtendedClassNameTest.php
@@ -19,7 +19,7 @@
  * @author    Phil Davis <phil@jankaritech.com>
  *
  * @copyright 2016-2019 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;

--- a/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
+++ b/Tests/BackCompat/BCFile/FindImplementedInterfaceNamesTest.php
@@ -18,7 +18,7 @@
  * @author    Phil Davis <phil@jankaritech.com>
  *
  * @copyright 2016-2019 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;

--- a/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMemberPropertiesTest.php
@@ -17,7 +17,7 @@
  * @author    Phil Davis <phil@jankaritech.com>
  *
  * @copyright 2017-2019 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;

--- a/Tests/BackCompat/BCFile/GetMethodParametersTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodParametersTest.php
@@ -18,7 +18,7 @@
  * @author    George Mponos <gmponos@gmail.com>
  *
  * @copyright 2010-2019 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;

--- a/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
+++ b/Tests/BackCompat/BCFile/GetMethodPropertiesTest.php
@@ -15,7 +15,7 @@
  * @author    Juliette Reinders Folmer <jrf@phpcodesniffer.info>
  *
  * @copyright 2018-2019 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;

--- a/Tests/BackCompat/BCFile/IsReferenceTest.php
+++ b/Tests/BackCompat/BCFile/IsReferenceTest.php
@@ -17,7 +17,7 @@
  * @author    Phil Davis <phil@jankaritech.com>
  *
  * @copyright 2017-2019 Squiz Pty Ltd (ABN 77 084 670 600)
- * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @license   https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/HEAD/licence.txt BSD Licence
  */
 
 namespace PHPCSUtils\Tests\BackCompat\BCFile;

--- a/Tests/BackCompat/Helper/GetVersionTest.php
+++ b/Tests/BackCompat/Helper/GetVersionTest.php
@@ -61,7 +61,7 @@ final class GetVersionTest extends TestCase
 
         $result = Helper::getVersion();
 
-        if ($expected === 'dev-master') {
+        if ($expected === '3.x-dev') {
             $this->assertTrue(\version_compare(self::LATEST_3X_VERSION, $result, '<='));
         } elseif ($expected === '4.x-dev') {
             $this->assertTrue(\version_compare(self::LATEST_4X_VERSION, $result, '<='));


### PR DESCRIPTION
* Change `dev-master` to `3.x-dev`.
* Add explicit runs against the lowest supported PHPCS 4.x version - currently `4.0.0`.
* Update `@copyright` tags referring to the upstream repo to remove the `master` reference.