### PR TITLE
AbstractArrayDeclarationSniff::getActualArrayKey(): catch catchable exceptions

### DIFF
--- a/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
+++ b/PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
@@ -10,6 +10,7 @@
 
 namespace PHPCSUtils\AbstractSniffs;
 
+use Exception;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
@@ -20,6 +21,7 @@ use PHPCSUtils\Utils\Arrays;
 use PHPCSUtils\Utils\Numbers;
 use PHPCSUtils\Utils\PassedParameters;
 use PHPCSUtils\Utils\TextStrings;
+use Throwable;
 
 /**
  * Abstract sniff to easily examine all parts of an array declaration.
@@ -591,8 +593,16 @@ abstract class AbstractArrayDeclarationSniff implements Sniff
             $content .= $this->tokens[$i]['content'];
         }
 
-        // The PHP_EOL is to prevent getting parse errors when the key is a heredoc/nowdoc.
-        $key = eval('return ' . $content . ';' . \PHP_EOL);
+        try {
+            // The PHP_EOL is to prevent getting parse errors when the key is a heredoc/nowdoc.
+            $key = @eval('return ' . $content . ';' . \PHP_EOL);
+        } catch (Throwable $e) { // phpcs:ignore PHPCompatibility.Interfaces.NewInterfaces.throwableFound
+            // The code didn't evaluate cleanly on PHP >= 7.0. Bow out.
+            return;
+        } catch (Exception $e) {
+            // The code didn't evaluate cleanly on PHP < 7.0. Bow out.
+            return;
+        }
 
         /*
          * Ok, so now we know the base value of the key, let's determine whether it is

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.inc
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.inc
@@ -229,3 +229,15 @@ $excluded = array(
 $excluded = [
     array($obj, 'stripEmbeds')('arg') => 'excluded',
 ];
+
+/* testCatchableExceptionInExecutedCodeResultsInVoid1 */
+$excluded = [ 1/0     => 1 ];  // Uncaught DivisionByZeroError.
+
+/* testCatchableExceptionInExecutedCodeResultsInVoid2 */
+$excluded = [ 5 % 0   => 1 ];  // Uncaught DivisionByZeroError.
+
+/* testCatchableExceptionInExecutedCodeResultsInVoid3 */
+$excluded = [ null + 'x' => 1 ]; // Uncaught TypeError.
+
+/* testCatchableExceptionInExecutedCodeResultsInVoid4 */
+$excluded = [ (100 - ) => 1 ]; // Uncaught ParseError.

--- a/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.php
+++ b/Tests/AbstractSniffs/AbstractArrayDeclaration/GetActualArrayKeyTest.php
@@ -232,22 +232,7 @@ final class GetActualArrayKeyTest extends UtilityMethodTestCase
      */
     public function testGetActualArrayKeyDoesNotExecuteCallbacks($testMarker)
     {
-        $testObj         = new ArrayDeclarationSniffTestDouble();
-        $testObj->tokens = self::$phpcsFile->getTokens();
-
-        $stackPtr   = $this->getTargetToken($testMarker, [\T_ARRAY, \T_OPEN_SHORT_ARRAY]);
-        $arrayItems = PassedParameters::getParameters(self::$phpcsFile, $stackPtr);
-
-        foreach ($arrayItems as $itemNr => $arrayItem) {
-            $arrowPtr = Arrays::getDoubleArrowPtr(self::$phpcsFile, $arrayItem['start'], $arrayItem['end']);
-            if ($arrowPtr !== false) {
-                $result = $testObj->getActualArrayKey(self::$phpcsFile, $arrayItem['start'], ($arrowPtr - 1));
-                $this->assertNull(
-                    $result,
-                    'Failed: actual key ' . \var_export($result, true) . ' is not void for item number ' . $itemNr
-                );
-            }
-        }
+        $this->assertArrayKeyCouldNotBeDeterminedForAnyItemInTheArray($testMarker);
     }
 
     /**
@@ -266,5 +251,81 @@ final class GetActualArrayKeyTest extends UtilityMethodTestCase
         }
 
         return $data;
+    }
+
+    /**
+     * Verify that if evaluated code from an array key would result in a catchable exception, this exception is handled.
+     *
+     * @dataProvider dataGetActualArrayKeyCatchesCatchableException
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     *
+     * @return void
+     */
+    public function testGetActualArrayKeyCatchesCatchableException($testMarker)
+    {
+        $this->assertArrayKeyCouldNotBeDeterminedForAnyItemInTheArray($testMarker);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGetActualArrayKeyCatchesCatchableException() For the array format.
+     *
+     * @return array<string, array<string>>
+     */
+    public static function dataGetActualArrayKeyCatchesCatchableException()
+    {
+        $data = [];
+
+        if (PHP_VERSION_ID >= 80000) {
+            // Prior to PHP 8.0, this was a warning, not a catchable exception.
+            $data['exception-1'] = ['/* testCatchableExceptionInExecutedCodeResultsInVoid1 */'];
+        }
+
+        if (PHP_VERSION_ID >= 70000) {
+            // Prior to PHP 7.0, this was a warning, not a DivisionByZeroError.
+            $data['exception-2'] = ['/* testCatchableExceptionInExecutedCodeResultsInVoid2 */'];
+        }
+
+        if (PHP_VERSION_ID >= 80000) {
+            // Prior to PHP 8.0, this was a (non-numeric value) warning, not a TypeError.
+            $data['exception-3'] = ['/* testCatchableExceptionInExecutedCodeResultsInVoid3 */'];
+        }
+
+        if (PHP_VERSION_ID >= 70000) {
+            // Prior to PHP 7.0, parse errors in the eval-ed code would result in a `false` return value.
+            $data['exception-4'] = ['/* testCatchableExceptionInExecutedCodeResultsInVoid4 */'];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Test helper to verify that the `getActualArrayKey()` method bows out for array items
+     * where the value of the key could not be determined.
+     *
+     * @param string $testMarker The comment which prefaces the target token in the test file.
+     *
+     * @return void
+     */
+    public function assertArrayKeyCouldNotBeDeterminedForAnyItemInTheArray($testMarker)
+    {
+        $testObj         = new ArrayDeclarationSniffTestDouble();
+        $testObj->tokens = self::$phpcsFile->getTokens();
+
+        $stackPtr   = $this->getTargetToken($testMarker, [\T_ARRAY, \T_OPEN_SHORT_ARRAY]);
+        $arrayItems = PassedParameters::getParameters(self::$phpcsFile, $stackPtr);
+
+        foreach ($arrayItems as $itemNr => $arrayItem) {
+            $arrowPtr = Arrays::getDoubleArrowPtr(self::$phpcsFile, $arrayItem['start'], $arrayItem['end']);
+            if ($arrowPtr !== false) {
+                $result = $testObj->getActualArrayKey(self::$phpcsFile, $arrayItem['start'], ($arrowPtr - 1));
+                $this->assertNull(
+                    $result,
+                    'Failed: actual key ' . \var_export($result, true) . ' is not void for item number ' . $itemNr
+                );
+            }
+        }
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -87,6 +87,12 @@ parameters:
             path: PHPCSUtils/Tokens/Collections.php
             count: 1
 
+        # This is by design for PHP cross-version compatibility.
+        -
+            message: '`^Dead catch - Exception is already caught above\.$`'
+            path: PHPCSUtils/AbstractSniffs/AbstractArrayDeclarationSniff.php
+            count: 1
+
         # Ignoring these as availability depends on which PHPUnit/PHPUnit Polyfills version is loaded/installed. This is 100% okay.
         -
             message: "`^Call to function method_exists\\(\\) with \\$this\\([^)]+\\) and 'expectError' will always evaluate to false\\.$`"


### PR DESCRIPTION
As things were, if the `eval()`-ed code would result in a catchable exception, PHPCS would crash and exit.

This commit hardens the method by adding extra defensive coding to prevent this.

Includes tests.