### PR TITLE
Remark: selectively skip URL patterns [update]

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -13,6 +13,7 @@
         {
             "skipUrlPatterns": [
                 "^https?://github\\.com/PHPCSStandards/PHPCSUtils/compare/[0-9\\.]+?\\.{3}[0-9\\.]+",
+                "^https?://github\\.com/PHPCSStandards/PHPCSUtils/commits/develop",
                 "^https://phpcsutils\\.com/phpdoc/classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_isArrowFunction",
                 "^https://phpcsutils\\.com/phpdoc/classes/PHPCSUtils-Utils-FunctionDeclarations.html#method_getArrowFunctionOpenClose",
                 "^https://packagist.org/packages/phpcsstandards/phpcsutils#dev-develop"


### PR DESCRIPTION
Skip a particular URL on which Remark keeps failing due to GH throwing a 429 ("too many requests") error.