### PR TITLE
AbstractArrayDeclarationSniff::getActualArrayKey(): prevent executing arbitrary callback

### DIFF
--- a/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
+++ b/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
@@ -123,6 +123,24 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
     ];
 
     /**
+     * List of tokens which, when found directly before an open parenthesis, indicate a function call/callback.
+     *
+     * Note: some of these (end heredoc/nowdoc) can not result in valid code (parse error), but that's not our concern.
+     *
+     * @since 1.2.3
+     *
+     * @var array<int|string, int|string>
+     */
+    private $callbackIndicators = [
+        \T_CONSTANT_ENCAPSED_STRING => \T_CONSTANT_ENCAPSED_STRING,
+        \T_END_HEREDOC              => \T_END_HEREDOC,
+        \T_END_NOWDOC               => \T_END_NOWDOC,
+        \T_CLOSE_PARENTHESIS        => \T_CLOSE_PARENTHESIS,
+        \T_CLOSE_CURLY_BRACKET      => \T_CLOSE_CURLY_BRACKET,
+        \T_CLOSE_SQUARE_BRACKET     => \T_CLOSE_SQUARE_BRACKET,
+    ];
+
+    /**
      * Set up this class.
      *
      * @since 1.0.0
@@ -468,7 +486,10 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
 
         $content = '';
 
-        for ($i = $firstNonEmpty; $i <= $lastNonEmpty; $i++) {
+        for ($i = $firstNonEmpty, $lastEffective = null;
+            $i <= $lastNonEmpty;
+            ($lastEffective = isset(Tokens::$emptyTokens[$this->tokens[$i]['code']]) === false ? $i : $lastEffective), $i++
+        ) {
             if (isset(Tokens::$commentTokens[$this->tokens[$i]['code']]) === true) {
                 continue;
             }
@@ -540,6 +561,14 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
                     $content .= '(string)';
                     continue;
                 }
+            }
+
+            if (isset($lastEffective) === true
+                && $this->tokens[$i]['code'] === \T_OPEN_PARENTHESIS
+                && isset($this->callbackIndicators[$this->tokens[$lastEffective]['code']]) === true
+            ) {
+                // Bow out for potential function call in callback format.
+                return;
             }
 
             // Account for heredoc with vars.

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.inc
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.inc
@@ -27,6 +27,7 @@ $var text
 EOD
                                 => 'excluded',
     (unset) false               => 'excluded', // Type cast deprecated per PHP 7.2, removed 8.0.
+    ClassName::method('arg')    => 'excluded',
 ];
 
 /* testAllEmptyString */
@@ -174,3 +175,57 @@ $validNumericStringKeys = array(
     '0x7' => 'value5',
     '0.0' => 'value6',
 );
+
+/* testCallbackInKeyResultsInVoid1 */
+$excluded = [
+    ('tr'. /*comment*/ 'im')('arg') => 'excluded',
+];
+
+/* testCallbackInKeyResultsInVoid2 */
+$excluded = [
+    'trim'('arg') => 'excluded',
+];
+
+/* testCallbackInKeyResultsInVoid3 */
+$excluded = [
+    {'trim'}('arg') => 'excluded',
+];
+
+/* testCallbackInKeyResultsInVoid4 */
+$excluded = [
+    'PHPCSUtils\\Utils\\TextStrings::stripEmbeds'('arg') => 'excluded',
+];
+
+/* testCallbackInKeyResultsInVoid5 */
+$excluded = array(
+    (<<<'EOT'
+trim
+EOT
+)('arg') => 'excluded',
+);
+
+/* testCallbackInKeyResultsInVoid6 */
+$excluded = [
+    (<<<EOT
+trim
+EOT
+)('arg') => 'excluded',
+];
+
+/* testCallbackInKeyResultsInVoid7 */
+$excluded = [
+    (<<<"EOT"
+trim
+EOT
+)('arg') => 'excluded',
+];
+
+/* testCallbackInKeyResultsInVoid8 */
+$excluded = array(
+    ['PHPCSUtils\\Utils\\TextStrings', 'stripEmbeds']('arg') => 'excluded',
+);
+
+/* testCallbackInKeyResultsInVoid9 */
+$excluded = [
+    array($obj, 'stripEmbeds')('arg') => 'excluded',
+];

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.php
@@ -220,4 +220,51 @@ final class GetActualArrayKeyTest extends UtilityMethodTestCase
         $actualKeys   = \array_keys(\array_combine($expected, $expected));
         $this->assertSame($expectedKeys, $actualKeys, 'getActualArrayKey() results do not match PHP native handling');
     }
+
+    /**
+     * Verify that callbacks in array keys are not executed.
+     *
+     * @dataProvider dataGetActualArrayKeyDoesNotExecuteCallbacks
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     *
+     * @return void
+     */
+    public function testGetActualArrayKeyDoesNotExecuteCallbacks($testMarker)
+    {
+        $testObj         = new ArrayDeclarationSniffTestDouble();
+        $testObj->tokens = self::$phpcsFile->getTokens();
+
+        $stackPtr   = $this->getTargetToken($testMarker, [\T_ARRAY, \T_OPEN_SHORT_ARRAY]);
+        $arrayItems = PassedParameters::getParameters(self::$phpcsFile, $stackPtr);
+
+        foreach ($arrayItems as $itemNr => $arrayItem) {
+            $arrowPtr = Arrays::getDoubleArrowPtr(self::$phpcsFile, $arrayItem['start'], $arrayItem['end']);
+            if ($arrowPtr !== false) {
+                $result = $testObj->getActualArrayKey(self::$phpcsFile, $arrayItem['start'], ($arrowPtr - 1));
+                $this->assertNull(
+                    $result,
+                    'Failed: actual key ' . \var_export($result, true) . ' is not void for item number ' . $itemNr
+                );
+            }
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetActualArrayKeyDoesNotExecuteCallbacks() For the array format.
+     *
+     * @return array<string, array<string>>
+     */
+    public static function dataGetActualArrayKeyDoesNotExecuteCallbacks()
+    {
+        $data = [];
+
+        for ($i = 1; $i <= 9; $i++) {
+            $data['callback-type-' . $i] = ['/* testCallbackInKeyResultsInVoid' . $i . ' */'];
+        }
+
+        return $data;
+    }
 }


### PR DESCRIPTION

This is a security fix for CVE-2026-65954 / [GHSA-r6hr-vr92-vv28](https://github.com/PHPCSStandards/PHPCSUtils/security/advisories/GHSA-r6hr-vr92-vv28).

As things were, it was possible for an arbitrary function call using callback format to be executed via `eval()` when the `AbstractArrayDeclarationSniff::getActualArrayKey()` method was used by a sniff.

This would require for the "code under scan" to have a function call using callback format in the key of an array item. Worst case scenario, this function call could result in system commands being run on the local system running the PHPCS scan.

Fixed now by bowing out for any syntax combination which _could_ indicate that the code in question is part of a function call using callback format.

Includes tests.

Note: the included tests have been specially crafted to be safe, even if they would be failing.