### PR TITLE
Composer: update to PHPCSDevCS 1.2.0

### DIFF
--- a/.github/GHPages/UpdateWebsite.php
+++ b/.github/GHPages/UpdateWebsite.php
@@ -268,7 +268,7 @@ seo:
     private function getContents(string $source): string
     {
         $contents = \file_get_contents($source);
-        if (!$contents) {
+        if (\is_string($contents) === false) {
             throw new RuntimeException(\sprintf('Failed to read doc file: %s', $source));
         }
 

--- a/.github/GHPages/update-docgen-config.php
+++ b/.github/GHPages/update-docgen-config.php
@@ -44,7 +44,7 @@ $phpcsutilsPhpdocVersionUpdater = static function () {
         echo 'This is your own responsibility!' . \PHP_EOL, \PHP_EOL;
 
         $config = \file_get_contents($projectRoot . '/' . $destination);
-        if (!$config) {
+        if (\is_string($config) === false) {
             echo "ERROR: Failed to read phpDocumentor $destination configuration file.", \PHP_EOL;
             exit(1);
         }
@@ -59,7 +59,7 @@ $phpcsutilsPhpdocVersionUpdater = static function () {
         );
     } else {
         $config = \file_get_contents($projectRoot . '/' . $source);
-        if (!$config) {
+        if (\is_string($config) === false) {
             echo "ERROR: Failed to read phpDocumentor $source configuration template file.", \PHP_EOL;
             exit(1);
         }

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -46,9 +46,8 @@ jobs:
         run: |
           # The sniff stage doesn't run the unit tests, so no need for PHPUnit.
           composer remove --no-update --dev phpunit/phpunit --no-scripts
-          # Using PHPCS `3.x` as an early detection system for bugs upstream.
-          # This should be changed to 4.x, but we'll need to wait for PHPCSDevCS to be compatible with 4.x.
-          composer require --no-update squizlabs/php_codesniffer:"3.x-dev"
+          # Using PHPCS `4.x` as an early detection system for bugs upstream.
+          composer require --no-update squizlabs/php_codesniffer:"4.x-dev"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -72,7 +72,7 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
+      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS "lowest".
       - name: 'Composer: remove PHPCSDevCS'
         run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,7 +201,7 @@ jobs:
           ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
           coverage: none
 
-      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS 4.x.
+      # Remove PHPCSDevCS as it would (for now) prevent the tests from being able to run against PHPCS "lowest".
       - name: 'Composer: remove PHPCSDevCS'
         run: composer remove --dev phpcsstandards/phpcsdevcs --no-update --no-interaction
 

--- a/PHPCSUtils/Utils/Namespaces.php
+++ b/PHPCSUtils/Utils/Namespaces.php
@@ -109,8 +109,8 @@ final class Namespaces
         $start = BCFile::findStartOfStatement($phpcsFile, $stackPtr);
         if ($start === $stackPtr
             && ($tokens[$next]['code'] === \T_STRING
-               || $tokens[$next]['code'] === \T_NAME_QUALIFIED
-               || $tokens[$next]['code'] === \T_OPEN_CURLY_BRACKET)
+                || $tokens[$next]['code'] === \T_NAME_QUALIFIED
+                || $tokens[$next]['code'] === \T_OPEN_CURLY_BRACKET)
         ) {
             return 'declaration';
         }

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.php
@@ -198,7 +198,7 @@ final class GetActualArrayKeyTest extends UtilityMethodTestCase
             2 => '002',
             3 => '0o3',
             4 => '0b1',
-            5 => '0x7', // phpcs:ignore PHPCompatibility.Miscellaneous.ValidIntegers.HexNumericStringFound
+            5 => '0x7', // phpcs:ignore PHPCompatibility.Numbers.RemovedHexadecimalNumericStrings.Found
             6 => '0.0',
         ];
 

--- a/Tests/AssertPropertySame.php
+++ b/Tests/AssertPropertySame.php
@@ -36,7 +36,7 @@ trait AssertPropertySame
      *
      * @return void
      */
-    public function assertPropertySame($expected, $propertyName, $actualObject, $message = '')
+    final public function assertPropertySame($expected, $propertyName, $actualObject, $message = '')
     {
         // Will throw a warning on PHPUnit 8, but will still work.
         if (\method_exists($this, 'assertAttributeSame')) {
@@ -66,7 +66,7 @@ trait AssertPropertySame
      *
      * @throws \Exception
      */
-    public static function getObjectPropertyValue($objectUnderTest, $propertyName)
+    final public static function getObjectPropertyValue($objectUnderTest, $propertyName)
     {
         $reflector = new ReflectionObject($objectUnderTest);
 
@@ -74,6 +74,7 @@ trait AssertPropertySame
             try {
                 $property = $reflector->getProperty($propertyName);
 
+                // phpcs:ignore Squiz.Operators.ComparisonOperatorUsage.NotAllowed -- This is deliberate to mirror the PHPUnit method.
                 if (!$property || $property->isPublic()) {
                     return $objectUnderTest->$propertyName;
                 }

--- a/Tests/BackCompat/BCTokens/NameTokensTest.php
+++ b/Tests/BackCompat/BCTokens/NameTokensTest.php
@@ -59,6 +59,6 @@ final class NameTokensTest extends TestCase
             $this->markTestSkipped('Test only applicable to PHPCS >= 4.x');
         }
 
-        $this->assertSame(Tokens::NAME_TOKENS, BCTokens::nameTokens()); // @phpstan-ignore classConstant.notFound
+        $this->assertSame(Tokens::NAME_TOKENS, BCTokens::nameTokens());
     }
 }

--- a/Tests/Utils/Numbers/GetCompleteNumberTest.php
+++ b/Tests/Utils/Numbers/GetCompleteNumberTest.php
@@ -103,7 +103,7 @@ final class GetCompleteNumberTest extends PolyfilledTestCase
          * Disabling the hexnumeric string detection for the rest of the file.
          * These are only strings within the context of PHPCS and need to be tested as such.
          *
-         * @phpcs:disable PHPCompatibility.Miscellaneous.ValidIntegers.HexNumericStringFound
+         * @phpcs:disable PHPCompatibility.Numbers.RemovedHexadecimalNumericStrings.Found
          */
 
         return [

--- a/Tests/Utils/Numbers/GetDecimalValueTest.php
+++ b/Tests/Utils/Numbers/GetDecimalValueTest.php
@@ -62,7 +62,7 @@ final class GetDecimalValueTest extends TestCase
             'multi-digit-scientific-float-with-underscores' => ['6.674_083e+11', '6.674083e+11'],
 
             // Hex.
-            // phpcs:disable PHPCompatibility.Miscellaneous.ValidIntegers.HexNumericStringFound
+            // phpcs:disable PHPCompatibility.Numbers.RemovedHexadecimalNumericStrings.Found
             'hex-int-no-numbers'                            => ['0xA', '10'],
             'hex-int-all-numbers'                           => ['0x400', '1024'],
             'hex-int-mixed-uppercase-x'                     => ['0XAB953C', '11244860'],

--- a/Tests/Utils/Numbers/NumberTypesTest.php
+++ b/Tests/Utils/Numbers/NumberTypesTest.php
@@ -708,7 +708,7 @@ final class NumberTypesTest extends TestCase
             ],
 
             // Hexidecimal numeric strings.
-            // phpcs:disable PHPCompatibility.Miscellaneous.ValidIntegers.HexNumericStringFound
+            // phpcs:disable PHPCompatibility.Numbers.RemovedHexadecimalNumericStrings.Found
             'hexidecimal-single-digit-zero' => [
                 'input'    => '0x0',
                 'expected' => [

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev" : {
         "ext-filter": "*",
-        "phpcsstandards/phpcsdevcs": "^1.1.6",
+        "phpcsstandards/phpcsdevcs": "^1.2.0",
         "php-parallel-lint/php-parallel-lint": "^1.4.0",
         "php-parallel-lint/php-console-highlighter": "^1.0",
         "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -36,11 +36,7 @@
     -->
 
     <rule ref="PHPCSDev">
-        <!-- Allow for the file docblock on the line directly following the PHP open tag.
-             As the sniff in PHPCS does not use modular error codes (yet - see PR #2729),
-             the complete error code needs to be disabled, not just the bit involving
-             the file docblocks.
-        -->
+        <!-- Only needed for PHPCS 3.x. This exclusion can be removed when PHPCSDevCS drops support for PHPCS 3.x. -->
         <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock"/>
     </rule>
 
@@ -107,6 +103,31 @@
     <rule ref="PEAR.Commenting.FileComment.LinkTagOrder">
         <exclude-pattern>/PHPCSUtils/BackCompat/BCFile\.php$</exclude-pattern>
         <exclude-pattern>/Tests/BackCompat/BCFile/*Test\.php$</exclude-pattern>
+    </rule>
+
+    <!-- This is fine. -->
+    <rule ref="PHPCompatibility.Attributes.NewAttributes.PHPUnitAttributeFound">
+        <exclude-pattern>/PHPCSUtils/TestUtils/UtilityMethodTestCase\.php$</exclude-pattern>
+    </rule>
+
+    <!-- Disregard this rule in code which doesn't need to be tested (or is part of the test code itself). -->
+    <rule ref="Universal.FunctionDeclarations.NoLongClosures.ExceedsMaximum">
+        <exclude-pattern>/.github/GHPages/update-docgen-config\.php$</exclude-pattern>
+        <exclude-pattern>/Tests/</exclude-pattern>
+    </rule>
+
+    <rule ref="Universal.Classes.RequireFinalClass">
+        <!-- The BackCompat tests cannot be final as it is verified that the PHPCSUtils functionality
+             mirrors the PHPCS native functionality by extending these tests and re-running them
+             using the PHPCSUtils methods. -->
+        <exclude-pattern>*/Tests/BackCompat/*Test\.php$</exclude-pattern>
+        <exclude-pattern>*/Tests/*Mock\.php$</exclude-pattern>
+        <exclude-pattern>*/Tests/*Double\.php$</exclude-pattern>
+    </rule>
+
+    <!-- Allow for return value from PassedParameters::getParameters() potentially having mixed keys. -->
+    <rule ref="Universal.Arrays.MixedArrayKeyTypes">
+        <exclude-pattern>/Tests/Utils/PassedParameters/GetParametersNamedTest\.php$</exclude-pattern>
     </rule>
 
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -26,6 +26,12 @@ parameters:
             path: PHPCSUtils/TestUtils/UtilityMethodTestCase.php
             count: 1
 
+        # PHPCS 3.x vs 4.x. This is 100% okay.
+        -
+            message: '`^Static call to instance method PHP_CodeSniffer\\Config::setConfigData\(\)\.$`'
+            path: PHPCSUtils/BackCompat/Helper.php
+            count: 1
+
         # Level 1
         # These are on purpose for testing the magic method. This is 100% okay.
         -
@@ -36,6 +42,12 @@ parameters:
             message: '`^Call to an undefined static method PHPCSUtils\\Tokens\\Collections::notATokenArray\(\)\.$`'
             path: Tests/Tokens/Collections/PropertyBasedTokenArraysTest.php
             count: 1
+
+        # PHPCS 3.x vs 4.x. This is 100% okay.
+        -
+            message: '`^Constant T_(ZSR_EQUAL|OBJECT|PROPERTY) not found\.$`'
+            path: Tests/BackCompat/BCTokens/
+            count: 4
 
         # Level 2
         # The __destruct() method exists on the ConfigDouble, not the PHPCS native Config. This is 100% okay.


### PR DESCRIPTION
### Composer: update to PHPCSDevCS 1.2.0

PHPCSDevCS now allows for PHPCS 4.0 and includes PHPCompatibility 10.0.0-alpha1 and a range of sniffs from PHPCSExtra.

Includes:
* Includes minor documentation update in the ruleset.
* Includes a few selective exclusions in the ruleset.
* Updating ignore comments for PHPCompatibility 10.0.0.
* Includes various small CS fixes.
* Includes a few PHPStan related updates as the `composer install` run for the PHPStan job will now use PHPCS 4.x.

Refs:
* https://github.com/PHPCSStandards/PHPCSDevCS/releases/tag/1.2.0
* https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/10.0.0-alpha1
* https://github.com/PHPCompatibility/PHPCompatibility/wiki/Upgrading-to-PHPCompatibility-10.0

### GH Actions: run CS check against PHPCS 4.x dev 