### PR TITLE
GH Actions: update for the release of PHP 8.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,11 +30,11 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', '7.0', '7.4', '8.0', '8.4', '8.5']
+        php: ['5.4', '7.0', '7.4', '8.0', '8.5', 'nightly']
 
     name: "Lint: PHP ${{ matrix.php }}"
 
-    continue-on-error: ${{ matrix.php == '8.5' }}
+    continue-on-error: ${{ matrix.php == 'nightly' }}
 
     steps:
       - name: Checkout code
@@ -54,16 +54,16 @@ jobs:
         uses: "ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520" # 3.1.1
         with:
           # For PHP "nightly", we need to install with ignore platform reqs as not all dependencies may allow it yet.
-          composer-options: ${{ matrix.php == '8.5' && '--ignore-platform-req=php+' || '' }}
+          composer-options: ${{ matrix.php == 'nightly' && '--ignore-platform-req=php+' || '' }}
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: "Lint against parse errors (PHP < 7.2)"
-        if: ${{ matrix.php < 7.2 }}
+        if: ${{ matrix.php < 7.2 && matrix.php != 'nightly' }}
         run: composer lint-lt72 -- --checkstyle | cs2pr
 
       - name: "Lint against parse errors (PHP 7.2+)"
-        if: ${{ matrix.php >= 7.2 }}
+        if: ${{ matrix.php >= 7.2 || matrix.php == 'nightly' }}
         run: composer lint -- --checkstyle | cs2pr
 
 
@@ -86,7 +86,7 @@ jobs:
         # IMPORTANT: test runs shouldn't fail because of PHPCS being incompatible with a PHP version.
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
-        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         phpcs_version: ['lowest', '3.x-dev', '4.0.1', '4.x-dev']
         risky: [false]
         experimental: [false]
@@ -127,11 +127,11 @@ jobs:
             extensions: ':iconv' # Run with iconv disabled.
 
           # Experimental builds. These are allowed to fail.
-          - php: '8.5'
+          - php: '8.6'
             phpcs_version: '3.x-dev'
             risky: false
             experimental: true
-          - php: '8.5'
+          - php: '8.6'
             phpcs_version: '4.x-dev'
             risky: false
             experimental: true
@@ -152,22 +152,22 @@ jobs:
             risky: true
             experimental: true
 
-          - php: '8.4'
+          - php: '8.5'
             phpcs_version: 'lowest'
             risky: true
             experimental: true
 
-          - php: '8.4'
+          - php: '8.5'
             phpcs_version: '3.x-dev'
             risky: true
             experimental: true
 
-          - php: '8.4'
+          - php: '8.5'
             phpcs_version: '4.0.1'
             risky: true
             experimental: true
 
-          - php: '8.4'
+          - php: '8.5'
             phpcs_version: '4.x-dev'
             risky: true
             experimental: true
@@ -219,7 +219,7 @@ jobs:
         uses: "ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520" # 3.1.1
         with:
           # For PHP "nightly", we need to install with ignore platform reqs as not all dependencies may allow it yet.
-          composer-options: ${{ matrix.php == '8.5' && '--ignore-platform-req=php+' || '' }}
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }}
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
@@ -295,14 +295,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: '8.4'
+          - php: '8.5'
             phpcs_version: '4.x-dev'
             extensions: ':iconv' # Run one build with iconv disabled.
-          - php: '8.4'
+          - php: '8.5'
             phpcs_version: '4.0.1'
-          - php: '8.4'
+          - php: '8.5'
             phpcs_version: '3.x-dev'
-          - php: '8.4'
+          - php: '8.5'
             phpcs_version: 'lowest'
           - php: '7.2'
             phpcs_version: '4.x-dev'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/PHPCSStandards/PHPCSUtils/badge.svg?branch=develop)](https://coveralls.io/github/PHPCSStandards/PHPCSUtils?branch=develop)
 
 [![Minimum PHP Version](https://img.shields.io/packagist/dependency-v/phpcsstandards/phpcsutils/php.svg)][phpcsutils-packagist]
-[![Tested on PHP 5.4 to 8.4](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3%20|%208.4-brightgreen.svg?maxAge=2419200)][phpcsutils-tests-gha]
+[![Tested on PHP 5.4 to 8.5](https://img.shields.io/badge/tested%20on-PHP%205.4%20|%205.5%20|%205.6%20|%207.0%20|%207.1%20|%207.2%20|%207.3%20|%207.4%20|%208.0%20|%208.1%20|%208.2%20|%208.3%20|%208.4%20|%208.5-brightgreen.svg?maxAge=2419200)][phpcsutils-tests-gha]
 
 [![License: LGPLv3](https://img.shields.io/github/license/PHPCSStandards/PHPCSUtils)](https://github.com/PHPCSStandards/PHPCSUtils/blob/stable/LICENSE)
 ![Awesome](https://img.shields.io/badge/awesome%3F-yes!-brightgreen.svg)


### PR DESCRIPTION
... which is expected to be released this Thursday.

* Builds against PHP 8.5 are no longer allowed to fail.
* Update PHP version on which code coverage is run (high should now be 8.5).
* Add _allowed to fail_ build against PHP 8.6.
* Update "tested against" badge in the README.