### PR TITLE
FunctionDeclarations::getProperties(): add more defensive coding

### DIFF
--- a/PHPCSUtils/Utils/FunctionDeclarations.php
+++ b/PHPCSUtils/Utils/FunctionDeclarations.php
@@ -150,6 +150,7 @@ final class FunctionDeclarations
      *   - `"has_body"` index could be set to `true` for functions without body in the case of
      *      parse errors or live coding.
      * - Defensive coding against incorrect calls to this method.
+     * - Defensive coding against incorrect results due to parse errors in the code under scan.
      * - More efficient checking whether a function has a body.
      * - Support for PHP 8.0 identifier name tokens in return types, cross-version PHP & PHPCS.
      * - The results of this function call are cached during a PHPCS run for faster response times.
@@ -277,7 +278,10 @@ final class FunctionDeclarations
                     break;
                 }
 
-                if ($scopeOpener === null && $tokens[$i]['code'] === \T_SEMICOLON) {
+                if ($scopeOpener === null
+                    && ($tokens[$i]['code'] === \T_SEMICOLON
+                    || $tokens[$i]['code'] === \T_OPEN_CURLY_BRACKET)
+                ) {
                     // End of abstract/interface function definition.
                     break;
                 }

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.inc
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.inc
@@ -1,5 +1,9 @@
 <?php
 
+/* testInvalidTypeParseError */
+// This test MUST have code containing name tokens after this code sample.
+function InvalidType($param): ?\&\SomeType {}
+
 /* testMessyPhpcsAnnotationsMethod */
 trait FooTrait {
     /**

--- a/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
+++ b/Tests/Utils/FunctionDeclarations/GetPropertiesDiffTest.php
@@ -59,6 +59,32 @@ final class GetPropertiesDiffTest extends PolyfilledTestCase
     }
 
     /**
+     * Test that for invalid code, the return type parsing doesn't grab too many tokens.
+     *
+     * @return void
+     */
+    public function testInvalidTypeParseError()
+    {
+        $php8Names = parent::usesPhp8NameTokens();
+
+        // Offsets are relative to the T_FUNCTION token.
+        $expected = [
+            'scope'                 => 'public',
+            'scope_specified'       => false,
+            'return_type'           => ($php8Names === true) ? '?\\\\SomeType' : '?\\&\\SomeType',
+            'return_type_token'     => 9,
+            'return_type_end_token' => ($php8Names === true) ? 11 : 12,
+            'nullable_return_type'  => true,
+            'is_abstract'           => false,
+            'is_final'              => false,
+            'is_static'             => false,
+            'has_body'              => true,
+        ];
+
+        $this->getPropertiesTestHelper('/* ' . __FUNCTION__ . ' */', $expected);
+    }
+
+    /**
      * Test handling of the PHPCS 3.2.0+ annotations between the keywords.
      *
      * @return void


### PR DESCRIPTION
... to prevent a particular type of parse error from grabbing too many tokens as the "return type".

Includes test.