### PR TITLE
Arrays::getDoubleArrowPtr(): allow for arrays in array item keys

### DIFF
--- a/PHPCSUtils/Utils/Arrays.php
+++ b/PHPCSUtils/Utils/Arrays.php
@@ -228,15 +228,17 @@ final class Arrays
                 continue;
             }
 
-            // Skip over potentially keyed long lists.
-            if ($tokens[$doubleArrow]['code'] === \T_LIST
-                && isset($tokens[$doubleArrow]['parenthesis_closer'])
-            ) {
+            // Skip over any parenthesized/bracketed expression (potential keyed list or callback in array format).
+            if (isset($tokens[$doubleArrow]['parenthesis_closer'])) {
                 $doubleArrow = $tokens[$doubleArrow]['parenthesis_closer'];
                 continue;
             }
 
-            // Start of nested long/short array.
+            if (isset($tokens[$doubleArrow]['bracket_closer'])) {
+                $doubleArrow = $tokens[$doubleArrow]['bracket_closer'];
+                continue;
+            }
+
             break;
         } while ($doubleArrow < $end);
 

--- a/Tests/Utils/Arrays/GetDoubleArrowPtrTest.inc
+++ b/Tests/Utils/Arrays/GetDoubleArrowPtrTest.inc
@@ -111,6 +111,12 @@ $array = [
     /* testNoArrowKeyedShortListInValue */
     [ 'key1' => $a, 'key2' => $b ] = $array,
 
+    /* testArrowKeyIsCallbackInLongArrayFormat */
+    array($obj, 'method')('arg') => 'excluded',
+
+    /* testArrowKeyIsCallbackInShortArrayFormat */
+    ['ClassName', 'method']('arg') => 'excluded',
+
     /* testNoArrowValueClosureWithAttribute */
     #[MyAttribute([0 => 'value'])] function() { /* do something */ }(),
 

--- a/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
+++ b/Tests/Utils/Arrays/GetDoubleArrowPtrTest.php
@@ -272,6 +272,16 @@ final class GetDoubleArrowPtrTest extends PolyfilledTestCase
                 'expected'   => false,
             ],
 
+            // Verify that the arrow will be found even if the array item key contains a (nested) array.
+            'test-arrow-key-is-callback-in-long-array-format' => [
+                'testMarker' => '/* testArrowKeyIsCallbackInLongArrayFormat */',
+                'expected'   => 17,
+            ],
+            'test-arrow-key-is-callback-in-short-array-format' => [
+                'testMarker' => '/* testArrowKeyIsCallbackInShortArrayFormat */',
+                'expected'   => 16,
+            ],
+
             // Safeguard that double arrows in PHP 8.0 attributes are disregarded.
             'test-no-arrow-value-closure-with-attached-attribute-containing-arrow' => [
                 'testMarker' => '/* testNoArrowValueClosureWithAttribute */',


### PR DESCRIPTION
While probably pretty darn rare, it is valid PHP to call a function using callback format in an array key, so the `Arrays::getDoubleArrowPtr()` method should handle this correctly.

Includes tests.