### PR TITLE
Cache Tests: fix PHP 8.5 warning for float cast

### DIFF
--- a/Tests/Internal/Cache/SetTest.php
+++ b/Tests/Internal/Cache/SetTest.php
@@ -95,7 +95,7 @@ final class SetTest extends UtilityMethodTestCase
      */
     public function testSetAcceptsEveryTypeOfInput($input)
     {
-        $id = \base_convert((string) \rand((int) 10e16, (int) 10e20), 10, 36);
+        $id = \base_convert((string) \rand((int) 10e13, (int) 10e17), 10, 36);
         Cache::set(self::$phpcsFile, __METHOD__, $id, $input);
 
         $this->assertTrue(

--- a/Tests/Internal/NoFileCache/SetTest.php
+++ b/Tests/Internal/NoFileCache/SetTest.php
@@ -89,7 +89,7 @@ final class SetTest extends TestCase
      */
     public function testSetAcceptsEveryTypeOfInput($input)
     {
-        $id = \base_convert((string) \rand((int) 10e16, (int) 10e20), 10, 36);
+        $id = \base_convert((string) \rand((int) 10e13, (int) 10e17), 10, 36);
         NoFileCache::set(__METHOD__, $id, $input);
 
         $this->assertTrue(


### PR DESCRIPTION
PHP 8.5 introduces a new warning about casting floats which are outside the range of supported integers to int. This will now throw a "The float ... is not representable as an int, cast occurred" warning.

PHPCSUtils was running into this warning for two tests where a semi-random cache ID was being generated.

Fixed now, by using a slightly smaller range of numbers to pick a random number from, but that should be inconsequential.

Ref:
* https://wiki.php.net/rfc/warnings-php-8-5#casting_out_of_range_floats_to_int