### PR TITLE
Composer: raise the minimum supported PHPCS version to 3.13.6/4.0.2

### DIFF
--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -38,11 +38,11 @@ jobs:
 
         include:
           - php: '7.2'
-            phpcs_version: '4.0.1'
+            phpcs_version: '4.0.2'
           - php: '7.2'
             phpcs_version: '4.x-dev'
           - php: 'latest'
-            phpcs_version: '4.0.1'
+            phpcs_version: '4.0.2'
           - php: 'latest'
             phpcs_version: '4.x-dev'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,30 +89,30 @@ jobs:
         #
         # The matrix is set up so as not to duplicate the builds which are run for code coverage.
         php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
-        phpcs_version: ['lowest', '3.x-dev', '4.0.1', '4.x-dev']
+        phpcs_version: ['lowest', '3.x-dev', '4.0.2', '4.x-dev']
         risky: [false]
         experimental: [false]
 
         exclude:
           - php: '5.5'
-            phpcs_version: '4.0.1'
+            phpcs_version: '4.0.2'
           - php: '5.5'
             phpcs_version: '4.x-dev'
           - php: '5.6'
-            phpcs_version: '4.0.1'
+            phpcs_version: '4.0.2'
           - php: '5.6'
             phpcs_version: '4.x-dev'
           - php: '7.0'
-            phpcs_version: '4.0.1'
+            phpcs_version: '4.0.2'
           - php: '7.0'
             phpcs_version: '4.x-dev'
           - php: '7.1'
-            phpcs_version: '4.0.1'
+            phpcs_version: '4.0.2'
           - php: '7.1'
             phpcs_version: '4.x-dev'
           # Also exclude the 7.2 builds as those are run in code coverage, no need to duplicate.
           - php: '7.2'
-            phpcs_version: '4.0.1'
+            phpcs_version: '4.0.2'
           - php: '7.2'
             phpcs_version: '4.x-dev'
 
@@ -165,7 +165,7 @@ jobs:
             experimental: true
 
           - php: '8.5'
-            phpcs_version: '4.0.1'
+            phpcs_version: '4.0.2'
             risky: true
             experimental: true
 
@@ -303,7 +303,7 @@ jobs:
             phpcs_version: '4.x-dev'
             extensions: ':iconv' # Run one build with iconv disabled.
           - php: '8.5'
-            phpcs_version: '4.0.1'
+            phpcs_version: '4.0.2'
           - php: '8.5'
             phpcs_version: '3.x-dev'
           - php: '8.5'
@@ -311,7 +311,7 @@ jobs:
           - php: '7.2'
             phpcs_version: '4.x-dev'
           - php: '7.2'
-            phpcs_version: '4.0.1'
+            phpcs_version: '4.0.2'
           - php: '5.4'
             phpcs_version: '3.x-dev'
           - php: '5.4'

--- a/PHPCSUtils/BackCompat/BCFile.php
+++ b/PHPCSUtils/BackCompat/BCFile.php
@@ -524,7 +524,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.13.5.
+     * - The upstream method has received no significant updates since PHPCS 3.13.6.
      *
      * @see \PHP_CodeSniffer\Files\File::getMethodProperties()      Original source.
      * @see \PHPCSUtils\Utils\FunctionDeclarations::getProperties() PHPCSUtils native improved version.
@@ -765,7 +765,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.3.0.
-     * - The upstream method has received no significant updates since PHPCS 3.13.5.
+     * - The upstream method has received no significant updates since PHPCS 3.13.6.
      *
      * @see \PHP_CodeSniffer\Files\File::getClassProperties()          Original source.
      * @see \PHPCSUtils\Utils\ObjectDeclarations::getClassProperties() PHPCSUtils native improved version.
@@ -793,7 +793,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.13.5.
+     * - The upstream method has received no significant updates since PHPCS 3.13.6.
      *
      * @see \PHP_CodeSniffer\Files\File::isReference() Original source.
      * @see \PHPCSUtils\Utils\Operators::isReference() PHPCSUtils native improved version.
@@ -819,7 +819,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.13.5.
+     * - The upstream method has received no significant updates since PHPCS 3.13.6.
      *
      * @see \PHP_CodeSniffer\Files\File::getTokensAsString() Original source.
      * @see \PHPCSUtils\Utils\GetTokensAsString              Related set of functions.
@@ -848,7 +848,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.1.0.
-     * - The upstream method has received no significant updates since PHPCS 3.13.5.
+     * - The upstream method has received no significant updates since PHPCS 3.13.6.
      *
      * @see \PHP_CodeSniffer\Files\File::findStartOfStatement() Original source.
      *
@@ -872,7 +872,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 2.1.0.
-     * - The upstream method has received no significant updates since PHPCS 3.13.5.
+     * - The upstream method has received no significant updates since PHPCS 3.13.6.
      *
      * @see \PHP_CodeSniffer\Files\File::findEndOfStatement() Original source.
      *
@@ -896,7 +896,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 0.0.5.
-     * - The upstream method has received no significant updates since PHPCS 3.13.5.
+     * - The upstream method has received no significant updates since PHPCS 3.13.6.
      *
      * @see \PHP_CodeSniffer\Files\File::hasCondition()  Original source.
      * @see \PHPCSUtils\Utils\Conditions::hasCondition() PHPCSUtils native alternative.
@@ -921,7 +921,7 @@ final class BCFile
      *
      * Changelog for the PHPCS native function:
      * - Introduced in PHPCS 1.3.0.
-     * - The upstream method has received no significant updates since PHPCS 3.13.5.
+     * - The upstream method has received no significant updates since PHPCS 3.13.6.
      *
      * @see \PHP_CodeSniffer\Files\File::getCondition()  Original source.
      * @see \PHPCSUtils\Utils\Conditions::getCondition() More versatile alternative.

--- a/PHPCSUtils/BackCompat/BCTokens.php
+++ b/PHPCSUtils/BackCompat/BCTokens.php
@@ -71,7 +71,7 @@ final class BCTokens
 
     /**
      * Handle calls to (undeclared) methods for token arrays which haven't received any
-     * changes since PHPCS 3.13.5.
+     * changes since PHPCS 3.13.6.
      *
      * @since 1.0.0
      *

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Whether you need to split an `array` into the individual items, are trying to de
 
 Includes improved versions of the PHPCS native utility functions and plenty of new utility functions.
 
-These functions are compatible with PHPCS 3.13.5 up to PHPCS `4.x`.
+These functions are compatible with PHPCS 3.13.6 up to PHPCS `4.x`.
 
 ### A collection of static properties and methods for often-used token groups
 
@@ -78,7 +78,7 @@ To see detailed information about all the available abstract sniffs, utility fun
 ## Minimum Requirements
 
 * PHP 5.4 or higher.
-* [PHP_CodeSniffer] 3.13.5+/4.0.1+.
+* [PHP_CodeSniffer] 3.13.6+/4.0.2+.
 * Recommended PHP extensions for optimal functionality:
     - PCRE with Unicode support (normally enabled by default)
 

--- a/Tests/BackCompat/Helper/GetVersionTest.php
+++ b/Tests/BackCompat/Helper/GetVersionTest.php
@@ -30,7 +30,7 @@ final class GetVersionTest extends TestCase
      *
      * @var string
      */
-    const LATEST_3X_VERSION = '3.13.5';
+    const LATEST_3X_VERSION = '3.13.6';
 
     /**
      * Version number of the last PHPCS 4.x release.
@@ -39,7 +39,7 @@ final class GetVersionTest extends TestCase
      *
      * @var string
      */
-    const LATEST_4X_VERSION = '4.0.1';
+    const LATEST_4X_VERSION = '4.0.4';
 
     /**
      * Test the method.
@@ -56,7 +56,7 @@ final class GetVersionTest extends TestCase
         }
 
         if ($expected === 'lowest') {
-            $expected = '3.13.5';
+            $expected = '3.13.6';
         }
 
         $result = Helper::getVersion();

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require" : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer" : "^3.13.5 || ^4.0.1",
+        "squizlabs/php_codesniffer" : "^3.13.6 || ^4.0.2",
         "dealerdirect/phpcodesniffer-composer-installer" : "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0"
     },
     "require-dev" : {


### PR DESCRIPTION
PHP_CodeSniffer released security versions yesterday, so unless we actively ignore security advisories, all CI will fail on a failure to install for `lowest`.

As it would be prudent to encourage users to upgrade anyhow, let's raise the minimum supported PHPCS versions to get round this.

Refs:
* https://github.com/PHPCSStandards/PHP_CodeSniffer/releases#release-3.13.6
* https://github.com/PHPCSStandards/PHP_CodeSniffer/releases#release-4.0.2

Closes #781