### PR TITLE
BCTokens: let `castTokens()` method include void cast

### DIFF
--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -46,7 +46,6 @@ use PHPCSUtils\Tokens\Collections;
  * @method static array<int|string, int|string> arithmeticTokens()         Tokens that represent arithmetic operators.
  * @method static array<int|string, int|string> booleanOperators()         Tokens that perform boolean operations.
  * @method static array<int|string, int|string> bracketTokens()            Tokens that represent brackets and parenthesis.
- * @method static array<int|string, int|string> castTokens()               Tokens that represent type casting.
  * @method static array<int|string, int|string> commentTokens()            Tokens that are comments.
  * @method static array<int|string, int|string> comparisonTokens()         Tokens that represent comparison operator.
  * @method static array<int|string, int|string> contextSensitiveKeywords() Tokens representing context sensitive keywords
@@ -139,6 +138,31 @@ final class BCTokens
 
         if (\defined('T_OBJECT') && isset($tokens[\T_OBJECT])) {
             unset($tokens[\T_OBJECT]);
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * Tokens that represent casting.
+     *
+     * Retrieve the PHPCS cast tokens array in a cross-version compatible manner.
+     *
+     * Changelog for the PHPCS native array:
+     * - PHPCS 4.0.2: The PHP 8.5 T_VOID_CAST token was added.
+     *
+     * @see \PHP_CodeSniffer\Util\Tokens::$castTokens Original array.
+     *
+     * @since 1.2.1
+     *
+     * @return array<int|string, int|string> Token array.
+     */
+    public static function castTokens()
+    {
+        $tokens = Tokens::$castTokens;
+
+        if (\defined('T_VOID_CAST')) {
+            $tokens[\T_VOID_CAST] = \T_VOID_CAST;
         }
 
         return $tokens;

--- a/Tests/BackCompat/BCTokens/CastTokensTest.php
+++ b/Tests/BackCompat/BCTokens/CastTokensTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * PHPCSUtils, utility functions and classes for PHP_CodeSniffer sniff developers.
+ *
+ * @package   PHPCSUtils
+ * @copyright 2019-2020 PHPCSUtils Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSUtils
+ */
+
+namespace PHPCSUtils\Tests\BackCompat\BCTokens;
+
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\BackCompat\BCTokens;
+use PHPCSUtils\BackCompat\Helper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class.
+ *
+ * @covers \PHPCSUtils\BackCompat\BCTokens::castTokens
+ *
+ * @group tokens
+ *
+ * @since 1.2.1
+ */
+final class CastTokensTest extends TestCase
+{
+
+    /**
+     * Test the method.
+     *
+     * @return void
+     */
+    public function testCastTokens()
+    {
+        $expected = [
+            \T_INT_CAST    => \T_INT_CAST,
+            \T_STRING_CAST => \T_STRING_CAST,
+            \T_DOUBLE_CAST => \T_DOUBLE_CAST,
+            \T_ARRAY_CAST  => \T_ARRAY_CAST,
+            \T_BOOL_CAST   => \T_BOOL_CAST,
+            \T_OBJECT_CAST => \T_OBJECT_CAST,
+            \T_UNSET_CAST  => \T_UNSET_CAST,
+            \T_BINARY_CAST => \T_BINARY_CAST,
+        ];
+
+        if (\version_compare(Helper::getVersion(), '4.0.2', '>=') === true
+            || \PHP_VERSION_ID >= 80500
+        ) {
+            $expected[\T_VOID_CAST] = \T_VOID_CAST;
+        }
+
+        $this->assertSame($expected, BCTokens::castTokens());
+    }
+
+    /**
+     * Test whether the method in BCTokens is still in sync with the latest version of PHPCS.
+     *
+     * This group is not run by default and has to be specifically requested to be run.
+     *
+     * @group compareWithPHPCS
+     *
+     * @return void
+     */
+    public function testPHPCSCastTokens()
+    {
+        $this->assertSame(Tokens::$castTokens, BCTokens::castTokens());
+    }
+}

--- a/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
+++ b/Tests/BackCompat/BCTokens/UnchangedTokenArraysTest.php
@@ -107,22 +107,6 @@ final class UnchangedTokenArraysTest extends TestCase
     ];
 
     /**
-     * Tokens that represent casting.
-     *
-     * @var array<int|string, int|string>
-     */
-    private $castTokens = [
-        \T_INT_CAST    => \T_INT_CAST,
-        \T_STRING_CAST => \T_STRING_CAST,
-        \T_DOUBLE_CAST => \T_DOUBLE_CAST,
-        \T_ARRAY_CAST  => \T_ARRAY_CAST,
-        \T_BOOL_CAST   => \T_BOOL_CAST,
-        \T_OBJECT_CAST => \T_OBJECT_CAST,
-        \T_UNSET_CAST  => \T_UNSET_CAST,
-        \T_BINARY_CAST => \T_BINARY_CAST,
-    ];
-
-    /**
      * Tokens that represent scope modifiers.
      *
      * @var array<int|string, int|string>


### PR DESCRIPTION
.. to account for the PHP 8.5 `(void)` cast token `T_VOID_CAST` being polyfilled as of the upcoming PHPCS 4.0.2 release.

Ref: PHPCSStandards/PHP_CodeSniffer#1325