### PR TITLE
Dependabot: remove `composer` ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: "composer"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5 # Set to 0 to (temporarily) disable.
-    versioning-strategy: widen
-    commit-message:
-      prefix: "Composer:"
-      include: "scope"
-    labels:
-      - "Type: chores/QA"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Dependabot has basically _never_ submitted any useful PRs updating the dependencies managed via Composer.

In most cases, it wouldn't be able to anyway as the "widen" strategy only really causes update PRs when a new major of a dependency is released and with a new major of a dependency, we'll generally need to do a managed update, so wouldn't be able to use the Dependabot PR anyhow.

On top of that, it appears to be completely impossible to set any environment variables for the running of Dependabot via GH Actions.

This is problematic as we have a circular dependency via the `phpcsstandards/phpcsdevcs` package since the update to PHPCSDevCS 1.2.0 (PR #726) and the only way to get round that is to set a `COMPOSER_ROOT_VERSION` environment variable.

In practice, this means that since the update to PHPCSDevCS 1.2.0, the action runs for Dependabot are failing, which is not useful.

All in all, I see no upside to continue to have Dependabot enabled for the Composer packages.