### PR TITLE
✨ New PHPCSUtils\Utils\AttributeBlock::appliesTo() method 

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -38,11 +38,11 @@ jobs:
 
         include:
           - php: '7.2'
-            phpcs_version: '4.0.0'
+            phpcs_version: '4.0.1'
           - php: '7.2'
             phpcs_version: '4.x-dev'
           - php: 'latest'
-            phpcs_version: '4.0.0'
+            phpcs_version: '4.0.1'
           - php: 'latest'
             phpcs_version: '4.x-dev'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,30 +87,30 @@ jobs:
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
         php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
-        phpcs_version: ['lowest', '3.x-dev', '4.0.0', '4.x-dev']
+        phpcs_version: ['lowest', '3.x-dev', '4.0.1', '4.x-dev']
         risky: [false]
         experimental: [false]
 
         exclude:
           - php: '5.5'
-            phpcs_version: '4.0.0'
+            phpcs_version: '4.0.1'
           - php: '5.5'
             phpcs_version: '4.x-dev'
           - php: '5.6'
-            phpcs_version: '4.0.0'
+            phpcs_version: '4.0.1'
           - php: '5.6'
             phpcs_version: '4.x-dev'
           - php: '7.0'
-            phpcs_version: '4.0.0'
+            phpcs_version: '4.0.1'
           - php: '7.0'
             phpcs_version: '4.x-dev'
           - php: '7.1'
-            phpcs_version: '4.0.0'
+            phpcs_version: '4.0.1'
           - php: '7.1'
             phpcs_version: '4.x-dev'
           # Also exclude the 7.2 builds as those are run in code coverage, no need to duplicate.
           - php: '7.2'
-            phpcs_version: '4.0.0'
+            phpcs_version: '4.0.1'
           - php: '7.2'
             phpcs_version: '4.x-dev'
 
@@ -163,7 +163,7 @@ jobs:
             experimental: true
 
           - php: '8.4'
-            phpcs_version: '4.0.0'
+            phpcs_version: '4.0.1'
             risky: true
             experimental: true
 
@@ -299,7 +299,7 @@ jobs:
             phpcs_version: '4.x-dev'
             extensions: ':iconv' # Run one build with iconv disabled.
           - php: '8.4'
-            phpcs_version: '4.0.0'
+            phpcs_version: '4.0.1'
           - php: '8.4'
             phpcs_version: '3.x-dev'
           - php: '8.4'
@@ -307,7 +307,7 @@ jobs:
           - php: '7.2'
             phpcs_version: '4.x-dev'
           - php: '7.2'
-            phpcs_version: '4.0.0'
+            phpcs_version: '4.0.1'
           - php: '5.4'
             phpcs_version: '3.x-dev'
           - php: '5.4'

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -524,7 +524,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.13.3.
+     * - The upstream method has received no significant updates since PHPCS 3.13.5.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodProperties()      Original source.
      * @see \PHPCSUtils\Utils\FunctionDeclarations::getProperties() PHPCSUtils native improved version.
@@ -765,7 +765,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.3.0.
-     * - The upstream method has received no significant updates since PHPCS 3.13.3.
+     * - The upstream method has received no significant updates since PHPCS 3.13.5.
      *
      * @see \PHP_CodeSniffer\Files\File::getClassProperties()          Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::getClassProperties() PHPCSUtils native improved version.
@@ -793,7 +793,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.13.3.
+     * - The upstream method has received no significant updates since PHPCS 3.13.5.
      *
      * @see \PHP_CodeSniffer\Files\File::isReference() Original source.
      * @see \PHPCSUtils\Utils\Operators::isReference() PHPCSUtils native improved version.
@@ -819,7 +819,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.13.3.
+     * - The upstream method has received no significant updates since PHPCS 3.13.5.
      *
      * @see \PHP_CodeSniffer\Files\File::getTokensAsString() Original source.
      * @see \PHPCSUtils\Utils\GetTokensAsString              Related set of functions.
@@ -848,7 +848,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.1.0.
-     * - The upstream method has received no significant updates since PHPCS 3.13.3.
+     * - The upstream method has received no significant updates since PHPCS 3.13.5.
      *
      * @see \PHP_CodeSniffer\Files\File::findStartOfStatement() Original source.
      *
@@ -872,7 +872,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.1.0.
-     * - The upstream method has received no significant updates since PHPCS 3.13.3.
+     * - The upstream method has received no significant updates since PHPCS 3.13.5.
      *
      * @see \PHP_CodeSniffer\Files\File::findEndOfStatement() Original source.
      *
@@ -896,7 +896,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.13.3.
+     * - The upstream method has received no significant updates since PHPCS 3.13.5.
      *
      * @see \PHP_CodeSniffer\Files\File::hasCondition()  Original source.
      * @see \PHPCSUtils\Utils\Conditions::hasCondition() PHPCSUtils native alternative.
@@ -921,7 +921,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.3.0.
-     * - The upstream method has received no significant updates since PHPCS 3.13.3.
+     * - The upstream method has received no significant updates since PHPCS 3.13.5.
      *
      * @see \PHP_CodeSniffer\Files\File::getCondition()  Original source.
      * @see \PHPCSUtils\Utils\Conditions::getCondition() More versatile alternative.

--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -72,7 +72,7 @@ final class BCTokens
 
     /**
      * Handle calls to (undeclared) methods for token arrays which haven't received any
-     * changes since PHPCS 3.13.3.
+     * changes since PHPCS 3.13.5.
      *
      * @since 1.0.0
      *

--- a/PHPCSUtils/Utils/AttributeBlock.php
+++ b/PHPCSUtils/Utils/AttributeBlock.php
@@ -27,6 +27,120 @@ final class AttributeBlock
 {
 
     /**
+     * Given an attribute opener, find the relevant construct token the attribute applies to.
+     *
+     * @since 1.2.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the T_ATTRIBUTE (attribute opener) token.
+     *
+     * @return int|false The stackPtr to the OO, function, closure, fn, constant, or variable token the attribute block
+     *                   applies to; or FALSE if the attribute target could not be determined.
+     *
+     * @throws \PHPCSUtils\Exceptions\TypeError           If the $stackPtr parameter is not an integer.
+     * @throws \PHPCSUtils\Exceptions\OutOfBoundsStackPtr If the token passed does not exist in the $phpcsFile.
+     * @throws \PHPCSUtils\Exceptions\UnexpectedTokenType If the token passed is not an attribute token and
+     *                                                    not within an attribute.
+     */
+    public static function appliesTo(File $phpcsFile, $stackPtr)
+    {
+        static $allowedTokens;
+
+        $tokens = $phpcsFile->getTokens();
+
+        if (\is_int($stackPtr) === false) {
+            throw TypeError::create(2, '$stackPtr', 'integer', $stackPtr);
+        }
+
+        if (isset($tokens[$stackPtr]) === false) {
+            throw OutOfBoundsStackPtr::create(2, '$stackPtr', $stackPtr);
+        }
+
+        if ($tokens[$stackPtr]['code'] !== \T_ATTRIBUTE
+            && $tokens[$stackPtr]['code'] !== \T_ATTRIBUTE_END
+            && Context::inAttribute($phpcsFile, $stackPtr) === false
+        ) {
+            $acceptedTokens = 'T_ATTRIBUTE, T_ATTRIBUTE_END or a token within an attribute';
+            throw UnexpectedTokenType::create(2, '$stackPtr', $acceptedTokens, $tokens[$stackPtr]['type']);
+        }
+
+        if (isset($tokens[$stackPtr]['attribute_closer']) === false) {
+            return false;
+        }
+
+        if (Cache::isCached($phpcsFile, __METHOD__, $stackPtr) === true) {
+            return Cache::get($phpcsFile, __METHOD__, $stackPtr);
+        }
+
+        $attributeTarget = false;
+
+        if (isset($allowedTokens) === false) {
+            /*
+             * Allow every type of token which could be encountered between the attribute and the target construct,
+             * even though some are only allowed in specific circumstances or for specific constructs.
+             * That, however, is not a concern for this method.
+             * Parse error tolerance prevails to give sniffs the most flexibility.
+             */
+            $allowedTokens = Tokens::$emptyTokens;
+
+            // OO constants.
+            $allowedTokens += Collections::constantModifierKeywords();
+
+            // Functions, closures, arrow functions and methods.
+            $allowedTokens += [\T_STATIC => \T_STATIC];
+            $allowedTokens += Tokens::$methodPrefixes;
+
+            // OO declarations.
+            $allowedTokens += Collections::classModifierKeywords();
+
+            // Properties and parameters
+            $allowedTokens += [\T_NULLABLE => \T_NULLABLE];
+            $allowedTokens += Collections::propertyModifierKeywords();
+            $allowedTokens += Collections::propertyTypeTokens();
+            $allowedTokens += Collections::parameterTypeTokens();
+            $allowedTokens += [
+                \T_BITWISE_AND => \T_BITWISE_AND,
+                \T_ELLIPSIS    => \T_ELLIPSIS,
+            ];
+        }
+
+        for ($i = ($tokens[$stackPtr]['attribute_closer'] + 1); $i <= $phpcsFile->numTokens; $i++) {
+            // Skip over potentially large docblocks.
+            if ($tokens[$i]['code'] === \T_DOC_COMMENT_OPEN_TAG
+                && isset($tokens[$i]['comment_closer'])
+            ) {
+                $i = $tokens[$i]['comment_closer'];
+                continue;
+            }
+
+            if ($tokens[$i]['code'] === \T_ATTRIBUTE
+                && isset($tokens[$i]['attribute_closer']) === true
+            ) {
+                $i = $tokens[$i]['attribute_closer'];
+                continue;
+            }
+
+            if (isset($allowedTokens[$tokens[$i]['code']])) {
+                continue;
+            }
+
+            // Okay, so this _must_ be the token for the construct.
+            if (isset(Tokens::$ooScopeTokens[$tokens[$i]['code']]) === true
+                || isset(Collections::functionDeclarationTokens()[$tokens[$i]['code']]) === true
+                || $tokens[$i]['code'] === \T_CONST
+                || $tokens[$i]['code'] === \T_VARIABLE
+            ) {
+                $attributeTarget = $i;
+            }
+
+            break;
+        }
+
+        Cache::set($phpcsFile, __METHOD__, $stackPtr, $attributeTarget);
+        return $attributeTarget;
+    }
+
+    /**
      * Retrieve information on each attribute instantiation within an attribute block.
      *
      * @since 1.2.0

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Whether you need to split an `array` into the individual items, are trying to de
 
 Includes improved versions of the PHPCS native utility functions and plenty of new utility functions.
 
-These functions are compatible with PHPCS 3.13.3 up to PHPCS `4.x`.
+These functions are compatible with PHPCS 3.13.5 up to PHPCS `4.x`.
 
 ### A collection of static properties and methods for often-used token groups
 
@@ -78,7 +78,7 @@ To see detailed information about all the available abstract sniffs, utility fun
 ## Minimum Requirements
 
 * PHP 5.4 or higher.
-* [PHP_CodeSniffer] 3.13.3+/4.0.0+.
+* [PHP_CodeSniffer] 3.13.5+/4.0.1+.
 * Recommended PHP extensions for optimal functionality:
     - PCRE with Unicode support (normally enabled by default)
 

--- a/Tests/BackCompat/Helper/GetVersionTest.php
+++ b/Tests/BackCompat/Helper/GetVersionTest.php
@@ -56,7 +56,7 @@ final class GetVersionTest extends TestCase
         }
 
         if ($expected === 'lowest') {
-            $expected = '3.13.3';
+            $expected = '3.13.5';
         }
 
         $result = Helper::getVersion();

--- a/Tests/Utils/AttributeBlock/AppliesToParseError1Test.inc
+++ b/Tests/Utils/AttributeBlock/AppliesToParseError1Test.inc
@@ -1,0 +1,8 @@
+<?php
+
+// Intentional parse error.
+// This must be the only test in the file.
+
+/* testLiveCoding */
+#[AttributeName(10)
+function hasUnfinishedAttribute() {}

--- a/Tests/Utils/AttributeBlock/AppliesToParseError1Test.php
+++ b/Tests/Utils/AttributeBlock/AppliesToParseError1Test.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2025 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\AttributeBlock;
+
+use PHPCSUtils\Tests\PolyfilledTestCase;
+use PHPCSUtils\Utils\AttributeBlock;
+
+/**
+ * Test for the \PHPCSUtils\Utils\AttributeBlock::appliesTo() method.
+ *
+ * @covers \PHPCSUtils\Utils\AttributeBlock::appliesTo
+ *
+ * @group attributes
+ *
+ * @since 1.2.0
+ */
+final class AppliesToParseError1Test extends PolyfilledTestCase
+{
+
+    /**
+     * Verify that a broken attribute results in a `false` return when passed the attribute opener.
+     *
+     * @return void
+     */
+    public function testUnfinishedAttributeWithOpener()
+    {
+        $targetPtr = $this->getTargetToken('/* testLiveCoding */', \T_ATTRIBUTE);
+        $result    = AttributeBlock::appliesTo(self::$phpcsFile, $targetPtr);
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Verify that if a token from within a broken attribute is passed, an exception is thrown.
+     *
+     * @dataProvider dataUnfinishedAttributeWithTokenWithin
+     *
+     * @param int|string  $tokenType    Type of token to select as the target.
+     * @param string|null $tokenContent Optional. Token content of the target token.
+     *
+     * @return void
+     */
+    public function testUnfinishedAttributeWithTokenWithin($tokenType, $tokenContent = null)
+    {
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be of type T_ATTRIBUTE, T_ATTRIBUTE_END or a token within an attribute'
+        );
+
+        $targetPtr = $this->getTargetToken('/* testLiveCoding */', $tokenType, $tokenContent);
+        AttributeBlock::appliesTo(self::$phpcsFile, $targetPtr);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testUnfinishedAttributeWithTokenWithin()
+     *
+     * @return array<string, array<string, int|string>>
+     */
+    public static function dataUnfinishedAttributeWithTokenWithin()
+    {
+        return [
+            'attribute name' => [
+                'tokenType'    => \T_STRING,
+                'tokenContent' => 'AttributeName',
+            ],
+            'parenthesis' => [
+                'tokenType' => \T_OPEN_PARENTHESIS,
+            ],
+            'attribute parameter' => [
+                'tokenType' => \T_LNUMBER,
+            ],
+        ];
+    }
+}

--- a/Tests/Utils/AttributeBlock/AppliesToParseError2Test.inc
+++ b/Tests/Utils/AttributeBlock/AppliesToParseError2Test.inc
@@ -1,0 +1,16 @@
+<?php
+
+// Intentional parse error.
+// This must be the only test in the file.
+
+/* testAttributeWithoutTarget */
+#[MissingTarget]
+#[AnotherAttribute]
+/**
+ * Docblock
+ */
+#[YetAnotherAttribute]
+
+echo 'Hello!';
+
+const FOO = 10;

--- a/Tests/Utils/AttributeBlock/AppliesToParseError2Test.php
+++ b/Tests/Utils/AttributeBlock/AppliesToParseError2Test.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2025 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\AttributeBlock;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\AttributeBlock;
+
+/**
+ * Test for the \PHPCSUtils\Utils\AttributeBlock::appliesTo() method.
+ *
+ * @covers \PHPCSUtils\Utils\AttributeBlock::appliesTo
+ *
+ * @group attributes
+ *
+ * @since 1.2.0
+ */
+final class AppliesToParseError2Test extends UtilityMethodTestCase
+{
+
+    /**
+     * Verify that `false` is returned if the construct the attribute applies to cannot be determined.
+     *
+     * @return void
+     */
+    public function testAttributeWithoutTarget()
+    {
+        $targetPtr = $this->getTargetToken('/* testAttributeWithoutTarget */', \T_ATTRIBUTE);
+        $result    = AttributeBlock::appliesTo(self::$phpcsFile, $targetPtr);
+
+        $this->assertFalse($result);
+    }
+}

--- a/Tests/Utils/AttributeBlock/AppliesToParseError3Test.inc
+++ b/Tests/Utils/AttributeBlock/AppliesToParseError3Test.inc
@@ -1,0 +1,15 @@
+<?php
+
+// Intentional parse error.
+// This must be the only test in the file.
+// Testing parse error tolerance (keywords used in an invalid context).
+
+/* testInvalidPHP */
+#[MyAttribute]
+#[AnotherAttribute]
+/**
+ * Docblock
+ */
+#[YetAnotherAttribute]
+
+final protected const FOO = 10;

--- a/Tests/Utils/AttributeBlock/AppliesToParseError3Test.php
+++ b/Tests/Utils/AttributeBlock/AppliesToParseError3Test.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2025 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\AttributeBlock;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\AttributeBlock;
+
+/**
+ * Test for the \PHPCSUtils\Utils\AttributeBlock::appliesTo() method.
+ *
+ * @covers \PHPCSUtils\Utils\AttributeBlock::appliesTo
+ *
+ * @group attributes
+ *
+ * @since 1.2.0
+ */
+final class AppliesToParseError3Test extends UtilityMethodTestCase
+{
+
+    /**
+     * Document parse error tolerance.
+     *
+     * When attributes are used in invalid context or keywords which can exist between the attribute
+     * and the target construct are used incorrectly, the utility method will still find the
+     * target construct, even though the code under scan would amount to invalid PHP.
+     *
+     * @return void
+     */
+    public function testTargetGetsFoundForInvalidPhp()
+    {
+        $targetPtr   = $this->getTargetToken('/* testInvalidPHP */', \T_ATTRIBUTE);
+        $expectedPtr = $this->getTargetToken('/* testInvalidPHP */', \T_CONST);
+        $result      = AttributeBlock::appliesTo(self::$phpcsFile, $targetPtr);
+
+        $this->assertSame($expectedPtr, $result);
+    }
+}

--- a/Tests/Utils/AttributeBlock/AppliesToParseError4Test.inc
+++ b/Tests/Utils/AttributeBlock/AppliesToParseError4Test.inc
@@ -1,0 +1,11 @@
+<?php
+
+// Intentional parse error.
+// This must be the only test in the file.
+// Testing parse error tolerance (keywords used in an invalid context).
+
+function invalidNotAPropertyNorParameter() {
+    /* testInvalidPHP */
+    #[MyAttribute]
+    static $target;
+}

--- a/Tests/Utils/AttributeBlock/AppliesToParseError4Test.php
+++ b/Tests/Utils/AttributeBlock/AppliesToParseError4Test.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2025 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\AttributeBlock;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\AttributeBlock;
+
+/**
+ * Test for the \PHPCSUtils\Utils\AttributeBlock::appliesTo() method.
+ *
+ * @covers \PHPCSUtils\Utils\AttributeBlock::appliesTo
+ *
+ * @group attributes
+ *
+ * @since 1.2.0
+ */
+final class AppliesToParseError4Test extends UtilityMethodTestCase
+{
+
+    /**
+     * Document parse error tolerance.
+     *
+     * When attributes are used in invalid context or keywords which can exist between the attribute
+     * and the target construct are used incorrectly, the utility method will still find the
+     * target construct, even though the code under scan would amount to invalid PHP.
+     *
+     * @return void
+     */
+    public function testTargetGetsFoundForInvalidPhp()
+    {
+        $targetPtr   = $this->getTargetToken('/* testInvalidPHP */', \T_ATTRIBUTE);
+        $expectedPtr = $this->getTargetToken('/* testInvalidPHP */', \T_VARIABLE);
+        $result      = AttributeBlock::appliesTo(self::$phpcsFile, $targetPtr);
+
+        $this->assertSame($expectedPtr, $result);
+    }
+}

--- a/Tests/Utils/AttributeBlock/AppliesToParseError5Test.inc
+++ b/Tests/Utils/AttributeBlock/AppliesToParseError5Test.inc
@@ -1,0 +1,12 @@
+<?php
+
+// Intentional parse error.
+// This must be the only test in the file.
+// Testing parse error tolerance (keywords used in an invalid context).
+
+/* testInvalidPHP */
+#[MyAttribute]
+/**
+ * Docblock
+ */
+final readonly trait InvalidKeywordsForTrait {}

--- a/Tests/Utils/AttributeBlock/AppliesToParseError5Test.php
+++ b/Tests/Utils/AttributeBlock/AppliesToParseError5Test.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2025 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\AttributeBlock;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\AttributeBlock;
+
+/**
+ * Test for the \PHPCSUtils\Utils\AttributeBlock::appliesTo() method.
+ *
+ * @covers \PHPCSUtils\Utils\AttributeBlock::appliesTo
+ *
+ * @group attributes
+ *
+ * @since 1.2.0
+ */
+final class AppliesToParseError5Test extends UtilityMethodTestCase
+{
+
+    /**
+     * Document parse error tolerance.
+     *
+     * When attributes are used in invalid context or keywords which can exist between the attribute
+     * and the target construct are used incorrectly, the utility method will still find the
+     * target construct, even though the code under scan would amount to invalid PHP.
+     *
+     * @return void
+     */
+    public function testTargetGetsFoundForInvalidPhp()
+    {
+        $targetPtr   = $this->getTargetToken('/* testInvalidPHP */', \T_ATTRIBUTE);
+        $expectedPtr = $this->getTargetToken('/* testInvalidPHP */', \T_TRAIT);
+        $result      = AttributeBlock::appliesTo(self::$phpcsFile, $targetPtr);
+
+        $this->assertSame($expectedPtr, $result);
+    }
+}

--- a/Tests/Utils/AttributeBlock/AppliesToParseError6Test.inc
+++ b/Tests/Utils/AttributeBlock/AppliesToParseError6Test.inc
@@ -1,0 +1,9 @@
+<?php
+
+// Intentional parse error.
+// This must be the only test in the file.
+// Testing parse error tolerance (keywords used in an invalid context).
+
+/* testInvalidPHP */
+#[MyAttribute]
+$closure = function() {};

--- a/Tests/Utils/AttributeBlock/AppliesToParseError6Test.php
+++ b/Tests/Utils/AttributeBlock/AppliesToParseError6Test.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2025 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\AttributeBlock;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\AttributeBlock;
+
+/**
+ * Test for the \PHPCSUtils\Utils\AttributeBlock::appliesTo() method.
+ *
+ * @covers \PHPCSUtils\Utils\AttributeBlock::appliesTo
+ *
+ * @group attributes
+ *
+ * @since 1.2.0
+ */
+final class AppliesToParseError6Test extends UtilityMethodTestCase
+{
+
+    /**
+     * Document parse error tolerance.
+     *
+     * When attributes are used in invalid context or keywords which can exist between the attribute
+     * and the target construct are used incorrectly, the utility method will still find the
+     * target construct, even though the code under scan would amount to invalid PHP.
+     *
+     * @return void
+     */
+    public function testTargetGetsFoundForInvalidPhp()
+    {
+        $targetPtr   = $this->getTargetToken('/* testInvalidPHP */', \T_ATTRIBUTE);
+        $expectedPtr = $this->getTargetToken('/* testInvalidPHP */', \T_VARIABLE);
+        $result      = AttributeBlock::appliesTo(self::$phpcsFile, $targetPtr);
+
+        $this->assertSame($expectedPtr, $result);
+    }
+}

--- a/Tests/Utils/AttributeBlock/AppliesToParseError7Test.inc
+++ b/Tests/Utils/AttributeBlock/AppliesToParseError7Test.inc
@@ -1,0 +1,9 @@
+<?php
+
+// Intentional parse error.
+// This must be the only test in the file.
+// Testing parse error tolerance (keywords used in an invalid context).
+
+/* testInvalidPHP */
+#[MyAttribute]
+public static readonly int function Invalid() {}

--- a/Tests/Utils/AttributeBlock/AppliesToParseError7Test.php
+++ b/Tests/Utils/AttributeBlock/AppliesToParseError7Test.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2025 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\AttributeBlock;
+
+use PHPCSUtils\TestUtils\UtilityMethodTestCase;
+use PHPCSUtils\Utils\AttributeBlock;
+
+/**
+ * Test for the \PHPCSUtils\Utils\AttributeBlock::appliesTo() method.
+ *
+ * @covers \PHPCSUtils\Utils\AttributeBlock::appliesTo
+ *
+ * @group attributes
+ *
+ * @since 1.2.0
+ */
+final class AppliesToParseError7Test extends UtilityMethodTestCase
+{
+
+    /**
+     * Document parse error tolerance.
+     *
+     * When attributes are used in invalid context or keywords which can exist between the attribute
+     * and the target construct are used incorrectly, the utility method will still find the
+     * target construct, even though the code under scan would amount to invalid PHP.
+     *
+     * @return void
+     */
+    public function testTargetGetsFoundForInvalidPhp()
+    {
+        $targetPtr   = $this->getTargetToken('/* testInvalidPHP */', \T_ATTRIBUTE);
+        $expectedPtr = $this->getTargetToken('/* testInvalidPHP */', \T_FUNCTION);
+        $result      = AttributeBlock::appliesTo(self::$phpcsFile, $targetPtr);
+
+        $this->assertSame($expectedPtr, $result);
+    }
+}

--- a/Tests/Utils/AttributeBlock/AppliesToTest.inc
+++ b/Tests/Utils/AttributeBlock/AppliesToTest.inc
@@ -1,0 +1,184 @@
+<?php
+
+/* testNotAcceptedTypeExceptionOutsideAttribute1 */
+/**
+ * Docblock
+ */
+#[MyAttribute]
+function notAcceptedTokenOutsideAttributeTest() {}
+
+/* testNotAcceptedTypeExceptionOutsideAttribute2 */
+echo 'notAcceptedTokenOutsideAttributeTest';
+
+/* testAcceptedTokens */
+#[AttributeName(10), \AnotherAttribute, namespace\ThirdAttribute(self::CONSTANT, 'foo')]
+function acceptedTokensAttributeTarget() {}
+
+/* testFindUnscopedConst */
+#[MyAttribute]
+const UNSCOPED = true;
+
+array_map(
+    /* testFindUnscopedClosure */
+    #[MyAttribute]
+    function($a) {
+        return $a++;
+    },
+    $array
+);
+
+/* testFindUnscopedClosureStatic */
+$closure = #[MyAttribute] static function($a) {};
+
+array_map(
+    /* testFindUnscopedArrowFunction */
+    #[MyAttribute]
+    fn($a) => $a++,
+    $array
+);
+
+/* testFindUnscopedArrowFunctionStatic */
+$closure = #[MyAttribute] static fn ($a) => $a * 10;
+
+function hasParamAttributes(
+    /* testFindFunctionParameter */
+    #[MyAttribute]
+    #[AnotherAttribute]
+    $paramA,
+
+    /* testFindFunctionParameterTypedNullable */
+    #[MyAttribute] ?int $paramB,
+
+    /* testFindFunctionParameterTypedUnion */
+    #[MyAttribute] int|false $paramC,
+
+    /* testFindFunctionParameterWithRef */
+    #[MyAttribute]
+    // Unrelated comment
+    &$paramD,
+
+    /* testFindFunctionParameterWithSpread */
+    #[MyAttribute]
+    /** docblock */
+    ...$paramE,
+) {}
+
+function hasParamAttributesToo(
+    /* testFindFunctionParameterAllTogetherNow */
+    #[MyAttribute] (\Foo&Partial\Bar&namespace\Other)|array &...$paramF,
+) {}
+
+/* testFindClass */
+#[MyAttribute]
+class classHasAttribute {}
+
+/* testFindClassFinal */
+#[MyAttribute]
+/**
+ * Docblock.
+ */
+#[AnotherAttribute]
+final class finalClass {}
+
+/* testFindClassReadonly */
+#[MyAttribute]
+readonly class readonlyClass {}
+
+/* testFindClassAbstract */
+#[MyAttribute]
+abstract class abstractClass {}
+
+/* testFindClassFinalReadonly */
+#[MyAttribute]
+// Unrelated comment.
+
+// Another unrelated comment.
+final readonly class finalReadonlyClass {}
+
+/* testFindAnonClass */
+$anon = new #[MyAttribute] #[SecondAttribute] class {};
+
+/* testFindAnonClassReadonly */
+$anon = new #[MyAttribute] readonly class {};
+
+/* testFindTrait */
+#[MyAttribute(10), \Another]
+trait traitHasAttribute {}
+
+/* testFindInterface */
+#[MyAttribute]
+
+
+
+#[AnotherAttributeWithBlankLinesAroundIt(
+    name: VALUE,
+    other_name: VALUE,
+)]
+
+
+
+interface interfaceHasAttribute {}
+
+/* testFindEnum */
+#[MyAttribute]
+/**
+ * Docblock.
+ *
+ * @since 1.2.0
+ * @see Some\Ref
+ */
+enum enumHasAttribute {}
+
+abstract class AttributesEverywhere {
+    /* testFindConstFinal */
+    #[MyAttribute]
+    final const FINAL_CONST = false;
+
+    /* testFindConstPublicFinal */
+    #[MyAttribute]
+    public final const PUBLIC_FINAL_CONST = true;
+
+    /* testFindConstPrivateTyped */
+    #[MyAttribute]
+    private const TypeA|TypeB PRIVATE_CONST = new TypeA;
+
+    /* testFindPropertyVar */
+    #[MyAttribute]
+    var $propertyA;
+
+    /* testFindPropertyPublicStatic */
+    #[MyAttribute]
+    public static $propertyB;
+
+    /* testFindPropertyFinalProtectedReadonlyNullableType */
+    #[MyAttribute]
+    final protected readonly ?\TypeA $propertyC;
+
+    // Intentional parse error, abstract private, but not our concern.
+    /* testFindPropertyPrivateAbstractDNFType */
+    #[MyAttribute]
+    private abstract array|(DN&\F)|false $propertyD { get; }
+
+    /* testFindPropertyReadonlyAsymPrivateIntersectionType */
+    #[MyAttribute]
+    readonly private(set) TypeA&namespace\TypeB $propertyE;
+
+    /* testFindMethodPublicStaticReturnByRef */
+    #[MyAttribute]
+    public static function &methodA() {}
+
+    /* testFindMethodAbstractProtected */
+    #[MyAttribute]
+    abstract protected function methodB();
+
+    // Intentional parse error, final private, but not our concern.
+    /* testFindMethodPrivateFinal */
+    #[MyAttribute]
+    private final function methodC() {}
+
+    public function __construct(
+        /* testFindPromotedProperty */
+        #[MyAttribute] #[AnotherAttribute]
+        public private(set) final ?int $propA,
+    ) {}
+}

--- a/Tests/Utils/AttributeBlock/AppliesToTest.php
+++ b/Tests/Utils/AttributeBlock/AppliesToTest.php
@@ -1,0 +1,324 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2025 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\Utils\AttributeBlock;
+
+use PHPCSUtils\Internal\Cache;
+use PHPCSUtils\Tests\PolyfilledTestCase;
+use PHPCSUtils\Utils\AttributeBlock;
+
+/**
+ * Test for the \PHPCSUtils\Utils\AttributeBlock::appliesTo() method.
+ *
+ * @covers \PHPCSUtils\Utils\AttributeBlock::appliesTo
+ *
+ * @group attributes
+ *
+ * @since 1.2.0
+ */
+final class AppliesToTest extends PolyfilledTestCase
+{
+
+    /**
+     * Test receiving an exception when passing a non-integer token pointer.
+     *
+     * @return void
+     */
+    public function testNonIntegerToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\TypeError');
+        $this->expectExceptionMessage('Argument #2 ($stackPtr) must be of type integer, boolean given');
+
+        AttributeBlock::appliesTo(self::$phpcsFile, false);
+    }
+
+    /**
+     * Test receiving an exception when passing a non-existent token pointer.
+     *
+     * @return void
+     */
+    public function testNonExistentToken()
+    {
+        $this->expectException('PHPCSUtils\Exceptions\OutOfBoundsStackPtr');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be a stack pointer which exists in the $phpcsFile object, 100000 given'
+        );
+
+        AttributeBlock::appliesTo(self::$phpcsFile, 100000);
+    }
+
+    /**
+     * Test receiving an expected exception when a token which is not part of an attribute block is passed.
+     *
+     * @dataProvider dataNotAcceptedTypeException
+     *
+     * @param string     $identifier Comment which precedes the test case.
+     * @param int|string $targetType Type of token to select as the target.
+     *
+     * @return void
+     */
+    public function testNotAcceptedTypeException($identifier, $targetType)
+    {
+        $this->expectException('PHPCSUtils\Exceptions\UnexpectedTokenType');
+        $this->expectExceptionMessage(
+            'Argument #2 ($stackPtr) must be of type T_ATTRIBUTE, T_ATTRIBUTE_END or a token within an attribute'
+        );
+
+        $targetPtr = $this->getTargetToken($identifier, $targetType);
+        AttributeBlock::appliesTo(self::$phpcsFile, $targetPtr);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNotAcceptedTypeException()
+     *
+     * @return array<string, array<string, int|string>>
+     */
+    public static function dataNotAcceptedTypeException()
+    {
+        return [
+            'docblock, not attribute' => [
+                'identifier' => '/* testNotAcceptedTypeExceptionOutsideAttribute1 */',
+                'targetType' => \T_DOC_COMMENT_OPEN_TAG,
+            ],
+            'whitespace' => [
+                'identifier' => '/* testNotAcceptedTypeExceptionOutsideAttribute1 */',
+                'targetType' => \T_WHITESPACE,
+            ],
+            'function keyword, not attribute' => [
+                'identifier' => '/* testNotAcceptedTypeExceptionOutsideAttribute1 */',
+                'targetType' => \T_FUNCTION,
+            ],
+            'token which can\'t even exist in an attribute' => [
+                'identifier' => '/* testNotAcceptedTypeExceptionOutsideAttribute2 */',
+                'targetType' => \T_ECHO,
+            ],
+        ];
+    }
+
+    /**
+     * Test that all tokens in an attribute block are accepted as the "stackPtr".
+     *
+     * @return void
+     */
+    public function testAllTokensFromAnAttributeBlockAreAccepted()
+    {
+        $tokens      = self::$phpcsFile->getTokens();
+        $startPtr    = $this->getTargetToken('/* testAcceptedTokens */', \T_ATTRIBUTE);
+        $endPtr      = $tokens[$startPtr]['attribute_closer'];
+        $expectedPtr = $this->getTargetToken('/* testAcceptedTokens */', \T_FUNCTION);
+
+        for ($i = $startPtr; $i <= $endPtr; $i++) {
+            $this->assertSame(
+                $expectedPtr,
+                AttributeBlock::appliesTo(self::$phpcsFile, $i),
+                "Token $i with type " . $tokens[$i]['type'] . ' did not yield correct results'
+            );
+        }
+    }
+
+    /**
+     * Test the appliesTo() method.
+     *
+     * @dataProvider dataAppliesTo
+     *
+     * @param string     $identifier   Comment which precedes the test case.
+     * @param int|string $expectedType Type of token which the attribute is expected to point to.
+     *
+     * @return void
+     */
+    public function testAppliesTo($identifier, $expectedType)
+    {
+        $targetPtr   = $this->getTargetToken($identifier, \T_ATTRIBUTE);
+        $expectedPtr = $this->getTargetToken($identifier, $expectedType);
+        $result      = AttributeBlock::appliesTo(self::$phpcsFile, $targetPtr);
+
+        $this->assertSame($expectedPtr, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testAppliesTo()
+     *
+     * @return array<string, array<string, string|int>>
+     */
+    public static function dataAppliesTo()
+    {
+        return [
+            'unscoped constant' => [
+                'identifier'   => '/* testFindUnscopedConst */',
+                'expectedType' => \T_CONST,
+            ],
+            'unscoped closure' => [
+                'identifier'   => '/* testFindUnscopedClosure */',
+                'expectedType' => \T_CLOSURE,
+            ],
+            'unscoped closure, static' => [
+                'identifier'   => '/* testFindUnscopedClosureStatic */',
+                'expectedType' => \T_CLOSURE,
+            ],
+            'unscoped arrow function' => [
+                'identifier'   => '/* testFindUnscopedArrowFunction */',
+                'expectedType' => \T_FN,
+            ],
+            'unscoped arrow function, static' => [
+                'identifier'   => '/* testFindUnscopedArrowFunctionStatic */',
+                'expectedType' => \T_FN,
+            ],
+            'function param' => [
+                'identifier'   => '/* testFindFunctionParameter */',
+                'expectedType' => \T_VARIABLE,
+            ],
+            'function param with nullable type' => [
+                'identifier'   => '/* testFindFunctionParameterTypedNullable */',
+                'expectedType' => \T_VARIABLE,
+            ],
+            'function param with union type' => [
+                'identifier'   => '/* testFindFunctionParameterTypedUnion */',
+                'expectedType' => \T_VARIABLE,
+            ],
+            'function param pass by ref' => [
+                'identifier'   => '/* testFindFunctionParameterWithRef */',
+                'expectedType' => \T_VARIABLE,
+            ],
+            'function param variadic' => [
+                'identifier'   => '/* testFindFunctionParameterWithSpread */',
+                'expectedType' => \T_VARIABLE,
+            ],
+            'function param, DNF type, variadic, pass by ref' => [
+                'identifier'   => '/* testFindFunctionParameterAllTogetherNow */',
+                'expectedType' => \T_VARIABLE,
+            ],
+            'class' => [
+                'identifier'   => '/* testFindClass */',
+                'expectedType' => \T_CLASS,
+            ],
+            'class, final' => [
+                'identifier'   => '/* testFindClassFinal */',
+                'expectedType' => \T_CLASS,
+            ],
+            'class, readonly' => [
+                'identifier'   => '/* testFindClassReadonly */',
+                'expectedType' => \T_CLASS,
+            ],
+            'class, abstract' => [
+                'identifier'   => '/* testFindClassAbstract */',
+                'expectedType' => \T_CLASS,
+            ],
+            'class, final readonly' => [
+                'identifier'   => '/* testFindClassFinalReadonly */',
+                'expectedType' => \T_CLASS,
+            ],
+            'anon class' => [
+                'identifier'   => '/* testFindAnonClass */',
+                'expectedType' => \T_ANON_CLASS,
+            ],
+            'anon class, readonly' => [
+                'identifier'   => '/* testFindAnonClassReadonly */',
+                'expectedType' => \T_ANON_CLASS,
+            ],
+            'trait' => [
+                'identifier'   => '/* testFindTrait */',
+                'expectedType' => \T_TRAIT,
+            ],
+            'interface' => [
+                'identifier'   => '/* testFindInterface */',
+                'expectedType' => \T_INTERFACE,
+            ],
+            'enum' => [
+                'identifier'   => '/* testFindEnum */',
+                'expectedType' => \T_ENUM,
+            ],
+            'OO const, final' => [
+                'identifier'   => '/* testFindConstFinal */',
+                'expectedType' => \T_CONST,
+            ],
+            'OO const, public final' => [
+                'identifier'   => '/* testFindConstPublicFinal */',
+                'expectedType' => \T_CONST,
+            ],
+            'OO const, private typed' => [
+                'identifier'   => '/* testFindConstPrivateTyped */',
+                'expectedType' => \T_CONST,
+            ],
+            'OO property, var' => [
+                'identifier'   => '/* testFindPropertyVar */',
+                'expectedType' => \T_VARIABLE,
+            ],
+            'OO property, public static' => [
+                'identifier'   => '/* testFindPropertyPublicStatic */',
+                'expectedType' => \T_VARIABLE,
+            ],
+            'OO property, final protected readonly nullable type' => [
+                'identifier'   => '/* testFindPropertyFinalProtectedReadonlyNullableType */',
+                'expectedType' => \T_VARIABLE,
+            ],
+            'OO property, private abstract DNF type' => [
+                'identifier'   => '/* testFindPropertyPrivateAbstractDNFType */',
+                'expectedType' => \T_VARIABLE,
+            ],
+            'OO property, readonly private(set) intersection type' => [
+                'identifier'   => '/* testFindPropertyReadonlyAsymPrivateIntersectionType */',
+                'expectedType' => \T_VARIABLE,
+            ],
+            'OO method, public static, return by ref' => [
+                'identifier'   => '/* testFindMethodPublicStaticReturnByRef */',
+                'expectedType' => \T_FUNCTION,
+            ],
+            'OO method, abstract protected' => [
+                'identifier'   => '/* testFindMethodAbstractProtected */',
+                'expectedType' => \T_FUNCTION,
+            ],
+            'OO method, private final' => [
+                'identifier'   => '/* testFindMethodPrivateFinal */',
+                'expectedType' => \T_FUNCTION,
+            ],
+            'constructor property promotion' => [
+                'identifier'   => '/* testFindPromotedProperty */',
+                'expectedType' => \T_VARIABLE,
+            ],
+        ];
+    }
+
+    /**
+     * Verify that the build-in caching is used when caching is enabled.
+     *
+     * @return void
+     */
+    public function testResultIsCached()
+    {
+        $methodName   = 'PHPCSUtils\\Utils\\AttributeBlock::appliesTo';
+        $cases        = self::dataAppliesTo();
+        $identifier   = $cases['trait']['identifier'];
+        $expectedType = $cases['trait']['expectedType'];
+
+        $targetPtr   = $this->getTargetToken($identifier, \T_ATTRIBUTE);
+        $expectedPtr = $this->getTargetToken($identifier, $expectedType);
+
+        // Verify the caching works.
+        $origStatus     = Cache::$enabled;
+        Cache::$enabled = true;
+
+        $resultFirstRun  = AttributeBlock::appliesTo(self::$phpcsFile, $targetPtr);
+        $isCached        = Cache::isCached(self::$phpcsFile, $methodName, $targetPtr);
+        $resultSecondRun = AttributeBlock::appliesTo(self::$phpcsFile, $targetPtr);
+
+        if ($origStatus === false) {
+            Cache::clear();
+        }
+        Cache::$enabled = $origStatus;
+
+        $this->assertSame($expectedPtr, $resultFirstRun, 'First result did not match expectation');
+        $this->assertTrue($isCached, 'Cache::isCached() could not find the cached value');
+        $this->assertSame($resultFirstRun, $resultSecondRun, 'Second result did not match first');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.13.3 || ^4.0",
+        "squizlabs/php_codesniffer" : "^3.13.5 || ^4.0.1",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0"
     },
     "require-dev" : {


### PR DESCRIPTION
### Composer: raise the minimum supported PHPCS version to 3.13.5/4.0.1 

... to benefit from a bug fix in the PHPCS tokenizer related to attributes during live coding.

Includes updating references to the PHPCS version whenever relevant throughout the codebase.

### ✨ New PHPCSUtils\Utils\AttributeBlock::appliesTo() method 

This commit adds an additional method to the `AttributeBlock` utility class to allow for finding the language construct (function, constant, parameter etc) an arbitrary attribute applies to.

This method can be passed any token in an attribute block (opener, closer or any token within) and will try to determine the target of the attribute.

The return value will be the stack pointer to a `T_CONST`, `T_FUNCTION`, `T_CLOSURE`, `T_FN`, `T_CLASS`, `T_ANON_CLASS`, `T_INTERFACE`, `T_TRAIT`, `T_ENUM` or `T_VARIABLE` token; or `false` if the attribute target could not be determined.

For multi-property declarations, the `T_VARIABLE` token returned will be to the first property in the declaration.

Mind: this method includes some parse error tolerance for keywords used in an incorrect context. This is deliberate.

Includes extensive unit tests.

Related to #616

Closes #616