### PR TITLE
PHP 8.5 | AbstractArrayDeclarationSniff::getActualArrayKey(): prevent notices about deprecated casts

### DIFF
--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.inc
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.inc
@@ -26,6 +26,7 @@ EOD
 $var text
 EOD
                                 => 'excluded',
+    (unset) false               => 'excluded', // Type cast deprecated per PHP 7.2, removed 8.0.
 ];
 
 /* testAllEmptyString */
@@ -34,6 +35,7 @@ $emptyStringKey = array(
     null           => 'null',
     (string) false => 'false',
     \null          => 'null',
+    (binary) false => 'binary false', // Type cast deprecated per PHP 8.5.
 );
 
 /* testAllZero */
@@ -61,6 +63,10 @@ $everythingZero = [
     (true) ? 0 : 1   => 't',
     ! true           => 'u',
     \false           => 'v',
+    (integer) ''     => 'w', // Type cast deprecated per PHP 8.5.
+    (float) 0.14     => 'x',
+    (real) 0.2       => 'y', // Type cast deprecated per PHP 7.4, removed 8.0.
+    (double) 0.005   => 'z', // Type cast deprecated per PHP 8.5.
 ];
 
 /* testAllOne */
@@ -89,6 +95,11 @@ $everythingOne = [
     ! false          => 't',
     (string) true    => 'u',
     \true            => 'v',
+    (boolean) 1      => 'w',  // Type cast deprecated per PHP 8.5.
+    (binary) true    => 'x',
+    (float) 1.14     => 'y',
+    (real) 1.2       => 'z',  // Type cast deprecated per PHP 7.4, removed 8.0.
+    (double) 1.005   => 'aa', // Type cast deprecated per PHP 8.5.
 ];
 
 /* testAllEleven */
@@ -110,6 +121,7 @@ $everythingEleven = [
     "11"               => 'o',
     11.                => 'p',
     35 % 12            => 'q',
+    (integer) '11'     => 'r', // Type cast deprecated per PHP 8.5.
 ];
 
 /* testAllStringAbc */


### PR DESCRIPTION

The `AbstractArrayDeclarationSniff::getActualArrayKey()` method collects the contents of a subset of tokens and then runs `eval()` on this contents to determine what the array key would be.

The code allows for "collecting" type casts tokens as safe for use in the `eval()`, however, it did not take into account that there have been a number of changes in the available type casts in PHP over time.

Say, the code under scan uses the `(real)` type cast in an array key. This type cast was deprecated in PHP 7.4 and has been removed since PHP 8.0.

While the code under scan may run on PHP < 8.0 in production, the PHPCS scan _might_ be run on a different PHP version.
- If the scan would be run on PHP 7.4, the scan would bork out on the deprecation notice triggered by running the code in the `eval()` and PHPCS catching any such PHP notices and bowing out of scanning the file if/when such notices are encountered.
- If the scan would be run on PHP >= 8.0, the scan would bork out on a fatal error for the cast no longer being supported.

Now, what with PHP 8.5 deprecating another four type casts variants, this issue is now more relevant than ever before.

The changes made in this commit are intended to prevent such notices about deprecated/removed type casts from negatively impacting a PHPCS scan.

Includes tests.