### PR TITLE
GH Actions/website: update PHP version used by phpDocumentor

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -69,7 +69,7 @@ jobs:
         uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # 2.35.5
         with:
           # Use a version known to be safe for last phpDocumentor release.
-          php-version: '8.1'
+          php-version: '8.4'
           ini-file: 'development'
           coverage: none
           # Install the latest phpDocumentor release as a PHAR.


### PR DESCRIPTION
As of phpDocumentor 3.9.0, the recommended PHP version to run phpDocumentor on is PHP 8.4.

Ref: https://github.com/phpDocumentor/phpDocumentor/releases/tag/v3.9.0